### PR TITLE
Created list of the OpenStack SIG team members.

### DIFF
--- a/sig-openstack/SIG-members.md
+++ b/sig-openstack/SIG-members.md
@@ -2,10 +2,10 @@ List of the OpenStack Special Interest Group team members.
 
 Use @kubernetes/sig-openstack to mention this team in comments.
 
-[David Oppenheimer](https://github.com/davidopp) (owner)
-[Steve Gordon](https://github.com/xsgordon) (SIG lead)
-[Ihor Dvoretskyi](https://github.com/idvoretskyi) (SIG lead)
-[Angus Lees](https://github.com/anguslees)
-[Pengfei Ni](https://github.com/feiskyer)
-[Joshua Harlow](https://github.com/harlowja)
-[Stephen McQuaid](https://github.com/stevemcquaid)
+* [David Oppenheimer](https://github.com/davidopp) (owner)
+* [Steve Gordon](https://github.com/xsgordon) (SIG lead)
+* [Ihor Dvoretskyi](https://github.com/idvoretskyi) (SIG lead)
+* [Angus Lees](https://github.com/anguslees)
+* [Pengfei Ni](https://github.com/feiskyer)
+* [Joshua Harlow](https://github.com/harlowja)
+* [Stephen McQuaid](https://github.com/stevemcquaid)

--- a/sig-openstack/SIG-members.md
+++ b/sig-openstack/SIG-members.md
@@ -1,0 +1,11 @@
+List of the OpenStack Special Interest Group team members.
+
+Use @kubernetes/sig-openstack to mention this team in comments.
+
+[David Oppenheimer](https://github.com/davidopp) (owner)
+[Steve Gordon](https://github.com/xsgordon) (SIG lead)
+[Ihor Dvoretskyi](https://github.com/idvoretskyi) (SIG lead)
+[Angus Lees](https://github.com/anguslees)
+[Pengfei Ni](https://github.com/feiskyer)
+[Joshua Harlow](https://github.com/harlowja)
+[Stephen McQuaid](https://github.com/stevemcquaid)

--- a/sig-openstack/SIG-members.md
+++ b/sig-openstack/SIG-members.md
@@ -9,3 +9,4 @@ Use @kubernetes/sig-openstack to mention this team in comments.
 * [Pengfei Ni](https://github.com/feiskyer)
 * [Joshua Harlow](https://github.com/harlowja)
 * [Stephen McQuaid](https://github.com/stevemcquaid)
+* [Huamin Chen](https://github.com/rootfs)


### PR DESCRIPTION
As GitHub doesn't allow to view the list of team members within an organization for the users, who are not the members of the organization, this list has been created to be viewable by everyone.