### PR TITLE
replace calendar link with zoom link

### DIFF
--- a/community/fixit201606.md
+++ b/community/fixit201606.md
@@ -10,7 +10,14 @@ Another important piece of fixit culture is rewards.  **Everyone who contributes
 
 Since improvement isn't only about code and issues, we'd like to also help grow our community skills.  And, to that end,  below is a schedule of some interesting content and community events.  
 
-The community meeting calendar is [available as an iCal] (https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics) to subscribe to (simply copy and paste the url into any calendar product that supports the iCal format) or [html to view] (https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles).  All sessions listed below are listed on the community calendar and will be broadcast on the [community meeting URL] (https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles).
+The community meeting calendar is [available as an iCal]
+(https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics)
+to subscribe to (simply copy and paste the url into any calendar
+product that supports the iCal format) or [html to view]
+(https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles).
+All sessions listed below are listed on the community calendar and
+will be broadcast on the [community meeting URL]
+(https://zoom.us/my/kubernetescommunity).
 
 ##Tuesday 05:00 PT
 


### PR DESCRIPTION
I think the last link is supposed to be to the zoom community meeting directly.

Also formatted the paragraph so it's not a giant blob. 