### PR TITLE
kubernetes/charts to incubate but not move.

### DIFF
--- a/incubator.md
+++ b/incubator.md
@@ -118,11 +118,11 @@ These projects are young but have significant user facing docs pointing at their
 
 - github.com/kubernetes/minikube
 - github.com/kubernetes/helm
+- github.com/kubernetes/charts 
  
 **Projects to Move to Incubator**
 
 - github.com/kubernetes/kube2consul
-- github.com/kubernetes/charts
 - github.com/kubernetes/frakti
 - github.com/kubernetes/kops
 - github.com/kubernetes/kube-deploy


### PR DESCRIPTION
Kubernetes charts is closely tied to kubernetes/helm which not moving out of the kubernetes org.  Therefore, leave kubernetes/charts in place too.

