### PR TITLE
Update sig-service-catalog meeting agenda link

### DIFF
--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -6,11 +6,9 @@
 
 **Mailing List:** [kubernetes-sig-service-catalog](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog)
 
-**Meetings:** Mondays, 4pm Eastern / 1pm Pacific time
+**Meetings:** [Mondays, 4pm Eastern / 1pm Pacific time](https://plus.google.com/hangouts/_/google.com/k8s-sig-service-catalog)
 
-**Meeting Agenda:** https://docs.google.com/document/d/1jc2M-U8l0rbmudW7JdKXhIHe9ruX88xsJL9yZ8IcV9A/edit
-
-**Hangout Link:** https://plus.google.com/hangouts/_/google.com/k8s-sig-service-catalog
+[**Meeting Agenda**](http://goo.gl/A0m24V)
 
 ### SIG Mission
 


### PR DESCRIPTION
Update the sig-service-catalog agenda link to a publicly viewable one.