### PR TITLE
Adding SIG CLI info

### DIFF
--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -1,1 +1,19 @@
+# SIG CLI
 
+The Kubernetes Command Line Interface SIG (sig-cli) is a working group for the contributor community interested in `kubectl` and related tools.
+
+We focus on the development and standardization of the CLI [framework](https://github.com/kubernetes/kubernetes/tree/master/pkg/kubectl) and its dependencies, the establishment of [conventions](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/kubectl-conventions.md) for writing CLI commands, POSIX compliance, and improving the command line tools from a developer and devops user experience and usability perspective.
+
+## Meetings:
+* Bi-weekly on Wednesdays @ 9am [America/Los_Angeles](http://time.is/Los_Angeles) (check [the calendar](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles))
+* Zoom Link: <https://zoom.us/my/sigcli>
+* Meeting [Agenda and Minutes](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing)
+
+## Communication:
+* Slack: <https://kubernetes.slack.com/messages/sig-cli> ([archive](http://kubernetes.slackarchive.io/sig-cli))
+* Google Group: <https://groups.google.com/forum/#!forum/kubernetes-sig-cli>
+
+## Organizers:
+* Fabiano Franz <ffranz@redhat.com>, Red Hat
+* Phillip Wittrock <pwittroc@google.com>, Google
+* Tony Ado <coolhzb@gmail.com>, Alibaba


### PR DESCRIPTION
SIG CLI basic info with links to the needed resources. @pwittrock @AdoHe let me know if you want to tweak anything.