### PR TITLE
No need to go get go-bindata

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -56,11 +56,10 @@ source control system). Use `apt-get install mercurial` or `yum install
 mercurial` on Linux, or [brew.sh](http://brew.sh) on OS X, or download directly
 from mercurial.
 
-Install godep and go-bindata (may require sudo):
+Install godep (may require sudo):
 
 ```sh
 go get -u github.com/tools/godep
-go get -u github.com/jteeuwen/go-bindata/go-bindata
 ```
 
 Note:


### PR DESCRIPTION
`devel/development.md` change pulled out of https://github.com/kubernetes/kubernetes/pull/36964. It should probably merge after that one.