### PR TITLE
Add client-python to supported clients

### DIFF
--- a/contributors/devel/client-libraries.md
+++ b/contributors/devel/client-libraries.md
@@ -1,8 +1,9 @@
 ## Kubernetes API client libraries
 
-### Supported
+### Supported by [Kubernetes SIG API Machinery](https://github.com/kubernetes/community/tree/master/sig-api-machinery)
 
    * [Go](https://github.com/kubernetes/client-go)
+   * [Python] (https://github.com/kubernetes-incubator/client-python)
 
 ### User Contributed
 


### PR DESCRIPTION
Client is in development and soon to be released out of alpha, but it is supported. I would like to add it to this list so it gets more attraction.
I also want this to be updated at main kubernetes repo, how does that work from this repo to main repo? ref: kubernetes/kubernetes#37719