### PR TITLE
go 1.7 is now required - updating the docs

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -30,8 +30,9 @@ some of which may be incompatible in subtle ways, so we recommend
 
 Kubernetes is written in the [Go](http://golang.org) programming language.
 To build Kubernetes without using Docker containers, you'll need a Go
-development environment. Builds for Kubernetes 1.0 - 1.2 require Go version
-1.4.2. Builds for Kubernetes 1.3 and higher require Go version 1.6.0. If you
+development environment. Builds for Kubernetes 1.0 - 1.2 require Go version 1.4.2. 
+Builds for Kubernetes 1.3 and 1.4 require Go version 1.6. Builds for Kubernetes 1.5
+and higher require Go version 1.7. If you
 haven't set up a Go development environment, please follow [these
 instructions](http://golang.org/doc/code.html) to install the go tools.
 


### PR DESCRIPTION
Follow up on https://github.com/kubernetes/kubernetes/issues/28960
Also for example in https://github.com/kubernetes/kubernetes/pull/36020 http.ErrUseLastResponse is used which was introduced in go 1.7.