### PR TITLE
Fix links of cri protobuf API

### DIFF
--- a/contributors/devel/container-runtime-interface.md
+++ b/contributors/devel/container-runtime-interface.md
@@ -3,7 +3,7 @@
 ## What is CRI?
 
 CRI (_Container Runtime Interface_) consists of a
-[protobuf API](../../pkg/kubelet/api/v1alpha1/runtime/api.proto),
+[protobuf API](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/api/v1alpha1/runtime/api.proto),
 specifications/requirements (to-be-added),
 and [libraries] (https://github.com/kubernetes/kubernetes/tree/master/pkg/kubelet/server/streaming)
 for container runtimes to integrate with kubelet on a node. CRI is currently in Alpha.


### PR DESCRIPTION
Fix the link of cri protobuf API.

cc @yujuhong 