### PR TITLE
Expand sig-openstack README.md

### DIFF
--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -1,10 +1,15 @@
 # OpenStack SIG
 
+This is the wiki page of the Kubernetes OpenStack SIG: a special interest group
+co-ordinating contributions of OpenStack-related changes to Kubernetes.
+
+Relevant [Issues](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen%20label%3Asig%2Fopenstack%20is%3Aissue)
+and [Pull Requests](https://github.com/kubernetes/kubernetes/pulls?q=is%3Aopen%20is%3Apr%20label%3Asig%2Fopenstack)
+are tagged with the **sig-openstack** label.
+
 **Leads:** Steve Gordon (@xsgordon) and Ihor Dvoretskyi (@idvoretskyi)
 
 **Slack Channel:** [#sig-openstack](https://kubernetes.slack.com/messages/sig-openstack/).  [Archive](http://kubernetes.slackarchive.io/sig-openstack/)
-
-**IRC:** #openstack-kubernetes on irc.freenode.net
 
 **Mailing List:** [kubernetes-sig-openstack](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack)
 


### PR DESCRIPTION
Introduce basic premise of sig-openstack, add links to open issues and
pull requests. Remove IRC channel as it is not a primary mechanism of
communication for the group at this point, the main avenue for IM is
slack.kubernetes.com.