### PR TITLE
Removes unused KUBE_DNS_REPLICAS var

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -167,7 +167,6 @@ To start the DNS service, you need to set the following variables:
 KUBE_ENABLE_CLUSTER_DNS=true
 KUBE_DNS_SERVER_IP="10.0.0.10"
 KUBE_DNS_DOMAIN="cluster.local"
-KUBE_DNS_REPLICAS=1
 ```
 
 To know more on DNS service you can look [here](http://issue.k8s.io/6667). Related documents can be found [here](../../build-tools/kube-dns/#how-do-i-configure-it)


### PR DESCRIPTION
From kubernetes/kubernetes#38726.

Deletes the unused var `KUBE_DNS_REPLICAS` from `running-locally.md`.

@thockin 