### PR TITLE
Corrected DaemonSet example

### DIFF
--- a/contributors/design-proposals/daemon.md
+++ b/contributors/design-proposals/daemon.md
@@ -81,7 +81,7 @@ nodes, preempting other pods if necessary.
         nodeSelector: 
           app: datastore-node
         containers:
-          name: datastore-shard
+        - name: datastore-shard
           image: kubernetes/sharded
           ports:
             - containerPort: 9042


### PR DESCRIPTION
Corrects DaemonSet design doc including an example which would not validate.
`spec.template.spec.containers` was type `map` instead of type an `array`.