### PR TITLE
Fix YAML indentation

### DIFF
--- a/contributors/design-proposals/service-external-name.md
+++ b/contributors/design-proposals/service-external-name.md
@@ -143,8 +143,8 @@ metadata:
 spec:
   ports:
   - port: 12345
-type: ExternalName
-externalName: myapp.rds.whatever.aws.says
+  type: ExternalName
+  externalName: myapp.rds.whatever.aws.says
 ```
 
 There is one issue to take into account, that no other alternative considered


### PR DESCRIPTION
`type` and `externalName` are child elements of `spec`.