### PR TITLE
Update SIG OpenStack Meeting times for 2017

### DIFF
--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -13,5 +13,9 @@ are tagged with the **sig-openstack** label.
 
 **Mailing List:** [kubernetes-sig-openstack](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack)
 
-**Meetings:** Every second Wednesday at 2100 UTC (2 PM PDT / 5 PM EDT) - [Connect using Zoom](https://zoom.us/j/417251241), [Agenda/Notes](https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit#
+**Meetings:** Meetings are held every second Wednesday. The meetings occur at
+1500 UTC or 2100 UTC, alternating. To check which time is being used for the
+upcoming meeting refer to the [Agenda/Notes](https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit#).
+Meeting reminders are also sent to the mailing list linked above. Meetings are 
+held on [Zoom](https://zoom.us) in the room at [https://zoom.us/j/417251241](https://zoom.us/j/417251241).
 )


### PR DESCRIPTION
As we closed out 2016 we ran a poll to select new meeting times for the
coming year. As discussed in the last meeting there was no clear winner
in the results but there were a handful of slots in particular that came
up as "least bad".

In the hope of encouraging participation from those who have not been able
to attend in the past we are going to trial running a 1500 UTC meeting time,
alternating with our traditional 2100 UTC meeting time. Meetings remain
only every second week for now.