### PR TITLE
Update e2e doc to add [Volume] label.

### DIFF
--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -482,7 +482,7 @@ some separate test suites owned by the feature owner(s)
 
 In order to simplify running component-specific test suites, it may also be
 necessary to tag tests with a component label.  The component may include
-standard and non-standard tests, so the [Feature:.+] label is not sufficient for
+standard and non-standard tests, so the `[Feature:.+]` label is not sufficient for
 this purpose.  These component labels have no impact on the standard e2e test
 suites.  The following component labels have been defined:
 

--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -480,6 +480,15 @@ breaking changes, it does *not* block the merge-queue, and thus should run in
 some separate test suites owned by the feature owner(s)
 (see [Continuous Integration](#continuous-integration) below).
 
+In order to simplify running component-specific test suites, it may also be
+necessary to tag tests with a component label.  The component may include
+standard and non-standard tests, so the [Feature:.+] label is not sufficient for
+this purpose.  These component labels have no impact on the standard e2e test
+suites.  The following component labels have been defined:
+
+  - `[Volume]`: All tests related to volumes and storage: volume plugins,
+attach/detatch controller, persistent volume controller, etc.
+
 ### Viper configuration and hierarchichal test parameters.
 
 The future of e2e test configuration idioms will be increasingly defined using viper, and decreasingly via flags.


### PR DESCRIPTION
Added a new [Volume] label as part of [PR 39171](https://github.com/kubernetes/kubernetes/pull/39171).

cc @kubernetes/sig-testing-misc