### PR TITLE
Add shared link for sig-openstack meeting minutes

### DIFF
--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -15,7 +15,7 @@ are tagged with the **sig-openstack** label.
 
 **Meetings:** Meetings are held every second Wednesday. The meetings occur at
 1500 UTC or 2100 UTC, alternating. To check which time is being used for the
-upcoming meeting refer to the [Agenda/Notes](https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit#).
+upcoming meeting refer to the [Agenda/Notes](https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit?usp=sharing_eixpa_nl&ts=588b986f).
 Meeting reminders are also sent to the mailing list linked above. Meetings are 
 held on [Zoom](https://zoom.us) in the room at [https://zoom.us/j/417251241](https://zoom.us/j/417251241).
 )


### PR DESCRIPTION
Add shared link for sig-openstack meeting minutes, the old link does not
include share information which means it's not viewable for folks who
haven't already been granted access.