### PR TITLE
`kubectl get` and `kubectl describe` extensions

### DIFF
--- a/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
+++ b/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
@@ -81,8 +81,8 @@ resource builder, lookup the group version kind from the populated map.
 
 #### Option 2: Modify api-machinery RestMapper
 
-Modify the api-machinery RestMapper to parse the column tags and
-include them in the *RestMapping* used by the resource builder.
+Modify the api-machinery RestMapper to parse extensions prefixed
+with `x-kubernetes` and include them in the *RestMapping* used by the resource builder.
 
 ```go
 type RESTMapping struct {
@@ -97,13 +97,12 @@ type RESTMapping struct {
 	runtime.ObjectConvertor
 	MetadataAccessor
 
-    // New for kubectl get / describe
-    DisplayOptions DisplayOptions
+    // Extensions
+    OpenApiExtensions OpenApiExtensions
 }
 
 type DisplayOptions struct {
-  GetColumns []string
-  DescribeColumns []string
+  OpenApiExtensions map[string]interface{}
 }
 ```
 
@@ -113,6 +112,7 @@ functions through:  `resource.Builder -> Infos -> Mapping -> DisplayOptions`
 **Pros:**
   - Clean + generalized solution
   - The same strategy can be applied to support TPR
+  - Can support exposing future extensions such as patchStrategy and mergeKey
   - Can be used by other clients / tools
 
 **Cons:**

--- a/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
+++ b/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
@@ -1,0 +1,89 @@
+# Provide open-api extensions for kubectl get / kubectl describe columns
+
+Status: Pending
+
+## Motivation
+
+`kubectl get` and `kubectl describe` do not provide a rich experience
+for resources retrieved through federated apiservers and types not
+compiled into the kubectl binary.  Kubectl should support printing
+columns configured per-type without having the types compiled in.
+
+## Proposal
+
+Allow the apiserver to define the type specific columns that will be
+printed using the open-api swagger.json spec already fetched by kubectl.
+This provides a limited describe to only print out fields on the object
+and related events.
+
+## User Experience
+
+### Use Cases
+
+- As a user, when I run `kubectl get` on sig-service-catalog resources
+  defined in a federated apiserver, I want to see more than just the
+  name and the type of the resource.
+- As a user, when I run `kubectl describe` on sig-service-catalog
+  resources defined in a federated apiserver, I want the command
+  to succeed, and to see events for the resource along with important
+  fields of the resource.
+
+## Implementation
+
+Define the open-api extensions `x-kubernetes-kubectl-get-columns` and
+`x-kubernetes-kubectl-describe-columns`.  These extensions have a
+string value containing the columns to be printed by kubectl.  The
+string format is the same as the `--custom-columns` for `kubectl get`.
+
+### Apiserver
+
+- Populate the open-api extension value for resource types.
+
+### Kubectl
+
+- In `kubectl get` use the `x-kubernetes-kubectl-get-columns` value
+  when printing an object iff 1) it is defined and 2) the output type
+  is "" (empty string) or "wide".
+
+- In `kubectl describe` use the `x-kubernetes-kubectl-describe-columns` value
+  when printing an object iff 1) it is defined
+
+### Client/Server Backwards/Forwards compatibility
+
+#### Newer client
+
+Client doesn't find the open-api extensions.  Fallback on 1.5 behavior.
+
+#### Newer server
+
+Client doesn't respect open-api extensions.  Uses 1.5 behavior.
+
+## Alternatives considered
+
+### Kubectl describe fully implemented in the server
+
+Implement a sub-resource "/describe" in the apiserver.  This executes
+the describe business logic for the object and returns either a string
+or json blob for kubectl to print.
+
+**Pros:** Higher fidelity.  Can aggregate data and fetch other objects.
+
+**Cons:** Higher complexity.  Requires more api changes.
+
+### Write per-type columns to kubectl.config or another local file
+
+Support checking a local file containing per-type information including
+the columns to print.
+
+**Pros:** Simplest solution.  Easy for user to override values.
+
+**Cons:** Requires manual configuration on user side.  Does not provide a consistent experience across clients.
+
+### Write per-type go templates to kubectl.config or another local file
+
+Support checking a local file containing per-type information including
+the go template.
+
+**Pros:** Higher fidelity.  Easy for user to override values.
+
+**Cons:** Higher complexity. Requires manual configuration on user side.  Does not provide a consistent experience across clients.

--- a/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
+++ b/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
@@ -98,11 +98,11 @@ type RESTMapping struct {
 	MetadataAccessor
 
     // Extensions
-    OpenApiExtensions OpenApiExtensions
+    ApiExtensions ApiExtensions
 }
 
-type DisplayOptions struct {
-  OpenApiExtensions map[string]interface{}
+type ApiExtensions struct {
+  Extensions map[string]interface{}
 }
 ```
 

--- a/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
+++ b/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
@@ -59,10 +59,6 @@ Overview:
 - In `kubectl describe` use the `x-kubernetes-kubectl-describe-columns` value
   when printing an object iff 1) it is defined
 
-If no open-api extension is present for a type, fallback on the 1.5
-behavior.
-
-Details:
 
 #### Option 1: Re-parse the open-api swagger.json in a kubectl library
 
@@ -122,11 +118,30 @@ functions through:  `resource.Builder -> Infos -> Mapping -> DisplayOptions`
   - Complicated due to the broad scope and impact
   - May not be doable in 1.6
 
+#### Considerations
+
+What should be used for oth an open-api extension columns tag AND a
+compiled in printer exist for a type?
+
+- Apiserver only provides `describe` for types that are never compiled in
+  - Compiled in `describe` is much more rich - aggregating data across many other types.
+    e.g. Node describe aggregating Pod data
+  - kubectl will not be able to provide any `describe` information for new types when version skewed against a newer server
+- Always use the extensions if present
+  - Allows server to control columns.  Adds new columns for types on old clients that maybe missing the columns.
+- Always use the compiled in commands if present
+  - The compiled in `describe` is richer and provides aggregated information about many types.
+- Always use the `get` extension if present.  Always use the `describe` compiled in code if present.
+  - Inconsistent behavior across how extensions are handled
+
 ### Client/Server Backwards/Forwards compatibility
 
 #### Newer client
 
 Client doesn't find the open-api extensions.  Fallback on 1.5 behavior.
+
+In the future, this will provide stronger backwards / forwards compability
+as it will allow clients to print objects
 
 #### Newer server
 

--- a/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
+++ b/contributors/design-proposals/sig-cli/get-describe-apiserver-extensions.md
@@ -2,6 +2,8 @@
 
 Status: Pending
 
+Version: Alpha
+
 ## Motivation
 
 `kubectl get` and `kubectl describe` do not provide a rich experience


### PR DESCRIPTION
…ns for non-compiled in types.

@fabianofranz The sig-service-catalog was going to fork kubectl and compile in custom types for get and describe to work.  I really don't like this solution, and think we could support their needs in a simple way.

Would you be open to discussing this on Wednesday?

sig-service-catalog has agreed to donate the development resources to implement.  @simonleung8
