### PR TITLE
only list two files

### DIFF
--- a/contributors/devel/api_changes.md
+++ b/contributors/devel/api_changes.md
@@ -414,14 +414,10 @@ inefficient).
 
 The conversion code resides with each versioned API. There are two files:
 
-   - `pkg/api/<version>/conversion.go` containing manually written conversion
-functions
-   - `pkg/api/<version>/conversion_generated.go` containing auto-generated
-conversion functions
    - `pkg/apis/extensions/<version>/conversion.go` containing manually written
-conversion functions
-   - `pkg/apis/extensions/<version>/conversion_generated.go` containing
-auto-generated conversion functions
+     conversion functions
+   - `pkg/apis/extensions/<version>/zz_generated.conversion.go` containing
+     auto-generated conversion functions
 
 Since auto-generated conversion functions are using manually written ones,
 those manually written should be named with a defined convention, i.e. a


### PR DESCRIPTION
reading this doc, it says `two files` and lists four files. As far as I understand it, we should prefer to use examples from `pkg/apis/`.

I adjusted the example to have the matching name in the repo.

I also adjusted the formatting so the text is all at the same level.