### PR TITLE
Fix typo in sig-pm README

### DIFF
--- a/sig-pm/README.md
+++ b/sig-pm/README.md
@@ -2,7 +2,7 @@
 
 ### Focus
 
-The Kubernetes PM Group focuses on aspects of product management, such as the qualification and successful management of user requests, and aspects of project and program management such as he continued improvement of the processes used by the Kubernetes community to maintain the Kubernetes Project itself. 
+The Kubernetes PM Group focuses on aspects of product management, such as the qualification and successful management of user requests, and aspects of project and program management such as the continued improvement of the processes used by the Kubernetes community to maintain the Kubernetes Project itself. 
 
 Besides helping to discover both what to build and how to build it, the PM Group also helps to try and keep the wheels on this spaceship we are all building together; bringing together people who think about Kubernetes as both a vibrant community of humans and technical program is another primary focus of this group. 
 


### PR DESCRIPTION
Typo wasn't fixed in 3 reviews.
Now fixed in additional commit.