### PR TITLE
Fixed broken link to generic_scheduler.go

### DIFF
--- a/contributors/devel/scheduler.md
+++ b/contributors/devel/scheduler.md
@@ -64,7 +64,7 @@ The Scheduler tries to find a node for each Pod, one at a time.
 - First it applies a set of "predicates" to filter out inappropriate nodes. For example, if the PodSpec specifies resource requests, then the scheduler will filter out nodes that don't have at least that much resources available (computed as the capacity of the node minus the sum of the resource requests of the containers that are already running on the node).
 - Second, it applies a set of "priority functions"
 that rank the nodes that weren't filtered out by the predicate check. For example, it tries to spread Pods across nodes and zones while at the same time favoring the least (theoretically) loaded nodes (where "load" - in theory - is measured as the sum of the resource requests of the containers running on the node, divided by the node's capacity).
-- Finally, the node with the highest priority is chosen (or, if there are multiple such nodes, then one of them is chosen at random). The code for this main scheduling loop is in the function `Schedule()` in [plugin/pkg/scheduler/generic_scheduler.go](http://releases.k8s.io/HEAD/plugin/pkg/scheduler/generic_scheduler.go)
+- Finally, the node with the highest priority is chosen (or, if there are multiple such nodes, then one of them is chosen at random). The code for this main scheduling loop is in the function `Schedule()` in [plugin/pkg/scheduler/generic_scheduler.go](http://releases.k8s.io/HEAD/plugin/pkg/scheduler/core/generic_scheduler.go)
 
 ### Predicates and priorities policies
 

--- a/contributors/devel/scheduler.md
+++ b/contributors/devel/scheduler.md
@@ -11,7 +11,7 @@ We are dividng scheduler into three layers from high level:
   This is the main() entry that does initialization before calling the scheduler framework.
 - [pkg/scheduler/scheduler.go](http://releases.k8s.io/HEAD/pkg/scheduler/scheduler.go):
   This is the scheduler framework that handles stuff (e.g. binding) beyond the scheduling algorithm.
-- [pkg/scheduler/generic_scheduler.go](http://releases.k8s.io/HEAD/pkg/scheduler/generic_scheduler.go):
+- [pkg/scheduler/generic_scheduler.go](http://releases.k8s.io/HEAD/plugin/pkg/scheduler/core/generic_scheduler.go):
   The scheduling algorithm that assigns nodes for pods.
 
 ## The scheduling algorithm


### PR DESCRIPTION
404 Error because file was moved from plugin/pkg/scheduler/generic_scheduler.go to plugin/pkg/scheduler/core/generic_scheduler.go

change was made correspond to that change