### PR TITLE
Correct kubenet config on node e2e tests

### DIFF
--- a/contributors/devel/e2e-node-tests.md
+++ b/contributors/devel/e2e-node-tests.md
@@ -202,8 +202,10 @@ related test, Remote execution is recommended.**
 To enable/disable kubenet:
 
 ```sh
-make test_e2e_node TEST_ARGS="--disable-kubenet=true" # enable kubenet
-make test_e2e_node TEST_ARGS="--disable-kubenet=false" # disable kubenet
+# enable kubenet
+make test-e2e-node TEST_ARGS='--kubelet-flags="--network-plugin=kubenet --network-plugin-dir=/opt/cni/bin"'
+# disable kubenet
+make test-e2e-node TEST_ARGS='--kubelet-flags="--network-plugin= --network-plugin-dir="'
 ```
 
 ## Additional QoS Cgroups Hierarchy level testing


### PR DESCRIPTION
`--disable-kubenet` has been removed and replaced with `--kubelet-flags` in node e2e tests.

cc @Random-Liu @yujuhong 