### PR TITLE
Clarify the sig-openstack mission statement

### DIFF
--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -1,7 +1,12 @@
 # OpenStack SIG
 
-This is the wiki page of the Kubernetes OpenStack SIG: a special interest group
-co-ordinating contributions of OpenStack-related changes to Kubernetes.
+This is the community page of the Kubernetes OpenStack SIG: a special
+interest group coordinating the cross-community efforts of the OpenStack
+and Kubernetes communities. This includes OpenStack-related contributions
+to Kubernetes projects with OpenStack as:
+* a deployment platform for Kubernetes,
+* a service provider for Kubernetes,
+* a collection of applications to run on Kubernetes.
 
 Relevant [Issues](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen%20label%3Asig%2Fopenstack%20is%3Aissue)
 and [Pull Requests](https://github.com/kubernetes/kubernetes/pulls?q=is%3Aopen%20is%3Apr%20label%3Asig%2Fopenstack)
@@ -16,6 +21,5 @@ are tagged with the **sig-openstack** label.
 **Meetings:** Meetings are held every second Wednesday. The meetings occur at
 1500 UTC or 2100 UTC, alternating. To check which time is being used for the
 upcoming meeting refer to the [Agenda/Notes](https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit?usp=sharing_eixpa_nl&ts=588b986f).
-Meeting reminders are also sent to the mailing list linked above. Meetings are 
+Meeting reminders are also sent to the mailing list linked above. Meetings are
 held on [Zoom](https://zoom.us) in the room at [https://zoom.us/j/417251241](https://zoom.us/j/417251241).
-)


### PR DESCRIPTION
After discussion in the kubernetes-sig-openstack group, this
patch clarifies the mission of sig-openstack to cover all
interactions between the Kubernetes and OpenStack communities. 

Issue #376 

https://groups.google.com/forum/#!topic/kubernetes-sig-openstack/yTjt2_kJb4o