### PR TITLE
Fix the relative path to kubernetes in doc

### DIFF
--- a/contributors/devel/cherry-picks.md
+++ b/contributors/devel/cherry-picks.md
@@ -16,8 +16,7 @@ depending on the point in the release cycle.
    to set the same label to confirm that no release note is needed.
 1. `release-note` labeled PRs generate a release note using the PR title by
    default OR the release-note block in the PR template if filled in.
-  * See the [PR template](../../.github/PULL_REQUEST_TEMPLATE.md) for more
-    details.
+  * See the [PR template](https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md) for more details.
   * PR titles and body comments are mutable and can be modified at any time
     prior to the release to reflect a release note friendly message.
 

--- a/contributors/devel/pull-requests.md
+++ b/contributors/devel/pull-requests.md
@@ -50,7 +50,7 @@ For cherry-pick PRs, see the [Cherrypick instructions](cherry-picks.md)
  at release time.
 1. `release-note` labeled PRs generate a release note using the PR title by
    default OR the release-note block in the PR template if filled in.
-  * See the [PR template](../../.github/PULL_REQUEST_TEMPLATE.md) for more
+  * See the [PR template](https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md) for more
     details.
   * PR titles and body comments are mutable and can be modified at any time
     prior to the release to reflect a release note friendly message.


### PR DESCRIPTION
Couple of links in docs still referencing relative path to kubernetes github. 

This makes "PR Template" links not working in these links -  https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes  and https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md#propose-a-cherry-pick

fixes #362