### PR TITLE
fix the obvious link error

### DIFF
--- a/contributors/design-proposals/README.md
+++ b/contributors/design-proposals/README.md
@@ -34,7 +34,7 @@ physical hosts.
 A single Kubernetes cluster is not intended to span multiple availability zones.
 Instead, we recommend building a higher-level layer to replicate complete
 deployments of highly available applications across multiple zones (see
-[the multi-cluster doc](../admin/multi-cluster.md) and [cluster federation proposal](../proposals/federation.md)
+[the multi-cluster doc](https://kubernetes.io/docs/admin/multi-cluster/) and [cluster federation proposal](federation.md)
 for more details).
 
 Finally, Kubernetes aspires to be an extensible, pluggable, building-block OSS


### PR DESCRIPTION
1.`multi-cluster.md` link navigate a incorrect link. It seems to be at another doc repo [kubernetes.github.io](https://github.com/kubernetes/kubernetes.github.io/blob/master/docs/admin/multi-cluster.md) 
but i think we should use the [link](https://kubernetes.io/docs/admin/multi-cluster/) , i am not sure :)

2.Obviously, the path `../proposals/federation.md` is incorrect. Should be use `federation.md` directly.
