### PR TITLE
fix error links in test docs

### DIFF
--- a/contributors/devel/e2e-node-tests.md
+++ b/contributors/devel/e2e-node-tests.md
@@ -137,7 +137,7 @@ make test-e2e-node REMOTE=true IMAGE_PROJECT="<name-of-project-with-images>" IMA
 ```
 
 Setting up your own host image may require additional steps such as installing etcd or docker.  See
-[setup_host.sh](../../test/e2e_node/environment/setup_host.sh) for common steps to setup hosts to run node tests.
+[setup_host.sh](https://github.com/kubernetes/kubernetes/tree/master/test/e2e_node/environment/setup_host.sh) for common steps to setup hosts to run node tests.
 
 ## Create instances using a different instance name prefix
 
@@ -223,9 +223,9 @@ the bottom of the comments section.  To re-run just the node e2e tests from the 
 `@k8s-bot node e2e test this issue: #<Flake-Issue-Number or IGNORE>` and **include a link to the test
 failure logs if caused by a flake.**
 
-The PR builder runs tests against the images listed in [jenkins-pull.properties](../../test/e2e_node/jenkins/jenkins-pull.properties)
+The PR builder runs tests against the images listed in [jenkins-pull.properties](https://github.com/kubernetes/kubernetes/tree/master/test/e2e_node/jenkins/jenkins-pull.properties)
 
-The post submit tests run against the images listed in [jenkins-ci.properties](../../test/e2e_node/jenkins/jenkins-ci.properties)
+The post submit tests run against the images listed in [jenkins-ci.properties](https://github.com/kubernetes/kubernetes/tree/master/test/e2e_node/jenkins/jenkins-ci.properties)
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -515,7 +515,7 @@ To use viper, rather than flags, to configure your tests:
 
 - Just add "e2e.json" to the current directory you are in, and define parameters in it... i.e. `"kubeconfig":"/tmp/x"`.
 
-Note that advanced testing parameters, and hierarchichally defined parameters, are only defined in viper, to see what they are, you can dive into [TestContextType](../../test/e2e/framework/test_context.go).
+Note that advanced testing parameters, and hierarchichally defined parameters, are only defined in viper, to see what they are, you can dive into [TestContextType](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/test_context.go).
 
 In time, it is our intent to add or autogenerate a sample viper configuration that includes all e2e parameters, to ship with kubernetes.
 

--- a/contributors/devel/node-performance-testing.md
+++ b/contributors/devel/node-performance-testing.md
@@ -26,7 +26,7 @@ Heapster will hide the performance cost of serving those stats in the Kubelet.
 
 Disabling addons is simple. Just ssh into the Kubernetes master and move the
 addon from `/etc/kubernetes/addons/` to a backup location. More details
-[here](../../cluster/addons/).
+[here](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/).
 
 ### Which / how many pods?
 
@@ -57,7 +57,7 @@ sampling.
 ## E2E Performance Test
 
 There is an end-to-end test for collecting overall resource usage of node
-components: [kubelet_perf.go](../../test/e2e/kubelet_perf.go). To
+components: [kubelet_perf.go](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/kubelet_perf.go). To
 run the test, simply make sure you have an e2e cluster running (`go run
 hack/e2e.go -- -up`) and [set up](#cluster-set-up) correctly.
 

--- a/contributors/devel/writing-good-e2e-tests.md
+++ b/contributors/devel/writing-good-e2e-tests.md
@@ -146,7 +146,7 @@ right thing.
 
 Here are a few pointers:
 
-+ [E2e Framework](../../test/e2e/framework/framework.go):
++ [E2e Framework](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/framework.go):
    Familiarise yourself with this test framework and how to use it.
    Amongst others, it automatically creates uniquely named namespaces
    within which your tests can run to avoid name clashes, and reliably
@@ -160,7 +160,7 @@ Here are a few pointers:
    should always use this framework.  Trying other home-grown
    approaches to avoiding name clashes and resource leaks has proven
    to be a very bad idea.
-+ [E2e utils library](../../test/e2e/framework/util.go):
++ [E2e utils library](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/util.go):
    This handy library provides tons of reusable code for a host of
    commonly needed test functionality, including waiting for resources
    to enter specified states, safely and consistently retrying failed
@@ -178,9 +178,9 @@ Here are a few pointers:
 + **Follow the examples of stable, well-written tests:** Some of our
    existing end-to-end tests are better written and more reliable than
    others.  A few examples of well-written tests include:
-   [Replication Controllers](../../test/e2e/rc.go),
-   [Services](../../test/e2e/service.go),
-   [Reboot](../../test/e2e/reboot.go).
+   [Replication Controllers](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/rc.go),
+   [Services](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/service.go),
+   [Reboot](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/reboot.go).
 + [Ginkgo Test Framework](https://github.com/onsi/ginkgo): This is the
    test library and runner upon which our e2e tests are built.  Before
    you write or refactor a test, read the docs and make sure that you


### PR DESCRIPTION
Fix error links in test docs:
* [e2e-tests.md](https://github.com/kubernetes/community/tree/master/contributors/devel/e2e-tests.md)
* [e2e-node-tests.md](https://github.com/kubernetes/community/tree/master/contributors/devel/e2e-node-tests.md)
* [writing-good-e2e-tests.md](https://github.com/kubernetes/community/tree/master/contributors/devel/writing-good-e2e-tests.md)
* [node-performance-testing.md](https://github.com/kubernetes/community/tree/master/contributors/devel/node-performance-testing.md)