### PR TITLE
Adds proposal for ELB tagging

### DIFF
--- a/contributors/design-proposals/aws_under_the_hood.md
+++ b/contributors/design-proposals/aws_under_the_hood.md
@@ -158,6 +158,18 @@ ELB at the other end of its connection) when forwarding requests.
 TCP and SSL will select layer 4 proxying: the ELB will forward traffic without
 modifying the headers.
 
+#### Adding addional tags to an ELB
+
+Additional tags can be set on a created ELB by annotating a service with
+
+```
+aws.kubernetes.io/aws-load-balancer-additional-resource-tags="TagName=TagValue,..."
+```
+Note that any tags which conflict with tags set by the AWS Cloud Provider will be ignored.
+Ignored tags are
+- `KubernetesCluster`
+
+
 ### Identity and Access Management (IAM)
 
 kube-proxy sets up two IAM roles, one for the master called


### PR DESCRIPTION
## User story

Customer likes AWS ELBs but they need the ELBs to have [custom AWS resource tags](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) so that their internal billback system doesn't delete ELBs created by Kubernetes that don't have a customer specific team tag. The Kubernetes AWS tagging feature [currently offered isn't flexible enough](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/aws_under_the_hood.md#tagging).

## Proposal

Create a new AWS specific annotation for services which will list the additional tags that should be applied to an AWS ELB Resource. Any labels which overlap with those used internally by the AWS Cloud Provider would be ignored. An example annotation would have the form

```
aws.kubernetes.io/additional-resource-tags="Owner=AwesomeTeam,Project=Testing"
```

and would create tags at the same time all other tags are created by the cloud provider. In the future it may make sense to add the ability to specify additional labels [in the cloud provider configuration](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/aws.go#L385) in order to allow all provisioning tools to apply labels to resources besides ELBs.
