### PR TITLE
Propose allowing explicit elb subnet selection

### DIFF
--- a/contributors/design-proposals/aws_under_the_hood.md
+++ b/contributors/design-proposals/aws_under_the_hood.md
@@ -158,6 +158,18 @@ ELB at the other end of its connection) when forwarding requests.
 TCP and SSL will select layer 4 proxying: the ELB will forward traffic without
 modifying the headers.
 
+#### Explicit Subnet Selection
+
+To explicitly select which subnets should be associated with an ELB an AWS 
+specific annotation can be added to a service
+
+```
+aws.kubernetes.io/elb-subnets="subnet-012345a6,subnet-912345b6"
+```
+
+which will cause the created ELB to have _only_ the specified subnets
+attached.
+
 ### Identity and Access Management (IAM)
 
 kube-proxy sets up two IAM roles, one for the master called


### PR DESCRIPTION
### User Story

Customer has many subnets spanning multiple AZs in which they'd like to explicitly define which two subnets a given Load balancer Service's ELB should be created. For example, one load balancer service can create an ELB attached to subnets A and B while another load balancer service can create an ELB attached to subnets C and D. Currently, Kubernetes supports subnet tagging allowing users to ensure ELBs are attached to specific subnets but this need comes out of a desire for greater subnet granularity in subnet selection on a per-service basis.