### PR TITLE
Fix link to contributing instructions

### DIFF
--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -26,7 +26,7 @@ We focus on the development and standardization of the CLI [framework](https://g
 
 ## Contributing
 
-See [this document](https://github.com/kubernetes/community/blob/master/sig-cli/contributing.md) for contributing instructions.
+See [this document](https://github.com/kubernetes/community/blob/master/sig-cli/CONTRIBUTING.md) for contributing instructions.
 
 ## Sig-cli teams
 


### PR DESCRIPTION
Fixed link to contributing instructions for sig-cli in this file: https://github.com/kubernetes/community/blob/master/sig-cli/README.md (original link was broken).
