### PR TITLE
Fix integration test example

### DIFF
--- a/contributors/devel/testing.md
+++ b/contributors/devel/testing.md
@@ -215,7 +215,7 @@ script to run a specific integration test case:
 
 ```sh
 # Run integration test TestPodUpdateActiveDeadlineSeconds with the verbose flag set.
-make test-integration WHAT=./test/integration/pods KUBE_GOFLAGS="-v" KUBE_TEST_ARGS="-run ^TestPodUpdateActiveDeadlineSeconds$"
+make test-integration WHAT=pods KUBE_GOFLAGS="-v" KUBE_TEST_ARGS="-run ^TestPodUpdateActiveDeadlineSeconds$"
 ```
 
 If you set `KUBE_TEST_ARGS`, the test case will be run with only the `v1` API


### PR DESCRIPTION
In integration test we have a [logic](https://github.com/kubernetes/kubernetes/blob/master/hack/make-rules/test-integration.sh#L41) to find integration test dirs and prefix to WHAT, so no need to supply full path while running the tests.