### PR TITLE
Update aws_under_the_hood.md to clarify pod vs node instance

### DIFF
--- a/contributors/design-proposals/aws_under_the_hood.md
+++ b/contributors/design-proposals/aws_under_the_hood.md
@@ -89,8 +89,8 @@ We do not currently run the master in an AutoScalingGroup, but we should
 
 Kubernetes uses an IP-per-pod model. This means that a node, which runs many
 pods, must have many IPs. AWS uses virtual private clouds (VPCs) and advanced
-routing support so each pod is assigned a /24 CIDR. The assigned CIDR is then
-configured to route to an instance in the VPC routing table.
+routing support so each EC2 instance is assigned a /24 CIDR. The assigned CIDR
+is then configured to route to an instance in the VPC routing table.
 
 It is also possible to use overlay networking on AWS, but that is not the
 default configuration of the kube-up script.

--- a/contributors/design-proposals/aws_under_the_hood.md
+++ b/contributors/design-proposals/aws_under_the_hood.md
@@ -90,7 +90,7 @@ We do not currently run the master in an AutoScalingGroup, but we should
 Kubernetes uses an IP-per-pod model. This means that a node, which runs many
 pods, must have many IPs. AWS uses virtual private clouds (VPCs) and advanced
 routing support so each EC2 instance is assigned a /24 CIDR. The assigned CIDR
-is then configured to route to an instance in the VPC routing table.
+is then configured to route to that instance in the VPC routing table.
 
 It is also possible to use overlay networking on AWS, but that is not the
 default configuration of the kube-up script.

--- a/contributors/design-proposals/aws_under_the_hood.md
+++ b/contributors/design-proposals/aws_under_the_hood.md
@@ -89,8 +89,8 @@ We do not currently run the master in an AutoScalingGroup, but we should
 
 Kubernetes uses an IP-per-pod model. This means that a node, which runs many
 pods, must have many IPs. AWS uses virtual private clouds (VPCs) and advanced
-routing support so each EC2 instance is assigned a /24 CIDR. The assigned CIDR
-is then configured to route to that instance in the VPC routing table.
+routing support so each EC2 instance is assigned a /24 CIDR in the VPC routing
+table.
 
 It is also possible to use overlay networking on AWS, but that is not the
 default configuration of the kube-up script.


### PR DESCRIPTION
I don't think it's the POD that's getting a /24 CIDR but rather the virtual machine itself, a POD has a single address, not a range.

Please close PR if my understanding is incorrect, thanks!