### PR TITLE
Fixes KUBE_MASTER_IP in contributors/devel/e2e-tests.md.

### DIFF
--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -416,7 +416,7 @@ at a custom host directly:
 
 ```sh
 export KUBECONFIG=/path/to/kubeconfig
-export KUBE_MASTER_IP="http://127.0.0.1:<PORT>"
+export KUBE_MASTER_IP="127.0.0.1:<PORT>"
 export KUBE_MASTER=local
 go run hack/e2e.go -- -v --test
 ```


### PR DESCRIPTION
KUBE_MASTER_IP must not contain prefix "http://".