### PR TITLE
Create announcement.md for public awareness

### DIFF
--- a/community/2017-events/05-leadership-summit/announcement.md
+++ b/community/2017-events/05-leadership-summit/announcement.md
@@ -1,0 +1,7 @@
+This is an announcement for the 2017 Kubernetes Leadership Summit, which will occur on June 2nd, 2017 in San Jose, CA. This event will be similar to the [Kubernetes Developer's Summit](https://github.com/kubernetes/community/blob/master/community/developer-summit-2016/Kubernetes_Dev_Summit.md) in November 2016, but involving a smaller smaller audience comprised solely of leaders and influencers of the community. These leaders and influences include the SIG leads, release managers, and representatives from several companies, including (but not limited to) Google, Red Hat, CoreOS, WeaveWorks, Deis, and Mirantis.
+
+The summit will provide an avenue for leaders in the Kubernetes community to connect face to face and mindshare about future community development and community governance endeavors. 
+
+This announcement serves to notify the broader community of the existence and goals of the event.
+
+This is an **invite-only event**. All invitees will receive a direct invitation from Cameron (czahedi *at* google *dot* com). 

--- a/community/2017-events/05-leadership-summit/announcement.md
+++ b/community/2017-events/05-leadership-summit/announcement.md
@@ -5,3 +5,17 @@ The summit will provide an avenue for leaders in the Kubernetes community to con
 This announcement serves to notify the broader community of the existence and goals of the event.
 
 This is an **invite-only event**. All invitees will receive a direct invitation from Cameron (czahedi *at* google *dot* com). 
+
+### Event Format
+###
+
+The Leadership Summit will mirror the format of the Developer’s Summit, which was a "loosely-structured unconference”. We will have moderators/facilitators and discussion topics, alongside all-day completely unstructured / spontaneous breakouts. 
+
+The various sessions will be proposed and voted on by the community in the weeks leading up to the event. This allows the community to motivate the events of the day without dedicating precious day-of time to choosing the sessions and making a schedule. 
+
+### Desired outcomes
+### 
+
+* Generate notes from the sessions to feed the project's documentation and knowledge base, and also to keep non-attendees plugged in 
+* Make (and document) recommendations and decisions for the near-term and mid-term future of the project 
+* Come up with upcoming action items, as well as leaders for those action items, for the various topics that we discuss

--- a/community/2017-events/05-leadership-summit/announcement.md
+++ b/community/2017-events/05-leadership-summit/announcement.md
@@ -1,20 +1,25 @@
-This is an announcement for the 2017 Kubernetes Leadership Summit, which will occur on June 2nd, 2017 in San Jose, CA. This event will be similar to the [Kubernetes Developer's Summit](https://github.com/kubernetes/community/blob/master/community/developer-summit-2016/Kubernetes_Dev_Summit.md) in November 2016, but involving a smaller smaller audience comprised solely of leaders and influencers of the community. These leaders and influences include the SIG leads, release managers, and representatives from several companies, including (but not limited to) Google, Red Hat, CoreOS, WeaveWorks, Deis, and Mirantis.
+This is an announcement for the 2017 Kubernetes Leadership Summit, which will occur on June 2nd, 2017 in San Jose, CA. 
+This event will be similar to the [Kubernetes Developer's Summit](https://github.com/kubernetes/community/blob/master/community/developer-summit-2016/Kubernetes_Dev_Summit.md) in November 
+2016, but involving a smaller smaller audience comprised solely of leaders and influencers of the community. These leaders and
+influences include the SIG leads, release managers, and representatives from several companies, including (but not limited to)
+Google, Red Hat, CoreOS, WeaveWorks, Deis, and Mirantis.
 
-The summit will provide an avenue for leaders in the Kubernetes community to connect face to face and mindshare about future community development and community governance endeavors. 
+The summit will provide an avenue for leaders in the Kubernetes community to connect face to face and mindshare about future
+community development and community governance endeavors. 
 
 This announcement serves to notify the broader community of the existence and goals of the event.
 
 This is an **invite-only event**. All invitees will receive a direct invitation from Cameron (czahedi *at* google *dot* com). 
 
 ### Event Format
-###
 
 The Leadership Summit will mirror the format of the Developer’s Summit, which was a "loosely-structured unconference”. We will have moderators/facilitators and discussion topics, alongside all-day completely unstructured / spontaneous breakouts. 
 
-The various sessions will be proposed and voted on by the community in the weeks leading up to the event. This allows the community to motivate the events of the day without dedicating precious day-of time to choosing the sessions and making a schedule. 
+The various sessions will be proposed and voted on by the community in the weeks leading up to the event. This allows the
+community to motivate the events of the day without dedicating precious day-of time to choosing the sessions and making a
+schedule. 
 
 ### Desired outcomes
-### 
 
 * Generate notes from the sessions to feed the project's documentation and knowledge base, and also to keep non-attendees plugged in 
 * Make (and document) recommendations and decisions for the near-term and mid-term future of the project 


### PR DESCRIPTION
Publicly announcing leadership summit on the same day as sending invitations to the smaller list of prospective attendees. 