### PR TITLE
Fix markup for link to docker build

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -99,8 +99,8 @@ single line of code is reviewed.
 
 ## Building Kubernetes with Docker
 
-Official releases are built using Docker containers. To build Kubernetes using Docker please follow [these instructions]
-(http://releases.k8s.io/HEAD/build/README.md).
+Official releases are built using Docker containers. To build Kubernetes using Docker please follow 
+[these instructions](http://releases.k8s.io/HEAD/build/README.md).
 
 ## Building Kubernetes on a local OS/shell environment
 


### PR DESCRIPTION
Markup was broken because of newline