### PR TITLE
Trivial: fix typo in aggregated-api-servers proposal

### DIFF
--- a/contributors/design-proposals/aggregated-api-servers.md
+++ b/contributors/design-proposals/aggregated-api-servers.md
@@ -77,7 +77,7 @@ There are two configurations in which it makes sense to run `kube-aggregator`.
   `api.mycompany.com/v1` from one apiserver and the replacement
   `api.mycompany.com/v2` from another apiserver while you update clients. But
   you can't serve `api.mycompany.com/v1/frobbers` and
-  `api.mcompany.com/v1/grobinators` from different apiservers. This restriction
+  `api.mycompany.com/v1/grobinators` from different apiservers. This restriction
   allows us to limit the scope of `kube-aggregator` to a manageable level.
 * Follow API conventions: APIs exposed by every API server should adhere to [kubernetes API
   conventions](../devel/api-conventions.md).


### PR DESCRIPTION
This is a trivial patch fixing the typo found in a design-proposal. The typo may cause confusion for readers.