### PR TITLE
Document naming convention for boolean API fields

### DIFF
--- a/contributors/devel/api-conventions.md
+++ b/contributors/devel/api-conventions.md
@@ -1138,6 +1138,8 @@ be called `fooName`. The name of a field referring to another resource of kind
 `Foo` by ObjectReference (or subset thereof) should be called `fooRef`.
 * More generally, include the units and/or type in the field name if they could
 be ambiguous and they are not specified by the value or value type.
+* The name of a field expressing a boolean property called 'fooable' should be
+called `Fooable`, not `IsFooable`.
 
 ## Label, selector, and annotation conventions
 


### PR DESCRIPTION
Document to avoid `IsBla`-type names for boolean properties.

This is extremely consistent throughout our APIs, but not written down.