### PR TITLE
correct the link for aggregated api servers

### DIFF
--- a/contributors/design-proposals/monitoring_architecture.md
+++ b/contributors/design-proposals/monitoring_architecture.md
@@ -98,7 +98,7 @@ These sources are scraped by a component we call *metrics-server* which is like 
 version of today's Heapster. metrics-server stores locally only latest values and has no sinks.
 metrics-server exposes the master metrics API. (The configuration described here is similar
 to the current Heapster in “standalone” mode.)
-[Discovery summarizer](../../docs/proposals/federated-api-servers.md)
+[Discovery summarizer](aggregated-api-servers.md)
 makes the master metrics API available to external clients such that from the client's perspective
 it looks the same as talking to the API server.
 


### PR DESCRIPTION
federated-api-servers.md has been redirect to aggregated-api-servers.md, correct and update the link.