### PR TITLE
[SIG Service Catalog] Persist cluster-wide data in configmap

### DIFF
--- a/contributors/design-proposals/cluster-info-configmap.md
+++ b/contributors/design-proposals/cluster-info-configmap.md
@@ -1,5 +1,16 @@
 # Persist cluster-wide data in ConfigMap
 
+### Terminology
+
+The following terminology will be used throughout the rest of this design proposal. The meanings are excerpted from the sig-service-catalog [terminology page](https://github.com/kubernetes-incubator/service-catalog/blob/master/terminology.md).
+
+**Service**: Running code that is made available for use by an application. Traditionally, services are available via HTTP REST endpoints, but this is not a requirement.
+
+**Service Broker**: An endpoint that manages a set of services. Responsible for translating Service Catalog activities (like provision, bind, unbind, deprovision) into appropriate actions for the service.
+
+**Service Catalog**: An endpoint that manages a set of registered Service Brokers and (2) the list of services that are available for instantiation from those Service Brokers. For more information please see [sig-service-catalog](https://github.com/kubernetes-incubator/service-catalog).
+
+
 ## Abstract
 
 We want to allow cluster-wide data to be persisted for general purposes, currently for us (service catalog) is to focus on the ability to identify different clusters that access our service broker with a 'cluster-id'.
@@ -23,3 +34,6 @@ metadata:
 ```
 
 The controller attempts to read the configmap at startup, if the configmap does not already exist, the controller generates a cluster-id and creates a new configmap. To avoid discrepancy, the controller also reconciles with the configmap periodically.
+
+
+

--- a/contributors/design-proposals/cluster-info-configmap.md
+++ b/contributors/design-proposals/cluster-info-configmap.md
@@ -1,0 +1,25 @@
+# Persist cluster-wide data in ConfigMap
+
+## Abstract
+
+We want to allow cluster-wide data to be persisted for general purposes, currently for us (service catalog) is to focus on the ability to identify different clusters that access our service broker with a 'cluster-id'.
+
+## Motivation
+
+Currently there is no way for service catalog api server to identify the different clusters that access our service brokers. The goal of this design is to have a unify storage for cluster related information. The information should be retained and survive between component failures. 
+
+## Detailed design
+
+A configmap `cluster-info` is created in the `default` namespace at the starup of the controller. The initial content of the map will be as the following:
+
+```
+apiVersion: v1
+data:
+  cluster-id: uuid-of-the-cluster
+kind: ConfigMap
+metadata:
+  name: cluster-info
+  namespace: default
+```
+
+The controller attempts to read the configmap at startup, if the configmap does not already exist, the controller generates a cluster-id and creates a new configmap. To avoid discrepancy, the controller also reconciles with the configmap periodically.


### PR DESCRIPTION
This is an attempt to introduce a way to persist cluster-wide data. We have a need to identify different clusters accessing our api server. With this design, a clusters can be identified through the new `cluster-id` in the configmap.

*note: We just need a simple unique ID to identify one cluster from another, the cluster-id will not  tell us how to talk back to the cluster, and it is out of the scope of this proposal.

A implementation has been submitted for this design proposal #46384

/cc @duglin 