### PR TITLE
Fixed broken references to sig-pm, sig-contribx, sig-onprem

### DIFF
--- a/sig-governance.md
+++ b/sig-governance.md
@@ -11,7 +11,7 @@ In order to standardize Special Interest Group efforts, create maximum transpare
 * Participate in release planning meetings and retrospectives, and burndown meetings, as needed
 * Ensure related work happens in a project-owned github org and repository, with code and tests explicitly owned and supported by the SIG, including issue triage, PR reviews, test-failure response, bug fixes, etc. 
 * Use the above forums as the primary means of working, communicating, and collaborating, as opposed to private emails and meetings
-* Represent the SIG for the PM group - see [PM SIG representatives](https://github.com/kubernetes/community/blob/master/sig-pm/SIG%20PM%20representatives.md).
+* Represent the SIG for the PM group - see [PM SIG representatives](https://github.com/kubernetes/community/blob/master/sig-product-management/SIG%20PM%20representatives.md).
 
 ## SIG roles
 - **SIG Participant**: active in one or more areas of the project; wide 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -33,7 +33,7 @@ sigs:
     leads:
     - name: Michelle Noorali
       github: michelleN
-      company: Deis
+      company: Microsoft
     - name: Matt Farina
       github: mattfarina
       company: HPE
@@ -101,7 +101,7 @@ sigs:
       github: justinsb
     - name: Kris Nova
       github: kris-nova
-      company: Deis
+      company: Microsoft
     - name: Chris Love
       github: chrislovecnm
     - name: Mackenzie Burnett
@@ -189,9 +189,9 @@ sigs:
     - name: Rob Hirschfeld
       github: zehicle
       company: RackN
-    - name: Jason Singer DuMars
+    - name: Jaice Singer DuMars
       github: jdumars
-      company: Deis
+      company: Microsoft
     meetings:
     - day: Thursday
       utc: "20:00"
@@ -202,7 +202,7 @@ sigs:
       slack: sig-cluster-ops
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-ops
   - name: Contributor Experience
-    dir: sig-contribx
+    dir: sig-contributor-experience
     mission_statement: >
       Developing and sustaining a healthy community of contributors is critical
       to scaling the project and growing the ecosystem. We need to ensure our
@@ -226,7 +226,7 @@ sigs:
     meeting_url: https://zoom.us/j/7658488911
     meeting_archive_url: https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/
     contact:
-      slack: wg-contribex
+      slack: sig-contribex
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-contribex
   - name: Docs
     dir: sig-docs
@@ -337,7 +337,7 @@ sigs:
       slack: sig-node
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-node
   - name: On Premise
-    dir: sig-on-prem
+    dir: sig-on-premise
     mission_statement: >
       Brings together member of Kubernetes community interested in running
       Kubernetes on premise, on bare metal or more generally beyond cloud
@@ -386,7 +386,7 @@ sigs:
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-openstack
       full_github_teams: true
   - name: Product Management
-    dir: sig-pm
+    dir: sig-product-management
     mission_statement: >
       Focuses on aspects of product management, such as the qualification and
       successful management of user requests, and aspects of project and
@@ -423,7 +423,7 @@ sigs:
     meeting_url: https://zoom.us/j/845373595
     meeting_archive_url: https://docs.google.com/document/d/1YqIpyjz4mV1jjvzhLx9JYy8LAduedzaoBMjpUKGUJQo/edit?usp=sharing
     contact:
-      slack: sig-pm
+      slack: kubernetes-pm
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-pm
   - name: Scalability
     dir: sig-scalability
@@ -489,7 +489,7 @@ sigs:
       company: Red Hat
     - name: Aaron Schlesinger
       github: arschles
-      company: Deis
+      company: Microsoft
     - name: Brendan Melville
       github: bmelville
       company: Google


### PR DESCRIPTION
Changed all deprecated links to sig-pm (now sig-product-management), sig-onprem (now sig-on-premise), and sig-contribx (now sig-contributor-experience), also updated the sigs.yml file to match sig-list

CC: @sarahnovotny 