### PR TITLE
Add missing link for new users of kubernetes Slack

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -23,7 +23,7 @@ We also work closely with [sig-storage](../sig-storage) and [sig-networking](../
 
 ## Contact us:
 
-* via [Slack](https://kubernetes.slack.com/messages/sig-node/)
+* via [Slack](https://kubernetes.slack.com/messages/sig-node/) (new users can register [here](http://slack.k8s.io))
 * via [Google Groups](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
 
 ## GitHub Aliases:


### PR DESCRIPTION
The sig-node document invites users to participate in kubernetes.slack.com Slack group. But as a new user I got stuck trying to login there. This PR therefore provides a link where one should go get the invitation prior trying to use Kubernetes Slack channels.