### PR TITLE
Remove old references to SIG service catalog leads

### DIFF
--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -1,6 +1,6 @@
 # SIG Service Catalog
 
-**Leads:** Paul Morie (@pmorie, Red Hat), Aaron Schlesinger (@arschles, Deis), Brendan Melville (@bmelville, Google), Doug Davis (@duglin, IBM)
+**Leads:** Paul Morie (@pmorie, Red Hat), Aaron Schlesinger (@arschles, Microsoft), Ville Aikas (@vaikas-google, Google), Doug Davis (@duglin, IBM)
 
 **Slack Channel:** [#sig-service-catalog](https://kubernetes.slack.com/messages/sig-service-catalog/).  [Archive](http://kubernetes.slackarchive.io/sig-service-catalog/)
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -490,8 +490,8 @@ sigs:
     - name: Aaron Schlesinger
       github: arschles
       company: Microsoft
-    - name: Brendan Melville
-      github: bmelville
+    - name: Ville Aikas
+      github: vaikas-google
       company: Google
     - name: Doug Davis
       github: duglin


### PR DESCRIPTION
Looks like I missed some previously.