### PR TITLE
Update PodPreset modification annotation format

### DIFF
--- a/contributors/design-proposals/pod-preset.md
+++ b/contributors/design-proposals/pod-preset.md
@@ -220,7 +220,7 @@ changes to `Volumes` apply to the pod spec for all pods matching `Selector`.
 
 The resultant modified pod spec will be annotated to show that it was modified by
 the `PodPreset`. This will be of the form
-`podpreset.admission.kubernetes.io/<pip name>": "<resource version>"`.
+`podpreset.admission.kubernetes.io/podpreset-<pip name>": "<resource version>"`.
 
 *Why modify all containers in a pod?*
 


### PR DESCRIPTION
The new format simply adds a prefix of "podpreset-" to the current
annotation that records what presets have acted on a pod. The new naming
makes it such that there is no chance of collision with the newly
introduced opt-out annotation (or future ones yet to be added).

Opt-out annotation PR:
kubernetes/kubernetes#44965