### PR TITLE
Allow specifying the primary group id of the container

### DIFF
--- a/contributors/design-proposals/runas-groupid.md
+++ b/contributors/design-proposals/runas-groupid.md
@@ -5,21 +5,21 @@ As a Kubernetes User, I should be able to specify both user id and group id for 
 Inside a pod on a per Container basis, similar to how docker allows that using docker run options -u, 
 --user="" Username or UID (format: <name|uId>[:<group|gid>]) format.
 
-PodSecurItyContext allows Kubernetes users to specify RunAsUser which can be overriden by RunAsUser
+PodSecurityContext allows Kubernetes users to specify RunAsUser which can be overriden by RunAsUser
 In SecurityContext on a per Container basis. There is no equivalent field for specifying the primary
-Group of the runnIng container.
+Group of the running container.
 
 ## Motivation
 
-EnterprIse Kubernetes users want to run containers as non root. This means running containers with a 
-non zero user Id and non zero group id. This gives Enterprises confidence that their customer code
-Is running with least privilege and if it escapes the container boundary, will still cause least harm
-by decreasIng the attack surface.
+Enterprise Kubernetes users want to run containers as non root. This means running containers with a 
+non zero user id and non zero group id. This gives Enterprises confidence that their customer code
+is running with least privilege and if it escapes the container boundary, will still cause least harm
+by decreasing the attack surface.
 
 ## Goals
 
-1: ProvIde the ability to specify the Primary Group Id for a container inside a Pod
-2: BrIng launching of containers using Kubernetes at par with Dockers by supporting the same features.
+1: Provide the ability to specify the Primary Group id for a container inside a Pod
+2: Bring launching of containers using Kubernetes at par with Dockers by supporting the same features.
 
 
 ## Use Cases
@@ -38,25 +38,25 @@ in the Dockerfile of the container image, without having to create a new Docker 
 
 ### Model
 
-Introduce a new API fIeld in SecurityContext and PodSecurityContext called `RunAsGroup`
+Introduce a new API field in SecurityContext and PodSecurityContext called `RunAsGroup`
 
 // SecurityContext holds security configuration that will be applied to a container.
 // Some fields are present in both SecurityContext and PodSecurityContext.  When both
-// are set, the values In SecurityContext take precedence.
+// are set, the values in SecurityContext take precedence.
 type SecurityContext struct {
      //Other fields not shown for brevity
     ..... 
 
-     // The UID to run the entrypoInt of the container process.
-     // Defaults to user specIfied in image metadata if unspecified.
-     // May also be set In PodSecurityContext.  If set in both SecurityContext and
+     // The UID to run the entrypoint of the container process.
+     // Defaults to user specified in image metadata if unspecified.
+     // May also be set in PodSecurityContext.  If set in both SecurityContext and
      // PodSecurityContext, the value specified in SecurityContext takes precedence.
      // +optional
      RunAsUser *Int64
-     // The GID to run the entrypoInt of the container process.
+     // The GID to run the entrypoint of the container process.
      // Defaults to group specified in image metadata if unspecified.
-     // May also be set In PodSecurityContext.  If set in both SecurityContext and
-     // PodSecurItyContext, the value specified in SecurityContext takes precedence.
+     // May also be set in PodSecurityContext.  If set in both SecurityContext and
+     // PodSecurityContext, the value specified in SecurityContext takes precedence.
      // +optional
      RunAsGroup *Int64
 
@@ -68,16 +68,16 @@ type PodSecurityContext struct {
      //Other fields not shown for brevity
     ..... 
 
-     // The UID to run the entrypoInt of the container process.
-     // Defaults to user specIfied in image metadata if unspecified.
-     // May also be set In SecurityContext.  If set in both SecurityContext and
-     // PodSecurItyContext, the value specified in SecurityContext takes precedence
-     // for that contaIner.
-     // +optIonal
+     // The UID to run the entrypoint of the container process.
+     // Defaults to user specified in image metadata if unspecified.
+     // May also be set in SecurityContext.  If set in both SecurityContext and
+     // PodSecurityContext, the value specified in SecurityContext takes precedence
+     // for that container.
+     // +optional
      RunAsUser *Int64
-     // The GID to run the entrypoInt of the container process.
+     // The GID to run the entrypoint of the container process.
      // Defaults to group specified in image metadata if unspecified.
-     // May also be set In PodSecurityContext.  If set in both SecurityContext and
+     // May also be set in PodSecurityContext.  If set in both SecurityContext and
      // PodSecurityContext, the value specified in SecurityContext takes precedence.
      // +optional
      RunAsGroup *Int64
@@ -91,15 +91,15 @@ Following points should be noted:-
 
 - `FSGroup` and `SupplementalGroups` will continue to have their old meanings and would be untouched.  
 - The `RunAsGroup` In the SecurityContext will override the `RunAsGroup` in the PodSecurityContext.
-- If no RunAsGroup Is provided in the PodSecurityContext and SecurityContext, the Group provided 
+- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, the Group provided 
   In the Docker image will be used.
-- If no RunAsGroup Is provided in the PodSecurityContext and SecurityContext, and none in the image,
-  the contaIner will run with primary Group as root(0).
+- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, and none in the image,
+  the container will run with primary Group as root(0).
 
 ## PodSecurityPolicy
 
-PodSecurItyPolicy defines strategies or conditions that a pod must run with in order to be accepted
-Into the system. Two of the relevant strategies are RunAsUser and SupplementalGroups. We introduce 
+PodSecurityPolicy defines strategies or conditions that a pod must run with in order to be accepted
+into the system. Two of the relevant strategies are RunAsUser and SupplementalGroups. We introduce 
 a new strategy called RunAsGroup which will support the following options:-
 - MustRunAs
 - MustRunAsNonRoot

--- a/contributors/design-proposals/runas-groupid.md
+++ b/contributors/design-proposals/runas-groupid.md
@@ -158,6 +158,33 @@ Following points should be noted:
 - If no `RunAsGroup` is provided in the PodSecurityContext and SecurityContext, and none in the image,
   the container will run with primary Group as root(0).
 
+## Summary of Changes needed
+
+At a high level, the changes classify into:
+1. API
+2. Validation
+3. CRI
+4. Runtime for Docker and rkt
+5. Swagger
+6. DockerShim
+7. Admission
+8. Registry
+
+- plugin/pkg/admission/security/podsecuritypolicy
+- plugin/pkg/admission/securitycontext
+- pkg/securitycontext/util.go
+- pkg/security/podsecuritypolicy/selinux
+- pkg/security/podsecuritypolicy/user
+- pkg/security/podsecuritypolicy/group
+- pkg/registry/extensions/podsecuritypolicy/storage
+- pkg/kubelet/rkt
+- pkg/kubelet/kuberuntime
+- pkg/kubelet/dockershim/
+- pkg/kubelet/apis/cri/v1alpha1/runtime
+- pkg/apis/extensions/validation/
+- pkg/api/validation/
+- api/swagger-spec/
+- api/openapi-spec/swagger.json
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![AnalytIcs](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/proposals/security-context-constraints.md?pixel)]()

--- a/contributors/design-proposals/runas-groupid.md
+++ b/contributors/design-proposals/runas-groupid.md
@@ -3,7 +3,7 @@
 
 As a Kubernetes User, we should be able to specify both user id and group id for the containers running 
 inside a pod on a per Container basis, similar to how docker allows that using docker run options `-u, 
---user="" Username or UID (format: <name|uId>[:<group|gid>]) format`.
+--user="" Username or UID (format: <name|uid>[:<group|gid>]) format`.
 
 PodSecurityContext allows Kubernetes users to specify RunAsUser which can be overriden by RunAsUser
 in SecurityContext on a per Container basis. There is no equivalent field for specifying the primary
@@ -45,7 +45,7 @@ in the Dockerfile of the container image, without having to create a new Docker 
 
 ### Model
 
-Introduce a new API field in SecurityContext and PodSecurityContext called `RunAsGroup`
+Introduce a new API field in SecurityContext and PodSecurityContext called `RunAsGroup`.
 
 #### SecurityContext
 
@@ -62,13 +62,13 @@ type SecurityContext struct {
      // May also be set in PodSecurityContext.  If set in both SecurityContext and
      // PodSecurityContext, the value specified in SecurityContext takes precedence.
      // +optional
-     RunAsUser *Int64
+     RunAsUser *int64
      // The GID to run the entrypoint of the container process.
      // Defaults to group specified in image metadata if unspecified.
      // May also be set in PodSecurityContext.  If set in both SecurityContext and
      // PodSecurityContext, the value specified in SecurityContext takes precedence.
      // +optional
-     RunAsGroup *Int64
+     RunAsGroup *int64
 
     .....
  }
@@ -87,13 +87,13 @@ type PodSecurityContext struct {
      // PodSecurityContext, the value specified in SecurityContext takes precedence
      // for that container.
      // +optional
-     RunAsUser *Int64
+     RunAsUser *int64
      // The GID to run the entrypoint of the container process.
      // Defaults to group specified in image metadata if unspecified.
      // May also be set in PodSecurityContext.  If set in both SecurityContext and
      // PodSecurityContext, the value specified in SecurityContext takes precedence.
      // +optional
-     RunAsGroup *Int64
+     RunAsGroup *int64
 
     .....
  }
@@ -103,7 +103,7 @@ type PodSecurityContext struct {
 
 PodSecurityPolicy defines strategies or conditions that a pod must run with in order to be accepted
 into the system. Two of the relevant strategies are RunAsUser and SupplementalGroups. We introduce 
-a new strategy called RunAsGroup which will support the following options:-
+a new strategy called RunAsGroup which will support the following options:
 - MustRunAs
 - MustRunAsNonRoot
 - RunAsAny
@@ -149,7 +149,7 @@ a new strategy called RunAsGroup which will support the following options:-
 
 ## Behavior
 
-Following points should be noted:-
+Following points should be noted:
 
 - `FSGroup` and `SupplementalGroups` will continue to have their old meanings and would be untouched.  
 - The `RunAsGroup` In the SecurityContext will override the `RunAsGroup` in the PodSecurityContext.

--- a/contributors/design-proposals/runas-groupid.md
+++ b/contributors/design-proposals/runas-groupid.md
@@ -153,10 +153,18 @@ Following points should be noted:
 
 - `FSGroup` and `SupplementalGroups` will continue to have their old meanings and would be untouched.  
 - The `RunAsGroup` In the SecurityContext will override the `RunAsGroup` in the PodSecurityContext.
-- If no `RunAsGroup` is provided in the PodSecurityContext and SecurityContext, the Group provided 
-  in the Docker image will be used.
+- If no `RunAsGroup` is provided in the PodSecurityContext and SecurityContext, the Primary Group Id
+  is decided by the Runtime. Current Runtime behavior is to use 0.
 - If no `RunAsGroup` is provided in the PodSecurityContext and SecurityContext, and none in the image,
   the container will run with primary Group as root(0).
+
+Basically, we guarantee to set the values provided by user, and the runtime dictates the rest.
+
+Here is an example of what gets passed to docker User
+- runAsUser set to 9999, runAsGroup set to 9999 -> Config.User set to 9999:9999
+- runAsUser set to 9999, runAsGroup unset -> Config.User set to 9999 -> docker runs you with 9999:0
+- runAsUser unset, runAsGroup set to 9999 -> Config.User set to :9999 -> docker runs you with 0:9999 
+This is to keep the behavior backward compatible and as expected.
 
 ## Summary of Changes needed
 

--- a/contributors/design-proposals/runas-groupid.md
+++ b/contributors/design-proposals/runas-groupid.md
@@ -1,0 +1,112 @@
+## Abstract
+
+
+As a Kubernetes User, i should be able to specify both user id and group id for the containers running 
+inside a pod on a per Container basis, similar to how docker allows that using docker run options -u, 
+--user="" Username or UID (format: <name|uid>[:<group|gid>]) format.
+
+PodSecurityContext allows Kubernetes users to specify RUnAsUser which can be overriden by RunAsUser
+in SecurtiyContext on a per Container basis. There is no equivalent field for specifying the primary
+Group of the running container.
+
+## Motivation
+
+Enterprise Kubernetes users want to run containers as non root. This means running containers with a 
+non zero user id and non zero group id. This gives Enterprises confidence that their customer code
+is running with least privilege and if it escapes the container boundary, will still cause least harm
+by decreasing the attack surface.
+
+## Goals
+
+1: Provide the ability to specify the Primary Group Id for a container inside a Pod
+2: Bring launching of containers using Kubernetes at par with Dockers by supporting the same features.
+
+
+## Use Cases
+
+Use case 1:
+As a cluster operator, i should be able to control both user id and primary group id of containers 
+launched using Kubernetes.
+
+Use case 2:
+As a cluster operator, i should be able to override user id and primary group id of a container as 
+specified in the Dockerfile without having to create a new docker image for the container.
+
+## Design
+
+### Model
+
+Introduce a new API field in SecurityContext and PodSecurityContext called `RunAsGroup`
+
+// SecurityContext holds security configuration that will be applied to a container.
+// Some fields are present in both SecurityContext and PodSecurityContext.  When both
+// are set, the values in SecurityContext take precedence.
+type SecurityContext struct {
+     //Other fields not shown for brevity
+    ..... 
+
+     // The UID to run the entrypoint of the container process.
+     // Defaults to user specified in image metadata if unspecified.
+     // May also be set in PodSecurityContext.  If set in both SecurityContext and
+     // PodSecurityContext, the value specified in SecurityContext takes precedence.
+     // +optional
+     RunAsUser *int64
+     // The GID to run the entrypoint of the container process.
+     // Defaults to user specified in image metadata if unspecified.
+     // May also be set in PodSecurityContext.  If set in both SecurityContext and
+     // PodSecurityContext, the value specified in SecurityContext takes precedence.
+     // +optional
+     RunAsGroup *int64
+
+    .....
+ }
+ 
+
+type PoddSecurityContext struct {
+     //Other fields not shown for brevity
+    ..... 
+
+     // The UID to run the entrypoint of the container process.
+     // Defaults to user specified in image metadata if unspecified.
+     // May also be set in SecurityContext.  If set in both SecurityContext and
+     // PodSecurityContext, the value specified in SecurityContext takes precedence
+     // for that container.
+     // +optional
+     RunAsUser *int64
+     // The GID to run the entrypoint of the container process.
+     // Defaults to user specified in image metadata if unspecified.
+     // May also be set in PodSecurityContext.  If set in both SecurityContext and
+     // PodSecurityContext, the value specified in SecurityContext takes precedence.
+     // +optional
+     RunAsGroup *int64
+
+    .....
+ }
+
+## Behavior
+
+Following points should be noted:-
+
+- `FSGroup` and `SupplementalGroups` will continue to have their old meanings and would be untouched.  
+- The `RunAsGroup` in the SecurityContext will ovveride the `RunAsGroup` in the PodSecurityContext.
+- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, the Group provided 
+  in the image will be used.
+- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, and none in the image,
+  the container will run with primary Group as root(0).
+
+## Not In Scope
+
+PodSecurityPolicy defines strategies or conditions that a pod must run with in order to be accepted
+into the system. Some of these stratgies are RunAsUser and SupplementalGroups. After this change we
+would introduce a new strategy called RunAsGroup which will support the following options:-
+- MustRunAs
+- MustRunAsNonRoot
+- RunAsAny
+ Although these changes are simple, i would like a wider discussion on whether we want this as part 
+of this feature or we need some kind of consolidation both RunASUser and RunAsGroup strategy into
+one.
+
+
+<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/proposals/security-context-constraints.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/contributors/design-proposals/runas-groupid.md
+++ b/contributors/design-proposals/runas-groupid.md
@@ -1,20 +1,27 @@
 ## Abstract
 
 
-As a Kubernetes User, I should be able to specify both user id and group id for the containers running 
-Inside a pod on a per Container basis, similar to how docker allows that using docker run options -u, 
---user="" Username or UID (format: <name|uId>[:<group|gid>]) format.
+As a Kubernetes User, we should be able to specify both user id and group id for the containers running 
+inside a pod on a per Container basis, similar to how docker allows that using docker run options `-u, 
+--user="" Username or UID (format: <name|uId>[:<group|gid>]) format`.
 
 PodSecurityContext allows Kubernetes users to specify RunAsUser which can be overriden by RunAsUser
-In SecurityContext on a per Container basis. There is no equivalent field for specifying the primary
+in SecurityContext on a per Container basis. There is no equivalent field for specifying the primary
 Group of the running container.
 
 ## Motivation
 
 Enterprise Kubernetes users want to run containers as non root. This means running containers with a 
-non zero user id and non zero group id. This gives Enterprises confidence that their customer code
+non zero user id and non zero primary group id. This gives Enterprises, confidence that their customer code
 is running with least privilege and if it escapes the container boundary, will still cause least harm
 by decreasing the attack surface.
+
+### What is the significance of Primary Group Id ?
+Primary Group Id is the group id used when creating files and directories. It is also the default group 
+associated with a user, when he/she logins. All groups are defined in `/etc/group` file and are created
+with the `groupadd` command. A Process/Container runs with uid/primary gid of the calling user. If no
+primary group is specified for a user, 0(root) group is assumed. This means , any files/directories created
+by a process running as user with no primary group associated with it, will be owned by group id 0(root).
 
 ## Goals
 

--- a/contributors/design-proposals/runas-groupid.md
+++ b/contributors/design-proposals/runas-groupid.md
@@ -18,18 +18,18 @@ by decreasing the attack surface.
 
 ## Goals
 
-1: Provide the ability to specify the Primary Group id for a container inside a Pod
-2: Bring launching of containers using Kubernetes at par with Dockers by supporting the same features.
+1. Provide the ability to specify the Primary Group id for a container inside a Pod
+2. Bring launching of containers using Kubernetes at par with Dockers by supporting the same features.
 
 
 ## Use Cases
 
-Use case 1:
+### Use case 1:
 As a Kubernetes User, I should be able to control both user id and primary group id of containers 
 launched using Kubernetes at runtime, so that i can run the container as non root with least possible
 privilege.
 
-Use case 2:
+### Use case 2:
 As a Kubernetes User, I should be able to control both user id and primary group id of containers 
 launched using Kubernetes at runtime, so that i can override the user id and primary group id specified
 in the Dockerfile of the container image, without having to create a new Docker image.
@@ -40,6 +40,9 @@ in the Dockerfile of the container image, without having to create a new Docker 
 
 Introduce a new API field in SecurityContext and PodSecurityContext called `RunAsGroup`
 
+#### SecurityContext
+
+```
 // SecurityContext holds security configuration that will be applied to a container.
 // Some fields are present in both SecurityContext and PodSecurityContext.  When both
 // are set, the values in SecurityContext take precedence.
@@ -62,8 +65,11 @@ type SecurityContext struct {
 
     .....
  }
- 
+```
 
+#### PodSecurityContext 
+
+```
 type PodSecurityContext struct {
      //Other fields not shown for brevity
     ..... 
@@ -84,19 +90,9 @@ type PodSecurityContext struct {
 
     .....
  }
+```
 
-## Behavior
-
-Following points should be noted:-
-
-- `FSGroup` and `SupplementalGroups` will continue to have their old meanings and would be untouched.  
-- The `RunAsGroup` In the SecurityContext will override the `RunAsGroup` in the PodSecurityContext.
-- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, the Group provided 
-  In the Docker image will be used.
-- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, and none in the image,
-  the container will run with primary Group as root(0).
-
-## PodSecurityPolicy
+#### PodSecurityPolicy
 
 PodSecurityPolicy defines strategies or conditions that a pod must run with in order to be accepted
 into the system. Two of the relevant strategies are RunAsUser and SupplementalGroups. We introduce 
@@ -105,6 +101,7 @@ a new strategy called RunAsGroup which will support the following options:-
 - MustRunAsNonRoot
 - RunAsAny
 
+```
 // PodSecurityPolicySpec defines the policy enforced.
  type PodSecurityPolicySpec struct {
      //Other fields not shown for brevity
@@ -141,6 +138,18 @@ a new strategy called RunAsGroup which will support the following options:-
      // container may make requests for any gid.
      RunAsGroupStrategyRunAsAny RunAsGroupStrategy = "RunAsAny"
  )
+```
+
+## Behavior
+
+Following points should be noted:-
+
+- `FSGroup` and `SupplementalGroups` will continue to have their old meanings and would be untouched.  
+- The `RunAsGroup` In the SecurityContext will override the `RunAsGroup` in the PodSecurityContext.
+- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, the Group provided 
+  In the Docker image will be used.
+- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, and none in the image,
+  the container will run with primary Group as root(0).
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->

--- a/contributors/design-proposals/runas-groupid.md
+++ b/contributors/design-proposals/runas-groupid.md
@@ -1,84 +1,86 @@
 ## Abstract
 
 
-As a Kubernetes User, i should be able to specify both user id and group id for the containers running 
-inside a pod on a per Container basis, similar to how docker allows that using docker run options -u, 
---user="" Username or UID (format: <name|uid>[:<group|gid>]) format.
+As a Kubernetes User, I should be able to specify both user id and group id for the containers running 
+Inside a pod on a per Container basis, similar to how docker allows that using docker run options -u, 
+--user="" Username or UID (format: <name|uId>[:<group|gid>]) format.
 
-PodSecurityContext allows Kubernetes users to specify RUnAsUser which can be overriden by RunAsUser
-in SecurtiyContext on a per Container basis. There is no equivalent field for specifying the primary
-Group of the running container.
+PodSecurItyContext allows Kubernetes users to specify RunAsUser which can be overriden by RunAsUser
+In SecurityContext on a per Container basis. There is no equivalent field for specifying the primary
+Group of the runnIng container.
 
 ## Motivation
 
-Enterprise Kubernetes users want to run containers as non root. This means running containers with a 
-non zero user id and non zero group id. This gives Enterprises confidence that their customer code
-is running with least privilege and if it escapes the container boundary, will still cause least harm
-by decreasing the attack surface.
+EnterprIse Kubernetes users want to run containers as non root. This means running containers with a 
+non zero user Id and non zero group id. This gives Enterprises confidence that their customer code
+Is running with least privilege and if it escapes the container boundary, will still cause least harm
+by decreasIng the attack surface.
 
 ## Goals
 
-1: Provide the ability to specify the Primary Group Id for a container inside a Pod
-2: Bring launching of containers using Kubernetes at par with Dockers by supporting the same features.
+1: ProvIde the ability to specify the Primary Group Id for a container inside a Pod
+2: BrIng launching of containers using Kubernetes at par with Dockers by supporting the same features.
 
 
 ## Use Cases
 
 Use case 1:
-As a cluster operator, i should be able to control both user id and primary group id of containers 
-launched using Kubernetes.
+As a Kubernetes User, I should be able to control both user id and primary group id of containers 
+launched using Kubernetes at runtime, so that i can run the container as non root with least possible
+privilege.
 
 Use case 2:
-As a cluster operator, i should be able to override user id and primary group id of a container as 
-specified in the Dockerfile without having to create a new docker image for the container.
+As a Kubernetes User, I should be able to control both user id and primary group id of containers 
+launched using Kubernetes at runtime, so that i can override the user id and primary group id specified
+in the Dockerfile of the container image, without having to create a new Docker image.
 
 ## Design
 
 ### Model
 
-Introduce a new API field in SecurityContext and PodSecurityContext called `RunAsGroup`
+Introduce a new API fIeld in SecurityContext and PodSecurityContext called `RunAsGroup`
 
 // SecurityContext holds security configuration that will be applied to a container.
 // Some fields are present in both SecurityContext and PodSecurityContext.  When both
-// are set, the values in SecurityContext take precedence.
+// are set, the values In SecurityContext take precedence.
 type SecurityContext struct {
      //Other fields not shown for brevity
     ..... 
 
-     // The UID to run the entrypoint of the container process.
-     // Defaults to user specified in image metadata if unspecified.
-     // May also be set in PodSecurityContext.  If set in both SecurityContext and
+     // The UID to run the entrypoInt of the container process.
+     // Defaults to user specIfied in image metadata if unspecified.
+     // May also be set In PodSecurityContext.  If set in both SecurityContext and
      // PodSecurityContext, the value specified in SecurityContext takes precedence.
      // +optional
-     RunAsUser *int64
-     // The GID to run the entrypoint of the container process.
-     // Defaults to user specified in image metadata if unspecified.
-     // May also be set in PodSecurityContext.  If set in both SecurityContext and
-     // PodSecurityContext, the value specified in SecurityContext takes precedence.
+     RunAsUser *Int64
+     // The GID to run the entrypoInt of the container process.
+     // Defaults to group specified in image metadata if unspecified.
+     // May also be set In PodSecurityContext.  If set in both SecurityContext and
+     // PodSecurItyContext, the value specified in SecurityContext takes precedence.
      // +optional
-     RunAsGroup *int64
+     RunAsGroup *Int64
 
     .....
  }
  
 
-type PoddSecurityContext struct {
+type PodSecurityContext struct {
      //Other fields not shown for brevity
     ..... 
 
-     // The UID to run the entrypoint of the container process.
-     // Defaults to user specified in image metadata if unspecified.
-     // May also be set in SecurityContext.  If set in both SecurityContext and
-     // PodSecurityContext, the value specified in SecurityContext takes precedence
-     // for that container.
-     // +optional
-     RunAsUser *int64
-     // The GID to run the entrypoint of the container process.
-     // Defaults to user specified in image metadata if unspecified.
-     // May also be set in PodSecurityContext.  If set in both SecurityContext and
+     // The UID to run the entrypoInt of the container process.
+     // Defaults to user specIfied in image metadata if unspecified.
+     // May also be set In SecurityContext.  If set in both SecurityContext and
+     // PodSecurItyContext, the value specified in SecurityContext takes precedence
+     // for that contaIner.
+     // +optIonal
+     RunAsUser *Int64
+     // The GID to run the entrypoInt of the container process.
+     // Defaults to group specified in image metadata if unspecified.
+     // May also be set In PodSecurityContext.  If set in both SecurityContext and
      // PodSecurityContext, the value specified in SecurityContext takes precedence.
      // +optional
-     RunAsGroup *int64
+     RunAsGroup *Int64
 
     .....
  }
@@ -88,25 +90,59 @@ type PoddSecurityContext struct {
 Following points should be noted:-
 
 - `FSGroup` and `SupplementalGroups` will continue to have their old meanings and would be untouched.  
-- The `RunAsGroup` in the SecurityContext will ovveride the `RunAsGroup` in the PodSecurityContext.
-- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, the Group provided 
-  in the image will be used.
-- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, and none in the image,
-  the container will run with primary Group as root(0).
+- The `RunAsGroup` In the SecurityContext will override the `RunAsGroup` in the PodSecurityContext.
+- If no RunAsGroup Is provided in the PodSecurityContext and SecurityContext, the Group provided 
+  In the Docker image will be used.
+- If no RunAsGroup Is provided in the PodSecurityContext and SecurityContext, and none in the image,
+  the contaIner will run with primary Group as root(0).
 
-## Not In Scope
+## PodSecurityPolicy
 
-PodSecurityPolicy defines strategies or conditions that a pod must run with in order to be accepted
-into the system. Some of these stratgies are RunAsUser and SupplementalGroups. After this change we
-would introduce a new strategy called RunAsGroup which will support the following options:-
+PodSecurItyPolicy defines strategies or conditions that a pod must run with in order to be accepted
+Into the system. Two of the relevant strategies are RunAsUser and SupplementalGroups. We introduce 
+a new strategy called RunAsGroup which will support the following options:-
 - MustRunAs
 - MustRunAsNonRoot
 - RunAsAny
- Although these changes are simple, i would like a wider discussion on whether we want this as part 
-of this feature or we need some kind of consolidation both RunASUser and RunAsGroup strategy into
-one.
+
+// PodSecurityPolicySpec defines the policy enforced.
+ type PodSecurityPolicySpec struct {
+     //Other fields not shown for brevity
+    ..... 
+  // RunAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
+  RunAsUser RunAsUserStrategyOptions
+  // SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+  SupplementalGroups SupplementalGroupsStrategyOptions
+
+
+  // RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set.
+  RunAsGroup RunAsGroupStrategyOptions
+   .....
+}
+
+// RunAsGroupStrategyOptions defines the strategy type and any options used to create the strategy.
+ type RunAsUserStrategyOptions struct {
+     // Rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
+     Rule RunAsGroupStrategy
+     // Ranges are the allowed ranges of gids that may be used.
+     // +optional
+     Ranges []GroupIDRange
+ }
+
+// RunAsGroupStrategy denotes strategy types for generating RunAsGroup values for a
+ // SecurityContext.
+ type RunAsGroupStrategy string
+ 
+ const (
+     // container must run as a particular gid.
+     RunAsGroupStrategyMustRunAs RunAsGroupStrategy = "MustRunAs"
+     // container must run as a non-root gid
+     RunAsGroupStrategyMustRunAsNonRoot RunAsGroupStrategy = "MustRunAsNonRoot"
+     // container may make requests for any gid.
+     RunAsGroupStrategyRunAsAny RunAsGroupStrategy = "RunAsAny"
+ )
 
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/proposals/security-context-constraints.md?pixel)]()
-<!-- END MUNGE: GENERATED_ANALYTICS -->
+[![AnalytIcs](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/proposals/security-context-constraints.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->  

--- a/contributors/design-proposals/runas-groupid.md
+++ b/contributors/design-proposals/runas-groupid.md
@@ -153,9 +153,9 @@ Following points should be noted:
 
 - `FSGroup` and `SupplementalGroups` will continue to have their old meanings and would be untouched.  
 - The `RunAsGroup` In the SecurityContext will override the `RunAsGroup` in the PodSecurityContext.
-- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, the Group provided 
-  In the Docker image will be used.
-- If no RunAsGroup is provided in the PodSecurityContext and SecurityContext, and none in the image,
+- If no `RunAsGroup` is provided in the PodSecurityContext and SecurityContext, the Group provided 
+  in the Docker image will be used.
+- If no `RunAsGroup` is provided in the PodSecurityContext and SecurityContext, and none in the image,
   the container will run with primary Group as root(0).
 
 


### PR DESCRIPTION
Allows specifying the Primary Group ID of the container, in addition to Primary User Id when running in Docker similar to how docker supports this.