### PR TITLE
Remove timestamp from sig file generation

### DIFF
--- a/generator/app.go
+++ b/generator/app.go
@@ -25,7 +25,6 @@ import (
 	"sort"
 	"strings"
 	"text/template"
-	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -42,7 +41,6 @@ var (
 	githubTeamNames     = []string{"misc", "test-failures", "bugs", "feature-requests", "proposals", "pr-reviews", "api-reviews"}
 	beginMarker         = "<!-- BEGIN CUSTOM CONTENT -->"
 	endMarker           = "<!-- END CUSTOM CONTENT -->"
-	lastGeneratedPrefix = "Last generated: "
 )
 
 type Lead struct {
@@ -204,9 +202,6 @@ func writeTemplate(templatePath, outputPath string, data interface{}) error {
 	// custom content block
 	writeCustomContentBlock(f, content)
 
-	// last generated
-	writeLastGenerated(f)
-
 	fmt.Printf("Generated %s\n", outputPath)
 	return nil
 }
@@ -216,11 +211,6 @@ func writeCustomContentBlock(f *os.File, content string) {
 	for _, line := range lines {
 		f.Write([]byte(line))
 	}
-}
-
-func writeLastGenerated(f *os.File) {
-	lastGenerated := fmt.Sprintf("\n%s %s", lastGeneratedPrefix, time.Now().Format("Mon Jan 2 2006 15:04:05"))
-	f.Write([]byte(lastGenerated))
 }
 
 func createReadmeFiles(ctx Context) error {

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -31,5 +31,3 @@ Meeting notes and Agenda can be found [here](https://goo.gl/x5nWrF).
 ## Areas
 apiserver, api registration and discovery, generic API CRUD semantics, admission control, encoding/decoding, conversion, defaulting, persistence layer (etcd), OpenAPI, third-party resource, garbage collection, client libraries
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -38,5 +38,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 * Do not pick which apps to run on top of the platform
 * Do not recommend one way to do things
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -34,5 +34,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 * Proactive or general security discussion about Kubelet should go to kubernetes-sig-node@googlegroups.com.
 * Proactive or general security discussion about the API server should go to kubernetes-sig-api-machinery@googlegroups.com.  
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -30,5 +30,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 * setting initial resources for pods,
 * topics related to monitoring pods and gathering their metrics (e.g.: Heapster)
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -28,5 +28,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -8,7 +8,7 @@ To understand how this file is generated, see generator/README.md.
 -->
 # Azure SIG
 
-A Special Interest Group for building, deploying, maintaining, supporting,  and using Kubernetes on Azure Container Service.
+A Special Interest Group for building, deploying, maintaining, supporting, and using Kubernetes on Azure Container Service.
 
 ## Meetings
 * [Wednesdays at 16:00 UTC](https://deis.zoom.us/j/2018742972) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
@@ -27,5 +27,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Thu Jun 8 2017 14:40:16

--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -32,5 +32,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 ## Non-goals
 * Endorsing any particular tool/framework
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -27,5 +27,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -35,5 +35,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/a/weave.wor
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Tue Jun 13 2017 16:34:38

--- a/sig-cluster-ops/README.md
+++ b/sig-cluster-ops/README.md
@@ -26,5 +26,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -27,5 +27,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -32,5 +32,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 * Identify and implement ways to get documentation feedback and metrics
 * Help community contributors get involved in kubernetes documentation
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-federation/README.md
+++ b/sig-federation/README.md
@@ -26,5 +26,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -25,5 +25,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-list.md
+++ b/sig-list.md
@@ -47,7 +47,7 @@ When the need arises, a [new SIG can be created](sig-creation-procedure.md)
 |[Storage](sig-storage/README.md)|* [Saad Ali](https://github.com/saad-ali), Google<br>* [Bradley Childs](https://github.com/childsb), Red Hat<br>|* [Slack](https://kubernetes.slack.com/messages/sig-storage)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)|* [Thursdays at 16:00 UTC (biweekly)](https://zoom.us/j/614261834)<br>
 |[Testing](sig-testing/README.md)|* [Aaron Crickenberger](https://github.com/spiffxp), Samsung SDS<br>* [Erick Feja](https://github.com/fejta), Google<br>* [Timothy St. Clair](https://github.com/timothysc), Heptio<br>|* [Slack](https://kubernetes.slack.com/messages/sig-testing)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-testing)|* [Tuesdays at 20:00 UTC (weekly)](https://zoom.us/j/2419653117)<br>
 |[UI](sig-ui/README.md)|* [Dan Romlein](https://github.com/romlein), Apprenda<br>* [Piotr Bryk](https://github.com/bryk), Google<br>|* [Slack](https://kubernetes.slack.com/messages/sig-ui)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)|* [Wednesdays at 14:00 UTC (weekly)](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)<br>
-|[Windows](sig-windows/README.md)|* [Michael Michael](https://github.com/michmike77), Apprenda<br>|* [Slack](https://kubernetes.slack.com/messages/sig-windows)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-windows)|* [Tuesdays at 16:30 UTC (weekly)](https://zoom.us/my/sigwindows)<br>
+|[Windows](sig-windows/README.md)|* [Michael Michael](https://github.com/michmike), Apprenda<br>|* [Slack](https://kubernetes.slack.com/messages/sig-windows)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-windows)|* [Tuesdays at 16:30 UTC (weekly)](https://zoom.us/my/sigwindows)<br>
 
 ### Master Working Group List
 
@@ -57,5 +57,3 @@ When the need arises, a [new SIG can be created](sig-creation-procedure.md)
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Tue Jun 13 2017 22:28:12

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -44,5 +44,3 @@ SIG Network is responsible for a number of issues and PRs. A summary can be foun
 
 * [2017 Planning](https://docs.google.com/document/d/1fBxC36UCBnqY_w3m3TjdnXFsIT--GS6HmKb5o0nhkTk/edit#)
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -41,5 +41,3 @@ Topics include, but are not limited to:
 
 We also work closely with [sig-storage](../sig-storage) and [sig-networking](../sig-networking). As you can see, this is a very cross-functional team!
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-on-premise/README.md
+++ b/sig-on-premise/README.md
@@ -16,8 +16,9 @@ Brings together member of Kubernetes community interested in running Kubernetes 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1AHF1a8ni7iMOpUgDMcPKrLQCML5EMZUAwP4rro3P6sk/edit#).
 
 ## Leads
-* [Joseph Jacks](https://github.com/josephjacks), Apprenda
 * [Tomasz Napierala](https://github.com/zen), Mirantis
+* [Marco Ceppi](https://github.com/marcoceppi), Canonical
+* [Dalton Hubble](https://github.com/dghubble), CoreOS
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-onprem)
@@ -36,5 +37,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -36,5 +36,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-product-management/README.md
+++ b/sig-product-management/README.md
@@ -39,5 +39,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 - Onboarding large groups of corporate contributors and welcoming them into the Kubernetes Community
 - Whatever is needed to help make the project go!
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -43,5 +43,3 @@ For more details how do we measure those, you can look at: http://blog.kubernete
 
 We are working on refining existing SLOs and defining more for other areas of the system.
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -26,5 +26,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -28,5 +28,3 @@ Meeting notes and Agenda can be found [here](http://goo.gl/A0m24V).
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -26,5 +26,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -27,5 +27,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -26,5 +26,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -8,7 +8,7 @@ To understand how this file is generated, see generator/README.md.
 -->
 # Windows SIG
 
-Focuses on bringing Kubernetes support to Windows.
+Focuses on supporting Windows Server Containers for Kubernetes.
 
 ## Meetings
 * [Tuesdays at 16:30 UTC](https://zoom.us/my/sigwindows) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:30&tz=UTC).
@@ -16,7 +16,7 @@ Focuses on bringing Kubernetes support to Windows.
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431).
 
 ## Leads
-* [Michael Michael](https://github.com/michmike77), Apprenda
+* [Michael Michael](https://github.com/michmike), Apprenda
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-windows)
@@ -25,5 +25,3 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Wed Jun 7 2017 14:27:56

--- a/wg-resource-management/README.md
+++ b/wg-resource-management/README.md
@@ -55,5 +55,3 @@ Topics include, but are not limited to:
 * APIs and extensions related to the features mentioned above 
 * ...
 <!-- END CUSTOM CONTENT -->
-
-Last generated:  Tue Jun 13 2017 22:28:12


### PR DESCRIPTION
Timestamps in the sig docs generation create more potential for merge conflicts, as well as touch/modify files that would otherwise not need to be modified when running `make all`.

cc: @jamiehannaford 