### PR TITLE
clean up description about "pre-commit" hook

### DIFF
--- a/contributors/devel/coding-conventions.md
+++ b/contributors/devel/coding-conventions.md
@@ -24,8 +24,6 @@ OS X
 
   - Go
 
-    - Ensure your code passes the [presubmit checks](development.md#define-a-pre-commit-hook)
-
     - [Go Code Review
 Comments](https://github.com/golang/go/wiki/CodeReviewComments)
 


### PR DESCRIPTION
This link is deleted by this:
https://github.com/kubernetes/community/commit/6b42e8126a7e36af4e880c922478f4ab1c066d00#diff-c61d1306839d4aa3fa96ff4bae197585L226

This is a dead link now.