### PR TITLE
Fix link to point to English docs instead of Chinese

### DIFF
--- a/contributors/devel/api-conventions.md
+++ b/contributors/devel/api-conventions.md
@@ -5,7 +5,7 @@ Updated: 3/7/2017
 
 *This document is oriented at users who want a deeper understanding of the
 Kubernetes API structure, and developers wanting to extend the Kubernetes API.
-An introduction to using resources with kubectl can be found in [the object management overview](https://kubernetes.io/docs/concepts/tools/kubectl/object-management-overview/).*
+An introduction to using resources with kubectl can be found in [the object management overview](https://kubernetes.io/docs/tutorials/object-management-kubectl/object-management/).*
 
 **Table of Contents**
 <!-- BEGIN MUNGE: GENERATED_TOC -->


### PR DESCRIPTION
Earlier the link redirected to docs in Chinese because of the redirects present here: https://github.com/kubernetes/kubernetes.github.io/blob/master/cn/docs/tutorials/object-management-kubectl/object-management.md.