### PR TITLE
Correct the resource management working group meeting_archive_url

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -660,7 +660,7 @@ workinggroups:
       utc: "18:00"
       frequency: weekly (On demand)
     meeting_url: https://zoom.us/j/4799874685
-    meeting_archive_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG
+    meeting_archive_url: https://docs.google.com/document/d/1j3vrG6BgE0hUDs2e-1ZUegKN4W4Adb1B6oJ6j-4kyPU
     contact:
       slack: wg-resource-mgmt
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-resource-management

--- a/wg-resource-management/README.md
+++ b/wg-resource-management/README.md
@@ -13,7 +13,7 @@ Designing and shepherding cross-cutting features around compute resource isolati
 ## Meetings
 * [Tuesdays at 18:00 UTC](https://zoom.us/j/4799874685) (weekly (On demand)). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:00&tz=UTC).
 
-Meeting notes and Agenda can be found [here](https://www.youtube.com/playlist?list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG).
+Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1j3vrG6BgE0hUDs2e-1ZUegKN4W4Adb1B6oJ6j-4kyPU).
 
 ## Organizers
 * [Vishnu Kannan](https://github.com/vishh), Google


### PR DESCRIPTION
old URL pointed to youtube recordings rather than Agenda.  Agenda has a link to youtube recordings.  Other SIGs point to their agenda doc in meeting_archive_url