### PR TITLE
Move client-libraries.md to kubernetes.io

### DIFF
--- a/contributors/devel/client-libraries.md
+++ b/contributors/devel/client-libraries.md
@@ -1,28 +1,6 @@
 ## Kubernetes API client libraries
 
-### Supported by [Kubernetes SIG API Machinery](https://github.com/kubernetes/community/tree/master/sig-api-machinery)
-
-   * [Go](https://github.com/kubernetes/client-go)
-   * [Python](https://github.com/kubernetes-incubator/client-python)
-
-### User Contributed
-
-*Note: Libraries provided by outside parties are supported by their authors, not
-the core Kubernetes team*
-
-   * [Clojure](https://github.com/yanatan16/clj-kubernetes-api)
-   * [Go](https://github.com/ericchiang/k8s)
-   * [Java (OSGi)](https://bitbucket.org/amdatulabs/amdatu-kubernetes)
-   * [Java (Fabric8, OSGi)](https://github.com/fabric8io/kubernetes-client)
-   * [Node.js](https://github.com/tenxcloud/node-kubernetes-client)
-   * [Node.js](https://github.com/godaddy/kubernetes-client)
-   * [Perl](https://metacpan.org/pod/Net::Kubernetes)
-   * [PHP](https://github.com/devstub/kubernetes-api-php-client)
-   * [PHP](https://github.com/maclof/kubernetes-client)
-   * [Python](https://github.com/eldarion-gondor/pykube)
-   * [Ruby](https://github.com/Ch00k/kuber)
-   * [Ruby](https://github.com/abonas/kubeclient)
-   * [Scala](https://github.com/doriordan/skuber)
+This document has been moved to https://kubernetes.io/docs/reference/client-libraries/.
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/devel/client-libraries.md?pixel)]()


### PR DESCRIPTION
This content is now served at https://kubernetes.io/docs/reference/client-libraries/
and removing this page will encourage people to keep the website up to date.
