### PR TITLE
Add missing update staging godeps command

### DIFF
--- a/contributors/devel/godep.md
+++ b/contributors/devel/godep.md
@@ -90,6 +90,9 @@ rm -rf vendor
 ./hack/update-bazel.sh
 ./hack/update-godep-licenses.sh
 ./hack/update-staging-client-go.sh
+# If you haven't followed this doc step-by-step and haven't created a dedicated GOPATH,
+# make sure there is no client-go or other staging repo in $GOPATH before running the next command.
+./hack/update-staging-godeps.sh
 git checkout -- $(git status -s | grep "^ D" | awk '{print $2}' | grep ^Godeps)
 ```
 


### PR DESCRIPTION
I'm not sure whether it should be before or after `update-staging-client-go.sh` is invoked.

For the record: found while working on https://github.com/kubernetes/kubernetes/pull/48384