### PR TITLE
add custom metrics API link

### DIFF
--- a/contributors/design-proposals/hpa-v2.md
+++ b/contributors/design-proposals/hpa-v2.md
@@ -281,7 +281,7 @@ Mechanical Concerns
 The HPA will derive metrics from two sources: resource metrics (i.e. CPU
 request percentage) will come from the
 [master metrics API](resource-metrics-api.md), while other metrics will
-come from the [custom metrics API](custom-metrics-api.md)(currently proposed as #34586), which is
+come from the [custom metrics API](custom-metrics-api.md), which is
 an adapter API which sources metrics directly from the monitoring
 pipeline.
 

--- a/contributors/design-proposals/hpa-v2.md
+++ b/contributors/design-proposals/hpa-v2.md
@@ -281,7 +281,7 @@ Mechanical Concerns
 The HPA will derive metrics from two sources: resource metrics (i.e. CPU
 request percentage) will come from the
 [master metrics API](resource-metrics-api.md), while other metrics will
-come from the custom metrics API (currently proposed as #34586), which is
+come from the [custom metrics API](custom-metrics-api.md)(currently proposed as #34586), which is
 an adapter API which sources metrics directly from the monitoring
 pipeline.
 


### PR DESCRIPTION
when  a link about master metrics API has added,I think the link of custom metrics api is necessary to given.