### PR TITLE
Remove extra whitespace from sig-arch

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -49,7 +49,7 @@ sigs:
   - name: Architecture
     dir: sig-architecture
     mission_statement: >
-      The Architecture SIG maintains and evolves the design principles of Kubernetes, and provides a consistent 
+      The Architecture SIG maintains and evolves the design principles of Kubernetes, and provides a consistent
       body of expertise necessary to ensure architectural consistency over time.
     leads:
     - name: Brian Grant


### PR DESCRIPTION
This just removed an extra whitespace that snuck in there.

/cc @xiangpengzhao 