### PR TITLE
Remove a not exist update-staging-client-go.sh

### DIFF
--- a/contributors/devel/godep.md
+++ b/contributors/devel/godep.md
@@ -86,10 +86,9 @@ godep get $DEP/...
 rm -rf Godeps
 rm -rf vendor
 ./hack/godep-save.sh
-# Regenerate removed BUILD, licenses, and client-go Godeps files.
+# Regenerate removed BUILD, licenses.
 ./hack/update-bazel.sh
 ./hack/update-godep-licenses.sh
-./hack/update-staging-client-go.sh
 # If you haven't followed this doc step-by-step and haven't created a dedicated GOPATH,
 # make sure there is no client-go or other staging repo in $GOPATH before running the next command.
 ./hack/update-staging-godeps.sh


### PR DESCRIPTION
The update-staging-client-go.sh has been removed, and there is no
need to run it.