### PR TITLE
Specify --provider option on local e2e test

### DIFF
--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -432,7 +432,7 @@ at a custom host directly:
 export KUBECONFIG=/path/to/kubeconfig
 export KUBE_MASTER_IP="127.0.0.1:<PORT>"
 export KUBE_MASTER=local
-go run hack/e2e.go -- -v --test
+go run hack/e2e.go -- -v --test --provider=local
 ```
 
 To control the tests that are run:


### PR DESCRIPTION
e2e test finds a suitable util.sh from "--provider" option.
However the e2e test way of community repo didn't show the setting of
the option and the gce's util.sh was selected as the default.

This patch fixes it.