### PR TITLE
Fix an obsolete link in on-call-federation-build-cop.md

### DIFF
--- a/contributors/devel/on-call-federation-build-cop.md
+++ b/contributors/devel/on-call-federation-build-cop.md
@@ -31,7 +31,7 @@ The configuration of CI tests are stored in:
 Results of all the federation CI tests, including the soak tests, are
 listed in the corresponding tabs on the Cluster Federation page in the
 testgrid.
-https://k8s-testgrid.appspot.com/cluster-federation
+https://k8s-testgrid.appspot.com/sig-federation
 
 ### Playbook
 


### PR DESCRIPTION
fix an obsolete link to federation ci test results
/assign @madhusudancs