### PR TITLE
api-conventions: status subresource updates metadata

### DIFF
--- a/contributors/devel/api-conventions.md
+++ b/contributors/devel/api-conventions.md
@@ -1,7 +1,7 @@
 API Conventions
 ===============
 
-Updated: 3/7/2017
+Updated: 8/7/2017
 
 *This document is oriented at users who want a deeper understanding of the
 Kubernetes API structure, and developers wanting to extend the Kubernetes API.
@@ -272,7 +272,7 @@ desired state.
 
 The PUT and POST verbs on objects MUST ignore the "status" values, to avoid
 accidentally overwriting the status in read-modify-write scenarios. A `/status`
-subresource MUST be provided to enable system components to update statuses of
+subresource MUST be provided to enable system components to update statuses and metadata of
 resources they manage.
 
 Otherwise, PUT expects the whole object to be specified. Therefore, if a field


### PR DESCRIPTION
Currently, the docs say that the `/status` sub-resource only updates the status of the resource. However, it also updates the metadata.

Examples:
1. [ReplicationController](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/replicationcontroller/strategy.go#L173)
2. [StatefulSet](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/apps/statefulset/strategy.go#L140)
3. [Deployment]( https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/extensions/deployment/strategy.go#L111)
4. [Job](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/batch/job/strategy.go#L157)