### PR TITLE
Update Example conventions

### DIFF
--- a/contributors/devel/kubectl-conventions.md
+++ b/contributors/devel/kubectl-conventions.md
@@ -255,8 +255,10 @@ input, output, commonly used flags, etc.
 
 
   * Example should contain examples
+    * A comment should precede each example command. Comment should start with
+      an uppercase letter and terminate with a period
     * Start commands with `$`
-    * A comment should precede each example command, and should begin with `#`
+
 
 
 * Use "FILENAME" for filenames


### PR DESCRIPTION
Currently code in `kubectl` for Example strings is not uniform and often does not follow the conventions. This PR updates the conventions to be more descriptive. If this PR is merged I will audit all Example strings in `kubernetes/pkg/kubectl/cmd/*.go` and bring them into line with the conventions. Trivial I know ;) 