### PR TITLE
change priority of backlog and add a few items

### DIFF
--- a/committee-steering/backlog.md
+++ b/committee-steering/backlog.md
@@ -5,7 +5,27 @@ This is a backlog of items that the steering committee needs to either handle or
 
 ## Backlog Items
 
-- Check the governance documents into the community repo
+- Check the boostraping governance documents into the community repo
+- Write project wide governance once steering committee is in place:
+	- Identify how the governance documents can be changed
+	- Describe the GitHub multi-organization strategy and how new org can be created
+	- Describe how SIGs are created, governed and how they interact with the steering committee
+	- Update incubator process based on new governance and new GitHub organization strategy
+	- Committee decision-making process (e.g., modified lazy consensus seeking) and quorum requirement
+	- Improve/expand definition of members of standing
+	- Simplify the contributor ladder
+
+
+- SIG charter template, including suggested governance and minimum required intra-SIG governance, its scope 
+  (topics, subsystems, code repos and directories), responsibilities, areas of authority, how members and roles
+  of authority/leadership are selected/granted, how decisions are made, and how conflicts are resolved
+- Formalize the concept of subprojects
+- Decide how/whether ecosystem subprojects (e.g., kops, helm) are governed differently
+- In particular, develop policies/procedures for donated code (e.g., helm, kubernetes-anywhere, kompose, kargo)
+- Resolve the disconnect between code organization (OWNERS, maintainers) and people organization (SIGs)
+- Define roles and responsibilities of incubator mentor/sponsor and graduation process.
+- Identify where the community lives (e.g slack, google group) so it can be reached
+- Identify where and how decisions are made (e.g slack, google group, SIG, kubernetes-dev, GitHub)
 - Clarify the inferface with the CNCF
 - Update the Code of Conduct Committee to a more recent version, documenting enforcement, broaden coverage
   beyond maintainers and committers, coding activities, and project/public spaces, specify our own reporting
@@ -14,27 +34,18 @@ This is a backlog of items that the steering committee needs to either handle or
 - Determine how members of the Code of Conduct Committee should be selected
 - Document resources that the community has and make sure they have a home: releases, twitter handles, etc
 - Find homes for unowned areas of the project, such as the build system
-- SIG charter template, including suggested governance and minimum required intra-SIG governance, its scope 
-  (topics, subsystems, code repos and directories), responsibilities, areas of authority, how members and roles
-  of authority/leadership are selected/granted, how decisions are made, and how conflicts are resolved
-- Formalize the concept of subprojects
-- Decide how/whether ecosystem subprojects (e.g., kops, helm) are governed differently
-- In particular, develop policies/procedures for donated code (e.g., helm, kubernetes-anywhere, kompose, kargo)
-- Resolve the disconnect between code organization (OWNERS, maintainers) and people organization (SIGs)
-- Simplify the contributor ladder
-- Update incubator process to explain new GitHub organization strategy
 - Explicitly delegate areas to SIGs
 - Escalation process
 - Fund-requesting and budget processes
-- Committee decision-making process (e.g., modified lazy consensus seeking) and quorum requirement
-- Improve/expand definition of members of standing
-- Identify who is responsible for evolving the governance going forward and how changes will be approved
 - Project-wide communication requirements, processes, and mechanisms
+- Develop processes to address staffing gaps (engineering, docs, test, release, ...), effort gaps 
+  (tragedy of the commons), expertise mismatches, priority conflicts, personnel conflicts
+  
+### Open questions:
+  
 - Do we need user groups?
 - Do we need insurance?
 - Do we need a policy similar to [Apache's release policy](http://www.apache.org/legal/release-policy.html)?
 - Update project values
 - Do we need a Conflict of Interest policy?
-- Develop processes to address staffing gaps (engineering, docs, test, release, ...), effort gaps 
-  (tragedy of the commons), expertise mismatches, priority conflicts, personnel conflicts
 


### PR DESCRIPTION
This PR is a follow up on:

https://github.com/kubernetes/community/issues/351#issuecomment-321859055

It changes priority of a few items and adds a few more.

Specifically I believe that the first task of the newly elected steering committee will be to draft new governance global to the project and submit this new governance to a vote of the "community of standing". This would finish the bootstrap process.

This is what I call bylaws in https://github.com/kubernetes/community/issues/351

They are (or is) the simplest document possible that describe the governance:

- the membership and how one moves in this membership (e.g vote, no vote, emeritus, nomination, etc...)
- the various groups (e.g steering committee, SIGs, incubator)
- how decisions are made (e.g vote, no vote, lazy consensus etc).
- how each "project" is governed (e.g how decisions are made in helm)
- where the community lives which implies where are decisions made.
