### PR TITLE
create owners files for community repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+reviewers:
+	- sarahnovotny
+	- idvoretskyi
+	- calebamiles
+	- grodrigues3
+approvers:
+	- sarahnovotny
+	- idvoretskyi
+	- calebamiles
+	- grodrigues3
+	- brendandburns
+	- dchen1107
+	- jbeda
+	- lavalamp
+	- smarterclayton
+	- thockin
+	- wojtek-t
+

--- a/committee-steering/OWNERS
+++ b/committee-steering/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+	- bgrant0607
+	- philips
+	- thockin
+	- sarahnovotny
+	- smarterclayton
+	- jbeda
+	- brendanburns
+approvers:
+	- bgrant0607
+	- philips
+	- thockin
+	- sarahnovotny
+	- smarterclayton
+	- jbeda
+	- brendanburns

--- a/community/OWNERS
+++ b/community/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+	- czahedi
+	- nyener
+	- zehicle
+	- sarahnovotny
+	- jberkus
+approvers:
+	- czahedi
+	- nyener
+	- zehicle
+	- sarahnovotny
+	- jberkus

--- a/contributors/design-proposals/clustering/OWNERS
+++ b/contributors/design-proposals/clustering/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- michelleN
+approvers:
+	- michelleN

--- a/contributors/design-proposals/images/OWNERS
+++ b/contributors/design-proposals/images/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- bsalamat
+	- michelleN
+approvers:
+	- bsalamat
+	- michelleN

--- a/contributors/design-proposals/sig-cli/OWNERS
+++ b/contributors/design-proposals/sig-cli/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- pwittrock
+approvers:
+	- pwittrock

--- a/contributors/devel/OWNERS
+++ b/contributors/devel/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+	- grodrigues3
+	- Phillels
+	- idvoretskyi
+	- calebamiles
+	- cblecker
+	- spiffxp
+approvers:
+	- grodrigues3
+	- Phillels
+	- idvoretskyi
+	- calebamiles
+	- cblecker
+	- spiffxp

--- a/contributors/devel/local-cluster/OWNERS
+++ b/contributors/devel/local-cluster/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+	- xilabao
+	- michelleN
+	- jianglingxia
+	- ruebenramirez
+	- davidxia
+approvers:
+	- xilabao
+	- michelleN
+	- jianglingxia
+	- ruebenramirez
+	- davidxia

--- a/contributors/devel/release/OWNERS
+++ b/contributors/devel/release/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+	- saad-ali
+	- pwittrock
+	- steveperry-53
+	- chenopis
+	- sig-release
+approvers:
+	- saad-ali
+	- pwittrock
+	- steveperry-53
+	- chenopis
+	- sig-release

--- a/generator/OWNERS
+++ b/generator/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- vishh
+	- cblecker
+approvers:
+	- vishh
+	- cblecker

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- cblecker
+approvers:
+	- cblecker

--- a/project-managers/OWNERS
+++ b/project-managers/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- calebamiles
+	- idvoretskyi
+	- grodrigues3
+approvers:
+	- calebamiles
+	- idvoretskyi
+	- grodrigues3

--- a/sig-api-machinery/OWNERS
+++ b/sig-api-machinery/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+	- lavalamp
+	- deads2k
+	- mbohlool
+	- bgrant0607
+approvers:
+	- deads2k
+	- lavalamp
+	- mbohlool
+	- bgrant0607

--- a/sig-apps/OWNERS
+++ b/sig-apps/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- michelleN
+	- mattfarina
+approvers:
+	- michelleN
+	- mattfarina

--- a/sig-apps/minutes/OWNERS
+++ b/sig-apps/minutes/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- EnergyLiYN
+approvers:
+	- EnergyLiYN

--- a/sig-architecture/OWNERS
+++ b/sig-architecture/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- jdumars
+	- bgrant0607
+approvers:
+	- jdumars
+	- bgrant0607

--- a/sig-auth/OWNERS
+++ b/sig-auth/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- ericchiang
+	- liggitt
+	- deads2k
+approvers:
+	- ericchiang
+	- liggitt
+	- deads2k

--- a/sig-autoscaling/OWNERS
+++ b/sig-autoscaling/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- mwielgus
+	- directxman12
+approvers:
+	- mwielgus
+	- directxman12

--- a/sig-aws/OWNERS
+++ b/sig-aws/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- kris-nova
+	- justinsb
+	- chrislovecnm
+approvers:
+	- kris-nova
+	- justinsb
+	- chrislovecnm

--- a/sig-azure/OWNERS
+++ b/sig-azure/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- colemickens
+	- slack
+	- jdumars
+approvers:
+	- colemickens
+	- slack
+	- jdumars

--- a/sig-big-data/OWNERS
+++ b/sig-big-data/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- foxish
+approvers:
+	- foxish

--- a/sig-cli/OWNERS
+++ b/sig-cli/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- pwittrock
+	- AdoHe
+	- fabianofranz
+approvers:
+	- pwittrock
+	- AdoHe
+	- fabianofranz

--- a/sig-cluster-lifecycle/OWNERS
+++ b/sig-cluster-lifecycle/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- roberthbailey
+	- lukemarsden
+	- jbeda
+approvers:
+	- roberthbailey
+	- lukemarsden
+	- jbeda

--- a/sig-cluster-lifecycle/postmortems/OWNERS
+++ b/sig-cluster-lifecycle/postmortems/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- pipejakob
+approvers:
+	- pipejakob

--- a/sig-cluster-ops/OWNERS
+++ b/sig-cluster-ops/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- jdumars
+	- zehicle
+approvers:
+	- jdumars
+	- zehicle

--- a/sig-contributor-experience/OWNERS
+++ b/sig-contributor-experience/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- grodrigues3
+	- Phillels 
+approvers:
+	- grodrigues3
+	- Phillels 

--- a/sig-docs/OWNERS
+++ b/sig-docs/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- jaredbhatti
+	- devin-donnelly
+approvers:
+	- jaredbhatti
+	- devin-donnelly

--- a/sig-federation/OWNERS
+++ b/sig-federation/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- csbell
+	- quinton-hoole
+approvers:
+	- csbell
+	- quinton-hoole

--- a/sig-instrumentation/OWNERS
+++ b/sig-instrumentation/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- fabxc
+	- piosz
+approvers:
+	- fabxc
+	- piosz

--- a/sig-network/OWNERS
+++ b/sig-network/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- thockin
+	- dcbw
+approvers:
+	- thockin
+	- dcbw

--- a/sig-node/OWNERS
+++ b/sig-node/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- dchen1107
+	- derekawaynecarr
+approvers:
+	- dchen1107
+	- derekawaynecarr

--- a/sig-on-premise/OWNERS
+++ b/sig-on-premise/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- zen
+	- marcoceppi
+	- dghubble
+approvers:
+	- zen
+	- marcoceppi
+	- dghubble

--- a/sig-openstack/OWNERS
+++ b/sig-openstack/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- idvoretskyi
+	- xsgordon
+approvers:
+	- idvoretskyi
+	- xsgordon

--- a/sig-product-management/OWNERS
+++ b/sig-product-management/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- apsinha
+	- idvoretskyi
+	- calebamiles
+approvers:
+	- apsinha
+	- idvoretskyi
+	- calebamiles

--- a/sig-release/OWNERS
+++ b/sig-release/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- calebamiles
+approvers:
+	- calebamiles

--- a/sig-rktnetes/OWNERS
+++ b/sig-rktnetes/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- calebamiles
+approvers:
+	- calebamiles

--- a/sig-scalability/OWNERS
+++ b/sig-scalability/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- wojtek-t
+	- countspongebob
+	- jbeda
+approvers:
+	- wojtek-t
+	- countspongebob
+	- jbeda

--- a/sig-scalability/slo/OWNERS
+++ b/sig-scalability/slo/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- gmarek
+approvers:
+	- gmarek

--- a/sig-scheduling/OWNERS
+++ b/sig-scheduling/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- davidopp
+	- timothysc
+approvers:
+	- davidopp
+	- timothysc

--- a/sig-service-catalog/OWNERS
+++ b/sig-service-catalog/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+	- pmorie
+	- arschles
+	- vaikas-google
+	- duglin
+approvers:
+	- pmorie
+	- arschles
+	- vaikas-google
+	- duglin

--- a/sig-storage/1.3-retrospective/OWNERS
+++ b/sig-storage/1.3-retrospective/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- saad-ali
+	- EnergyLiYN
+approvers:
+	- saad-ali
+	- EnergyLiYN

--- a/sig-storage/OWNERS
+++ b/sig-storage/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- saad-ali
+	- childsb
+approvers:
+	- saad-ali
+	- childsb

--- a/sig-testing/OWNERS
+++ b/sig-testing/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+	- spiffxp
+	- fejta
+	- timothysc
+approvers:
+	- spiffxp
+	- fejta
+	- timothysc

--- a/sig-ui/OWNERS
+++ b/sig-ui/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- danielromlein
+	- bryk
+approvers:
+	- danielromlein
+	- bryk

--- a/sig-windows/OWNERS
+++ b/sig-windows/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+	- michmike
+approvers:
+	- michmike

--- a/wg-container-identity/OWNERS
+++ b/wg-container-identity/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- destijl
+	- smarterclayton
+approvers:
+	- destijl
+	- smarterclayton

--- a/wg-resource-management/OWNERS
+++ b/wg-resource-management/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+	- vishh
+	- derekwaynecarr
+approvers:
+	- vishh
+	- derekwaynecarr


### PR DESCRIPTION
In order to enable the mungebot on the community repo, we need OWNERS files.

As a first pass, I used coreos/findowners tool to create owners files for community.  These are just a start based on commits and likely need to be changed/updated.