### PR TITLE
Add meeting recording links to SIG README.md's

### DIFF
--- a/generator/app.go
+++ b/generator/app.go
@@ -71,14 +71,15 @@ type Contact struct {
 
 // Group represents either a Special Interest Group (SIG) or a Working Group (WG)
 type Group struct {
-	Name              string
-	Dir               string
-	MissionStatement  string `yaml:"mission_statement"`
-	Leads             []Lead
-	Meetings          []Meeting
-	MeetingURL        string `yaml:"meeting_url"`
-	MeetingArchiveURL string `yaml:"meeting_archive_url"`
-	Contact           Contact
+	Name                 string
+	Dir                  string
+	MissionStatement     string `yaml:"mission_statement"`
+	Leads                []Lead
+	Meetings             []Meeting
+	MeetingURL           string `yaml:"meeting_url"`
+	MeetingArchiveURL    string `yaml:"meeting_archive_url"`
+	MeetingRecordingsURL string `yaml:"meeting_recordings_url"`
+	Contact              Contact
 }
 
 // DirName returns the directory that a group's documentation will be

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -8,6 +8,7 @@
 {{- end }}
 
 Meeting notes and Agenda can be found [here]({{.MeetingArchiveURL}}).
+Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
 
 ## Leads
 {{- range .Leads }}

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -8,6 +8,7 @@
 {{- end }}
 
 Meeting notes and Agenda can be found [here]({{.MeetingArchiveURL}}).
+Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
 
 ## Organizers
 {{- range .Leads }}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -14,6 +14,7 @@ Covers all aspects of API server, API registration and discovery, generic API CR
 * [Wednesdays at 18:00 UTC](https://staging.talkgadget.google.com/hangouts/_/google.com/kubernetes-sig) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://goo.gl/x5nWrF).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=Lj1ScbXpnpY&list=PL69nYSiGNLP21oW3hbLyjjj4XhrwKxH2R).
 
 ## Leads
 * [Daniel Smith](https://github.com/lavalamp), Google

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -14,6 +14,7 @@ Covers deploying and operating applications in Kubernetes. We focus on the devel
 * [Mondays at 16:00 UTC](https://zoom.us/j/4526666954) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=hn23Z-vL_cM&list=PL69nYSiGNLP2LMq7vznITnpd2Fk1YIZF3).
 
 ## Leads
 * [Michelle Noorali](https://github.com/michelleN), Microsoft

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -14,6 +14,7 @@ The Architecture SIG maintains and evolves the design principles of Kubernetes, 
 * [Mondays at 17:00 UTC](https://zoom.us/j/2018742972) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1BlmHq5uPyBUDlppYqAAzslVbAO8hilgjqZUTaNXUhKM/edit).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=d5ERqm3oHN0&list=PL69nYSiGNLP2m6198LaLN6YahX7EEac5g).
 
 ## Leads
 * [Brian Grant](https://github.com/bgrant0607), Google

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -14,6 +14,7 @@ Covers improvements to Kubernetes authorization, authentication, and cluster sec
 * [Wednesdays at 18:00 UTC](https://zoom.us/my/k8s.sig.auth) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1woLGRoONE3EBVx-wTb4pvp4CI7tmLZ6lS26VTbosLKM/edit#).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=DJDuDNALcMo&list=PL69nYSiGNLP0VMOZ-V7-5AchXTHAQFzJw).
 
 ## Leads
 * [Eric Chiang](https://github.com/ericchiang), CoreOS

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -14,6 +14,7 @@ Covers autoscaling of clusters, horizontal and vertical autoscaling of pods, set
 * [Thursdays at 15:30 UTC](https://plus.google.com/hangouts/_/google.com/k8s-autoscaling) (biweekly/triweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:30&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1RvhQAEIrVLHbyNnuaT99-6u9ZUMp7BfkPupT2LAZK7w/edit).
+Meeting recordings can be found [here]().
 
 ## Leads
 * [Marcin Wielgus](https://github.com/mwielgus), Google

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -14,6 +14,7 @@ Covers maintaining, supporting, and using Kubernetes hosted on AWS Cloud.
 * [Fridays at 17:00 UTC](https://zoom.us/my/k8ssigaws) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit).
+Meeting recordings can be found [here]().
 
 ## Leads
 * [Justin Santa Barbara](https://github.com/justinsb)

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -14,6 +14,7 @@ A Special Interest Group for building, deploying, maintaining, supporting, and u
 * [Wednesdays at 16:00 UTC](https://deis.zoom.us/j/2018742972) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1SpxvmOgHDhnA72Z0lbhBffrfe9inQxZkU9xqlafOW9k/edit).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4).
 
 ## Leads
 * [Jason Hansen](https://github.com/slack), Microsoft

--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -14,6 +14,7 @@ Covers deploying and operating big data applications (Spark, Kafka, Hadoop, Flin
 * [Wednesdays at 17:00 UTC](https://zoom.us/my/sig.big.data) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit).
+Meeting recordings can be found [here]().
 
 ## Leads
 * [Anirudh Ramanathan](https://github.com/foxish), Google

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -14,6 +14,7 @@ Covers kubectl and related tools. We focus on the development and standardizatio
 * [Wednesdays at 16:00 UTC](https://zoom.us/my/sigcli) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=X29sffrQJU4&list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF).
 
 ## Leads
 * [Fabiano Franz](https://github.com/fabianofranz), Red Hat

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -14,6 +14,7 @@ The Cluster Lifecycle SIG is responsible for building the user experience for de
 * [Tuesdays at 16:00 UTC](https://zoom.us/j/166836%E2%80%8B624) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/a/weave.works/document/d/1deJYPIF4LmhGjDVaqrswErIrV7mtwJgovtLnPCDxP7U/edit).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=ljK5dgSA7vc&list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 
 ## Leads
 * [Luke Marsden](https://github.com/lukemarsden), Weave

--- a/sig-cluster-ops/README.md
+++ b/sig-cluster-ops/README.md
@@ -14,6 +14,7 @@ Promote operability and interoperability of Kubernetes clusters. We focus on sha
 * [Thursdays at 20:00 UTC](https://zoom.us/j/297937771) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=20:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1IhN5v6MjcAUrvLd9dAWtKcGWBWSaRU8DNyPiof3gYMY/edit#).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=7uyy37pCk4U&list=PL69nYSiGNLP3b38liicqy6fm2-jWT4FQR).
 
 ## Leads
 * [Rob Hirschfeld](https://github.com/zehicle), RackN

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -14,6 +14,7 @@ Developing and sustaining a healthy community of contributors is critical to sca
 * [Wednesdays at 16:30 UTC](https://zoom.us/j/7658488911) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:30&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr).
 
 ## Leads
 * [Garrett Rodrigues](https://github.com/grodrigues3), Google

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -14,6 +14,7 @@ Covers documentation, doc processes, and doc publishing for Kubernetes.
 * [Tuesdays at 17:30 UTC](https://zoom.us/j/678394311) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:30&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1Ds87eRiNZeXwRBEbFr6Z7ukjbTow5RQcNZLaSvWWQsE/edit).
+Meeting recordings can be found [here]().
 
 ## Leads
 * [Devin Donnelly](https://github.com/devin-donnelly), Google

--- a/sig-federation/README.md
+++ b/sig-federation/README.md
@@ -14,6 +14,7 @@ Covers the Federation of Kubernetes Clusters and related topics. This includes: 
 * [Tuesdays at 16:30 UTC](https://plus.google.com/hangouts/_/google.com/k8s-federation) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:30&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/18mk62nOXE_MCSSnb4yJD_8UadtzJrYyJxFwbrgabHe8/edit).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=iWKC3FsNHWg&list=PL69nYSiGNLP0HqgyqTby6HlDEz7i1mb0-).
 
 ## Leads
 * [Christian Bell](https://github.com/csbell), Google

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -14,6 +14,7 @@ Covers best practices for cluster observability through metrics, logging, and ev
 * [Thursdays at 16:30 UTC](https://zoom.us/j/5342565819) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:30&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1gWuAATtlmI7XJILXd31nA4kMq6U9u63L70382Y3xcbM/edit).
+Meeting recordings can be found [here]().
 
 ## Leads
 * [Piotr Szczesniak](https://github.com/piosz), Google

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -14,6 +14,7 @@ Covers networking in Kubernetes.
 * [Thursdays at 21:00 UTC](https://zoom.us/j/5806599998) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=21:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1_w77-zG_Xj0zYvEMfQZTQ-wPP4kXkpGD8smVtW_qqWM/edit).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=phCA5-vWkVM&list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb).
 
 ## Leads
 * [Tim Hockin](https://github.com/thockin), Google

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -13,6 +13,7 @@ To understand how this file is generated, see generator/README.md.
 * [Tuesdays at 17:00 UTC](https://plus.google.com/hangouts/_/google.com/sig-node-meetup?authuser=0) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit?usp=sharing).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=FbKOI9-x9hI&list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG).
 
 ## Leads
 * [Dawn Chen](https://github.com/dchen1107), Google

--- a/sig-on-premise/README.md
+++ b/sig-on-premise/README.md
@@ -14,6 +14,7 @@ Brings together member of Kubernetes community interested in running Kubernetes 
 * [Wednesdays at 16:00 UTC](https://zoom.us/my/k8s.sig.onprem) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1AHF1a8ni7iMOpUgDMcPKrLQCML5EMZUAwP4rro3P6sk/edit#).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=dyUWqqNYUio&list=PL69nYSiGNLP2MvqC6NeegrgtOl5s1KlYa).
 
 ## Leads
 * [Tomasz Napierala](https://github.com/zen), Mirantis

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -14,6 +14,7 @@ Coordinates the cross-community efforts of the OpenStack and Kubernetes communit
 * [Wednesdays at 15:00 UTC](https://zoom.us/j/417251241) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit?usp=sharing_eixpa_nl&ts=588b986f).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=iCfUx7ilh0E&list=PL69nYSiGNLP20iTSChQ_i2QQmTBl3M7ax).
 
 ## Leads
 * [Ihor Dvoretskyi](https://github.com/idvoretskyi), Mirantis

--- a/sig-product-management/README.md
+++ b/sig-product-management/README.md
@@ -17,6 +17,7 @@ It is also important to remember that the role of managing an open source projec
 * [Tuesdays at 15:00 UTC](https://zoom.us/j/845373595) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1YqIpyjz4mV1jjvzhLx9JYy8LAduedzaoBMjpUKGUJQo/edit?usp=sharing).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=VcdjaZAol2I&list=PL69nYSiGNLP3EBqpUGVsK1sMgUZVomfEQ).
 
 ## Leads
 * [Aparna Sinha](https://github.com/apsinha), Google

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -13,6 +13,7 @@ To understand how this file is generated, see generator/README.md.
 * [Tuesdays at 21:00 UTC](https://zoom.us/j/664772523) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=21:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1vhsixdT58iJFfoGZbpmvI_xnK59XyAjtadu3h6hHPpY/edit?usp=sharing).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=I0KbWz8MTMk&list=PL69nYSiGNLP3QKkOsDsO6A0Y1rhgP84iZ).
 
 ## Leads
 * [Phillip Wittrock](https://github.com/pwittrock), Google

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -16,6 +16,7 @@ For more details about our objectives please review our [Scaling And Performance
 * [Thursdays at 16:00 UTC](https://zoom.us/j/989573207) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/a/bobsplanet.com/document/d/1hEpf25qifVWztaeZPFmjNiJvPo-5JX1z0LSvvVY5G2g/edit?usp=drive_web).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=NDP1uYyom28&list=PL69nYSiGNLP2X-hzNTqyELU6jYS3p10uL).
 
 ## Leads
 * [Wojciech Tyczynski](https://github.com/wojtek-t), Google

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -14,6 +14,7 @@ To understand how this file is generated, see generator/README.md.
 * [Wednesdays at 07:30 UTC](https://zoom.us/zoomconference?m=rN2RrBUYxXgXY4EMiWWgQP6Vslgcsn86) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:30&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/13mwye7nvrmV11q9_Eg77z-1w3X7Q1GTbslpml4J7F3A/edit).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=PweKj6SU7UA&list=PL69nYSiGNLP2vwzcCOhxrL3JVBc-eaJWI).
 
 ## Leads
 * [David Oppenheimer](https://github.com/davidopp), Google

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -14,6 +14,7 @@ To develop a Kubernetes API for the CNCF service broker and Kubernetes broker im
 * [Mondays at 20:00 UTC](https://zoom.us/j/7201225346) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=20:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](http://goo.gl/A0m24V).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=ukPj1sFFkr0&list=PL69nYSiGNLP2k9ZXx9E1MvRSotFDoHUWs).
 
 ## Leads
 * [Paul Morie](https://github.com/pmorie), Red Hat

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -14,6 +14,7 @@ Covers storage and volume plugins.
 * [Thursdays at 16:00 UTC](https://zoom.us/j/614261834) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1-8KEG8AjAgKznS9NFm3qWqkGyCHmvU6HVl0sk5hwoAE/edit?usp=sharing).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=Eh7Qa7KOL8o&list=PL69nYSiGNLP02-BMqJdfFgGxYQ4Nb-2Qq).
 
 ## Leads
 * [Saad Ali](https://github.com/saad-ali), Google

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -14,6 +14,7 @@ Interested in how we can most effectively test Kubernetes. We're interested spec
 * [Tuesdays at 20:00 UTC](https://zoom.us/j/2419653117) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=20:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1z8MQpr_jTwhmjLMUaqQyBk1EYG_Y_3D4y4YdMJ7V1Kk).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=BbFjuxe3N4w&list=PL69nYSiGNLP0ofY51bEooJ4TKuQtUSizR).
 
 ## Leads
 * [Aaron Crickenberger](https://github.com/spiffxp), Samsung SDS

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -14,6 +14,7 @@ Covers all things UI related. Efforts are centered around Kubernetes Dashboard: 
 * [Wednesdays at 14:00 UTC](https://groups.google.com/forum/#!forum/kubernetes-sig-ui) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1PwHFvqiShLIq8ZpoXvE3dSUnOv1ts5BTtZ7aATuKd-E/edit?usp=sharing).
+Meeting recordings can be found [here]().
 
 ## Leads
 * [Dan Romlein](https://github.com/danielromlein), Apprenda

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -14,6 +14,7 @@ Focuses on supporting Windows Server Containers for Kubernetes.
 * [Tuesdays at 16:30 UTC](https://zoom.us/my/sigwindows) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:30&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=7zawb3KT9Xk&list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4).
 
 ## Leads
 * [Michael Michael](https://github.com/michmike), Apprenda

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -19,6 +19,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://staging.talkgadget.google.com/hangouts/_/google.com/kubernetes-sig
     meeting_archive_url: https://goo.gl/x5nWrF
+    meeting_recordings_url: https://www.youtube.com/watch?v=Lj1ScbXpnpY&list=PL69nYSiGNLP21oW3hbLyjjj4XhrwKxH2R
     contact:
       slack: sig-api-machinery
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery
@@ -43,6 +44,7 @@ sigs:
       frequency: weekly
     meeting_url: https://zoom.us/j/4526666954
     meeting_archive_url: https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#
+    meeting_recordings_url: https://www.youtube.com/watch?v=hn23Z-vL_cM&list=PL69nYSiGNLP2LMq7vznITnpd2Fk1YIZF3
     contact:
       slack: sig-apps
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-apps
@@ -64,6 +66,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/j/2018742972
     meeting_archive_url: https://docs.google.com/document/d/1BlmHq5uPyBUDlppYqAAzslVbAO8hilgjqZUTaNXUhKM/edit
+    meeting_recordings_url: https://www.youtube.com/watch?v=d5ERqm3oHN0&list=PL69nYSiGNLP2m6198LaLN6YahX7EEac5g
     contact:
       slack: sig-architecture
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-architecture
@@ -88,6 +91,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/my/k8s.sig.auth
     meeting_archive_url: https://docs.google.com/document/d/1woLGRoONE3EBVx-wTb4pvp4CI7tmLZ6lS26VTbosLKM/edit#
+    meeting_recordings_url: https://www.youtube.com/watch?v=DJDuDNALcMo&list=PL69nYSiGNLP0VMOZ-V7-5AchXTHAQFzJw
     contact:
       slack: sig-auth
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-auth
@@ -110,6 +114,7 @@ sigs:
       frequency: biweekly/triweekly
     meeting_url: https://plus.google.com/hangouts/_/google.com/k8s-autoscaling
     meeting_archive_url: https://docs.google.com/document/d/1RvhQAEIrVLHbyNnuaT99-6u9ZUMp7BfkPupT2LAZK7w/edit
+    meeting_recordings_url:
     contact:
       slack: sig-autoscaling
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling
@@ -134,6 +139,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/my/k8ssigaws
     meeting_archive_url: https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit
+    meeting_recordings_url:
     contact:
       slack: sig-aws
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-aws
@@ -158,6 +164,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://deis.zoom.us/j/2018742972
     meeting_archive_url: https://docs.google.com/document/d/1SpxvmOgHDhnA72Z0lbhBffrfe9inQxZkU9xqlafOW9k/edit
+    meeting_recordings_url: https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4
     contact:
       slack: sig-azure
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-azure
@@ -177,6 +184,7 @@ sigs:
       frequency: weekly
     meeting_url: https://zoom.us/my/sig.big.data
     meeting_archive_url: https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit
+    meeting_recordings_url:
     contact:
       slack: sig-big-data
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-big-data
@@ -204,6 +212,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/my/sigcli
     meeting_archive_url: https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing
+    meeting_recordings_url: https://www.youtube.com/watch?v=X29sffrQJU4&list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF
     contact:
       slack: sig-cli
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cli
@@ -228,6 +237,7 @@ sigs:
       frequency: weekly
     meeting_url: https://zoom.us/j/166836%E2%80%8B624
     meeting_archive_url: https://docs.google.com/a/weave.works/document/d/1deJYPIF4LmhGjDVaqrswErIrV7mtwJgovtLnPCDxP7U/edit
+    meeting_recordings_url: https://www.youtube.com/watch?v=ljK5dgSA7vc&list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
     contact:
       slack: sig-cluster-lifecycle
       full_github_teams: true
@@ -252,6 +262,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/j/297937771
     meeting_archive_url: https://docs.google.com/document/d/1IhN5v6MjcAUrvLd9dAWtKcGWBWSaRU8DNyPiof3gYMY/edit#
+    meeting_recordings_url: https://www.youtube.com/watch?v=7uyy37pCk4U&list=PL69nYSiGNLP3b38liicqy6fm2-jWT4FQR
     contact:
       slack: sig-cluster-ops
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-ops
@@ -276,6 +287,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/j/7658488911
     meeting_archive_url: https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/
+    meeting_recordings_url: https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr
     contact:
       slack: sig-contribex
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-contribex
@@ -296,6 +308,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/j/678394311
     meeting_archive_url: https://docs.google.com/document/d/1Ds87eRiNZeXwRBEbFr6Z7ukjbTow5RQcNZLaSvWWQsE/edit
+    meeting_recordings_url:
     contact:
       slack: sig-docs
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-docs
@@ -320,6 +333,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://plus.google.com/hangouts/_/google.com/k8s-federation
     meeting_archive_url: https://docs.google.com/document/d/18mk62nOXE_MCSSnb4yJD_8UadtzJrYyJxFwbrgabHe8/edit
+    meeting_recordings_url: https://www.youtube.com/watch?v=iWKC3FsNHWg&list=PL69nYSiGNLP0HqgyqTby6HlDEz7i1mb0-
     contact:
       slack: sig-federation
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-federation
@@ -342,6 +356,7 @@ sigs:
       frequency: weekly
     meeting_url: https://zoom.us/j/5342565819
     meeting_archive_url: https://docs.google.com/document/d/1gWuAATtlmI7XJILXd31nA4kMq6U9u63L70382Y3xcbM/edit
+    meeting_recordings_url:
     contact:
       slack: sig-instrumentation
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation
@@ -365,6 +380,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/j/5806599998
     meeting_archive_url: https://docs.google.com/document/d/1_w77-zG_Xj0zYvEMfQZTQ-wPP4kXkpGD8smVtW_qqWM/edit
+    meeting_recordings_url: https://www.youtube.com/watch?v=phCA5-vWkVM&list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb
     contact:
       slack: sig-network
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-network
@@ -384,6 +400,7 @@ sigs:
       frequency: weekly
     meeting_url: https://plus.google.com/hangouts/_/google.com/sig-node-meetup?authuser=0
     meeting_archive_url: https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit?usp=sharing
+    meeting_recordings_url: https://www.youtube.com/watch?v=FbKOI9-x9hI&list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG
     contact:
       slack: sig-node
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-node
@@ -409,6 +426,7 @@ sigs:
       frequency: weekly
     meeting_url: https://zoom.us/my/k8s.sig.onprem
     meeting_archive_url: https://docs.google.com/document/d/1AHF1a8ni7iMOpUgDMcPKrLQCML5EMZUAwP4rro3P6sk/edit#
+    meeting_recordings_url: https://www.youtube.com/watch?v=dyUWqqNYUio&list=PL69nYSiGNLP2MvqC6NeegrgtOl5s1KlYa
     contact:
       slack: sig-onprem
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-on-prem
@@ -435,6 +453,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/j/417251241
     meeting_archive_url: https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit?usp=sharing_eixpa_nl&ts=588b986f
+    meeting_recordings_url: https://www.youtube.com/watch?v=iCfUx7ilh0E&list=PL69nYSiGNLP20iTSChQ_i2QQmTBl3M7ax
     contact:
       slack: sig-openstack
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-openstack
@@ -476,6 +495,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/j/845373595
     meeting_archive_url: https://docs.google.com/document/d/1YqIpyjz4mV1jjvzhLx9JYy8LAduedzaoBMjpUKGUJQo/edit?usp=sharing
+    meeting_recordings_url: https://www.youtube.com/watch?v=VcdjaZAol2I&list=PL69nYSiGNLP3EBqpUGVsK1sMgUZVomfEQ
     contact:
       slack: kubernetes-pm
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-pm
@@ -494,6 +514,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/j/664772523
     meeting_archive_url: https://docs.google.com/document/d/1vhsixdT58iJFfoGZbpmvI_xnK59XyAjtadu3h6hHPpY/edit?usp=sharing
+    meeting_recordings_url: https://www.youtube.com/watch?v=I0KbWz8MTMk&list=PL69nYSiGNLP3QKkOsDsO6A0Y1rhgP84iZ
     contact:
       slack: sig-release
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-release
@@ -525,6 +546,7 @@ sigs:
       frequency: weekly
     meeting_url: https://zoom.us/j/989573207
     meeting_archive_url: https://docs.google.com/a/bobsplanet.com/document/d/1hEpf25qifVWztaeZPFmjNiJvPo-5JX1z0LSvvVY5G2g/edit?usp=drive_web
+    meeting_recordings_url: https://www.youtube.com/watch?v=NDP1uYyom28&list=PL69nYSiGNLP2X-hzNTqyELU6jYS3p10uL
     contact:
       slack: sig-scalability
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-scale
@@ -547,6 +569,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/zoomconference?m=rN2RrBUYxXgXY4EMiWWgQP6Vslgcsn86
     meeting_archive_url: https://docs.google.com/document/d/13mwye7nvrmV11q9_Eg77z-1w3X7Q1GTbslpml4J7F3A/edit
+    meeting_recordings_url: https://www.youtube.com/watch?v=PweKj6SU7UA&list=PL69nYSiGNLP2vwzcCOhxrL3JVBc-eaJWI
     contact:
       slack: sig-scheduling
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling
@@ -574,6 +597,7 @@ sigs:
       frequency: weekly
     meeting_url: https://zoom.us/j/7201225346
     meeting_archive_url: http://goo.gl/A0m24V
+    meeting_recordings_url: https://www.youtube.com/watch?v=ukPj1sFFkr0&list=PL69nYSiGNLP2k9ZXx9E1MvRSotFDoHUWs
     contact:
       slack: sig-service-catalog
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog
@@ -594,6 +618,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/j/614261834
     meeting_archive_url: https://docs.google.com/document/d/1-8KEG8AjAgKznS9NFm3qWqkGyCHmvU6HVl0sk5hwoAE/edit?usp=sharing
+    meeting_recordings_url: https://www.youtube.com/watch?v=Eh7Qa7KOL8o&list=PL69nYSiGNLP02-BMqJdfFgGxYQ4Nb-2Qq
     contact:
       slack: sig-storage
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-storage
@@ -620,6 +645,7 @@ sigs:
       frequency: weekly
     meeting_url: https://zoom.us/j/2419653117
     meeting_archive_url: https://docs.google.com/document/d/1z8MQpr_jTwhmjLMUaqQyBk1EYG_Y_3D4y4YdMJ7V1Kk
+    meeting_recordings_url: https://www.youtube.com/watch?v=BbFjuxe3N4w&list=PL69nYSiGNLP0ofY51bEooJ4TKuQtUSizR
     contact:
       slack: sig-testing
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-testing
@@ -643,6 +669,7 @@ sigs:
       frequency: weekly
     meeting_url: https://groups.google.com/forum/#!forum/kubernetes-sig-ui
     meeting_archive_url: https://docs.google.com/document/d/1PwHFvqiShLIq8ZpoXvE3dSUnOv1ts5BTtZ7aATuKd-E/edit?usp=sharing
+    meeting_recordings_url:
     contact:
       slack: sig-ui
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-ui
@@ -660,6 +687,7 @@ sigs:
       frequency: weekly
     meeting_url: https://zoom.us/my/sigwindows
     meeting_archive_url: https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431
+    meeting_recordings_url: https://www.youtube.com/watch?v=7zawb3KT9Xk&list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4
     contact:
       slack: sig-windows
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-windows
@@ -681,6 +709,7 @@ workinggroups:
       frequency: weekly (On demand)
     meeting_url: https://zoom.us/j/4799874685
     meeting_archive_url: https://docs.google.com/document/d/1j3vrG6BgE0hUDs2e-1ZUegKN4W4Adb1B6oJ6j-4kyPU
+    meeting_recordings_url: https://www.youtube.com/watch?v=FUUJeWIEej0&list=PL69nYSiGNLP2uTrVwZCFtdEvLQvsbG2w4
     contact:
       slack: wg-resource-mgmt
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-resource-management
@@ -701,6 +730,7 @@ workinggroups:
       frequency: bi-weekly (On demand)
     meeting_url: TBD
     meeting_archive_url: https://docs.google.com/document/d/1bCK-1_Zy2WfsrMBJkdaV72d2hidaxZBhS5YQHAgscPI/edit
+    meeting_recordings_url:
     contact:
       slack: wg-container-identity
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-container-identity

--- a/wg-container-identity/README.md
+++ b/wg-container-identity/README.md
@@ -14,6 +14,7 @@ Ensure containers are able to interact with external systems and acquire secure 
 * [Tuesdays at 15:00 UTC](TBD) (bi-weekly (On demand)). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1bCK-1_Zy2WfsrMBJkdaV72d2hidaxZBhS5YQHAgscPI/edit).
+Meeting recordings can be found [here]().
 
 ## Organizers
 * [Clayton Coleman](https://github.com/smarterclayton), Red Hat

--- a/wg-resource-management/README.md
+++ b/wg-resource-management/README.md
@@ -14,6 +14,7 @@ Designing and shepherding cross-cutting features around compute resource isolati
 * [Tuesdays at 18:00 UTC](https://zoom.us/j/4799874685) (weekly (On demand)). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1j3vrG6BgE0hUDs2e-1ZUegKN4W4Adb1B6oJ6j-4kyPU).
+Meeting recordings can be found [here](https://www.youtube.com/watch?v=FUUJeWIEej0&list=PL69nYSiGNLP2uTrVwZCFtdEvLQvsbG2w4).
 
 ## Organizers
 * [Vishnu Kannan](https://github.com/vishh), Google


### PR DESCRIPTION
Note: Some SIG's do not have their meeting recordings and are left blank.