### PR TITLE
Updated with few changes in wording to reflect the k8s graduation state

### DIFF
--- a/committee-steering/cncf-and-k8s.md
+++ b/committee-steering/cncf-and-k8s.md
@@ -1,14 +1,14 @@
 # Relationship with CNCF
 
-The Kubernetes project is a CNCF project, currently in incubation. 
+The Kubernetes project is a CNCF (Cloud Native Computing Foundation) project. 
 
 The Steering Committee is the designated top-level project leadership body which serves 
 as the project's interface to the foundation (as opposed to all of the maintainers of all
-repositories). The Kubernetes project aims to satisfy the CNCF graduation criteria, but is
-self-governing, and reserves the right to resolve conflicts within its community, set its
-own governance policies, define its own scope, determine how and when official releases of
-Kubernetes are made and what they include, specify its own conformance criteria, maintain 
-its own marketing functions (e.g., its blog and Twitter account), establish its own resource 
+repositories). The Kubernetes project is self-governing, reserves the right to resolve 
+conflicts within its community, set its own governance policies, define its own scope, 
+determine how and when official releases of Kubernetes are made and what they include, 
+specify its own conformance criteria, maintain its own marketing functions 
+(e.g., its blog and Twitter account), establish its own resource 
 access policies, manage its own assets (including trademark enforcement boundaries), accept 
 contributions of additional subprojects, and so on. The Kubernetes project expects the CNCF
 to provide funds for essential assets and ongoing activities, requests for which must be 


### PR DESCRIPTION
Added - (Cloud Native Computing Foundation)
Removed - currently in incubation. 
Removed - aims to satisfy the CNCF graduation criteria, but
Aligned - spaces/lines after the above.