### PR TITLE
add design proposals owners

### DIFF
--- a/contributors/design-proposals/OWNERS
+++ b/contributors/design-proposals/OWNERS
@@ -1,0 +1,18 @@
+reviewers:
+  - brendandburns
+  - dchen1107
+  - jbeda
+  - lavalamp
+  - smarterclayton
+  - thockin
+  - wojtek-t
+  - bgrant0607
+approvers:
+  - brendandburns
+  - dchen1107
+  - jbeda
+  - lavalamp
+  - smarterclayton
+  - thockin
+  - wojtek-t
+  - bgrant0607


### PR DESCRIPTION
Can I get a few sig leads to propose reasonable reviewers for blunderbuss to use when assigning PRs in this dir?

I started with the top level [OWNERS](https://github.com/kubernetes/kubernetes/blob/master/OWNERS) from k/k.

If you make comment's with github handle's that should be included, I'll add them to the list of reviewers.

**NOTE** - Approvers isn't turned on yet in this repo so adding LGTM (anyone in the org can do this) will put the PR in the queue to be merged.  Being a reviewer just means you can be auto-assigned to design-proposals reviews.