### PR TITLE
Update godep instructions to recreate vendor/BUILD file

### DIFF
--- a/contributors/devel/godep.md
+++ b/contributors/devel/godep.md
@@ -87,6 +87,7 @@ rm -rf Godeps
 rm -rf vendor
 ./hack/godep-save.sh
 # Regenerate removed BUILD, licenses.
+touch vendor/BUILD
 ./hack/update-bazel.sh
 ./hack/update-godep-licenses.sh
 # If you haven't followed this doc step-by-step and haven't created a dedicated GOPATH,


### PR DESCRIPTION
If we don't recreate the `vendor/BUILD` file after deleting it, then the `all-srcs` rule in the root `BUILD.bazel` file will get updated for all changes to `vendor/`, which we definitely do not want.

/assign @nicksardo 