### PR TITLE
Update Example conventions

### DIFF
--- a/contributors/devel/kubectl-conventions.md
+++ b/contributors/devel/kubectl-conventions.md
@@ -256,10 +256,8 @@ input, output, commonly used flags, etc.
 
   * Example should contain examples
     * A comment should precede each example command. Comment should start with
-      an uppercase letter and terminate with a period
-    * Start commands with `$`
-
-
+      an uppercase letter
+    * Command examples should not include a `$` prefix
 
 * Use "FILENAME" for filenames
 


### PR DESCRIPTION
**Why this PR is needed**
Currently `kubectl-conventions.md` contains incorrect conventions for command examples. File currently stipulates that example commands should start with a `$`, this is incorrect.

Currently conventions stipulate that command example comments should terminate with a period. This is overly restrictive and trivial. Conventions would be better if this was relaxed to allow developer discretion.

**What this PR does**
Remove `$` convention and stipulate explicitly that command examples **do not** start with a `$`. Remove convention stipulating command examples terminate with a period.