### PR TITLE
Modify Eviction Strategy to take Priority into account

### DIFF
--- a/contributors/design-proposals/kubelet-eviction.md
+++ b/contributors/design-proposals/kubelet-eviction.md
@@ -249,7 +249,9 @@ their scheduling request.
 
 It will target pods whose usage of the starved resource exceeds its requests.
 Of those pods, it will rank by a function of priority, and usage - requests.
-If system daemons are exceeding their allocation (see [Strategy Caveat](strategy-caveat) below),
+Roughly speaking, if a pod has twice the priority of another pod, it will
+recieve half the penalty for usage above requests. If system daemons are 
+exceeding their allocation (see [Strategy Caveat](strategy-caveat) below),
 and all pods are using less than their requests, then it will evict a pod
 whose usage is less than requests, based on the function of priority, and
 usage - requests.


### PR DESCRIPTION
Previously, I introduced a number of possible methods for introducing priority: https://github.com/kubernetes/community/pull/846.
We came to agreement on using the strategy:
### Only evict pods where usage > requests.  Then sort by Function(priority, usage - requests)
This solution provides users with a clear path to avoiding evictions. It prevents abuse by high-priority pods by not allowing them to disrupt other pods that are below, or near their requests.  Using a function provides a more nuanced approach to allowing pods to consume "unused" (not requested) memory on the node.  Power users, or cluster administrators can determine how unused memory is allocated to pods by choosing priority levels for pods that are closer for more equal sharing of extra memory, or further apart to give better availability to higher priority pods.  For pods that have equal priority, the function is equivalent to usage - requests, so that clusters that do not have priority enabled maintain behavior that is similar (though not exactly the same) as today's behavior.

This PR changes the eviction documentation to include this change in the eviction strategy, and removes outdated information on inode eviction.
@kubernetes/sig-node-proposals
@derekwaynecarr @vishh @dchen1107 @sjenning
@davidopp @bsalamat