### PR TITLE
Adding new SIG BigData Lead

### DIFF
--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -18,6 +18,7 @@ Meeting recordings can be found [here]().
 
 ## Leads
 * [Anirudh Ramanathan](https://github.com/foxish), Google
+* [Erik Erlandson](https://github.com/erikerlandson), Redhat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-big-data)


### PR DESCRIPTION
Added new SIG Lead:
Announcement: https://groups.google.com/forum/#!topic/kubernetes-sig-big-data/CdJFcLVux4U