### PR TITLE
Display github handle for sig leads

### DIFF
--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -12,7 +12,7 @@ Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
 
 ## Leads
 {{- range .Leads }}
-* [{{.Name}}](https://github.com/{{.GitHub}}){{if .Company}}, {{.Company}}{{end}}
+* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
 {{- end }}
 
 ## Contact

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -12,14 +12,14 @@ Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
 
 ## Organizers
 {{- range .Leads }}
-* [{{.Name}}](https://github.com/{{.GitHub}}){{if .Company}}, {{.Company}}{{end}}
+* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
 {{- end }}
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
 * [Mailing list]({{.Contact.MailingList}})
 {{if .Contact.FullGitHubTeams}}
-## GitHub Teams
+## GitHub Teams
 {{range .Contact.GithubTeamNames -}}
 * [@{{.}}](https://github.com/kubernetes/teams/{{.}})
 {{end}}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://goo.gl/x5nWrF).
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=Lj1ScbXpnpY&list=PL69nYSiGNLP21oW3hbLyjjj4XhrwKxH2R).
 
 ## Leads
-* [Daniel Smith](https://github.com/lavalamp), Google
-* [David Eads](https://github.com/deads2k), Red Hat
+* Daniel Smith (**[@lavalamp](https://github.com/lavalamp)**), Google
+* David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-api-machinery)

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -17,9 +17,9 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=hn23Z-vL_cM&list=PL69nYSiGNLP2LMq7vznITnpd2Fk1YIZF3).
 
 ## Leads
-* [Michelle Noorali](https://github.com/michelleN), Microsoft
-* [Matt Farina](https://github.com/mattfarina), Samsung SDS
-* [Adnan Abdulhussein](https://github.com/prydonius), Bitnami
+* Michelle Noorali (**[@michelleN](https://github.com/michelleN)**), Microsoft
+* Matt Farina (**[@mattfarina](https://github.com/mattfarina)**), Samsung SDS
+* Adnan Abdulhussein (**[@prydonius](https://github.com/prydonius)**), Bitnami
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-apps)

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=d5ERqm3oHN0&list=PL69nYSiGNLP2m6198LaLN6YahX7EEac5g).
 
 ## Leads
-* [Brian Grant](https://github.com/bgrant0607), Google
-* [Jaice Singer DuMars](https://github.com/jdumars), Microsoft
+* Brian Grant (**[@bgrant0607](https://github.com/bgrant0607)**), Google
+* Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Microsoft
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-architecture)

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -17,9 +17,9 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=DJDuDNALcMo&list=PL69nYSiGNLP0VMOZ-V7-5AchXTHAQFzJw).
 
 ## Leads
-* [Eric Chiang](https://github.com/ericchiang), CoreOS
-* [Jordan Liggitt](https://github.com/liggitt), Red Hat
-* [David Eads](https://github.com/deads2k), Red Hat
+* Eric Chiang (**[@ericchiang](https://github.com/ericchiang)**), CoreOS
+* Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**), Red Hat
+* David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-auth)

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here]().
 
 ## Leads
-* [Marcin Wielgus](https://github.com/mwielgus), Google
-* [Solly Ross](https://github.com/directxman12), Red Hat
+* Marcin Wielgus (**[@mwielgus](https://github.com/mwielgus)**), Google
+* Solly Ross (**[@directxman12](https://github.com/directxman12)**), Red Hat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-autoscaling)

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -17,10 +17,10 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here]().
 
 ## Leads
-* [Justin Santa Barbara](https://github.com/justinsb)
-* [Kris Nova](https://github.com/kris-nova), Microsoft
-* [Chris Love](https://github.com/chrislovecnm)
-* [Mackenzie Burnett](https://github.com/mfburnett), Redspread
+* Justin Santa Barbara (**[@justinsb](https://github.com/justinsb)**)
+* Kris Nova (**[@kris-nova](https://github.com/kris-nova)**), Microsoft
+* Chris Love (**[@chrislovecnm](https://github.com/chrislovecnm)**)
+* Mackenzie Burnett (**[@mfburnett](https://github.com/mfburnett)**), Redspread
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-aws)

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -17,9 +17,9 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4).
 
 ## Leads
-* [Jason Hansen](https://github.com/slack), Microsoft
-* [Cole Mickens](https://github.com/colemickens), Microsoft
-* [Jaice Singer DuMars](https://github.com/jdumars), Microsoft
+* Jason Hansen (**[@slack](https://github.com/slack)**), Microsoft
+* Cole Mickens (**[@colemickens](https://github.com/colemickens)**), Microsoft
+* Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Microsoft
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-azure)

--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit).
 
 ## Leads
-* [Anirudh Ramanathan](https://github.com/foxish), Google
-* [Erik Erlandson](https://github.com/erikerlandson), Redhat
+* Anirudh Ramanathan (**[@foxish](https://github.com/foxish)**), Google
+* Erik Erlandson (**[@erikerlandson](https://github.com/erikerlandson)**), Redhat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-big-data)

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -17,9 +17,9 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=X29sffrQJU4&list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF).
 
 ## Leads
-* [Fabiano Franz](https://github.com/fabianofranz), Red Hat
-* [Phillip Wittrock](https://github.com/pwittrock), Google
-* [Tony Ado](https://github.com/AdoHe), Alibaba
+* Fabiano Franz (**[@fabianofranz](https://github.com/fabianofranz)**), Red Hat
+* Phillip Wittrock (**[@pwittrock](https://github.com/pwittrock)**), Google
+* Tony Ado (**[@AdoHe](https://github.com/AdoHe)**), Alibaba
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-cli)

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -17,15 +17,15 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/a/weave.wor
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=ljK5dgSA7vc&list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 
 ## Leads
-* [Luke Marsden](https://github.com/lukemarsden), Weave
-* [Joe Beda](https://github.com/jbeda), Heptio
-* [Robert Bailey](https://github.com/roberthbailey), Google
+* Luke Marsden (**[@lukemarsden](https://github.com/lukemarsden)**), Weave
+* Joe Beda (**[@jbeda](https://github.com/jbeda)**), Heptio
+* Robert Bailey (**[@roberthbailey](https://github.com/roberthbailey)**), Google
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-cluster-lifecycle)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
 
-## GitHub Teams
+## GitHub Teams
 * [@sig-cluster-lifecycle-misc](https://github.com/kubernetes/teams/sig-cluster-lifecycle-misc)
 * [@sig-cluster-lifecycle-test-failures](https://github.com/kubernetes/teams/sig-cluster-lifecycle-test-failures)
 * [@sig-cluster-lifecycle-bugs](https://github.com/kubernetes/teams/sig-cluster-lifecycle-bugs)

--- a/sig-cluster-ops/README.md
+++ b/sig-cluster-ops/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=7uyy37pCk4U&list=PL69nYSiGNLP3b38liicqy6fm2-jWT4FQR).
 
 ## Leads
-* [Rob Hirschfeld](https://github.com/zehicle), RackN
-* [Jaice Singer DuMars](https://github.com/jdumars), Microsoft
+* Rob Hirschfeld (**[@zehicle](https://github.com/zehicle)**), RackN
+* Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Microsoft
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-cluster-ops)

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr).
 
 ## Leads
-* [Garrett Rodrigues](https://github.com/grodrigues3), Google
-* [Elsie Phillips](https://github.com/Phillels), CoreOS
+* Garrett Rodrigues (**[@grodrigues3](https://github.com/grodrigues3)**), Google
+* Elsie Phillips (**[@Phillels](https://github.com/Phillels)**), CoreOS
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-contribex)

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here]().
 
 ## Leads
-* [Devin Donnelly](https://github.com/devin-donnelly), Google
-* [Jared Bhatti](https://github.com/jaredbhatti), Google
+* Devin Donnelly (**[@devin-donnelly](https://github.com/devin-donnelly)**), Google
+* Jared Bhatti (**[@jaredbhatti](https://github.com/jaredbhatti)**), Google
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-docs)

--- a/sig-federation/README.md
+++ b/sig-federation/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=iWKC3FsNHWg&list=PL69nYSiGNLP0HqgyqTby6HlDEz7i1mb0-).
 
 ## Leads
-* [Christian Bell](https://github.com/csbell), Google
-* [Quinton Hoole](https://github.com/quinton-hoole), Huawei
+* Christian Bell (**[@csbell](https://github.com/csbell)**), Google
+* Quinton Hoole (**[@quinton-hoole](https://github.com/quinton-hoole)**), Huawei
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-federation)

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here]().
 
 ## Leads
-* [Piotr Szczesniak](https://github.com/piosz), Google
-* [Fabian Reinartz](https://github.com/fabxc), CoreOS
+* Piotr Szczesniak (**[@piosz](https://github.com/piosz)**), Google
+* Fabian Reinartz (**[@fabxc](https://github.com/fabxc)**), CoreOS
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-instrumentation)

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -17,9 +17,9 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=phCA5-vWkVM&list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb).
 
 ## Leads
-* [Tim Hockin](https://github.com/thockin), Google
-* [Dan Williams](https://github.com/dcbw), Red Hat
-* [Casey Davenport](https://github.com/caseydavenport), Tigera
+* Tim Hockin (**[@thockin](https://github.com/thockin)**), Google
+* Dan Williams (**[@dcbw](https://github.com/dcbw)**), Red Hat
+* Casey Davenport (**[@caseydavenport](https://github.com/caseydavenport)**), Tigera
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-network)

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -16,8 +16,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=FbKOI9-x9hI&list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG).
 
 ## Leads
-* [Dawn Chen](https://github.com/dchen1107), Google
-* [Derek Carr](https://github.com/derekwaynecarr), Red Hat
+* Dawn Chen (**[@dchen1107](https://github.com/dchen1107)**), Google
+* Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**), Red Hat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-node)

--- a/sig-on-premise/README.md
+++ b/sig-on-premise/README.md
@@ -17,15 +17,15 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=dyUWqqNYUio&list=PL69nYSiGNLP2MvqC6NeegrgtOl5s1KlYa).
 
 ## Leads
-* [Tomasz Napierala](https://github.com/zen), Mirantis
-* [Marco Ceppi](https://github.com/marcoceppi), Canonical
-* [Dalton Hubble](https://github.com/dghubble), CoreOS
+* Tomasz Napierala (**[@zen](https://github.com/zen)**), Mirantis
+* Marco Ceppi (**[@marcoceppi](https://github.com/marcoceppi)**), Canonical
+* Dalton Hubble (**[@dghubble](https://github.com/dghubble)**), CoreOS
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-onprem)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-on-prem)
 
-## GitHub Teams
+## GitHub Teams
 * [@onprem-misc](https://github.com/kubernetes/teams/onprem-misc)
 * [@onprem-test-failures](https://github.com/kubernetes/teams/onprem-test-failures)
 * [@onprem-bugs](https://github.com/kubernetes/teams/onprem-bugs)

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=iCfUx7ilh0E&list=PL69nYSiGNLP20iTSChQ_i2QQmTBl3M7ax).
 
 ## Leads
-* [Ihor Dvoretskyi](https://github.com/idvoretskyi), Mirantis
-* [Steve Gordon](https://github.com/xsgordon), Red Hat
+* Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**), Mirantis
+* Steve Gordon (**[@xsgordon](https://github.com/xsgordon)**), Red Hat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-openstack)

--- a/sig-product-management/README.md
+++ b/sig-product-management/README.md
@@ -20,9 +20,9 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=VcdjaZAol2I&list=PL69nYSiGNLP3EBqpUGVsK1sMgUZVomfEQ).
 
 ## Leads
-* [Aparna Sinha](https://github.com/apsinha), Google
-* [Ihor Dvoretskyi](https://github.com/idvoretskyi), Mirantis
-* [Caleb Miles](https://github.com/calebamiles), CoreOS
+* Aparna Sinha (**[@apsinha](https://github.com/apsinha)**), Google
+* Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**), Mirantis
+* Caleb Miles (**[@calebamiles](https://github.com/calebamiles)**), CoreOS
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/kubernetes-pm)

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -16,8 +16,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=I0KbWz8MTMk&list=PL69nYSiGNLP3QKkOsDsO6A0Y1rhgP84iZ).
 
 ## Leads
-* [Phillip Wittrock](https://github.com/pwittrock), Google
-* [Caleb Miles](https://github.com/calebamiles), CoreOS
+* Phillip Wittrock (**[@pwittrock](https://github.com/pwittrock)**), Google
+* Caleb Miles (**[@calebamiles](https://github.com/calebamiles)**), CoreOS
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-release)

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -19,9 +19,9 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/a/bobsplane
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=NDP1uYyom28&list=PL69nYSiGNLP2X-hzNTqyELU6jYS3p10uL).
 
 ## Leads
-* [Wojciech Tyczynski](https://github.com/wojtek-t), Google
-* [Bob Wise](https://github.com/countspongebob), Samsung SDS
-* [Joe Beda](https://github.com/jbeda), Heptio
+* Wojciech Tyczynski (**[@wojtek-t](https://github.com/wojtek-t)**), Google
+* Bob Wise (**[@countspongebob](https://github.com/countspongebob)**), Samsung SDS
+* Joe Beda (**[@jbeda](https://github.com/jbeda)**), Heptio
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-scalability)

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=PweKj6SU7UA&list=PL69nYSiGNLP2vwzcCOhxrL3JVBc-eaJWI).
 
 ## Leads
-* [David Oppenheimer](https://github.com/davidopp), Google
-* [Timothy St. Clair](https://github.com/timothysc), Red Hat
+* David Oppenheimer (**[@davidopp](https://github.com/davidopp)**), Google
+* Timothy St. Clair (**[@timothysc](https://github.com/timothysc)**), Red Hat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-scheduling)

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -17,10 +17,10 @@ Meeting notes and Agenda can be found [here](http://goo.gl/A0m24V).
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=ukPj1sFFkr0&list=PL69nYSiGNLP2k9ZXx9E1MvRSotFDoHUWs).
 
 ## Leads
-* [Paul Morie](https://github.com/pmorie), Red Hat
-* [Aaron Schlesinger](https://github.com/arschles), Microsoft
-* [Ville Aikas](https://github.com/vaikas-google), Google
-* [Doug Davis](https://github.com/duglin), IBM
+* Paul Morie (**[@pmorie](https://github.com/pmorie)**), Red Hat
+* Aaron Schlesinger (**[@arschles](https://github.com/arschles)**), Microsoft
+* Ville Aikas (**[@vaikas-google](https://github.com/vaikas-google)**), Google
+* Doug Davis (**[@duglin](https://github.com/duglin)**), IBM
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-service-catalog)

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=Eh7Qa7KOL8o&list=PL69nYSiGNLP02-BMqJdfFgGxYQ4Nb-2Qq).
 
 ## Leads
-* [Saad Ali](https://github.com/saad-ali), Google
-* [Bradley Childs](https://github.com/childsb), Red Hat
+* Saad Ali (**[@saad-ali](https://github.com/saad-ali)**), Google
+* Bradley Childs (**[@childsb](https://github.com/childsb)**), Red Hat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-storage)

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -17,9 +17,9 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=BbFjuxe3N4w&list=PL69nYSiGNLP0ofY51bEooJ4TKuQtUSizR).
 
 ## Leads
-* [Aaron Crickenberger](https://github.com/spiffxp), Samsung SDS
-* [Erick Feja](https://github.com/fejta), Google
-* [Timothy St. Clair](https://github.com/timothysc), Heptio
+* Aaron Crickenberger (**[@spiffxp](https://github.com/spiffxp)**), Samsung SDS
+* Erick Feja (**[@fejta](https://github.com/fejta)**), Google
+* Timothy St. Clair (**[@timothysc](https://github.com/timothysc)**), Heptio
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-testing)

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here]().
 
 ## Leads
-* [Dan Romlein](https://github.com/danielromlein), Apprenda
-* [Sebastian Florek](https://github.com/floreks), Fujitsu
+* Dan Romlein (**[@danielromlein](https://github.com/danielromlein)**), Apprenda
+* Sebastian Florek (**[@floreks](https://github.com/floreks)**), Fujitsu
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-ui)

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -17,7 +17,7 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=7zawb3KT9Xk&list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4).
 
 ## Leads
-* [Michael Michael](https://github.com/michmike), Apprenda
+* Michael Michael (**[@michmike](https://github.com/michmike)**), Apprenda
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-windows)

--- a/wg-container-identity/README.md
+++ b/wg-container-identity/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here]().
 
 ## Organizers
-* [Clayton Coleman](https://github.com/smarterclayton), Red Hat
-* [Greg Gastle](https://github.com/destijl), Google
+* Clayton Coleman (**[@smarterclayton](https://github.com/smarterclayton)**), Red Hat
+* Greg Gastle (**[@destijl](https://github.com/destijl)**), Google
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/wg-container-identity)

--- a/wg-resource-management/README.md
+++ b/wg-resource-management/README.md
@@ -17,8 +17,8 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 Meeting recordings can be found [here](https://www.youtube.com/watch?v=FUUJeWIEej0&list=PL69nYSiGNLP2uTrVwZCFtdEvLQvsbG2w4).
 
 ## Organizers
-* [Vishnu Kannan](https://github.com/vishh), Google
-* [Derek Carr](https://github.com/derekwaynecarr), Red Hat
+* Vishnu Kannan (**[@vishh](https://github.com/vishh)**), Google
+* Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**), Red Hat
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/wg-resource-mgmt)


### PR DESCRIPTION
This changes the template format of the sig readmes so that the github handle for sig leads is displayed as well as linked to.