### PR TITLE
Remove getvolume, as it is not supported and ignored

### DIFF
--- a/contributors/devel/flexvolume.md
+++ b/contributors/devel/flexvolume.md
@@ -27,13 +27,6 @@ See [Driver output](#driver-output) for the capabilities map format.
 <driver executable> init
 ```
 
-#### Get volume name:
-Get a cluster wide unique volume name for the volume. Called from both Kubelet & Controller manager.
-
-```
-<driver executable> getvolumename <json options>
-```
-
 #### Attach:
 Attach the volume specified by the given spec on the given host. On success, returns the device path where the device is attached on the node. Nodename param is only valid/relevant if "--enable-controller-attach-detach" Kubelet option is enabled. Called from both Kubelet & Controller manager.
 


### PR DESCRIPTION
Based on discussion on kubernetes-sig-storage:

Some drivers implemented getvolume, some didn't[4]. Is it expected to be a name of an existing volume on the storage? Can nodename+volumename be considered unique?
[Chakri] GetVolumeName is not supported and is ignored. You don’t have to implement it.


[4] https://github.com/kubernetes/kubernetes/commit/7885aaf6896d66a69658a9f55cd6063488ad3e06