### PR TITLE
Fix 'Upgrading Go' outdated description

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -144,10 +144,7 @@ images.
 
 - The image for cross compiling in [build/build-image/cross].
   The `VERSION` file and `Dockerfile`.
-- Update [dockerized-e2e-runner.sh] to run a kubekins-e2e with the desired Go
-  version. This requires pushing the [e2e][e2e-image] and [test][test-image]
-  images that are `FROM` the desired Go version.
-- The cross tag `KUBE_BUILD_IMAGE_CROSS_TAG` in [build/common.sh].
+- This requires pushing the [test][test-image] image that are `FROM` the desired Go version.
 
 
 #### Dependency management
@@ -418,9 +415,6 @@ masse. This makes reviews easier.
 
 [OS X GNU tools]: https://www.topbug.net/blog/2013/04/14/install-and-use-gnu-command-line-tools-in-mac-os-x
 [build/build-image/cross]: https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross
-[build/common.sh]: https://github.com/kubernetes/kubernetes/blob/master/build/common.sh
-[dockerized-e2e-runner.sh]: https://github.com/kubernetes/test-infra/blob/master/jenkins/dockerized-e2e-runner.sh
-[e2e-image]: https://github.com/kubernetes/test-infra/tree/master/jenkins/e2e-image
 [etcd-latest]: https://coreos.com/etcd/docs/latest
 [etcd-install]: testing.md#install-etcd-dependency
 <!-- https://github.com/coreos/etcd/releases -->


### PR DESCRIPTION
1. dockerized-e2e-runner.sh has been deleted， FYI [#3702](https://github.com/kubernetes/test-infra/pull/3702)
2. The  [e2e-image](https://github.com/kubernetes/test-infra/tree/master/jenkins/e2e-image) and [build/common.sh](https://github.com/kubernetes/kubernetes/blob/master/build/common.sh) do not need to be updated