### PR TITLE
Removing prom-push-gateway flag

### DIFF
--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -229,10 +229,6 @@ when a failure occurs
 
 --kubeconfig="": Path to kubeconfig containing embedded authinfo.
 
---prom-push-gateway="": The URL to prometheus gateway, so that metrics can be
-pushed during e2es and scraped by prometheus. Typically something like
-127.0.0.1:9091.
-
 --provider="": The name of the Kubernetes provider (gce, gke, local, vagrant,
 etc.)
 


### PR DESCRIPTION
The flag does not work anymore as per https://github.com/kubernetes/kubernetes/issues/45947