### PR TITLE
WIP: versioning of external provisioner protocol

### DIFF
--- a/contributors/design-proposals/storage/volume-provisioning.md
+++ b/contributors/design-proposals/storage/volume-provisioning.md
@@ -60,26 +60,26 @@ We propose that:
 3.  An api object will be incubated in storage.k8s.io/v1beta1 to hold the a `StorageClass`
     API resource. Each StorageClass object contains parameters required by the provisioner to provision volumes of that class.  These parameters are opaque to the user.
 
-4.  `PersistentVolume.Spec.Class` attribute is added to volumes. This attribute
+4.  `PersistentVolume.Spec.StorageClassName` attribute is added to volumes. This attribute
     is optional and specifies which `StorageClass` instance represents
     storage characteristics of a particular PV.
 
-    During incubation, `Class` is an annotation and not
+    During incubation, `StorageClassName` is an annotation and not
     actual attribute.
 
 5.  `PersistentVolume` instances do not require labels by the provisioner.
 
-6.  `PersistentVolumeClaim.Spec.Class` attribute is added to claims. This
+6.  `PersistentVolumeClaim.Spec.StorageClassName` attribute is added to claims. This
     attribute specifies that only a volume with equal
-    `PersistentVolume.Spec.Class` value can satisfy a claim.
+    `PersistentVolume.Spec.StorageClassName` value can satisfy a claim.
 
-    During incubation, `Class` is just an annotation and not
+    During incubation, `StorageClassName` is just an annotation and not
     actual attribute.
 
 7.  The existing provisioner plugin implementations be modified to accept
     parameters as specified via `StorageClass`.
 
-8.  The persistent volume controller modified to invoke provisioners using `StorageClass` configuration and bind claims with `PersistentVolumeClaim.Spec.Class` to volumes with equivalent `PersistentVolume.Spec.Class`
+8.  The persistent volume controller modified to invoke provisioners using `StorageClass` configuration and bind claims with `PersistentVolumeClaim.Spec.StorageClassName` to volumes with equivalent `PersistentVolume.Spec.StorageClassName`
 
 9.  The existing alpha dynamic provisioning feature be phased out in the
     next release.
@@ -89,24 +89,24 @@ We propose that:
 0. Kubernetes administator can configure name of a default StorageClass. This
    StorageClass instance is then used when user requests a dynamically
    provisioned volume, but does not specify a StorageClass. In other words,
-   `claim.Spec.Class == ""`
+   `claim.Spec.StorageClassName == ""`
    (or annotation `volume.beta.kubernetes.io/storage-class == ""`).
 
 1.  When a new claim is submitted, the controller attempts to find an existing
     volume that will fulfill the claim.
 
-    1. If the claim has non-empty `claim.Spec.Class`, only PVs with the same
-        `pv.Spec.Class` are considered.
+    1. If the claim has non-empty `claim.Spec.StorageClassName`, only PVs with the same
+        `pv.Spec.StorageClassName` are considered.
 
-    2. If the claim has empty `claim.Spec.Class`, only PVs with an unset `pv.Spec.Class` are considered.
+    2. If the claim has empty `claim.Spec.StorageClassName`, only PVs with an unset `pv.Spec.StorageClassName` are considered.
 
     All "considered" volumes are evaluated and the
     smallest matching volume is bound to the claim.
 
-2.  If no volume is found for the claim and `claim.Spec.Class` is not set or is
+2.  If no volume is found for the claim and `claim.Spec.StorageClassName` is not set or is
     empty string dynamic provisioning is disabled.
 
-3.  If `claim.Spec.Class` is set the controller tries to find instance of StorageClass with this name.  If no
+3.  If `claim.Spec.StorageClassName` is set the controller tries to find instance of StorageClass with this name.  If no
     such StorageClass is found, the controller goes back to step 1. and
     periodically retries finding a matching volume or storage class again until
     a match is found. The claim is `Pending` during this period.
@@ -130,7 +130,7 @@ We propose that:
       periodically.
 
   8.  If `Provision` returns no error, the controller creates the returned
-      `api.PersistentVolume`, fills its `Class` attribute with `claim.Spec.Class`
+      `api.PersistentVolume`, fills its `StorageClassName` attribute with `claim.Spec.StorageClassName`
       and makes it already bound to the claim
 
     1.  If the create operation for the `api.PersistentVolume` fails, it is
@@ -141,7 +141,7 @@ We propose that:
         on the claim
 
 Existing behavior is unchanged for claims that do not specify
-`claim.Spec.Class`.
+`claim.Spec.StorageClassName`.
 
 * **Out of tree provisioning**
 
@@ -415,22 +415,22 @@ type StorageClass struct {
 
 ```
 
-`PersistentVolumeClaimSpec` and `PersistentVolumeSpec` both get Class attribute
+`PersistentVolumeClaimSpec` and `PersistentVolumeSpec` both get StorageClassName attribute
 (the existing annotation is used during incubation):
 
 ```go
 type PersistentVolumeClaimSpec struct {
     // Name of requested storage class. If non-empty, only PVs with this
-    // pv.Spec.Class will be considered for binding and if no such PV is
+    // pv.Spec.StorageClassName will be considered for binding and if no such PV is
     // available, StorageClass with this name will be used to dynamically
     // provision the volume.
-    Class string
+    StorageClassName string
 ...
 }
 
 type PersistentVolumeSpec struct {
     // Name of StorageClass instance that this volume belongs to.
-    Class string
+    StorageClassName string
 ...
 }
 ```
@@ -487,9 +487,9 @@ parameters:
 
 # Additional Implementation Details
 
-0. Annotation `volume.alpha.kubernetes.io/storage-class` is used instead of `claim.Spec.Class` and `volume.Spec.Class` during incubation.
+0. Annotation `volume.alpha.kubernetes.io/storage-class` is used instead of `claim.Spec.StorageClassName` and `volume.Spec.StorageClassName` during incubation.
 
-1. `claim.Spec.Selector` and `claim.Spec.Class` are mutually exclusive for now (1.4). User can either match existing volumes with `Selector` XOR match existing volumes with `Class` and get dynamic provisioning by using `Class`. This simplifies initial PR and also provisioners. This limitation may be lifted in future releases.
+1. `claim.Spec.Selector` and `claim.Spec.StorageClassName` are mutually exclusive for now (1.4). User can either match existing volumes with `Selector` XOR match existing volumes with `StorageClassName` and get dynamic provisioning by using `StorageClassName`. This simplifies initial PR and also provisioners. This limitation may be lifted in future releases.
 
 # Cloud Providers
 


### PR DESCRIPTION
In 1.8 we introduced new fields in `StorageClass` that old provisioner won't understand. Therefore we should introduce some generic versioning mechanism so old provisioner that don't support new features know that a newer feature is requested and not provision a PVC.

There are two new annotations introduced, one that makes the PVCs that need newer features invisible to the old provisioner, second one introduces very simple versioning based on Kubernetes release.

We missed this in 1.8 development and now it becomes a bug. Should we fix it before 1.8 is released?

@kubernetes/sig-storage-pr-reviews  @kangarlou 