### PR TITLE
Adjust the value of the current and long-term goal.

### DIFF
--- a/sig-scalability/thresholds.md
+++ b/sig-scalability/thresholds.md
@@ -42,7 +42,7 @@ Important notes about the numbers:
 | Total number of all objects         | 250000         |             | 1000000        |
 | Number of nodes                     | 5000           |             | 5000           |
 | Number of pods                      | 150000         |             | 500000         |
-| Number of pods per node<sup>1</sup> | 100            |             | 100            |
+| Number of pods per node<sup>1</sup> | 110            |             | 500            |
 | Number of pods per core<sup>1</sup> | 10             |             | 10             |
 | Number of namespaces (ns)           | 10000          |             | 100000         |
 | Number of pods per ns               | 15000          |             | 50000          |


### PR DESCRIPTION
Now, the number of max pods per machine is 110: https://github.com/kubernetes/kubernetes.github.io/blob/master/docs/admin/kubelet.md

The goal of max pods per machine is 500: https://github.com/kubernetes/community/blob/master/sig-scalability/goals.md