### PR TITLE
removed link from modified how-to-doc.md

### DIFF
--- a/contributors/devel/how-to-doc.md
+++ b/contributors/devel/how-to-doc.md
@@ -117,7 +117,6 @@ spec:
     - containerPort: 80
 ```
 
-[Download example](../../test/fixtures/doc-yaml/user-guide/pod.yaml?raw=true)
 <!-- END MUNGE: EXAMPLE ../../test/fixtures/doc-yaml/user-guide/pod.yaml -->
 
 ## Misc.


### PR DESCRIPTION
I could see that the example link is not available . I have removed the link form the doc