### PR TITLE
Fixed links to architecture.md and principles.md

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -6,7 +6,7 @@ The Kubernetes community adheres to the following principles:
 * Open: Kubernetes is open source. See repository guidelines and CLA, below.
 * Welcoming and respectful: See Code of Conduct, below.
 * Transparent and accessible: Work and collaboration should be done in public. See SIG governance, below.
-* Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, [scope](http://kubernetes.io/docs/whatisk8s/), and [design principles](contributors/design-proposals/principles.md).
+* Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, [scope](http://kubernetes.io/docs/whatisk8s/), and [design principles](contributors/design-proposals/architecture/principles.md).
 
 # Code of Conduct
 

--- a/sig-architecture/charter.md
+++ b/sig-architecture/charter.md
@@ -16,10 +16,10 @@ Specific areas of focus include:
 * Maintaining, evolving, and enforcing the deprecation policy
   * [Deprecation policy](https://kubernetes.io/docs/reference/deprecation-policy/)
 * Documenting and evolving the system architecture
-  * [Kubernetes Design and Architecture](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture.md)
+  * [Kubernetes Design and Architecture](../contributors/design-proposals/architecture/architecture.md)
 * Defining and driving necessary extensibility points
 * Establishing and documenting design principles
-  * [Design principles](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/principles.md)
+  * [Design principles](../contributors/design-proposals/architecture/principles.md)
 * Establishing and documenting conventions for system and user-facing APIs
   * [API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md)
 * Developing necessary technical review processes, such as the proposal and API review processes


### PR DESCRIPTION
Looks like principles.md and architecture.md, moved into the subdirectory architecture a few weeks ago. The links no longer work.

This PR fixes the links to these documents.