### PR TITLE
Fix sig-cli meeting recordings url

### DIFF
--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -14,7 +14,7 @@ Covers kubectl and related tools. We focus on the development and standardizatio
 * [Wednesdays at 16:00 UTC](https://zoom.us/my/sigcli) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing).
-Meeting recordings can be found [here](https://www.youtube.com/watch?v=X29sffrQJU4&list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF).
+Meeting recordings can be found [here](https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF).
 
 ## Leads
 * Fabiano Franz (**[@fabianofranz](https://github.com/fabianofranz)**), Red Hat

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -218,7 +218,7 @@ sigs:
       frequency: biweekly
     meeting_url: https://zoom.us/my/sigcli
     meeting_archive_url: https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing
-    meeting_recordings_url: https://www.youtube.com/watch?v=X29sffrQJU4&list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF
+    meeting_recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF
     contact:
       slack: sig-cli
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cli


### PR DESCRIPTION
Previously some random video was playing on clicking the hyperlink for meeting recordings.