### PR TITLE
Rename security-context-constraints.md to pod-security-policy.md

### DIFF
--- a/contributors/design-proposals/auth/apparmor.md
+++ b/contributors/design-proposals/auth/apparmor.md
@@ -85,7 +85,7 @@ annotation. If a profile is specified, the Kubelet will verify that the node mee
 the container, and will not run the container if the profile cannot be applied. If the requirements
 are met, the container runtime will configure the appropriate options to apply the profile. Profile
 requirements and defaults can be specified on the
-[PodSecurityPolicy](security-context-constraints.md).
+[PodSecurityPolicy](pod-security-policy.md).
 
 ## Prerequisites
 
@@ -136,7 +136,7 @@ The profiles can be specified in the following formats (following the convention
 
 ### Pod Security Policy
 
-The [PodSecurityPolicy](security-context-constraints.md) allows cluster administrators to control
+The [PodSecurityPolicy](pod-security-policy.md) allows cluster administrators to control
 the security context for a pod and its containers. An annotation can be specified on the
 PodSecurityPolicy to restrict which AppArmor profiles can be used, and specify a default if no
 profile is specified.

--- a/contributors/design-proposals/auth/pod-security-policy.md
+++ b/contributors/design-proposals/auth/pod-security-policy.md
@@ -343,9 +343,3 @@ for a specific UID and fail early if possible.  However, if the `RunAsUser` is n
 it should still admit the pod and allow the Kubelet to ensure that the image does not run as
 `root` with the existing non-root checks.
 
-
-
-
-<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/proposals/security-context-constraints.md?pixel)]()
-<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/contributors/design-proposals/auth/runas-groupid.md
+++ b/contributors/design-proposals/auth/runas-groupid.md
@@ -230,6 +230,3 @@ At a high level, the changes classify into:
 - api/swagger-spec/
 - api/openapi-spec/swagger.json
 
-<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
-[![AnalytIcs](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/proposals/security-context-constraints.md?pixel)]()
-<!-- END MUNGE: GENERATED_ANALYTICS -->  

--- a/contributors/design-proposals/dir_struct.txt
+++ b/contributors/design-proposals/dir_struct.txt
@@ -129,8 +129,8 @@ Uncategorized
 	image-provenance.md
 	no-new-privs.md
 	pod-security-context.md
+	pod-security-policy.md
 	secrets.md
-	security-context-constraints.md
 	security.md
 	security_context.md
 	service_accounts.md

--- a/contributors/design-proposals/node/sysctl.md
+++ b/contributors/design-proposals/node/sysctl.md
@@ -561,7 +561,7 @@ During kubelet launch the given value is checked against the list of known names
 
 #### Alternative 1: by name
 
-A list of permissible sysctls is to be added to `pkg/apis/extensions/types.go` (compare [security-context-constraints](security-context-constraints.md)):
+A list of permissible sysctls is to be added to `pkg/apis/extensions/types.go` (compare [pod-security-policy](pod-security-policy.md)):
 
 ```go
 // PodSecurityPolicySpec defines the policy enforced.


### PR DESCRIPTION
It's counter intuitive that proposal about PSP has name `security-context-constraints.md`.

@pweil- Do you have objections against renaming a file?

CC @simo5