### PR TITLE
Update generator to use WHAT variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build-image:
 	docker build -q -t $(IMAGE_NAME) -f generator/Dockerfile generator
 
 generate: build-image
-	docker run --rm -e WG -e SIG -v $(shell pwd):/go/src/app/generated:Z $(IMAGE_NAME) app
+	docker run --rm -e WHAT -v $(shell pwd):/go/src/app/generated:Z $(IMAGE_NAME) app
 
 verify:
 	@hack/verify.sh

--- a/generator/README.md
+++ b/generator/README.md
@@ -30,15 +30,16 @@ To (re)build documentation for all the SIGs, run these commands:
 make all
 ```
 
-To build docs for one SIG, run these commands:
+To build docs for one SIG, run one these commands:
 
 ```bash
-make SIG=sig-apps gen-docs
-make SIG=sig-testing gen-docs
-make WG=resource-management gen-docs
+make WHAT=sig-apps
+make WHAT=cluster-lifecycle
+make WHAT=wg-resource-management
+make WHAT=container-identity
 ```
 
-where the `SIG` or `WG` var refers to the directory being built.
+where the `WHAT` var refers to the directory being built.
 
 ## Adding custom content to your README
 

--- a/generator/app.go
+++ b/generator/app.go
@@ -200,14 +200,14 @@ func writeCustomContentBlock(f *os.File, content string) {
 func createGroupReadme(groups []Group, prefix string) error {
 	// figure out if the user wants to generate one group
 	var selectedGroupName *string
-	if envVal, ok := os.LookupEnv(strings.ToUpper(prefix)); ok {
+	if envVal, ok := os.LookupEnv("WHAT"); ok {
 		selectedGroupName = &envVal
 	}
 
 	for _, group := range groups {
 		group.Dir = group.DirName(prefix)
 		// skip generation if the user specified only one group
-		if selectedGroupName != nil && *selectedGroupName != group.Dir {
+		if selectedGroupName != nil && strings.HasSuffix(group.Dir, *selectedGroupName) == false {
 			fmt.Printf("Skipping %s/README.md\n", group.Dir)
 			continue
 		}


### PR DESCRIPTION
Having to set two different variables is confusing. Changed this to look at the `WHAT` envvar and match on a suffix.

Fixes #1126.

cc: @jamiehannaford 