### PR TITLE
Don't retire kube-state-metrics. Retire md-check.

### DIFF
--- a/incubator.md
+++ b/incubator.md
@@ -110,7 +110,7 @@ These are grandfathered in as full projects:
 - github.com/kubernetes/community
 - github.com/kubernetes/release
 - github.com/kubernetes/features
-- github.com/kubernetes/md-check
+- github.com/kubernetes/kube-state-metrics
 - github.com/kubernetes/pr-bot - move from mungebot, etc from contrib, currently running in "prod" on github.com/kubernetes
 - github.com/kubernetes/dashboard
 - github.com/kubernetes/helm  (Graduated from incubator on Feb 2017)
@@ -141,7 +141,7 @@ These projects are young but have significant user facing docs pointing at their
 - github.com/kubernetes/contrib - new projects could be created from the code in this repo, issue to move
 - github.com/kubernetes/kubedash
 - github.com/kubernetes/kubernetes-docs-cn
-- github.com/kubernetes/kube-state-metrics
+- github.com/kubernetes/md-check
 
 ## Thank You
 


### PR DESCRIPTION
kube-state-metrics is active once again (it became active soon after the first commit to this file when it was proposed to be retired). It seems to be the only popular tool that does what it does.

Decision to retire md-check was taken in https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/kubernetes-dev/0FcCGNtnxE0/JmQfETD0AwAJ