### PR TITLE
Clearer generator docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -3,13 +3,5 @@
 - If you are editing SIG information, please follow these instructions: https://github.com/kubernetes/community/tree/master/generator
   You will need to follow these steps:
   1. Edit sigs.yaml with your change 
-  2. Generate docs with `make all`. To build docs for one sig, run `make WHAT=sig-apps all`
+  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
 -->
-
-**What this PR does**:
-
-**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
-
-**SIG changes**
-
-- [] If changing SIG information, I have read [these instructions](https://github.com/kubernetes/community/tree/master/generator) and re-generated the docs

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,15 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
+- If you are editing SIG information, please follow these instructions: https://github.com/kubernetes/community/tree/master/generator
+  You will need to follow these steps:
+  1. Edit sigs.yaml with your change 
+  2. Generate docs with `make all`. To build docs for one sig, run `make WHAT=sig-apps all`
+-->
+
+**What this PR does**:
+
+**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
+
+**SIG changes**
+
+- [] If changing SIG information, I have read [these instructions](https://github.com/kubernetes/community/tree/master/generator) and re-generated the docs

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ A SIG can have its own policy for contribution,
 described in a `README` or `CONTRIBUTING` file in the SIG
 folder in this repo (e.g. [sig-cli/CONTRIBUTING](sig-cli/CONTRIBUTING.md)),
 and its own mailing list, slack channel, etc.
-  
+
+If you want to edit details about a SIG (e.g. its weekly meeting time or its leads), 
+please follow [these instructions](./generator) that detail how our docs are auto-generated.
+
 ## How Can I Help?
 
 Documentation (like the text you are reading now) can


### PR DESCRIPTION
There still seems to be a few PRs that are unaware of how to generate SIG docs, so this PR hopes to plug that knowledge gap by:

- adding a reference to the README
- adding a PR template that contributors see every time they send a changeset

We might not need the checkbox in the PR template, so I can remove if we feel it should go.

Fixes #1121.

/cc @xiangpengzhao @cblecker 