### PR TITLE
Update priority eviction docs

### DIFF
--- a/contributors/design-proposals/node/kubelet-eviction.md
+++ b/contributors/design-proposals/node/kubelet-eviction.md
@@ -248,15 +248,12 @@ Priority, and are the largest consumers of the starved resource relative to
 their scheduling request.
 
 It will target pods whose usage of the starved resource exceeds its requests.
-Of those pods, it will rank by a function of priority, and usage - requests.
-Roughly speaking, if a pod has twice the priority of another pod, it will
-recieve half the penalty for usage above requests. If system daemons are 
-exceeding their allocation (see [Strategy Caveat](strategy-caveat) below),
-and all pods are using less than their requests, then it will evict a pod
-whose usage is less than requests, based on the function of priority, and
-usage - requests.
+Of those pods, it will rank by priority, then usage - requests. If system 
+daemons are exceeding their allocation (see [Strategy Caveat](strategy-caveat) below),
+and all pods are using less than their requests, then it must evict a pod
+whose usage is less than requests, based on priority, then usage - requests.
 
-Prior to v1.8:
+Prior to v1.9:
 The `kubelet` will implement a default eviction strategy oriented around
 the pod quality of service class.
 


### PR DESCRIPTION
After discussion with @dchen1107 and @bsalamat I think it would be simpler to start with a tiered eviction sorting rather than by using a function.  See https://github.com/kubernetes/community/pull/846#pullrequestreview-66920328 for some of the rationale.

This PR makes two changes:

1. Changes the release at which changes take effect to 1.9 (since implementation missed 1.8)
2. Changes the strategy from (usage > requests, func(priority, usage - requests)) to (usage > requests, priority, usage - requests)

cc @dchen1107 @derekwaynecarr @vishh 