### PR TITLE
Fix name and link to k8s oncall.

### DIFF
--- a/contributors/devel/on-call-user-support.md
+++ b/contributors/devel/on-call-user-support.md
@@ -73,7 +73,7 @@ useful for someone else in the future, please send a PR or file an issue in
 
 ### Contact information
 
-[@k8s-support-oncall](https://github.com/k8s-support-oncall) will reach the
+[@k8s-oncall](https://github.com/k8s-oncall) will reach the
 current person on call.
 
 


### PR DESCRIPTION
https://github.com/k8s-oncall works
https://github.com/search?q=k8s-support-oncall&type=Users&utf8=%E2%9C%93
shows no matches, and https://github.com/k8s-support-oncall is a 404.

I guess this is another call for #359.