### PR TITLE
Remove a useless link to an empty document.

### DIFF
--- a/contributors/devel/README.md
+++ b/contributors/devel/README.md
@@ -20,8 +20,6 @@ Guide](http://kubernetes.io/docs/admin/).
 
 * **Kubernetes On-Call Rotations** ([on-call-rotations.md](on-call-rotations.md)): Descriptions of on-call rotations for build and end-user support.
 
-* **Faster PR reviews** ([faster_reviews.md](faster_reviews.md)): How to get faster PR reviews.
-
 * **Getting Recent Builds** ([getting-builds.md](getting-builds.md)): How to get recent builds including the latest builds that pass CI.
 
 * **Automated Tools** ([automation.md](automation.md)): Descriptions of the automation that is running on our github repository.


### PR DESCRIPTION
The target was merged with a different doc which is already linked from
this one.