### PR TITLE
Expand the e2e acronym.

### DIFF
--- a/contributors/devel/automation.md
+++ b/contributors/devel/automation.md
@@ -11,7 +11,7 @@ processes.
 
 In an effort to
    * reduce load on core developers
-   * maintain e2e stability
+   * maintain end-to-end test stability
    * load test github's label feature
 
 We have added an automated [submit-queue](https://github.com/kubernetes/test-infra/tree/master/mungegithub/submit-queue)


### PR DESCRIPTION
When a new k8s contributor reads through the developer guide, this
document is the first one which mentions e2e. Expanding the acronym
here helps to keep the learning curve gentle.