### PR TITLE
First pass at revising the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,39 @@
-# Contributing to the community repo
+# Contributing to the Community Repo
 
-Make a [pull request](https://help.github.com/articles/using-pull-requests) (PR).
+Welcome to the Kubernetes Community contributing guide. We are excited about the prospect of you joining our [community](https://github.com/kubernetes/community)!
 
-Upon successful review, someone will give the PR
+## Finding Something to Work On
+
+Before you begin, you can look at some places where you can help out:
+
+- [Existing open issues](https://github.com/kubernetes/community/issues)
+- [Open Pull Requests](https://github.com/kubernetes/community/pulls) - Most of the pull requests in this repository are not code, but documentation and process. This is a great place to get started. Even if you do not have the rights to merge you can still help by doing a review.
+
+## Steps
+
+1. Make a [Pull Request](https://help.github.com/articles/using-pull-requests) (PR).
+2. Upon successful review, someone will give the PR
 a __LGTM__ (_looks good to me_) in the review thread.
-
-A [SIG lead](sig-list.md) (or someone with approval powers
+3. A [SIG lead](sig-list.md) (or someone with approval powers
 as specified in an OWNERS file) may merge the PR immediately
 with or without an LGTM from someone else.
 Or they may wait a business day to get further feedback from other reviewers.
+
+### Trivial Edits
+
+Each incoming Pull Request needs to be reviewed, checked, and then merged. 
+While automation helps with this, each contribution also has an engineering cost. Therefore it is appreciated if you do NOT make trivial edits and fixes, but instead focus on giving the entire file a review.
+If you find one grammatical or spelling error, it is likely there are more in that file, you can really make your Pull Request count by checking formatting, checking for broken links, and fixing errors and then submitting all the fixes at once to that file.
+Some questions to consider:
+- Can the file be improved further?
+- Does the trivial edit greatly improve the quality of the content?
+
+## Contributing to Individual SIGs
+
+Each SIG may or may not have it's own policies for editing their section of this repository.
 
 Edits in SIG sub-directories should follow any additional guidelines described
 by the respective SIG leads in the sub-directory's `CONTRIBUTING` file
 (e.g. [sig-cli/CONTRIBUTING](sig-cli/CONTRIBUTING.md)).
 
- 
+Attending a [SIG meeting](https://github.com/kubernetes/community/blob/master/sig-list.md) or posting on their mailing list might be prudent if you want to make extensive contributions.


### PR DESCRIPTION
Note: There is a larger effort to write a full contributor guide, so this is mostly a revision. Biggest change is an addition of a section for how we should deal with trivial edits, which mostly is a crib from StackOverflow's policies on dealing with trivial edits. 

Fixes #1226