### PR TITLE
fix misspelled word `overriden` to `overridden`

### DIFF
--- a/contributors/design-proposals/apps/daemonset-update.md
+++ b/contributors/design-proposals/apps/daemonset-update.md
@@ -132,7 +132,7 @@ type DaemonSetSpec struct {
 
 // DaemonSetStatus represents the current status of a daemon set.
 type DaemonSetStatus struct {
-	// Note: Existing fields, including CurrentNumberScheduled, NumberMissscheduled,
+	// Note: Existing fields, including CurrentNumberScheduled, NumberMisscheduled,
 	// DesiredNumberScheduled, NumberReady, and ObservedGeneration are omitted in
 	// this proposal.
 
@@ -250,7 +250,7 @@ In DaemonSet strategy (pkg/registry/extensions/daemonset/strategy.go#PrepareForU
 increase DaemonSet's `.spec.templateGeneration` by 1 if any changes is made to
 DaemonSet's `.spec.template`.
 
-This was originally implmeneted in 1.6, and kept in 1.7 for backward compatibility.
+This was originally implemented in 1.6, and kept in 1.7 for backward compatibility.
 
 ### kubectl 
 

--- a/contributors/design-proposals/apps/stateful-apps.md
+++ b/contributors/design-proposals/apps/stateful-apps.md
@@ -346,7 +346,7 @@ Requested features:
 
 * Jobs can be used to perform a run-once initialization of the cluster
 * Init containers can be used to prime PVs and config with the identity of the pod.
-* Templates and how fields are overriden in the resulting object should have broad alignment
+* Templates and how fields are overridden in the resulting object should have broad alignment
 * DaemonSet defines the core model for how new controllers sit alongside replication controller and
   how upgrades can be implemented outside of Deployment objects.
 

--- a/contributors/design-proposals/auth/runas-groupid.md
+++ b/contributors/design-proposals/auth/runas-groupid.md
@@ -11,7 +11,7 @@ As a Kubernetes User, we should be able to specify both user id and group id for
 inside a pod on a per Container basis, similar to how docker allows that using docker run options `-u, 
 --user="" Username or UID (format: <name|uid>[:<group|gid>]) format`.
 
-PodSecurityContext allows Kubernetes users to specify RunAsUser which can be overriden by RunAsUser
+PodSecurityContext allows Kubernetes users to specify RunAsUser which can be overridden by RunAsUser
 in SecurityContext on a per Container basis. There is no equivalent field for specifying the primary
 Group of the running container.
 


### PR DESCRIPTION
fix misspelled word `overriden` to `overridden`