### PR TITLE
Fix #1263: bad reference for push-federation-images in e2e-test

### DIFF
--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -338,7 +338,7 @@ Next, specify the docker repository where your ci images will be pushed.
 * Push the federation container images
 
   ```sh
-  $ build/push-federation-images.sh
+  $ federation/develop/push-federation-images.sh
   ```
 
 #### Deploy federation control plane

--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -1,7 +1,5 @@
 # End-to-End Testing in Kubernetes
 
-Updated: 5/3/2016
-
 **Table of Contents**
 <!-- BEGIN MUNGE: GENERATED_TOC -->
 
@@ -389,8 +387,8 @@ to gather logs.
 This script requires that the cluster provider supports ssh. Assuming it does,
 running:
 
-```
-cluster/log-dump.sh <directory>
+```sh
+$ federation/cluster/log-dump.sh <directory>
 ```
 
 will ssh to the master and all nodes and download a variety of useful logs to


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

Fix #1263

1. According to https://github.com/kubernetes/kubernetes/pull/42140,  "build/push-federation-images.sh" shoud be "federation/develop/push-federation-images.sh"

2. " cluster/log-dump.sh" should be "federation/cluster/log-dump.sh"