### PR TITLE
Remove Disk Allocatable Evictions

### DIFF
--- a/contributors/design-proposals/node/kubelet-eviction.md
+++ b/contributors/design-proposals/node/kubelet-eviction.md
@@ -440,15 +440,6 @@ from placing new best effort pods on the node since they will be rejected by the
 On the other hand, the `DiskPressure` condition if true should dissuade the scheduler from
 placing **any** new pods on the node since they will be rejected by the `kubelet` in admission.
 
-## Enforcing Node Allocatable
-
-To enforce [Node Allocatable](./node-allocatable.md), Kubelet primarily uses cgroups.
-However `storage` cannot be enforced using cgroups.
-
-Once Kubelet supports `storage` as an `Allocatable` resource, Kubelet will perform evictions whenever the total storage usage by pods exceed node allocatable.
-
-If a pod cannot tolerate evictions, then ensure that requests is set and it will not exceed `requests`.
-
 ## Best Practices
 
 ### DaemonSet


### PR DESCRIPTION
After https://github.com/kubernetes/kubernetes/issues/52336, which uncovered a bug in disk accounting, I have struggled to see why ephemeral-storage allocatable evictions are necessary.
For CPU and Memory allocatable, enforcing allocatable through cgroups provides protection from being starved of compute resources by user pods.
However, for ephemeral-storage it seems that the node-level enforcement mechanisms are able to prevent the node from running out of disk, and thus prevent impact to system daemons.
Additionally, memory usage metrics read from cgroups or statfs are far more reliable than an aggregation of `du` calls which may be collected at different times (as https://github.com/kubernetes/kubernetes/issues/52336 demonstrated).
(As a side note, we should read from the /kubepods cgroup to determine allocatable memory usage)
We should still keep the scheduling aspects of node allocatable for ephemeral storage, as this allows for proper accounting.  But I would like to remove enforcement of node allocatable for ephemeral storage.

cc @dchen1107 @derekwaynecarr @jingxu97 @vishh @saad-ali 
@kubernetes/sig-node-proposals 