### PR TITLE
api-changes: update proto script

### DIFF
--- a/contributors/devel/api_changes.md
+++ b/contributors/devel/api_changes.md
@@ -576,7 +576,7 @@ The auto-generated code resides with each versioned API:
 To regenerate them run:
 
 ```sh
-hack/update-codecgen.sh
+hack/update-generated-protobuf.sh
 ```
 
 ## Making a new API Version


### PR DESCRIPTION
There is no script called `hack/update-codecgen.sh` anymore and the proto files are generated using `hack/update-generated-protobuf.sh`.