### PR TITLE
fixed get-describe-apiserver-extensions.md and container-init.md

### DIFF
--- a/contributors/design-proposals/cli/get-describe-apiserver-extensions.md
+++ b/contributors/design-proposals/cli/get-describe-apiserver-extensions.md
@@ -142,7 +142,7 @@ compiled in printer exist for a type?
 
 Client doesn't find the open-api extensions.  Fallback on 1.5 behavior.
 
-In the future, this will provide stronger backwards / forwards compability
+In the future, this will provide stronger backwards / forwards compatibility
 as it will allow clients to print objects
 
 #### Newer server

--- a/contributors/design-proposals/node/container-init.md
+++ b/contributors/design-proposals/node/container-init.md
@@ -426,7 +426,7 @@ container status `reason` and `message` fields while the pod is in the
               - mountPath: /var/run/docker.sock
                 volumeName: dockersocket
 
-## Backwards compatibilty implications
+## Backwards compatibility implications
 
 Since this is a net new feature in the API and Kubelet, new API servers during upgrade may not
 be able to rely on Kubelets implementing init containers. The management of feature skew between


### PR DESCRIPTION
`compability` to `compatibility`

`compatibilty` to `compatibility`
