### PR TITLE
fix miss-leading word in devel/api-conventionsOC

### DIFF
--- a/contributors/devel/api-conventions.md
+++ b/contributors/devel/api-conventions.md
@@ -531,7 +531,7 @@ duration in seconds before the object should be deleted. Individual kinds may
 declare fields which provide a default grace period, and different kinds may
 have differing kind-wide default grace periods. A user provided grace period
 overrides a default grace period, including the zero grace period ("now").
-* PUT /&lt;resourceNamePlural&gt;/&lt;name&gt; - Update or create the resource
+* PUT /&lt;resourceNamePlural&gt;/&lt;name&gt; - Update the resource
 with the given name with the JSON object provided by the client.
 * PATCH /&lt;resourceNamePlural&gt;/&lt;name&gt; - Selectively modify the
 specified fields of the resource. See more information [below](#patch-operations).


### PR DESCRIPTION
This expression `Update or create` is very miss-leading. As i know, In kubernetes （now 1.8）, `PUT` is used as `replace` other than `upsert`, which means it will not create any resource. 

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://github.com/kubernetes/community/tree/master/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->