### PR TITLE
add readOnly use case to raw block device proposal

### DIFF
--- a/contributors/design-proposals/storage/raw-block-pv.md
+++ b/contributors/design-proposals/storage/raw-block-pv.md
@@ -528,6 +528,40 @@ spec:
         name: my-nginx-data 
 	readOnly: false
 ```
+## UC9:
+
+DESCRIPTION:
+* A user wishes to read data from a read-only raw block device, an example might be a database for analytics processing. 
+
+ADMIN:
+* Admin creates a 1 block devices and with the intention consumption of read-only.
+
+USER:
+* User creates pod and specifies 'readOnly' as a parameter in the persistent volume claim to indicate they would
+like to be bound to a PV with this setting enabled.
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod-block-001
+spec:
+  containers:
+    - name: nginx-container
+      image: nginx:latest
+      ports:
+      - containerPort: 80
+      volumeDevices:
+        - name: data
+          devicePath: /dev/xvda
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: block-pvc001
+        readOnly: true #flag indicating read-only for container runtime
+```
+*** Note: the readOnly field already exists in the PersistentVolumeClaimVolumeSource above and will dictate the values set by the container runtime options ***
+
 
 # Container Runtime considerations
 It is important the values that are passed to the container runtimes are valid and support the current implementation of these various runtimes. Listed below are a table of various runtime and the mapping of their values to what is passed from the kubelet.

--- a/contributors/design-proposals/storage/raw-block-pv.md
+++ b/contributors/design-proposals/storage/raw-block-pv.md
@@ -533,9 +533,6 @@ spec:
 DESCRIPTION:
 * A user wishes to read data from a read-only raw block device, an example might be a database for analytics processing. 
 
-ADMIN:
-* Admin creates a 1 block devices and with the intention consumption of read-only.
-
 USER:
 * User creates pod and specifies 'readOnly' as a parameter in the persistent volume claim to indicate they would
 like to be bound to a PV with this setting enabled.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://github.com/kubernetes/community/tree/master/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
This PR is an addendum to the #1265 to dictate the behavior of the container runtime for read-only devices as specified in the PVCVolumeSource. The precedence already exists for filesystems thus having a consistent behavior for the user. UC9 was added to illustrate the usage.