### PR TITLE
Update links in sig docs

### DIFF
--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -22,6 +22,9 @@ Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
 * [Mailing list]({{.Contact.MailingList}})
+{{- if .Label }}
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2F{{.Label}})
+{{- end }}
 {{if .Contact.FullGitHubTeams}}
 ## GitHub Teams
 {{range .Contact.GithubTeamNames -}}

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -7,8 +7,12 @@
 * [{{.Day}}s at {{.UTC}} UTC]({{$.MeetingURL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.UTC}}&tz=UTC).
 {{- end }}
 
+{{ if .MeetingArchiveURL -}}
 Meeting notes and Agenda can be found [here]({{.MeetingArchiveURL}}).
+{{- end }}
+{{ if .MeetingRecordingsURL -}}
 Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
+{{- end }}
 
 ## Leads
 {{- range .Leads }}

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -22,6 +22,9 @@ Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
 * [Mailing list]({{.Contact.MailingList}})
+{{- if .Label }}
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2F{{.Label}})
+{{- end }}
 {{if .Contact.FullGitHubTeams}}
 ## GitHub Teams
 {{range .Contact.GithubTeamNames -}}

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -7,8 +7,12 @@
 * [{{.Day}}s at {{.UTC}} UTC]({{$.MeetingURL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.UTC}}&tz=UTC).
 {{- end }}
 
+{{ if .MeetingArchiveURL -}}
 Meeting notes and Agenda can be found [here]({{.MeetingArchiveURL}}).
+{{- end }}
+{{ if .MeetingRecordingsURL -}}
 Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
+{{- end }}
 
 ## Organizers
 {{- range .Leads }}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=Lj1ScbXpn
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-api-machinery)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapi-machinery)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Additional links

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -24,6 +24,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=hn23Z-vL_
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-apps)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapps)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=d5ERqm3oH
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-architecture)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Farchitecture)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -24,6 +24,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=DJDuDNALc
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-auth)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-auth)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fauth)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -14,7 +14,7 @@ Covers autoscaling of clusters, horizontal and vertical autoscaling of pods, set
 * [Mondays at 14:00 UTC](https://zoom.us/my/k8s.sig.autoscaling) (biweekly/triweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1RvhQAEIrVLHbyNnuaT99-6u9ZUMp7BfkPupT2LAZK7w/edit).
-Meeting recordings can be found [here]().
+
 
 ## Leads
 * Marcin Wielgus (**[@mwielgus](https://github.com/mwielgus)**), Google
@@ -23,6 +23,7 @@ Meeting recordings can be found [here]().
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-autoscaling)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fautoscaling)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Concerns

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -14,7 +14,7 @@ Covers maintaining, supporting, and using Kubernetes hosted on AWS Cloud.
 * [Fridays at 16:00 UTC](https://zoom.us/my/k8ssigaws) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit).
-Meeting recordings can be found [here]().
+
 
 ## Leads
 * Justin Santa Barbara (**[@justinsb](https://github.com/justinsb)**)
@@ -25,6 +25,7 @@ Meeting recordings can be found [here]().
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-aws)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-aws)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Faws)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -24,6 +24,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=yQLeUKi_d
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-azure)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-azure)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fazure)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://docs.google.com/document/d/1pnF38
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-big-data)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fbig-data)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -24,6 +24,7 @@ Meeting recordings can be found [here](https://www.youtube.com/playlist?list=PL6
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-cli)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cli)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcli)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -25,6 +25,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=ljK5dgSA7
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-cluster-lifecycle)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcluster-lifecycle)
 
 ## GitHub Teams
 * [@sig-cluster-lifecycle-misc](https://github.com/kubernetes/teams/sig-cluster-lifecycle-misc)

--- a/sig-cluster-ops/README.md
+++ b/sig-cluster-ops/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=7uyy37pCk
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-cluster-ops)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-ops)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcluster-ops)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=EMGUdOKwS
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-contribex)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-contribex)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/playlist?list=PL6
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-docs)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fdocs)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -14,7 +14,7 @@ Covers best practices for cluster observability through metrics, logging, and ev
 * [Thursdays at 16:30 UTC](https://zoom.us/j/5342565819) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:30&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1gWuAATtlmI7XJILXd31nA4kMq6U9u63L70382Y3xcbM/edit).
-Meeting recordings can be found [here]().
+
 
 ## Leads
 * Piotr Szczesniak (**[@piosz](https://github.com/piosz)**), Google
@@ -23,6 +23,7 @@ Meeting recordings can be found [here]().
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-instrumentation)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Finstrumentation)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=iWKC3FsNH
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-multicluster)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fmulticluster)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -24,6 +24,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=phCA5-vWk
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-network)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-network)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnetwork)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Areas of Responsibility

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -22,6 +22,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=FbKOI9-x9
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-node)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnode)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-on-premise/README.md
+++ b/sig-on-premise/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=dyUWqqNYU
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-onprem)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-on-prem)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fonprem)
 
 ## GitHub Teams
 * [@onprem-misc](https://github.com/kubernetes/teams/onprem-misc)

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=iCfUx7ilh
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-openstack)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fopenstack)
 
 ## GitHub Teams
 * [@sig-openstack-misc](https://github.com/kubernetes/teams/sig-openstack-misc)

--- a/sig-product-management/README.md
+++ b/sig-product-management/README.md
@@ -27,6 +27,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=VcdjaZAol
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/kubernetes-pm)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-pm)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnone)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Common activities

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -22,6 +22,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=I0KbWz8MT
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-release)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Frelease)
 
 <!-- BEGIN CUSTOM CONTENT -->
 [SIG Release][] has moved!

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -26,6 +26,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=NDP1uYyom
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-scalability)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scale)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscalability)
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Remaining 2017 Meeting Dates

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=PweKj6SU7
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-scheduling)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscheduling)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -25,6 +25,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=ukPj1sFFk
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-service-catalog)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fservice-catalog)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -23,6 +23,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=Eh7Qa7KOL
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-storage)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fstorage)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -24,6 +24,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=BbFjuxe3N
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-testing)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-testing)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Ftesting)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -14,7 +14,7 @@ Covers all things UI related. Efforts are centered around Kubernetes Dashboard: 
 * [Thursdays at 16:00 UTC](https://groups.google.com/forum/#!forum/kubernetes-sig-ui) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1PwHFvqiShLIq8ZpoXvE3dSUnOv1ts5BTtZ7aATuKd-E/edit?usp=sharing).
-Meeting recordings can be found [here]().
+
 
 ## Leads
 * Dan Romlein (**[@danielromlein](https://github.com/danielromlein)**), Google
@@ -23,6 +23,7 @@ Meeting recordings can be found [here]().
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-ui)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fui)
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -22,6 +22,7 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=7zawb3KT9
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-windows)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-windows)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fwindows)
 
 <!-- BEGIN CUSTOM CONTENT -->
 * Recorded Meetings Playlist on Youtube: https://www.youtube.com/playlist?list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4&jct=LZ9EIvD4DGrhr2h4r0ItaBmco7gTgw

--- a/wg-app-def/README.md
+++ b/wg-app-def/README.md
@@ -15,7 +15,7 @@ Charter can be found [here](https://docs.google.com/document/d/1TzRwzWYRulx4o8Fi
 * [Wednesdays at 16:00 UTC](https://zoom.us/j/748123863) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1Pxc-qwAt4FvuISZ_Ib5KdUwlynFkGueuzPx5Je_lbGM/edit).
-Meeting recordings can be found [here]().
+
 
 ## Organizers
 * Antoine Legrand (**[@ant31](https://github.com/ant31)**), CoreOS

--- a/wg-cluster-api/README.md
+++ b/wg-cluster-api/README.md
@@ -13,7 +13,7 @@ Define a portable API that represents a Kubernetes cluster. The API will contain
 ## Meetings
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/16ils69KImmE94RlmzjWDrkmFZysgB2J4lGnYMRN89WM/edit).
-Meeting recordings can be found [here]().
+
 
 ## Organizers
 * Kris Nova (**[@kris-nova](https://github.com/kris-nova)**), Microsoft

--- a/wg-container-identity/README.md
+++ b/wg-container-identity/README.md
@@ -14,7 +14,7 @@ Ensure containers are able to interact with external systems and acquire secure 
 * [Tuesdays at 15:00 UTC](TBD) (bi-weekly (On demand)). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC).
 
 Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/1uH60pNr1-jBn7N2pEcddk6-6NTnmV5qepwKUJe9tMRo/edit).
-Meeting recordings can be found [here]().
+
 
 ## Organizers
 * Clayton Coleman (**[@smarterclayton](https://github.com/smarterclayton)**), Red Hat


### PR DESCRIPTION
Does a couple of things:
- Only displays the archive/recording URL if there actually is one in sigs.yaml
- If a label exists for the sig/wg, then display a link to the open PRs/Issues for that sig.