### PR TITLE
Fixed anchor to ConfigMaps

### DIFF
--- a/contributors/design-proposals/service-catalog/pod-preset.md
+++ b/contributors/design-proposals/service-catalog/pod-preset.md
@@ -15,7 +15,7 @@
       * [PodPreset Exclude Annotation](#podpreset-exclude-annotation)
   * [Examples](#examples)
     * [Simple Pod Spec Example](#simple-pod-spec-example)
-    * [Pod Spec with `ConfigMap` Example](#pod-spec-with-`configmap`-example)
+    * [Pod Spec with `ConfigMap` Example](#pod-spec-with-configmap-example)
     * [ReplicaSet with Pod Spec Example](#replicaset-with-pod-spec-example)
     * [Multiple PodPreset Example](#multiple-podpreset-example)
     * [Conflict Example](#conflict-example)


### PR DESCRIPTION
Removed ' ' to fix anchor to ConfigMaps example part.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://github.com/kubernetes/community/tree/master/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->