### PR TITLE
Add a contributor cheatsheet

### DIFF
--- a/contributors/devel/contributor-cheatsheet.md
+++ b/contributors/devel/contributor-cheatsheet.md
@@ -1,0 +1,42 @@
+# Kubernetes Cheat Sheet
+
+A list of common resources when contributing to Kubernetes.
+
+| Repo | PRs | Issues | Notes |
+| ---- | --- | ------ | ----- |
+| [Kubernetes](https://github.com/kubernetes/kubernetes) | [PRs](https://github.com/kubernetes/kubernetes/pulls) | [Issues](https://github.com/kubernetes/kubernetes/issues) | [Meeting Notes](http://bit.ly/kubenotes)
+| [Community](https://github.com/kubernetes/community) | [PRs](https://github.com/kubernetes/community/pulls) | [Issues](https://github.com/kubernetes/community/issues) |
+| [Docs](https://github.com/kubernetes/website) | [PRs](https://github.com/kubernetes/website/pulls) | [Issues](https://github.com/kubernetes/website/issues)
+
+## Workflow
+
+- [Gubernator Dashboard - k8s.reviews](https://k8s-gubernator.appspot.com/pr)
+- [reviewable.kubernetes.io](https://reviewable.kubernetes.io/reviews#-)
+- [Submit Queue](https://submit-queue.k8s.io)
+- [Bot commands](https://github.com/kubernetes/test-infra/blob/master/commands.md)
+- [Release Buckets](http://gcsweb.k8s.io/gcs/kubernetes-release/)
+- Developer Guide
+  - [Cherry Picking Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md) - [Queue](http://cherrypick.k8s.io/#/queue)
+
+## SIGs and Working Groups
+
+- [Master SIG list](https://github.com/kubernetes/community/blob/master/sig-list.md#master-sig-list)
+
+## Community
+
+- [Calendar](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com)
+- [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev)
+- [kubernetes-users](https://groups.google.com/forum/#!forum/kubernetes-users)
+- [Slack channels](http://slack.k8s.io/)
+- [StackOverflow](https://stackoverflow.com/questions/tagged/kubernetes)
+- [YouTube Channel](https://www.youtube.com/c/KubernetesCommunity/)
+
+## Tests
+
+- [Current Test Status](https://prow.k8s.io/)
+- [Aggregated Failures](https://storage.googleapis.com/k8s-gubernator/triage/index.html)
+- [Test Grid](https://k8s-testgrid.appspot.com/)
+
+## Other
+
+- [Developer Statistics](https://devstats.k8s.io)


### PR DESCRIPTION
This started as a list of resources I would check on every day, sort of like a portal page from the 90s meets the kubectl cheat sheet. Then I started to ask around what URLs people use day-to-day and then people asked for a copy, so I figured it wouldn't be a bad thing to share: 

Contrib-ex discussion and proposal: https://groups.google.com/forum/#!topic/kubernetes-wg-contribex/-azSwMpLsZE

I think this still needs a few things to be useful to more people, perhaps someone with front end experience can make it shiny, in the meantime setting it as your new tab page in the browser has been working for me. 