### PR TITLE
change preserve-order-in-strategic-merge-patch.md

### DIFF
--- a/contributors/design-proposals/cli/preserve-order-in-strategic-merge-patch.md
+++ b/contributors/design-proposals/cli/preserve-order-in-strategic-merge-patch.md
@@ -4,7 +4,7 @@ Author: @mengqiy
 
 ## Motivation
 
-Background of the Strategic Merge Patch is convered [here](../devel/strategic-merge-patch.md).
+Background of the Strategic Merge Patch is covered [here](../devel/strategic-merge-patch.md).
 
 The Kubernetes API may apply semantic meaning to the ordering of items within a list,
 however the strategic merge patch does not keeping the ordering of elements.


### PR DESCRIPTION
I think `convered ` should be `covered `.