### PR TITLE
Fix api changes doc

### DIFF
--- a/contributors/devel/api_changes.md
+++ b/contributors/devel/api_changes.md
@@ -498,7 +498,7 @@ top of the generated file and should be checked with the
 [`repo-infra/verify/verify-boilerplane.sh`](https://github.com/kubernetes/repo-infra/blob/master/verify/verify-boilerplate.sh)
 script at a later stage of the build.
 
-To invoke these generators, you can run `make generated`, which runs a bunch of
+To invoke these generators, you can run `make update`, which runs a bunch of
 [scripts](https://github.com/kubernetes/kubernetes/blob/v1.8.0-alpha.2/hack/update-all.sh#L63-L78).
 Please continue to read the next a few sections, because some generators have
 prerequisites, also because they introduce how to invoke the generators


### PR DESCRIPTION
make generated does not exist

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://github.com/kubernetes/community/tree/master/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->