### PR TITLE
List teams for each sig in sig docs

### DIFF
--- a/generator/app_test.go
+++ b/generator/app_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 )
@@ -147,34 +145,6 @@ func TestGroupDirName(t *testing.T) {
 	group := Group{Name: "Foo Bar"}
 	if group.DirName("sig") != "sig-foo-bar" {
 		t.Fatal("DirName incorrect")
-	}
-}
-
-func TestSetupGithubTeams(t *testing.T) {
-	group := Group{Name: "Foo Bar"}
-	group.SetupGitHubTeams("sig")
-
-	var expected []string
-	for _, ght := range githubTeamNames {
-		expected = append(expected, fmt.Sprintf("sig-foo-bar-%s", ght))
-	}
-
-	if !reflect.DeepEqual(group.Contact.GithubTeamNames, expected) {
-		t.Fatalf("%v does not match %v", group.Contact.GithubTeamNames, expected)
-	}
-}
-
-func TestCustomPrefixSetupGithubTeams(t *testing.T) {
-	group := Group{Contact: Contact{GithubTeamPrefix: "foo"}}
-	group.SetupGitHubTeams("")
-
-	var expected []string
-	for _, ght := range githubTeamNames {
-		expected = append(expected, fmt.Sprintf("foo-%s", ght))
-	}
-
-	if !reflect.DeepEqual(group.Contact.GithubTeamNames, expected) {
-		t.Fatalf("%v does not match %v", group.Contact.GithubTeamNames, expected)
 	}
 }
 

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -25,9 +25,15 @@ Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
 {{- if .Label }}
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2F{{.Label}})
 {{- end }}
-{{if .Contact.FullGitHubTeams}}
+{{ if .Contact.GithubTeams }}
 ## GitHub Teams
-{{range .Contact.GithubTeamNames -}}
-* [@{{.}}](https://github.com/kubernetes/teams/{{.}})
-{{end}}
-{{end}}
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+{{- range .Contact.GithubTeams }}
+| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
+{{- end }}
+{{  end }}

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -25,9 +25,15 @@ Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
 {{- if .Label }}
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2F{{.Label}})
 {{- end }}
-{{if .Contact.FullGitHubTeams}}
+{{ if .Contact.GithubTeams }}
 ## GitHub Teams
-{{range .Contact.GithubTeamNames -}}
-* [@{{.}}](https://github.com/kubernetes/teams/{{.}})
-{{end}}
-{{end}}
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+{{- range .Contact.GithubTeams }}
+| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
+{{- end }}
+{{  end }}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -25,6 +25,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=Lj1ScbXpn
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapi-machinery)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-api-machinery-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-api-machinery-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-api-machinery-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-feature-requests) | Feature Requests |
+| @kubernetes/sig-api-machinery-misc | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-misc) | General Discussion |
+| @kubernetes/sig-api-machinery-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-pr-reviews) | PR Reviews |
+| @kubernetes/sig-api-machinery-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-proposals) | Design Proposals |
+| @kubernetes/sig-api-machinery-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 ## Additional links
 

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -26,6 +26,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=hn23Z-vL_
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapps)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-apps-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-apps-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-apps-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-apps-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-apps-feature-requests) | Feature Requests |
+| @kubernetes/sig-apps-misc | [link](https://github.com/orgs/kubernetes/teams/sig-apps-misc) | General Discussion |
+| @kubernetes/sig-apps-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-pr-reviews) | PR Reviews |
+| @kubernetes/sig-apps-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-apps-proposals) | Design Proposals |
+| @kubernetes/sig-apps-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-apps-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 * Discuss running applications in k8s

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -25,6 +25,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=d5ERqm3oH
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Farchitecture)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-architecture-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-architecture-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-architecture-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-feature-requests) | Feature Requests |
+| @kubernetes/sig-architecture-misc-use-only-as-a-last-resort | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-misc-use-only-as-a-last-resort) | General Discussion |
+| @kubernetes/sig-architecture-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-pr-reviews) | PR Reviews |
+| @kubernetes/sig-architecture-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-proposals) | Design Proposals |
+| @kubernetes/sig-architecture-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Additional materials

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -26,6 +26,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=DJDuDNALc
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-auth)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fauth)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-auth-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-auth-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-auth-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-auth-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-auth-feature-requests) | Feature Requests |
+| @kubernetes/sig-auth-misc | [link](https://github.com/orgs/kubernetes/teams/sig-auth-misc) | General Discussion |
+| @kubernetes/sig-auth-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-pr-reviews) | PR Reviews |
+| @kubernetes/sig-auth-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-auth-proposals) | Design Proposals |
+| @kubernetes/sig-auth-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-auth-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 * Discuss improvements Kubernetes Authorization and Authentication, and cluster security policy.

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -25,6 +25,21 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fautoscaling)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-autoscaling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-autoscaling-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-autoscaling-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-feature-requests) | Feature Requests |
+| @kubernetes/sig-autoscaling-misc | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-misc) | General Discussion |
+| @kubernetes/sig-autoscaling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-pr-reviews) | PR Reviews |
+| @kubernetes/sig-autoscaling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-proposals) | Design Proposals |
+| @kubernetes/sig-autoscaling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 ## Concerns
 * autoscaling of clusters,

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -27,6 +27,15 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-aws)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Faws)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-aws-misc | [link](https://github.com/orgs/kubernetes/teams/sig-aws-misc) | General Discussion |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -26,6 +26,15 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=yQLeUKi_d
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-azure)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fazure)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-azure-misc | [link](https://github.com/orgs/kubernetes/teams/sig-azure-misc) | General Discussion |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -25,6 +25,21 @@ Meeting recordings can be found [here](https://docs.google.com/document/d/1pnF38
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fbig-data)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-big-data-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-big-data-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-big-data-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-feature-requests) | Feature Requests |
+| @kubernetes/sig-big-data-misc | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-misc) | General Discussion |
+| @kubernetes/sig-big-data-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-pr-reviews) | PR Reviews |
+| @kubernetes/sig-big-data-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-proposals) | Design Proposals |
+| @kubernetes/sig-big-data-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 * Design and architect ways to run big data applications effectively on Kubernetes

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -26,6 +26,22 @@ Meeting recordings can be found [here](https://www.youtube.com/playlist?list=PL6
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cli)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcli)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-cli-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-cli-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-cli-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-cli-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-cli-feature-requests) | Feature Requests |
+| @kubernetes/sig-cli-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-cli-maintainers) | CLI Maintainers |
+| @kubernetes/sig-cli-misc | [link](https://github.com/orgs/kubernetes/teams/sig-cli-misc) | General Discussion |
+| @kubernetes/sig-cli-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-pr-reviews) | PR Reviews |
+| @kubernetes/sig-cli-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cli-proposals) | Design Proposals |
+| @kubernetes/sig-cli-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cli-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -28,14 +28,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=ljK5dgSA7
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcluster-lifecycle)
 
 ## GitHub Teams
-* [@sig-cluster-lifecycle-misc](https://github.com/kubernetes/teams/sig-cluster-lifecycle-misc)
-* [@sig-cluster-lifecycle-test-failures](https://github.com/kubernetes/teams/sig-cluster-lifecycle-test-failures)
-* [@sig-cluster-lifecycle-bugs](https://github.com/kubernetes/teams/sig-cluster-lifecycle-bugs)
-* [@sig-cluster-lifecycle-feature-requests](https://github.com/kubernetes/teams/sig-cluster-lifecycle-feature-requests)
-* [@sig-cluster-lifecycle-proposals](https://github.com/kubernetes/teams/sig-cluster-lifecycle-proposals)
-* [@sig-cluster-lifecycle-pr-reviews](https://github.com/kubernetes/teams/sig-cluster-lifecycle-pr-reviews)
-* [@sig-cluster-lifecycle-api-reviews](https://github.com/kubernetes/teams/sig-cluster-lifecycle-api-reviews)
 
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-cluster-lifecycle-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-cluster-lifecycle-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-cluster-lifecycle-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-feature-requests) | Feature Requests |
+| @kubernetes/sig-cluster-lifecycle-misc | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-misc) | General Discussion |
+| @kubernetes/sig-cluster-lifecycle-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-pr-reviews) | PR Reviews |
+| @kubernetes/sig-cluster-lifecycle-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-proposals) | Design Proposals |
+| @kubernetes/sig-cluster-lifecycle-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -25,6 +25,20 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=EMGUdOKwS
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-contribex)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-contributor-experience-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-contributor-experience-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-feature-requests) | Feature Requests |
+| @kubernetes/sig-contributor-experience-misc-use-only-as-a-last-resort | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-misc-use-only-as-a-last-resort) | General Discussion |
+| @kubernetes/sig-contributor-experience-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-pr-reviews) | PR Reviews |
+| @kubernetes/sig-contributor-experience-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-proposals) | Design Proposals |
+| @kubernetes/sig-contributor-experience-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -25,6 +25,15 @@ Meeting recordings can be found [here](https://www.youtube.com/playlist?list=PL6
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fdocs)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-docs-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers) | Documentation Maintainers |
+
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 * Discuss documentation and docs issues for kubernetes.io

--- a/sig-gcp/README.md
+++ b/sig-gcp/README.md
@@ -23,6 +23,21 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 * [Slack](https://kubernetes.slack.com/messages/sig-gcp)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-gcp-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-gcp-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-gcp-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-feature-requests) | Feature Requests |
+| @kubernetes/sig-gcp-misc | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-misc) | General Discussion |
+| @kubernetes/sig-gcp-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-pr-reviews) | PR Reviews |
+| @kubernetes/sig-gcp-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-proposals) | Design Proposals |
+| @kubernetes/sig-gcp-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -25,6 +25,21 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Finstrumentation)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-instrumentation-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-instrumentation-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-instrumentation-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-feature-requests) | Feature Requests |
+| @kubernetes/sig-instrumentation-misc | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-misc) | General Discussion |
+| @kubernetes/sig-instrumentation-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-pr-reviews) | PR Reviews |
+| @kubernetes/sig-instrumentation-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-proposals) | Design Proposals |
+| @kubernetes/sig-instrumentation-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -25,6 +25,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=iWKC3FsNH
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fmulticluster)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-multicluster-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-multicluster-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-multicluster-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-feature-requests) | Feature Requests |
+| @kubernetes/sig-multicluster-misc | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-misc) | General Discussion |
+| @kubernetes/sig-multicluster-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-pr-reviews) | PR Reviews |
+| @kubernetes/sig-multicluster-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-test-failures) | Test Failures and Triage |
+| @kubernetes/sig-mutlicluster-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-mutlicluster-proposals) | Design Proposals |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -26,6 +26,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=phCA5-vWk
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-network)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnetwork)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-network-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-network-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-network-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-network-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-network-feature-requests) | Feature Requests |
+| @kubernetes/sig-network-misc | [link](https://github.com/orgs/kubernetes/teams/sig-network-misc) | General Discussion |
+| @kubernetes/sig-network-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-pr-reviews) | PR Reviews |
+| @kubernetes/sig-network-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-network-proposals) | Design Proposals |
+| @kubernetes/sig-network-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-network-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 ## Areas of Responsibility
 

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -24,6 +24,20 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=FbKOI9-x9
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnode)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-node-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-node-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-node-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-node-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-node-feature-requests) | Feature Requests |
+| @kubernetes/sig-node-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) | PR Reviews |
+| @kubernetes/sig-node-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-node-proposals) | Design Proposals |
+| @kubernetes/sig-node-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 

--- a/sig-on-premise/README.md
+++ b/sig-on-premise/README.md
@@ -26,14 +26,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=dyUWqqNYU
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fonprem)
 
 ## GitHub Teams
-* [@onprem-misc](https://github.com/kubernetes/teams/onprem-misc)
-* [@onprem-test-failures](https://github.com/kubernetes/teams/onprem-test-failures)
-* [@onprem-bugs](https://github.com/kubernetes/teams/onprem-bugs)
-* [@onprem-feature-requests](https://github.com/kubernetes/teams/onprem-feature-requests)
-* [@onprem-proposals](https://github.com/kubernetes/teams/onprem-proposals)
-* [@onprem-pr-reviews](https://github.com/kubernetes/teams/onprem-pr-reviews)
-* [@onprem-api-reviews](https://github.com/kubernetes/teams/onprem-api-reviews)
 
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-onprem-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-onprem-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-onprem-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-feature-requests) | Feature Requests |
+| @kubernetes/sig-onprem-misc | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-misc) | General Discussion |
+| @kubernetes/sig-onprem-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-pr-reviews) | PR Reviews |
+| @kubernetes/sig-onprem-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-proposals) | Design Proposals |
+| @kubernetes/sig-onprem-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -26,14 +26,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=iCfUx7ilh
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fopenstack)
 
 ## GitHub Teams
-* [@sig-openstack-misc](https://github.com/kubernetes/teams/sig-openstack-misc)
-* [@sig-openstack-test-failures](https://github.com/kubernetes/teams/sig-openstack-test-failures)
-* [@sig-openstack-bugs](https://github.com/kubernetes/teams/sig-openstack-bugs)
-* [@sig-openstack-feature-requests](https://github.com/kubernetes/teams/sig-openstack-feature-requests)
-* [@sig-openstack-proposals](https://github.com/kubernetes/teams/sig-openstack-proposals)
-* [@sig-openstack-pr-reviews](https://github.com/kubernetes/teams/sig-openstack-pr-reviews)
-* [@sig-openstack-api-reviews](https://github.com/kubernetes/teams/sig-openstack-api-reviews)
 
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-openstack-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-openstack-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-openstack-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-feature-requests) | Feature Requests |
+| @kubernetes/sig-openstack-misc | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-misc) | General Discussion |
+| @kubernetes/sig-openstack-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-pr-reviews) | PR Reviews |
+| @kubernetes/sig-openstack-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-proposals) | Design Proposals |
+| @kubernetes/sig-openstack-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -24,6 +24,23 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=I0KbWz8MT
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Frelease)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-release-admins | [link](https://github.com/orgs/kubernetes/teams/sig-release-admins) | Release Team Admins |
+| @kubernetes/sig-release-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-release-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-release-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-release-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-release-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-release-feature-requests) | Feature Requests |
+| @kubernetes/sig-release-members | [link](https://github.com/orgs/kubernetes/teams/sig-release-members) | Release Team Members |
+| @kubernetes/sig-release-misc | [link](https://github.com/orgs/kubernetes/teams/sig-release-misc) | General Discussion |
+| @kubernetes/sig-release-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-release-pr-reviews) | PR Reviews |
+| @kubernetes/sig-release-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-release-proposals) | Design Proposals |
+| @kubernetes/sig-release-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-release-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 [SIG Release][] has moved!
 

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -28,6 +28,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=NDP1uYyom
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scale)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscalability)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-scalability-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-scalability-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-scalability-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-feature-requests) | Feature Requests |
+| @kubernetes/sig-scalability-misc | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-misc) | General Discussion |
+| @kubernetes/sig-scalability-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-pr-reviews) | PR Reviews |
+| @kubernetes/sig-scalability-proprosals | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-proprosals) | Design Proposals |
+| @kubernetes/sig-scalability-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 ## Remaining 2017 Meeting Dates
    * 10/5

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -25,6 +25,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=PweKj6SU7
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscheduling)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-scheduling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-scheduling-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-scheduling-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-feature-requests) | Feature Requests |
+| @kubernetes/sig-scheduling-misc | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-misc) | General Discussion |
+| @kubernetes/sig-scheduling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-pr-reviews) | PR Reviews |
+| @kubernetes/sig-scheduling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-proposals) | Design Proposals |
+| @kubernetes/sig-scheduling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -27,6 +27,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=ukPj1sFFk
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fservice-catalog)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-service-catalog-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-service-catalog-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-service-catalog-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-feature-requests) | Feature Requests |
+| @kubernetes/sig-service-catalog-misc | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-misc) | General Discussion |
+| @kubernetes/sig-service-catalog-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-pr-reviews) | PR Reviews |
+| @kubernetes/sig-service-catalog-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-proposals) | Design Proposals |
+| @kubernetes/sig-service-catalog-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -25,6 +25,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=Eh7Qa7KOL
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fstorage)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-storage-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-storage-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-storage-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-storage-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-storage-feature-requests) | Feature Requests |
+| @kubernetes/sig-storage-misc | [link](https://github.com/orgs/kubernetes/teams/sig-storage-misc) | General Discussion |
+| @kubernetes/sig-storage-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-pr-reviews) | PR Reviews |
+| @kubernetes/sig-storage-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-storage-proposals) | Design Proposals |
+| @kubernetes/sig-storage-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-storage-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Details

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -26,6 +26,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=BbFjuxe3N
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-testing)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Ftesting)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-testing-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-testing-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-testing-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-testing-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-testing-feature-requests) | Feature Requests |
+| @kubernetes/sig-testing-misc | [link](https://github.com/orgs/kubernetes/teams/sig-testing-misc) | General Discussion |
+| @kubernetes/sig-testing-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-pr-reviews) | PR Reviews |
+| @kubernetes/sig-testing-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-testing-proposals) | Design Proposals |
+| @kubernetes/sig-testing-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-testing-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -24,6 +24,17 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=7zawb3KT9
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-windows)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fwindows)
 
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/sig-windows-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-windows-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-windows-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-windows-feature-requests) | Feature Requests |
+| @kubernetes/sig-windows-misc | [link](https://github.com/orgs/kubernetes/teams/sig-windows-misc) | General Discussion |
+
 <!-- BEGIN CUSTOM CONTENT -->
 * Recorded Meetings Playlist on Youtube: https://www.youtube.com/playlist?list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4&jct=LZ9EIvD4DGrhr2h4r0ItaBmco7gTgw
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -25,6 +25,21 @@ sigs:
     contact:
       slack: sig-api-machinery
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery
+      teams:
+      - name: sig-api-machinery-api-reviews
+        description: API Changes and Reviews
+      - name: sig-api-machinery-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-api-machinery-feature-requests
+        description: Feature Requests
+      - name: sig-api-machinery-misc
+        description: General Discussion
+      - name: sig-api-machinery-pr-reviews
+        description: PR Reviews
+      - name: sig-api-machinery-proposals
+        description: Design Proposals
+      - name: sig-api-machinery-test-failures
+        description: Test Failures and Triage
   - name: Apps
     dir: sig-apps
     mission_statement: >
@@ -55,6 +70,21 @@ sigs:
     contact:
       slack: sig-apps
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-apps
+      teams:
+      - name: sig-apps-api-reviews
+        description: API Changes and Reviews
+      - name: sig-apps-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-apps-feature-requests
+        description: Feature Requests
+      - name: sig-apps-misc
+        description: General Discussion
+      - name: sig-apps-pr-reviews
+        description: PR Reviews
+      - name: sig-apps-proposals
+        description: Design Proposals
+      - name: sig-apps-test-failures
+        description: Test Failures and Triage
   - name: Architecture
     dir: sig-architecture
     mission_statement: >
@@ -79,6 +109,21 @@ sigs:
     contact:
       slack: sig-architecture
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-architecture
+      teams:
+      - name: sig-architecture-api-reviews
+        description: API Changes and Reviews
+      - name: sig-architecture-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-architecture-feature-requests
+        description: Feature Requests
+      - name: sig-architecture-misc-use-only-as-a-last-resort
+        description: General Discussion
+      - name: sig-architecture-pr-reviews
+        description: PR Reviews
+      - name: sig-architecture-proposals
+        description: Design Proposals
+      - name: sig-architecture-test-failures
+        description: Test Failures and Triage
   - name: Auth
     dir: sig-auth
     mission_statement: >
@@ -106,6 +151,21 @@ sigs:
     contact:
       slack: sig-auth
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-auth
+      teams:
+      - name: sig-auth-api-reviews
+        description: API Changes and Reviews
+      - name: sig-auth-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-auth-feature-requests
+        description: Feature Requests
+      - name: sig-auth-misc
+        description: General Discussion
+      - name: sig-auth-pr-reviews
+        description: PR Reviews
+      - name: sig-auth-proposals
+        description: Design Proposals
+      - name: sig-auth-test-failures
+        description: Test Failures and Triage
   - name: Autoscaling
     dir: sig-autoscaling
     mission_statement: >
@@ -131,6 +191,21 @@ sigs:
     contact:
       slack: sig-autoscaling
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling
+      teams:
+      - name: sig-autoscaling-api-reviews
+        description: API Changes and Reviews
+      - name: sig-autoscaling-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-autoscaling-feature-requests
+        description: Feature Requests
+      - name: sig-autoscaling-misc
+        description: General Discussion
+      - name: sig-autoscaling-pr-reviews
+        description: PR Reviews
+      - name: sig-autoscaling-proposals
+        description: Design Proposals
+      - name: sig-autoscaling-test-failures
+        description: Test Failures and Triage
   - name: AWS
     dir: sig-aws
     mission_statement: >
@@ -158,6 +233,9 @@ sigs:
     contact:
       slack: sig-aws
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-aws
+      teams:
+      - name: sig-aws-misc
+        description: General Discussion
   - name: Azure
     dir: sig-azure
     mission_statement: >
@@ -185,6 +263,9 @@ sigs:
     contact:
       slack: sig-azure
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-azure
+      teams:
+      - name: sig-azure-misc
+        description: General Discussion
   - name: Big Data
     dir: sig-big-data
     mission_statement: >
@@ -210,6 +291,21 @@ sigs:
     contact:
       slack: sig-big-data
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-big-data
+      teams:
+      - name: sig-big-data-api-reviews
+        description: API Changes and Reviews
+      - name: sig-big-data-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-big-data-feature-requests
+        description: Feature Requests
+      - name: sig-big-data-misc
+        description: General Discussion
+      - name: sig-big-data-pr-reviews
+        description: PR Reviews
+      - name: sig-big-data-proposals
+        description: Design Proposals
+      - name: sig-big-data-test-failures
+        description: Test Failures and Triage
   - name: CLI
     dir: sig-cli
     mission_statement: >
@@ -240,6 +336,23 @@ sigs:
     contact:
       slack: sig-cli
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cli
+      teams:
+      - name: sig-cli-api-reviews
+        description: API Changes and Reviews
+      - name: sig-cli-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-cli-feature-requests
+        description: Feature Requests
+      - name: sig-cli-maintainers
+        description: CLI Maintainers
+      - name: sig-cli-misc
+        description: General Discussion
+      - name: sig-cli-pr-reviews
+        description: PR Reviews
+      - name: sig-cli-proposals
+        description: Design Proposals
+      - name: sig-cli-test-failures
+        description: Test Failures and Triage
   - name: Cluster Lifecycle
     dir: sig-cluster-lifecycle
     mission_statement: >
@@ -269,8 +382,22 @@ sigs:
     meeting_recordings_url: https://www.youtube.com/watch?v=ljK5dgSA7vc&list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
     contact:
       slack: sig-cluster-lifecycle
-      full_github_teams: true
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle
+      teams:
+      - name: sig-cluster-lifecycle-api-reviews
+        description: API Changes and Reviews
+      - name: sig-cluster-lifecycle-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-cluster-lifecycle-feature-requests
+        description: Feature Requests
+      - name: sig-cluster-lifecycle-misc
+        description: General Discussion
+      - name: sig-cluster-lifecycle-pr-reviews
+        description: PR Reviews
+      - name: sig-cluster-lifecycle-proposals
+        description: Design Proposals
+      - name: sig-cluster-lifecycle-test-failures
+        description: Test Failures and Triage
   - name: Cluster Ops
     dir: sig-cluster-ops
     mission_statement: >
@@ -324,6 +451,19 @@ sigs:
     contact:
       slack: sig-contribex
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-contribex
+      teams:
+      - name: sig-contributor-experience-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-contributor-experience-feature-requests
+        description: Feature Requests
+      - name: sig-contributor-experience-misc-use-only-as-a-last-resort
+        description: General Discussion
+      - name: sig-contributor-experience-pr-reviews
+        description: PR Reviews
+      - name: sig-contributor-experience-proposals
+        description: Design Proposals
+      - name: sig-contributor-experience-test-failures
+        description: Test Failures and Triage
   - name: Docs
     dir: sig-docs
     mission_statement: >
@@ -347,6 +487,83 @@ sigs:
     contact:
       slack: sig-docs
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-docs
+      teams:
+      - name: sig-docs-maintainers
+        description: Documentation Maintainers
+  - name: GCP
+    dir: sig-gcp
+    mission_statement: >
+      A Special Interest Group for building, deploying, maintaining,
+      supporting, and using Kubernetes on the Google Cloud Platform.
+    leads:
+    - name: Adam Worrall
+      github: abgworrall
+      company: Google
+    meetings:
+    - day: Thursday
+      time: "16:00"
+      tz: "UTC"
+      frequency: biweekly
+    meeting_url: https://zoom.us/j/761149873
+    meeting_archive_url: https://docs.google.com/document/d/1mtmwZ4oVSSWhbEw8Lfzvc7ig84qxUpdK6uHyJp8rSGU/edit
+    contact:
+      slack: sig-gcp
+      mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-gcp
+      teams:
+      - name: sig-gcp-api-reviews
+        description: API Changes and Reviews
+      - name: sig-gcp-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-gcp-feature-requests
+        description: Feature Requests
+      - name: sig-gcp-misc
+        description: General Discussion
+      - name: sig-gcp-pr-reviews
+        description: PR Reviews
+      - name: sig-gcp-proposals
+        description: Design Proposals
+      - name: sig-gcp-test-failures
+        description: Test Failures and Triage
+  - name: Instrumentation
+    dir: sig-instrumentation
+    mission_statement: >
+      Covers best practices for cluster observability through metrics, logging, and events across all
+      Kubernetes components and development of relevant components such as Heapster and kube-state-metrics.
+      Coordinates metric requirements of different SIGs for other components through finding common APIs.
+    label: instrumentation
+    leads:
+    - name: Piotr Szczesniak
+      github: piosz
+      company: Google
+    - name: Fabian Reinartz
+      github: fabxc
+      company: CoreOS
+    meetings:
+    - day: Thursday
+      time: "16:30"
+      tz: "UTC"
+      frequency: weekly
+    meeting_url: https://zoom.us/j/5342565819
+    meeting_archive_url: https://docs.google.com/document/d/1gWuAATtlmI7XJILXd31nA4kMq6U9u63L70382Y3xcbM/edit
+    meeting_recordings_url:
+    contact:
+      slack: sig-instrumentation
+      mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation
+      teams:
+      - name: sig-instrumentation-api-reviews
+        description: API Changes and Reviews
+      - name: sig-instrumentation-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-instrumentation-feature-requests
+        description: Feature Requests
+      - name: sig-instrumentation-misc
+        description: General Discussion
+      - name: sig-instrumentation-pr-reviews
+        description: PR Reviews
+      - name: sig-instrumentation-proposals
+        description: Design Proposals
+      - name: sig-instrumentation-test-failures
+        description: Test Failures and Triage
   - name: Multicluster
     dir: sig-multicluster
     mission_statement: >
@@ -375,50 +592,21 @@ sigs:
     contact:
       slack: sig-multicluster
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster
-  - name: GCP
-    dir: sig-gcp
-    mission_statement: >
-      A Special Interest Group for building, deploying, maintaining,
-      supporting, and using Kubernetes on the Google Cloud Platform.
-    leads:
-    - name: Adam Worrall
-      github: abgworrall
-      company: Google
-    meetings:
-    - day: Thursday
-      time: "16:00"
-      tz: "UTC"
-      frequency: biweekly
-    meeting_url: https://zoom.us/j/761149873
-    meeting_archive_url: https://docs.google.com/document/d/1mtmwZ4oVSSWhbEw8Lfzvc7ig84qxUpdK6uHyJp8rSGU/edit
-    contact:
-      slack: sig-gcp
-      mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-gcp
-  - name: Instrumentation
-    dir: sig-instrumentation
-    mission_statement: >
-      Covers best practices for cluster observability through metrics, logging, and events across all
-      Kubernetes components and development of relevant components such as Heapster and kube-state-metrics.
-      Coordinates metric requirements of different SIGs for other components through finding common APIs.
-    label: instrumentation
-    leads:
-    - name: Piotr Szczesniak
-      github: piosz
-      company: Google
-    - name: Fabian Reinartz
-      github: fabxc
-      company: CoreOS
-    meetings:
-    - day: Thursday
-      time: "16:30"
-      tz: "UTC"
-      frequency: weekly
-    meeting_url: https://zoom.us/j/5342565819
-    meeting_archive_url: https://docs.google.com/document/d/1gWuAATtlmI7XJILXd31nA4kMq6U9u63L70382Y3xcbM/edit
-    meeting_recordings_url:
-    contact:
-      slack: sig-instrumentation
-      mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation
+      teams:
+      - name: sig-multicluster-api-reviews
+        description: API Changes and Reviews
+      - name: sig-multicluster-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-multicluster-feature-requests
+        description: Feature Requests
+      - name: sig-multicluster-misc
+        description: General Discussion
+      - name: sig-multicluster-pr-reviews
+        description: PR Reviews
+      - name: sig-multicluster-test-failures
+        description: Test Failures and Triage
+      - name: sig-mutlicluster-proposals
+        description: Design Proposals
   - name: Network
     dir: sig-network
     mission_statement: >
@@ -445,6 +633,21 @@ sigs:
     contact:
       slack: sig-network
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-network
+      teams:
+      - name: sig-network-api-reviews
+        description: API Changes and Reviews
+      - name: sig-network-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-network-feature-requests
+        description: Feature Requests
+      - name: sig-network-misc
+        description: General Discussion
+      - name: sig-network-pr-reviews
+        description: PR Reviews
+      - name: sig-network-proposals
+        description: Design Proposals
+      - name: sig-network-test-failures
+        description: Test Failures and Triage
   - name: Node
     dir: sig-node
     mission_statement: >
@@ -467,6 +670,19 @@ sigs:
     contact:
       slack: sig-node
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-node
+      teams:
+      - name: sig-node-api-reviews
+        description: API Changes and Reviews
+      - name: sig-node-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-node-feature-requests
+        description: Feature Requests
+      - name: sig-node-pr-reviews
+        description: PR Reviews
+      - name: sig-node-proposals
+        description: Design Proposals
+      - name: sig-node-test-failures
+        description: Test Failures and Triage
   - name: On Premise
     dir: sig-on-premise
     mission_statement: >
@@ -492,8 +708,21 @@ sigs:
     contact:
       slack: sig-onprem
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-on-prem
-      full_github_teams: true
-      github_team_prefix: onprem
+      teams:
+      - name: sig-onprem-api-reviews
+        description: API Changes and Reviews
+      - name: sig-onprem-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-onprem-feature-requests
+        description: Feature Requests
+      - name: sig-onprem-misc
+        description: General Discussion
+      - name: sig-onprem-pr-reviews
+        description: PR Reviews
+      - name: sig-onprem-proposals
+        description: Design Proposals
+      - name: sig-onprem-test-failures
+        description: Test Failures and Triage
   - name: OpenStack
     dir: sig-openstack
     mission_statement: >
@@ -521,7 +750,21 @@ sigs:
     contact:
       slack: sig-openstack
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-openstack
-      full_github_teams: true
+      teams:
+      - name: sig-openstack-api-reviews
+        description: API Changes and Reviews
+      - name: sig-openstack-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-openstack-feature-requests
+        description: Feature Requests
+      - name: sig-openstack-misc
+        description: General Discussion
+      - name: sig-openstack-pr-reviews
+        description: PR Reviews
+      - name: sig-openstack-proposals
+        description: Design Proposals
+      - name: sig-openstack-test-failures
+        description: Test Failures and Triage
   - name: Product Management
     dir: sig-product-management
     mission_statement: >
@@ -586,6 +829,25 @@ sigs:
     contact:
       slack: sig-release
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-release
+      teams:
+      - name: sig-release-admins
+        description: Release Team Admins
+      - name: sig-release-api-reviews
+        description: API Changes and Reviews
+      - name: sig-release-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-release-feature-requests
+        description: Feature Requests
+      - name: sig-release-members
+        description: Release Team Members
+      - name: sig-release-misc
+        description: General Discussion
+      - name: sig-release-pr-reviews
+        description: PR Reviews
+      - name: sig-release-proposals
+        description: Design Proposals
+      - name: sig-release-test-failures
+        description: Test Failures and Triage
   - name: Scalability
     dir: sig-scalability
     mission_statement: >
@@ -620,6 +882,21 @@ sigs:
     contact:
       slack: sig-scalability
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-scale
+      teams:
+      - name: sig-scalability-api-reviews
+        description: API Changes and Reviews
+      - name: sig-scalability-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-scalability-feature-requests
+        description: Feature Requests
+      - name: sig-scalability-misc
+        description: General Discussion
+      - name: sig-scalability-pr-reviews
+        description: PR Reviews
+      - name: sig-scalability-proprosals
+        description: Design Proposals
+      - name: sig-scalability-test-failures
+        description: Test Failures and Triage
   - name: Scheduling
     dir: sig-scheduling
     mission_statement: >
@@ -646,6 +923,21 @@ sigs:
     contact:
       slack: sig-scheduling
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling
+      teams:
+      - name: sig-scheduling-api-reviews
+        description: API Changes and Reviews
+      - name: sig-scheduling-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-scheduling-feature-requests
+        description: Feature Requests
+      - name: sig-scheduling-misc
+        description: General Discussion
+      - name: sig-scheduling-pr-reviews
+        description: PR Reviews
+      - name: sig-scheduling-proposals
+        description: Design Proposals
+      - name: sig-scheduling-test-failures
+        description: Test Failures and Triage
   - name: Service Catalog
     dir: sig-service-catalog
     mission_statement: >
@@ -676,6 +968,21 @@ sigs:
     contact:
       slack: sig-service-catalog
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog
+      teams:
+      - name: sig-service-catalog-api-reviews
+        description: API Changes and Reviews
+      - name: sig-service-catalog-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-service-catalog-feature-requests
+        description: Feature Requests
+      - name: sig-service-catalog-misc
+        description: General Discussion
+      - name: sig-service-catalog-pr-reviews
+        description: PR Reviews
+      - name: sig-service-catalog-proposals
+        description: Design Proposals
+      - name: sig-service-catalog-test-failures
+        description: Test Failures and Triage
   - name: Storage
     dir: sig-storage
     mission_statement: >
@@ -699,6 +1006,21 @@ sigs:
     contact:
       slack: sig-storage
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-storage
+      teams:
+      - name: sig-storage-api-reviews
+        description: API Changes and Reviews
+      - name: sig-storage-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-storage-feature-requests
+        description: Feature Requests
+      - name: sig-storage-misc
+        description: General Discussion
+      - name: sig-storage-pr-reviews
+        description: PR Reviews
+      - name: sig-storage-proposals
+        description: Design Proposals
+      - name: sig-storage-test-failures
+        description: Test Failures and Triage
   - name: Testing
     dir: sig-testing
     mission_statement: >
@@ -728,6 +1050,21 @@ sigs:
     contact:
       slack: sig-testing
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-testing
+      teams:
+      - name: sig-testing-api-reviews
+        description: API Changes and Reviews
+      - name: sig-testing-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-testing-feature-requests
+        description: Feature Requests
+      - name: sig-testing-misc
+        description: General Discussion
+      - name: sig-testing-pr-reviews
+        description: PR Reviews
+      - name: sig-testing-proposals
+        description: Design Proposals
+      - name: sig-testing-test-failures
+        description: Test Failures and Triage
   - name: UI
     dir: sig-ui
     mission_statement: >
@@ -774,6 +1111,13 @@ sigs:
     contact:
       slack: sig-windows
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-windows
+      teams:
+      - name: sig-windows-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-windows-feature-requests
+        description: Feature Requests
+      - name: sig-windows-misc
+        description: General Discussion
 workinggroups:
   - name: Resource Management
     dir: wg-resource-management


### PR DESCRIPTION
fixes #702, fixes #677

This adds a listing of all the teams for each sig to the sig docs. This helps for things like mentioning them in issues, as they're only visible to org members.

Note that this is manually generated. I know this isn't optimal, but I don't want to restrict docs generation to only those in the org.