### PR TITLE
Update serverfault link tag per updated site tag

### DIFF
--- a/contributors/devel/issues.md
+++ b/contributors/devel/issues.md
@@ -54,7 +54,7 @@ Support requests should be directed to the following:
 [troubleshooting guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/)
 
 * [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes) and
-[ServerFault](http://serverfault.com/questions/tagged/google-kubernetes)
+[ServerFault](http://serverfault.com/questions/tagged/kubernetes)
 
 * [Slack](https://kubernetes.slack.com) ([registration](http://slack.k8s.io))
   * Check out the [Slack Archive](http://kubernetes.slackarchive.io/) first.


### PR DESCRIPTION
The link with google-kubernetes tag doesn't give any search result. Updating
the tag to kubernetes from google-kubernetes to get an expected output. The changes are required in just one file in the repo as modified herewith. 

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://github.com/kubernetes/community/tree/master/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->