### PR TITLE
contrib guide: update "help wanted" issue url

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -99,7 +99,7 @@ You get the idea - if you ever see something you think should be fixed, you shou
 ### Find a good first topic
 
 There are multiple repositories within the Kubernetes community and a full list of repositories can be found [here](https://github.com/kubernetes/).
-Each repository in the Kubernetes organization has beginner-friendly issues that provide a good first issue. For example, [kubernetes/kubernetes](https://git.k8s.io/kubernetes) has [help-wanted issues](https://issues.k8s.io/?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted) that should not need deep knowledge of the system.
+Each repository in the Kubernetes organization has beginner-friendly issues that provide a good first issue. For example, [kubernetes/kubernetes](https://git.k8s.io/kubernetes) has [help-wanted issues](https://issues.k8s.io/?q=is%3Aopen+is%3Aissue+label%3A%22help%20wanted%22) that should not need deep knowledge of the system.
 Another good strategy is to find a documentation improvement, such as a missing/broken link, which will give you exposure to the code submission/review process without the added complication of technical depth. Please see [Contributing](#Contributing) below for the workflow.
 
 ### Learn about SIGs


### PR DESCRIPTION
The doc's referring to "help-wanted" labeled issues, but that shows zero
open and closed, where there's a bunch with "help wanted" through the
project history.  This patch updates the url to search issues with the
"help wanted label.

Signed-off-by: Tim Pepper <tpepper@vmware.com>