### PR TITLE
Add explicit invite to sig-aws-meetings

### DIFF
--- a/sig-aws/CONTRIBUTING.md
+++ b/sig-aws/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing
+
+The process for contributing code to Kubernetes via SIG-aws [community][community page].
+
+**Note**: This page is focused on helping new contributors become active
+members of the community through sustained contributions.
+
+## Introduction
+
+Welcome to the Kubernetes sig-aws contributing guide.  We are excited
+about the prospect of you joining our [community][community page]!
+Mentoring and on-boarding new contributors is critical to the success
+of the project.
+
+Please be aware that all contributions to Kubernetes require time
+and commitment from project maintainers to direct and review work.
+This is done in additional to many other maintainer responsibilities, and
+direct engagement from maintainers is a finite resource.
+
+## Before You Begin
+
+**Note**: Complete the following steps before reaching out to aws community members.
+
+### Agree to contribution rules
+
+Follow the [CLA signup instructions](../CLA.md).
+
+### Understand the big picture
+
+This is important.
+
+- Play around with Kubernetes [Kubernetes Basics Tutorial].
+- Get to know possibilities to set up Kubernetes on AWS https://kubernetes.io/docs/getting-started-guides/aws/
+- Understand how Kubernetes on aws differs from other installations of Kubernetes [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/aws/aws_under_the_hood.md]
+
+
+## Adopt an issue
+
+New contributors can try the following to work on an existing bug or approved design:
+
+- In [slack][slack-messages] (signup [here][slack-signup]),
+  @mention a [lead][leads] and ask if there are any issues you could pick up.
+  We also maintain a list of [sig aws issues where help is wanted][aws_good_starter_issues].
+  Most of them are not very complex, so that's probably a good starting point.
+  Leads can recommend issues that have enough priority to receive PR review bandwidth.
+- Send an email to the _kubernetes-sig-aws@googlegroups.com_ [group]
+
+  > Subject: New sig-aws contributor _${yourName}_
+  >
+  > Body: Hello, my name is _${yourName}_.  I would like to get involved in
+  > contributing to the Kubernetes project.  I have read all of the
+  > user documentation listed on the community contributing page.
+  > What should I do next to get started?
+
+- Attend a sig-aws [meeting] and introduce yourself as looking to get started.
+
+## Meet the community
+
+Engage with the SIG aws community!  Let us know who you are and how things are going!
+
+- In [slack][slack-messages] (signup [here][slack-signup]),
+  @mention a [lead][leads] and ask if there are any issues you could pick up, or
+  let them know what you are working on.
+
+- Attend a sig-aws [meeting] and introduce yourself and what you are working on.
+
+- The sig-aws [community page] lists sig-aws [leads], channels of [communication],
+and group [meeting] times.
+
+[@mentions]: https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-users-and-teams
+[Kubernetes Basics Tutorial]: https://kubernetes.io/docs/tutorials/kubernetes-basics
+[PR]: https://help.github.com/articles/creating-a-pull-request
+[agenda]: https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit
+[communication]:  https://github.com/kubernetes/community/tree/master/sig-aws#contact
+[community page]: https://github.com/kubernetes/community/tree/master/sig-aws
+[design repo]: https://github.com/kubernetes/community/tree/master/contributors/design-proposals/aws
+[development guide]: https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
+[group]: https://groups.google.com/forum/#!forum/kubernetes-sig-aws
+[kops]: https://github.com/kubernetes/kops/tree/master/
+[leads]: https://github.com/kubernetes/community/tree/master/sig-aws#leads
+[management overview]: https://kubernetes.io/docs/concepts/tools/kubectl/object-management-overview
+[meeting]: https://github.com/kubernetes/community/tree/master/sig-aws#meetings
+[slack-messages]: https://kubernetes.slack.com/messages/sig-aws
+[slack-signup]: http://slack.k8s.io/
+[kube-aws-tools]: kubernetes-on-aws.md
+[aws_good_starter_issues]: https://github.com/kubernetes/kops/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3Agood-starter-issue

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -37,8 +37,6 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-aws-misc | [link](https://github.com/orgs/kubernetes/teams/sig-aws-misc) | General Discussion |
 
 <!-- BEGIN CUSTOM CONTENT -->
-## Contributing
-Feel free to join our Meetings and help us growing. We depend on new people becoming members and regular code contributors.
-To find out more about our global community structure, different levels of membership and code contributors, please [explore here](/community-membership.md).
-
+## Participate
+Get more Informations how to participate in this community. ([Contribution guidelines for this project](CONTRIBUTING.md))
 <!-- END CUSTOM CONTENT -->

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -37,5 +37,8 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-aws-misc | [link](https://github.com/orgs/kubernetes/teams/sig-aws-misc) | General Discussion |
 
 <!-- BEGIN CUSTOM CONTENT -->
+## Contributing
+Feel free to join our Meetings and help us growing. We depend on new people becoming members and regular code contributors.
+To find out more about our global community structure, different levels of membership and code contributors, please [explore here](/community-membership.md).
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -38,5 +38,5 @@ Note that the links to display team membership will only work if you are a membe
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Participate
-Get more Informations how to participate in this community. ([Contribution guidelines for this project](CONTRIBUTING.md))
+For information on how to participate in this community, read our [contribution guidelines](CONTRIBUTING.md).
 <!-- END CUSTOM CONTENT -->


### PR DESCRIPTION
Add small section named Contributing which invites Users to attend meetings and link
them for more Informations to community-membership.md.

Greetings, Thomas

CC as discussed: @chrislovecnm