### PR TITLE
unbreak a few event links

### DIFF
--- a/events/2017/05-leadership-summit/announcement.md
+++ b/events/2017/05-leadership-summit/announcement.md
@@ -1,5 +1,5 @@
 This is an announcement for the 2017 Kubernetes Leadership Summit, which will occur on June 2nd, 2017 in San Jose, CA. 
-This event will be similar to the [Kubernetes Developer's Summit](/community/2016-events/developer-summit-2016/Kubernetes_Dev_Summit.md) in November 
+This event will be similar to the [Kubernetes Developer's Summit](/events/2016/developer-summit-2016/Kubernetes_Dev_Summit.md) in November
 2016, but involving a smaller smaller audience comprised solely of leaders and influencers of the community. These leaders and
 influences include the SIG leads, release managers, and representatives from several companies, including (but not limited to)
 Google, Red Hat, CoreOS, WeaveWorks, Deis, and Mirantis.

--- a/events/2017/12-contributor-summit/ContribSummitInformation.md
+++ b/events/2017/12-contributor-summit/ContribSummitInformation.md
@@ -18,7 +18,7 @@ Times in CST
 - 01:00 pm - Sessions resume  
 - 05:00 pm - Happy Hour onsite  
 
-View the complete session schedule [here](/community/2017-events/12-contributor-summit/schedule.png).  
+View the complete session schedule [here](schedule.png).
 Session schedule will be available onsite in print as well as on TVs.
 
 ## Where:


### PR DESCRIPTION
The k/community repo's events directories underwent a shuffle recently.
This led to a few broken links, fixed in this commit.

Signed-off-by: Tim Pepper <tpepper@vmware.com>