### PR TITLE
Fix the doc reference to Resource Quality-of-Service

### DIFF
--- a/contributors/design-proposals/node/troubleshoot-running-pods.md
+++ b/contributors/design-proposals/node/troubleshoot-running-pods.md
@@ -730,7 +730,7 @@ coupling it with container images.
 *   [CRI Tracking Issue](https://issues.k8s.io/28789)
 *   [CRI: expose optional runtime features](https://issues.k8s.io/32803)
 *   [Resource QoS in
-    Kubernetes](https://git.k8s.io/kubernetes/docs/design/resource-qos.md)
+    Kubernetes](resource-qos.md)
 *   Related Features
     *   [#1615](https://issues.k8s.io/1615) - Shared PID Namespace across
         containers in a pod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
Fix the doc reference to Resource Quality-of-Service