### PR TITLE
generator: add google groups for github teams

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -2,10 +2,17 @@
 
 This folder contains scripts to automatically generate documentation about the
 different Special Interest Groups (SIGs) of Kubernetes. The authoritative
-source for SIG information is the `sigs.yaml` file in the project root. All
-updates must be done there.
+source for SIG information is the [`sigs.yaml`](/sigs.yaml) file in the project root.
+All updates must be done there.
 
 The schema for this file should be self explanatory. However, if you need to see all the options check out the generator code in `app.go`.
+
+The documentation follows a template and uses the values from [`sigs.yaml`](/sigs.yaml):
+
+- Header: [`header.tmpl`](header.tmpl)
+- List: [`list.tmpl`](list.tmpl)
+- SIG README: [`sig_readme.tmpl`](sig_readme.tmpl)
+- WG README: [`wg_readme.tmpl`](wg_readme.tmpl)
 
 **Time Zone gotcha**:
 Time zones make everything complicated.
@@ -16,7 +23,7 @@ Practically, that means US pacific time must be `PT (Pacific Time)`.
 `PT` isn't good enough, unfortunately.
 
 When an update happens to the this file, the next step is generate the
-accompanying documentation. This takes the format of two types of doc file:
+accompanying documentation. This takes the format of three types of doc files:
 
 ```
 sig-<sig-name>/README.md

--- a/generator/app.go
+++ b/generator/app.go
@@ -142,7 +142,7 @@ func getExistingContent(path string) (string, error) {
 	return strings.Join(captured, "\n"), nil
 }
 
-var funcMap template.FuncMap = template.FuncMap{
+var funcMap = template.FuncMap{
 	"tzUrlEncode": tzUrlEncode,
 }
 

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -31,9 +31,13 @@ Meeting recordings can be found [here]({{.MeetingRecordingsURL}}).
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
 {{- range .Contact.GithubTeams }}
-| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
+| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | [link](https://groups.google.com/forum/#!forum/kubernetes-{{.Name}}) | {{.Description}} |
 {{- end }}
 {{  end }}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -8,7 +8,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 -->
 # API Machinery SIG
 
-Covers all aspects of API server, API registration and discovery, generic API CRUD semantics, admission control, encoding/decoding, conversion, defaulting, persistence layer (etcd), OpenAPI, third-party resource, garbage collection, and client libraries.
+Covers all aspects of API server, API registration and discovery, generic API CRUD semantics, admission control, encoding/decoding, conversion, defaulting, persistence layer (etcd), OpenAPI, CustomResourceDefinition, garbage collection, and client libraries.
 
 ## Meetings
 * [Wednesdays at 11:00 PT (Pacific Time)](https://staging.talkgadget.google.com/hangouts/_/google.com/kubernetes-sig) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
@@ -49,6 +49,4 @@ Monitor these for Github activity if you are not a member of the team.
 
 * [YouTube Playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP21oW3hbLyjjj4XhrwKxH2R) - find meeting recordings here
 
-## Areas
-apiserver, api registration and discovery, generic API CRUD semantics, admission control, encoding/decoding, conversion, defaulting, persistence layer (etcd), OpenAPI, third-party resource, garbage collection, client libraries
 <!-- END CUSTOM CONTENT -->

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -30,15 +30,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=Lj1ScbXpn
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-api-machinery-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-api-machinery-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-api-machinery-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-feature-requests) | Feature Requests |
-| @kubernetes/sig-api-machinery-misc | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-misc) | General Discussion |
-| @kubernetes/sig-api-machinery-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-pr-reviews) | PR Reviews |
-| @kubernetes/sig-api-machinery-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-proposals) | Design Proposals |
-| @kubernetes/sig-api-machinery-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-api-machinery-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-api-machinery-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-api-machinery-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery-feature-requests) | Feature Requests |
+| @kubernetes/sig-api-machinery-misc | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery-misc) | General Discussion |
+| @kubernetes/sig-api-machinery-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery-pr-reviews) | PR Reviews |
+| @kubernetes/sig-api-machinery-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery-proposals) | Design Proposals |
+| @kubernetes/sig-api-machinery-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Additional links

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -32,15 +32,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=hn23Z-vL_
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-apps-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-apps-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-apps-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-apps-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-apps-feature-requests) | Feature Requests |
-| @kubernetes/sig-apps-misc | [link](https://github.com/orgs/kubernetes/teams/sig-apps-misc) | General Discussion |
-| @kubernetes/sig-apps-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-pr-reviews) | PR Reviews |
-| @kubernetes/sig-apps-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-apps-proposals) | Design Proposals |
-| @kubernetes/sig-apps-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-apps-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-apps-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-apps-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-apps-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-apps-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-apps-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-apps-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-apps-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-apps-feature-requests) | Feature Requests |
+| @kubernetes/sig-apps-misc | [link](https://github.com/orgs/kubernetes/teams/sig-apps-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-apps-misc) | General Discussion |
+| @kubernetes/sig-apps-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-apps-pr-reviews) | PR Reviews |
+| @kubernetes/sig-apps-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-apps-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-apps-proposals) | Design Proposals |
+| @kubernetes/sig-apps-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-apps-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-apps-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -30,15 +30,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=d5ERqm3oH
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-architecture-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-architecture-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-architecture-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-feature-requests) | Feature Requests |
-| @kubernetes/sig-architecture-misc-use-only-as-a-last-resort | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-misc-use-only-as-a-last-resort) | General Discussion |
-| @kubernetes/sig-architecture-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-pr-reviews) | PR Reviews |
-| @kubernetes/sig-architecture-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-proposals) | Design Proposals |
-| @kubernetes/sig-architecture-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-architecture-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-architecture-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-architecture-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture-feature-requests) | Feature Requests |
+| @kubernetes/sig-architecture-misc-use-only-as-a-last-resort | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-misc-use-only-as-a-last-resort) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture-misc-use-only-as-a-last-resort) | General Discussion |
+| @kubernetes/sig-architecture-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture-pr-reviews) | PR Reviews |
+| @kubernetes/sig-architecture-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture-proposals) | Design Proposals |
+| @kubernetes/sig-architecture-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -31,15 +31,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=DJDuDNALc
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-auth-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-auth-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-auth-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-auth-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-auth-feature-requests) | Feature Requests |
-| @kubernetes/sig-auth-misc | [link](https://github.com/orgs/kubernetes/teams/sig-auth-misc) | General Discussion |
-| @kubernetes/sig-auth-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-pr-reviews) | PR Reviews |
-| @kubernetes/sig-auth-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-auth-proposals) | Design Proposals |
-| @kubernetes/sig-auth-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-auth-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-auth-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-auth-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-auth-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-auth-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-auth-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-auth-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-auth-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-auth-feature-requests) | Feature Requests |
+| @kubernetes/sig-auth-misc | [link](https://github.com/orgs/kubernetes/teams/sig-auth-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-auth-misc) | General Discussion |
+| @kubernetes/sig-auth-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-auth-pr-reviews) | PR Reviews |
+| @kubernetes/sig-auth-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-auth-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-auth-proposals) | Design Proposals |
+| @kubernetes/sig-auth-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-auth-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-auth-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -30,15 +30,19 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-autoscaling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-autoscaling-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-autoscaling-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-feature-requests) | Feature Requests |
-| @kubernetes/sig-autoscaling-misc | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-misc) | General Discussion |
-| @kubernetes/sig-autoscaling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-pr-reviews) | PR Reviews |
-| @kubernetes/sig-autoscaling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-proposals) | Design Proposals |
-| @kubernetes/sig-autoscaling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-autoscaling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-autoscaling-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-autoscaling-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling-feature-requests) | Feature Requests |
+| @kubernetes/sig-autoscaling-misc | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling-misc) | General Discussion |
+| @kubernetes/sig-autoscaling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling-pr-reviews) | PR Reviews |
+| @kubernetes/sig-autoscaling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling-proposals) | Design Proposals |
+| @kubernetes/sig-autoscaling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Concerns

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -32,9 +32,13 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-aws-misc | [link](https://github.com/orgs/kubernetes/teams/sig-aws-misc) | General Discussion |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-aws-misc | [link](https://github.com/orgs/kubernetes/teams/sig-aws-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-aws-misc) | General Discussion |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Participate

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -31,9 +31,13 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=yQLeUKi_d
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-azure-misc | [link](https://github.com/orgs/kubernetes/teams/sig-azure-misc) | General Discussion |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-azure-misc | [link](https://github.com/orgs/kubernetes/teams/sig-azure-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-azure-misc) | General Discussion |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -30,15 +30,19 @@ Meeting recordings can be found [here](https://docs.google.com/document/d/1pnF38
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-big-data-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-big-data-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-big-data-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-feature-requests) | Feature Requests |
-| @kubernetes/sig-big-data-misc | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-misc) | General Discussion |
-| @kubernetes/sig-big-data-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-pr-reviews) | PR Reviews |
-| @kubernetes/sig-big-data-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-proposals) | Design Proposals |
-| @kubernetes/sig-big-data-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-big-data-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-big-data-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-big-data-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data-feature-requests) | Feature Requests |
+| @kubernetes/sig-big-data-misc | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data-misc) | General Discussion |
+| @kubernetes/sig-big-data-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data-pr-reviews) | PR Reviews |
+| @kubernetes/sig-big-data-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data-proposals) | Design Proposals |
+| @kubernetes/sig-big-data-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -31,16 +31,20 @@ Meeting recordings can be found [here](https://www.youtube.com/playlist?list=PL6
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-cli-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-cli-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-cli-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-cli-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-cli-feature-requests) | Feature Requests |
-| @kubernetes/sig-cli-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-cli-maintainers) | CLI Maintainers |
-| @kubernetes/sig-cli-misc | [link](https://github.com/orgs/kubernetes/teams/sig-cli-misc) | General Discussion |
-| @kubernetes/sig-cli-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-pr-reviews) | PR Reviews |
-| @kubernetes/sig-cli-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cli-proposals) | Design Proposals |
-| @kubernetes/sig-cli-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cli-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-cli-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cli-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-cli-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-cli-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cli-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-cli-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-cli-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cli-feature-requests) | Feature Requests |
+| @kubernetes/sig-cli-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-cli-maintainers) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cli-maintainers) | CLI Maintainers |
+| @kubernetes/sig-cli-misc | [link](https://github.com/orgs/kubernetes/teams/sig-cli-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cli-misc) | General Discussion |
+| @kubernetes/sig-cli-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cli-pr-reviews) | PR Reviews |
+| @kubernetes/sig-cli-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cli-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cli-proposals) | Design Proposals |
+| @kubernetes/sig-cli-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cli-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cli-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -32,15 +32,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=ljK5dgSA7
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-cluster-lifecycle-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-cluster-lifecycle-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-cluster-lifecycle-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-feature-requests) | Feature Requests |
-| @kubernetes/sig-cluster-lifecycle-misc | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-misc) | General Discussion |
-| @kubernetes/sig-cluster-lifecycle-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-pr-reviews) | PR Reviews |
-| @kubernetes/sig-cluster-lifecycle-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-proposals) | Design Proposals |
-| @kubernetes/sig-cluster-lifecycle-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-cluster-lifecycle-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-cluster-lifecycle-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-cluster-lifecycle-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle-feature-requests) | Feature Requests |
+| @kubernetes/sig-cluster-lifecycle-misc | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle-misc) | General Discussion |
+| @kubernetes/sig-cluster-lifecycle-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle-pr-reviews) | PR Reviews |
+| @kubernetes/sig-cluster-lifecycle-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle-proposals) | Design Proposals |
+| @kubernetes/sig-cluster-lifecycle-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -30,14 +30,18 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=EMGUdOKwS
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-contributor-experience-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-contributor-experience-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-feature-requests) | Feature Requests |
-| @kubernetes/sig-contributor-experience-misc-use-only-as-a-last-resort | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-misc-use-only-as-a-last-resort) | General Discussion |
-| @kubernetes/sig-contributor-experience-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-pr-reviews) | PR Reviews |
-| @kubernetes/sig-contributor-experience-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-proposals) | Design Proposals |
-| @kubernetes/sig-contributor-experience-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-contributor-experience-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-contributor-experience-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-contributor-experience-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-contributor-experience-feature-requests) | Feature Requests |
+| @kubernetes/sig-contributor-experience-misc-use-only-as-a-last-resort | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-misc-use-only-as-a-last-resort) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-contributor-experience-misc-use-only-as-a-last-resort) | General Discussion |
+| @kubernetes/sig-contributor-experience-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-contributor-experience-pr-reviews) | PR Reviews |
+| @kubernetes/sig-contributor-experience-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-contributor-experience-proposals) | Design Proposals |
+| @kubernetes/sig-contributor-experience-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-contributor-experience-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -30,10 +30,14 @@ Meeting recordings can be found [here](https://www.youtube.com/playlist?list=PL6
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-docs-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers) | Documentation Maintainers |
-| @kubernetes/sig-docs-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-docs-pr-reviews) | Documentation PR Reviewers |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-docs-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-docs-maintainers) | Documentation Maintainers |
+| @kubernetes/sig-docs-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-docs-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-docs-pr-reviews) | Documentation PR Reviewers |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-gcp/README.md
+++ b/sig-gcp/README.md
@@ -28,15 +28,19 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-gcp-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-gcp-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-gcp-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-feature-requests) | Feature Requests |
-| @kubernetes/sig-gcp-misc | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-misc) | General Discussion |
-| @kubernetes/sig-gcp-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-pr-reviews) | PR Reviews |
-| @kubernetes/sig-gcp-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-proposals) | Design Proposals |
-| @kubernetes/sig-gcp-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-gcp-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-gcp-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-gcp-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp-feature-requests) | Feature Requests |
+| @kubernetes/sig-gcp-misc | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp-misc) | General Discussion |
+| @kubernetes/sig-gcp-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp-pr-reviews) | PR Reviews |
+| @kubernetes/sig-gcp-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp-proposals) | Design Proposals |
+| @kubernetes/sig-gcp-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -30,15 +30,19 @@ Meeting notes and Agenda can be found [here](https://docs.google.com/document/d/
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-instrumentation-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-instrumentation-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-instrumentation-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-feature-requests) | Feature Requests |
-| @kubernetes/sig-instrumentation-misc | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-misc) | General Discussion |
-| @kubernetes/sig-instrumentation-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-pr-reviews) | PR Reviews |
-| @kubernetes/sig-instrumentation-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-proposals) | Design Proposals |
-| @kubernetes/sig-instrumentation-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-instrumentation-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-instrumentation-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-instrumentation-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation-feature-requests) | Feature Requests |
+| @kubernetes/sig-instrumentation-misc | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation-misc) | General Discussion |
+| @kubernetes/sig-instrumentation-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation-pr-reviews) | PR Reviews |
+| @kubernetes/sig-instrumentation-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation-proposals) | Design Proposals |
+| @kubernetes/sig-instrumentation-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -30,15 +30,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=iWKC3FsNH
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-multicluster-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-multicluster-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-multicluster-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-feature-requests) | Feature Requests |
-| @kubernetes/sig-multicluster-misc | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-misc) | General Discussion |
-| @kubernetes/sig-multicluster-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-pr-reviews) | PR Reviews |
-| @kubernetes/sig-multicluster-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-test-failures) | Test Failures and Triage |
-| @kubernetes/sig-mutlicluster-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-mutlicluster-proposals) | Design Proposals |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-multicluster-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-multicluster-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-multicluster-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster-feature-requests) | Feature Requests |
+| @kubernetes/sig-multicluster-misc | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster-misc) | General Discussion |
+| @kubernetes/sig-multicluster-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster-pr-reviews) | PR Reviews |
+| @kubernetes/sig-multicluster-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster-test-failures) | Test Failures and Triage |
+| @kubernetes/sig-mutlicluster-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-mutlicluster-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-mutlicluster-proposals) | Design Proposals |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -31,15 +31,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=phCA5-vWk
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-network-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-network-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-network-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-network-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-network-feature-requests) | Feature Requests |
-| @kubernetes/sig-network-misc | [link](https://github.com/orgs/kubernetes/teams/sig-network-misc) | General Discussion |
-| @kubernetes/sig-network-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-pr-reviews) | PR Reviews |
-| @kubernetes/sig-network-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-network-proposals) | Design Proposals |
-| @kubernetes/sig-network-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-network-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-network-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-network-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-network-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-network-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-network-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-network-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-network-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-network-feature-requests) | Feature Requests |
+| @kubernetes/sig-network-misc | [link](https://github.com/orgs/kubernetes/teams/sig-network-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-network-misc) | General Discussion |
+| @kubernetes/sig-network-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-network-pr-reviews) | PR Reviews |
+| @kubernetes/sig-network-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-network-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-network-proposals) | Design Proposals |
+| @kubernetes/sig-network-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-network-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-network-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Areas of Responsibility

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -29,14 +29,18 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=FbKOI9-x9
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-node-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-node-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-node-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-node-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-node-feature-requests) | Feature Requests |
-| @kubernetes/sig-node-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) | PR Reviews |
-| @kubernetes/sig-node-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-node-proposals) | Design Proposals |
-| @kubernetes/sig-node-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-node-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-node-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-node-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-node-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-node-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-node-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-node-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-node-feature-requests) | Feature Requests |
+| @kubernetes/sig-node-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-node-pr-reviews) | PR Reviews |
+| @kubernetes/sig-node-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-node-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-node-proposals) | Design Proposals |
+| @kubernetes/sig-node-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-node-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-on-premise/README.md
+++ b/sig-on-premise/README.md
@@ -30,15 +30,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=dyUWqqNYU
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-onprem-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-onprem-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-onprem-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-feature-requests) | Feature Requests |
-| @kubernetes/sig-onprem-misc | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-misc) | General Discussion |
-| @kubernetes/sig-onprem-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-pr-reviews) | PR Reviews |
-| @kubernetes/sig-onprem-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-proposals) | Design Proposals |
-| @kubernetes/sig-onprem-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-onprem-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-onprem-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-onprem-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-onprem-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-onprem-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-onprem-feature-requests) | Feature Requests |
+| @kubernetes/sig-onprem-misc | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-onprem-misc) | General Discussion |
+| @kubernetes/sig-onprem-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-onprem-pr-reviews) | PR Reviews |
+| @kubernetes/sig-onprem-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-onprem-proposals) | Design Proposals |
+| @kubernetes/sig-onprem-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-onprem-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-onprem-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -31,15 +31,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=iCfUx7ilh
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-openstack-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-openstack-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-openstack-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-feature-requests) | Feature Requests |
-| @kubernetes/sig-openstack-misc | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-misc) | General Discussion |
-| @kubernetes/sig-openstack-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-pr-reviews) | PR Reviews |
-| @kubernetes/sig-openstack-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-proposals) | Design Proposals |
-| @kubernetes/sig-openstack-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-openstack-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-openstack-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-openstack-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack-feature-requests) | Feature Requests |
+| @kubernetes/sig-openstack-misc | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack-misc) | General Discussion |
+| @kubernetes/sig-openstack-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack-pr-reviews) | PR Reviews |
+| @kubernetes/sig-openstack-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack-proposals) | Design Proposals |
+| @kubernetes/sig-openstack-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -29,17 +29,21 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=I0KbWz8MT
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-release-admins | [link](https://github.com/orgs/kubernetes/teams/sig-release-admins) | Release Team Admins |
-| @kubernetes/sig-release-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-release-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-release-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-release-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-release-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-release-feature-requests) | Feature Requests |
-| @kubernetes/sig-release-members | [link](https://github.com/orgs/kubernetes/teams/sig-release-members) | Release Team Members |
-| @kubernetes/sig-release-misc | [link](https://github.com/orgs/kubernetes/teams/sig-release-misc) | General Discussion |
-| @kubernetes/sig-release-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-release-pr-reviews) | PR Reviews |
-| @kubernetes/sig-release-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-release-proposals) | Design Proposals |
-| @kubernetes/sig-release-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-release-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-release-admins | [link](https://github.com/orgs/kubernetes/teams/sig-release-admins) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-release-admins) | Release Team Admins |
+| @kubernetes/sig-release-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-release-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-release-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-release-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-release-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-release-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-release-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-release-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-release-feature-requests) | Feature Requests |
+| @kubernetes/sig-release-members | [link](https://github.com/orgs/kubernetes/teams/sig-release-members) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-release-members) | Release Team Members |
+| @kubernetes/sig-release-misc | [link](https://github.com/orgs/kubernetes/teams/sig-release-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-release-misc) | General Discussion |
+| @kubernetes/sig-release-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-release-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-release-pr-reviews) | PR Reviews |
+| @kubernetes/sig-release-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-release-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-release-proposals) | Design Proposals |
+| @kubernetes/sig-release-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-release-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-release-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 [SIG Release][] has moved!

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -32,15 +32,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=NDP1uYyom
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-scalability-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-scalability-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-scalability-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-feature-requests) | Feature Requests |
-| @kubernetes/sig-scalability-misc | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-misc) | General Discussion |
-| @kubernetes/sig-scalability-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-pr-reviews) | PR Reviews |
-| @kubernetes/sig-scalability-proprosals | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-proprosals) | Design Proposals |
-| @kubernetes/sig-scalability-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-scalability-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scalability-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-scalability-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scalability-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-scalability-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scalability-feature-requests) | Feature Requests |
+| @kubernetes/sig-scalability-misc | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scalability-misc) | General Discussion |
+| @kubernetes/sig-scalability-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scalability-pr-reviews) | PR Reviews |
+| @kubernetes/sig-scalability-proprosals | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-proprosals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scalability-proprosals) | Design Proposals |
+| @kubernetes/sig-scalability-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scalability-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Remaining 2017 Meeting Dates

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -30,15 +30,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=PweKj6SU7
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-scheduling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-scheduling-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-scheduling-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-feature-requests) | Feature Requests |
-| @kubernetes/sig-scheduling-misc | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-misc) | General Discussion |
-| @kubernetes/sig-scheduling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-pr-reviews) | PR Reviews |
-| @kubernetes/sig-scheduling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-proposals) | Design Proposals |
-| @kubernetes/sig-scheduling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-scheduling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-scheduling-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-scheduling-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling-feature-requests) | Feature Requests |
+| @kubernetes/sig-scheduling-misc | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling-misc) | General Discussion |
+| @kubernetes/sig-scheduling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling-pr-reviews) | PR Reviews |
+| @kubernetes/sig-scheduling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling-proposals) | Design Proposals |
+| @kubernetes/sig-scheduling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -32,15 +32,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=ukPj1sFFk
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-service-catalog-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-service-catalog-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-service-catalog-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-feature-requests) | Feature Requests |
-| @kubernetes/sig-service-catalog-misc | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-misc) | General Discussion |
-| @kubernetes/sig-service-catalog-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-pr-reviews) | PR Reviews |
-| @kubernetes/sig-service-catalog-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-proposals) | Design Proposals |
-| @kubernetes/sig-service-catalog-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-service-catalog-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-service-catalog-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-service-catalog-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog-feature-requests) | Feature Requests |
+| @kubernetes/sig-service-catalog-misc | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog-misc) | General Discussion |
+| @kubernetes/sig-service-catalog-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog-pr-reviews) | PR Reviews |
+| @kubernetes/sig-service-catalog-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog-proposals) | Design Proposals |
+| @kubernetes/sig-service-catalog-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -63,17 +63,6 @@ Interested in contributing to storage features in Kubernetes? [Please read our g
 * Public Slack Channel: https://kubernetes.slack.com/messages/sig-storage/details/
   * Get invite to join here: http://slack.k8s.io/
   * Our channel is `sig-storage`
-* Google Groups
-  * General storage SIG related discussions (join to participate).
-    * [kubernetes-sig-storage](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
-  * Archive of Github team notifications (Monitor these for Github activity, you don't have to join them):
-    * [kubernetes-sig-storage-api-reviews](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-api-reviews) - On GitHub  `@kubernetes/sig-storage-api-reviews` will CC this group.
-    * [kubernetes-sig-storage-bugs](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-bugs) - On GitHub metioning `@kubernetes/sig-storage-bugs` will CC this group.
-    * [kubernetes-sig-storage-feature-requests](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-feature-requests) - On GitHub metioning `@kubernetes/sig-storage-feature-requests` will CC this group.
-    * [kubernetes-sig-storage-misc](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-misc) - On GitHub metioning `@kubernetes/sig-storage-misc` will CC this group.
-    * [kubernetes-sig-storage-pr-reviews](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-pr-reviews) - On GitHub metioning `@kubernetes/sig-storage-pr-reviews` will CC this group.
-    * [kubernetes-sig-storage-proposals](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-proposals) - On GitHub metioning `@kubernetes/sig-storage-proposals` will CC this group.
-    * [kubernetes-sig-storage-test-failures](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-test-failures) - On GitHub metioning `@kubernetes/sig-storage-test-failures` will CC this group.
 * Github Issues
   * [link](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+is%3Aissue+label%3Asig%2Fstorage)
 * Documentation for currently supported volume plugins: https://kubernetes.io/docs/concepts/storage/volumes/

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -30,15 +30,19 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=Eh7Qa7KOL
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-storage-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-storage-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-storage-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-storage-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-storage-feature-requests) | Feature Requests |
-| @kubernetes/sig-storage-misc | [link](https://github.com/orgs/kubernetes/teams/sig-storage-misc) | General Discussion |
-| @kubernetes/sig-storage-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-pr-reviews) | PR Reviews |
-| @kubernetes/sig-storage-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-storage-proposals) | Design Proposals |
-| @kubernetes/sig-storage-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-storage-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-storage-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-storage-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-storage-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-storage-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-storage-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-feature-requests) | Feature Requests |
+| @kubernetes/sig-storage-misc | [link](https://github.com/orgs/kubernetes/teams/sig-storage-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-misc) | General Discussion |
+| @kubernetes/sig-storage-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-pr-reviews) | PR Reviews |
+| @kubernetes/sig-storage-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-storage-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-proposals) | Design Proposals |
+| @kubernetes/sig-storage-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-storage-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-storage-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -32,15 +32,19 @@ Meeting recordings can be found [here](https://bit.ly/k8s-sig-testing-videos).
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-testing-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-testing-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-testing-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-testing-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-testing-feature-requests) | Feature Requests |
-| @kubernetes/sig-testing-misc | [link](https://github.com/orgs/kubernetes/teams/sig-testing-misc) | General Discussion |
-| @kubernetes/sig-testing-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-pr-reviews) | PR Reviews |
-| @kubernetes/sig-testing-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-testing-proposals) | Design Proposals |
-| @kubernetes/sig-testing-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-testing-test-failures) | Test Failures and Triage |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-testing-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-testing-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-testing-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-testing-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-testing-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-testing-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-testing-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-testing-feature-requests) | Feature Requests |
+| @kubernetes/sig-testing-misc | [link](https://github.com/orgs/kubernetes/teams/sig-testing-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-testing-misc) | General Discussion |
+| @kubernetes/sig-testing-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-testing-pr-reviews) | PR Reviews |
+| @kubernetes/sig-testing-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-testing-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-testing-proposals) | Design Proposals |
+| @kubernetes/sig-testing-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-testing-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-testing-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -29,11 +29,15 @@ Meeting recordings can be found [here](https://www.youtube.com/watch?v=7zawb3KT9
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-windows-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-windows-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-windows-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-windows-feature-requests) | Feature Requests |
-| @kubernetes/sig-windows-misc | [link](https://github.com/orgs/kubernetes/teams/sig-windows-misc) | General Discussion |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-windows-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-windows-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-windows-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-windows-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-windows-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-windows-feature-requests) | Feature Requests |
+| @kubernetes/sig-windows-misc | [link](https://github.com/orgs/kubernetes/teams/sig-windows-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-windows-misc) | General Discussion |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Getting Started

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -4,7 +4,7 @@ sigs:
     mission_statement: >
       Covers all aspects of API server, API registration and discovery, generic
       API CRUD semantics, admission control, encoding/decoding, conversion,
-      defaulting, persistence layer (etcd), OpenAPI, third-party resource,
+      defaulting, persistence layer (etcd), OpenAPI, CustomResourceDefinition,
       garbage collection, and client libraries.
     label: api-machinery
     leads:


### PR DESCRIPTION
Each github team is associated with a google group. Example: https://github.com/orgs/kubernetes/teams/sig-api-machinery-pr-reviews is associated with https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery-pr-reviews.

I think it's helpful to document this because it allows someone to follow along even if they are not part of the team.

This PR contains the following changes:

- adds google groups for github teams in the generator.
- improves the generator `README`.
- `sig-storage`: removes info about google groups from custom content
- `sig-apimachinery`:
    - removes duplicate content
    - renames TPR to CRD

/assign cblecker spiffxp vishh 