### PR TITLE
fix dead link to the initial kep 001

### DIFF
--- a/keps/README.md
+++ b/keps/README.md
@@ -4,4 +4,4 @@ This directory contains both the template and process for KEPs.
 
 This process is still in an _alpha_ state and is opt-in for those that want to provide feedback for the process.
 
-See [KEP-1](1-kubernetes-enhancement-proposal-process.md) for details of this process.
+See [KEP-1](001-kubernetes-enhancement-proposal-process.md) for details of this process.


### PR DESCRIPTION
The readme link to kep 001 was incorrect, this change fixes it. Also
noted that the inital kep is "001" and not "0001", not sure if this
needs fixing as well.