### PR TITLE
contrib guide: tighten some language

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -128,7 +128,7 @@ For quick reference on contributor resources, we have a handy [contributor cheat
 
 It is best to contact your [SIG](#learn-about-sigs) for issues related to the SIG's topic. Your SIG will be able to help you much more quickly than a general question would.
 
-For questions and troubleshooting, please feel free to use any of the methods of communication listed [here](/communication.md). The [kubernetes website](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/) also lists this information.
+For general questions and troubleshooting, use the [kubernetes standard lines of communication](/communication.md) and work through the [kubernetes troubleshooting guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/).
 
 ## GitHub workflow
 


### PR DESCRIPTION
The difference between the two links for communications around questions
and troubleshooting was not clear to me, and the wording made them
seem somewhat redundant.  They're really two separate topic links,
so I've changed the wording to hopefully make it more clear that one has
general communications information and once is actually a
troubleshooting guide.

Signed-off-by: Tim Pepper <tpepper@vmware.com>