### PR TITLE
Break out the community meeting documentation into its own page

### DIFF
--- a/communication.md
+++ b/communication.md
@@ -53,18 +53,7 @@ Office hours are held once a month. Please refer to [this document](events/offic
 
 ## Weekly Meeting
 
-We have PUBLIC and RECORDED [weekly meeting] every Thursday at 10am US Pacific Time over Zoom.
-
-Map that to your local time with this [timezone table].
-
-See it on the web at [calendar.google.com], or paste this [iCal url] into any iCal client.
-
-To be added to the calendar items, join the Google group
-[kubernetes-community-video-chat] for further instructions.
-
-If you have a topic you'd like to present or would like to see discussed,
-please propose a specific date on the [Kubernetes Community Meeting Agenda].
-
+Refer to the [community meeting document](events/community-meeting.md) for information on our weekly meeting. 
 
 ## Conferences
 

--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -1,0 +1,73 @@
+# Kubernetes Weekly Community Meeting
+
+We have PUBLIC and RECORDED [weekly meeting](https://zoom.us/my/kubernetescommunity) every Thursday at 6pm UTC (1pm EST / 10am PST)
+ 
+Map that to your local time with this [timezone table](https://www.google.com/search?q=1800+in+utc)
+
+See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles) , or paste this [iCal url](https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics) into any iCal client.
+
+To be added to the calendar items, join the Google group
+[kubernetes-community-video-chat](https://groups.google.com/forum/#!forum/kubernetes-community-video-chat) for further instructions.
+
+All meetings are archived on the [Youtube Channel](https://www.youtube.com/watch?v=onlFHICYB4Q&list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ)
+
+Quick links:
+
+- [Agenda document](https://k8s.devstats.cncf.io/)
+- [Zoom meeting link](https://zoom.us/my/kubernetescommunity)
+
+## Purpose
+
+The purpose of the community meeting is the dissemination of information throughout the project. 
+Large changes in an area of Kubernetes that affect groups of people should be mentioned here. 
+
+
+## Meeting Agenda
+
+If you have a topic you'd like to present or would like to see discussed,
+please propose a specific date on the [Kubernetes Community Meeting Agenda](https://docs.google.com/document/d/1VQDIAB0OqiSjIHI8AWMvSdceWhnz56jNpZrLs6o7NJY/edit#).
+
+General speaking the meeting is structured like this:
+
+- Introduction by Host (~3 minutes)
+- Community Demo (~10 minutes)
+- Release Updates
+  - Development Release
+  - Stable Release and point releases
+  - Older stable releases and point releases
+- Graph of the Week (~2 minutes)
+  - This is meant to bring attention to different [devstats graphs](https://k8s.devstats.cncf.io/)
+- SIG Updates
+  - Three SIGs per meeting, 10 minutes per SIG 
+- Announcements (~5 minutes)
+  - Any other community announcements should go here
+
+## Demos
+
+The first 10 minutes of a meeting is dedicated to demonstrations from the community. 
+These demos are noted at the top of the community document. 
+There is a hard stop of the demo at 10 minutes, with up to 5 more minutes for questions.
+Feel free to add your demo request to the bottom of the list, then one of the organizers will get back to you to schedule an exact date. 
+Demo submissions MUST follow the the requirements listed below. 
+
+### Requirements
+
+This meeting is the largest meeting in the community, and is attended by many people, therefore we ask that you _prepare ahead of time_ and not waste this opportunity.
+
+- Your demo MUST NOT be a commercial pitch and MUST be related to Kubernetes. Commercial software and services can be demo'ed but _keep it classy_ and relevant to the audience.
+- You MUST show up to the community meeting _10 minutes_ prior to the start to test your audio and screensharing with the hosts. If you are not present on time, you will _lose your spot_ and be kicked back to the end of the demo queue. 
+- You MUST also commit to being available the week before your demo date in case there is an issue with that week's demo. 
+- The use of a headset or other high quality gear is _strongly_ recommended, typing from the same laptop you are speaking into is distracting
+- Ensure you are presenting from a quiet environment.
+- If you run out of time and your demo is a smashing hit we encourage you to schedule follow on events. 
+
+## SIG Updates 
+
+SIGs will give a community update at least once per release cycle per the [schedule](TBD). 
+
+## Archives
+
+The document gets slow as we add notes, so it is archived regularly into another document:
+
+- [2017](https://docs.google.com/document/d/1sAH-74kIGROvM5MhyAkbJPVcuE9-RDHiOqfv_4PAGdw/edit#heading=h.en8cy6hno0c6)
+- [2014-1016](https://docs.google.com/a/google.com/document/d/1fcs_POhXJCL1dqYrG3IxE4Ivh8jh2JYLCCdgRmBQeb8/edit?usp=sharing) 

--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -70,7 +70,7 @@ Also, if you are doing a live coding demo, please make sure it has a reasonable 
 
 ## SIG Updates 
 
-SIGs will give a community update at least once per release cycle per the [schedule](TBD). 
+SIGs will give a community update at least once per release cycle per the [schedule](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k). 
 
 ## Archives
 

--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -21,6 +21,12 @@ Quick links:
 The Kubernetes community meeting is intended to provide a holistic overview of community activities, critical release information, and governance updates. 
 It also provides a forum for discussion of project-level concerns that might need a wider audience than a single special interest group (SIG).
 
+## Notetaker(s)
+
+Notes from the meeting are published to the [Kubernetes dev](https://groups.google.com/forum/#!forum/kubernetes-dev) list. 
+A good notetaker is important to help get the information out to people who cannot attend. 
+Volunteers are always welcome to either add their notes directly to the document, or inform the host that they would like to help take notes at the beginning of the call.
+
 ## Meeting Agenda
 
 If you have a topic you'd like to present or would like to see discussed,
@@ -61,8 +67,6 @@ Also, if you are doing a live coding demo, please make sure it has a reasonable 
 - The use of a headset or other high-quality audio equipment is strongly encouraged. Typing on a laptop while using the system microphone is distracting, so please insulate your microphone from key noises.
 - Ensure you are presenting from a quiet environment.
 - If you run out of time while performing your demo, you may ask the audience if they would like a follow-up at a subsequent meeting. If there is enthusiastic support, the community team will help schedule a continuation.
-
-
 
 ## SIG Updates 
 

--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -13,21 +13,20 @@ All meetings are archived on the [Youtube Channel](https://www.youtube.com/watch
 
 Quick links:
 
-- [Agenda document](https://k8s.devstats.cncf.io/)
+- [Agenda document](http://bit.ly/k8scommunity)
 - [Zoom meeting link](https://zoom.us/my/kubernetescommunity)
 
 ## Purpose
 
-The purpose of the community meeting is the dissemination of information throughout the project. 
-Large changes in an area of Kubernetes that affect groups of people should be mentioned here. 
-
+The Kubernetes community meeting is intended to provide a holistic overview of community activities, critical release information, and governance updates. 
+It also provides a forum for discussion of project-level concerns that might need a wider audience than a single special interest group (SIG).
 
 ## Meeting Agenda
 
 If you have a topic you'd like to present or would like to see discussed,
-please propose a specific date on the [Kubernetes Community Meeting Agenda](https://docs.google.com/document/d/1VQDIAB0OqiSjIHI8AWMvSdceWhnz56jNpZrLs6o7NJY/edit#).
+please propose a specific date on the [Kubernetes Community Meeting Agenda](http://bit.ly/k8scommunity).
 
-General speaking the meeting is structured like this:
+General speaking the meeting is structured as follows:
 
 - Introduction by Host (~3 minutes)
 - Community Demo (~10 minutes)
@@ -52,14 +51,18 @@ Demo submissions MUST follow the the requirements listed below.
 
 ### Requirements
 
-This meeting is the largest meeting in the community, and is attended by many people, therefore we ask that you _prepare ahead of time_ and not waste this opportunity.
+This meeting has a large number of attendees. 
+Out of respect for their time, we ask that you be fully prepared for your demo. Make sure slides are clear if applicable, and the link to them is posted in the meeting agenda. 
+Also, if you are doing a live coding demo, please make sure it has a reasonable chance of completing within the allotted time box.
 
-- Your demo MUST NOT be a commercial pitch and MUST be related to Kubernetes. Commercial software and services can be demo'ed but _keep it classy_ and relevant to the audience.
-- You MUST show up to the community meeting _10 minutes_ prior to the start to test your audio and screensharing with the hosts. If you are not present on time, you will _lose your spot_ and be kicked back to the end of the demo queue. 
-- You MUST also commit to being available the week before your demo date in case there is an issue with that week's demo. 
-- The use of a headset or other high quality gear is _strongly_ recommended, typing from the same laptop you are speaking into is distracting
+- Your demo should provide clear, valuable information to the community without being commercial in nature. Typical sales pitches are not permitted, and could potentially alienate your audience. Commercial software and services can be demo'ed, but a prior discussion with the community team is advised to ensure a positive experience.
+- You are required to show up 10 minutes before the meeting to verify your audio and screensharing capabilities with the hosts. If you cannot make and keep this commitment, you will not be allowed to proceed with your demo until such time you can.
+- You also required to commit to being available the week before your demo date in case there is an issue with that week's demo.
+- The use of a headset or other high-quality audio equipment is strongly encouraged. Typing on a laptop while using the system microphone is distracting, so please insulate your microphone from key noises.
 - Ensure you are presenting from a quiet environment.
-- If you run out of time and your demo is a smashing hit we encourage you to schedule follow on events. 
+- If you run out of time while performing your demo, you may ask the audience if they would like a follow-up at a subsequent meeting. If there is enthusiastic support, the community team will help schedule a continuation.
+
+
 
 ## SIG Updates 
 


### PR DESCRIPTION
The community meeting google doc is starting to have too much info at the top, so I'd like to put it in the github repo for more permanence. 

It makes some changes which I have proposed at a prior meeting, so I'd like the reviewers to note the codification of things, notably the purpose of the meeting, and the addition of stricter requirements for the community demo.

/cc @jdumars @jberkus @tpepper 