### PR TITLE
fixed typo and missing link

### DIFF
--- a/contributors/devel/testing.md
+++ b/contributors/devel/testing.md
@@ -192,7 +192,7 @@ for those internal etcd instances with the `TEST_ETCD_DIR` environment variable.
 ### Run integration tests
 
 The integration tests are run using `make test-integration`.
-The Kubernetes integration tests are writting using the normal golang testing
+The Kubernetes integration tests are written using the normal golang testing
 package but expect to have a running etcd instance to connect to.  The `test-integration.sh`
 script wraps `make test` and sets up an etcd instance for the integration tests to use.
 

--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -12,6 +12,8 @@
 Per Go's [workspace instructions][go-workspace], place Kubernetes' code on your
 `GOPATH` using the following cloning procedure.
 
+[go-workspace]: https://golang.org/doc/code.html#Workspaces
+
 Define a local working directory:
 
 ```sh


### PR DESCRIPTION
`go-workspace` link taken from `contributors/devel/development.md:181`