### PR TITLE
fixed links to community expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Links in [contributors/devel/README.md](contributors/devel/README.md)
 lead to many relevant topics, including
  * [Developer's Guide] - how to start a build/test cycle
  * [Collaboration Guide] - how to work together
- * [expectations] - what the community expects
+ * [expectations](contributors/guide/community-expectations) - what the community expects
  * [pull request] policy - how to prepare a pull request
 
 ## Your First Contribution

--- a/community-membership.md
+++ b/community-membership.md
@@ -185,7 +185,7 @@ The following apply to the part of codebase for which one would be an approver i
 - Demonstrate sound technical judgement
 - Responsible for project quality control via [code reviews](contributors/devel/collab.md)
   - Focus on holistic acceptance of contribution such as dependencies with other features, backwards / forwards compatibility, API and flag definitions, etc
-- Expected to be responsive to review requests as per [community expectations](contributors/devel/community-expectations.md);
+- Expected to be responsive to review requests as per [community expectations](contributors/guide/community-expectations.md);
 - Mentor contributors and reviewers
 - May approve code contributions for acceptance
 

--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -178,7 +178,7 @@ The pull request workflow is described in detail [here](/contributors/devel/pull
 
 ## Code Review
 
-For a brief description of the importance of code review, please read [On Code Review](/contributors/devel/community-expectations.md#code-review).  There are two aspects of code review: giving and receiving.
+For a brief description of the importance of code review, please read [On Code Review](/contributors/guide/community-expectations.md#code-review).  There are two aspects of code review: giving and receiving.
 
 To make it easier for your PR to receive reviews, consider the reviewers will need you to:
 

--- a/mentoring/group-mentee-guide.md
+++ b/mentoring/group-mentee-guide.md
@@ -64,7 +64,7 @@ SIG Docs to come in and do a quick ‘what it means to be a tech reviewer’ and
 - the docs
 	- k/community is your friend for upstream workflows, processes, and information around contributing
 	- This repo includes the community/devel folder which will be extra helpful that includes docs such as:
-    - [Code Review Expectations](/contributors/devel/community-expectations.md)
+    - [Code Review Expectations](/contributors/guide/community-expectations.md)
     - [Collaboration on k8s](/contributors/devel/collab.md)
 
 


### PR DESCRIPTION
Some 404 errors fixed because community-expectations.md was moved to contributors/guide
/sig contributor-experience