### PR TITLE
Add bgrant0607 to top-level OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ reviewers:
   - idvoretskyi
   - sarahnovotny
 approvers:
+  - bgrant0607
   - brendandburns
   - calebamiles
   - castrojo


### PR DESCRIPTION
Somehow Brian was missed in the top-level OWNERS file of k/community

cc: @bgrant0607 @spiffxp 