### PR TITLE
Add OWNERS file for contributors/guide/

### DIFF
--- a/contributors/guide/OWNERS
+++ b/contributors/guide/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - castrojo
+  - guineveresaenger
+  - idvoretskyi
+  - tpepper
+approvers:
+  - castrojo
+  - parispittman


### PR DESCRIPTION
Right now changes to the contributor's guide flow up to the top level approvers. This creates an OWNERS file for the guide so that the people who are working on it can review it. Please let me know if anyone should be added/removed.

/hold
for comment

/cc @castrojo @guineveresaenger @tpepper @parispittman @spiffxp 