### PR TITLE
Fix link to community expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you want to work on a new idea of relatively small scope:
 [Collaboration Guide]: contributors/devel/collab.md
 [Developer's Guide]: contributors/devel/development.md
 [develop a new feature]: https://github.com/kubernetes/features
-[expectations]: contributors/devel/community-expectations.md
+[expectations]: contributors/guide/community-expectations.md
 [help wanted]: https://go.k8s.io/help-wanted
 [pull request]: contributors/devel/pull-requests.md
 


### PR DESCRIPTION
This file was renamed in 774750b5d22b16203a0ea18d352821cb0aa7d43a.
Then, the link was fixed in ec8afcb36282ae771a02c7b5568e896d61faeba2. But broken again by 069e6e50f91563e4efdb68e0a9c786a2a9f75d52