### PR TITLE
Add pointer to communication/

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -202,6 +202,9 @@ Have you ever noticed the total number of [open issues](https://issues.k8s.io)? 
 
 If you haven't noticed by now, we have a large, lively, and friendly open-source community. We depend on new people becoming members and regular code contributors, so we would like you to come join us. To find out more about our community structure, different levels of membership and code contributors, please [explore here](/community-membership.md).
 
+## Communication
+
+- [General Information](/communication) 
 
 ## Events
 


### PR DESCRIPTION
Communication resources are in their own directory, this points people
to it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->