### PR TITLE
Add TOC headers to contributor, developer, and mentorship guides

### DIFF
--- a/contributors/devel/README.md
+++ b/contributors/devel/README.md
@@ -1,3 +1,7 @@
+---
+Title: Kubernetes Developer Guide
+---
+
 # Kubernetes Developer Guide
 
 The developer guide is for anyone wanting to either write code which directly accesses the

--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -1,3 +1,7 @@
+---
+title: Kubernetes Contributor Guide
+---
+
 # Kubernetes Contributor Guide
 
 ## Disclaimer

--- a/mentoring/README.md
+++ b/mentoring/README.md
@@ -1,3 +1,7 @@
+---
+Title: Kubernetes Mentoring Initiative
+---
+
 # Kubernetes Mentoring Initiatives
 
 This folder will be used for all mentoring initiatives for Kubernetes.


### PR DESCRIPTION
This adds the necessary metadata to generate a table of contents when
when generating these pages for the documentation.