### PR TITLE
contrib guide: update ToC

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -16,10 +16,10 @@ Welcome to Kubernetes! This document is the single source of truth for how to co
 
 -   [Before you get started](#before-you-get-started)
     -   [Sign the CLA](#sign-the-cla)
+    -   [Code of Conduct](#code-of-conduct)
     -   [Setting up your development
         environment](#setting-up-your-development-environment)
     -   [Community Expectations](#community-expectations)
-        -   [Code of Conduct](#code-of-conduct)
         -   [Thanks](#thanks)
 -   [Your First Contribution](#your-first-contribution)
     -   [Find something to work on](#find-something-to-work-on)
@@ -36,9 +36,9 @@ Welcome to Kubernetes! This document is the single source of truth for how to co
     -   [Documentation](#documentation)
     -   [Issues Management or Triage](#issues-management-or-triage)
 -   [Community](#community)
+    -   [Communication](#communication-1)
     -   [Events](#events)
         -   [Meetups](#meetups)
-        -   [KubeCon](#kubecon)
     -   [Mentorship](#mentorship)
 
 # Before you get started


### PR DESCRIPTION
The table of contents has slipped out of date.

FYI I'm generating a ToC with a command like:
	pandoc -t markdown_github --toc -s README.md
and then picking up the modifications and dropping them in the document.

Not the best workflow, but..markdown.

Signed-off-by: Tim Pepper <tpepper@vmware.com>
