### PR TITLE
fix a typo in alternate api representations

### DIFF
--- a/contributors/design-proposals/api-machinery/alternate-api-representations.md
+++ b/contributors/design-proposals/api-machinery/alternate-api-representations.md
@@ -25,7 +25,7 @@ versions of the existing content and are not intended to support arbitrary param
 Also, the server today contains a number of objects which are common across multiple groups,
 but which clients must be able to deal with in a generic fashion. These objects - Status,
 ListMeta, ObjectMeta, List, ListOptions, ExportOptions, and Scale - are embedded into each
-group version but are actually part of a a shared API group. It must be possible for a naive
+group version but are actually part of a shared API group. It must be possible for a naive
 client to translate the Scale response returned by two different API group versions.
 
 


### PR DESCRIPTION
fix a typo in alternate api representations

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->