### PR TITLE
Change KEP state from accepted to draft

### DIFF
--- a/keps/0000-kep-template.md
+++ b/keps/0000-kep-template.md
@@ -16,7 +16,7 @@ approvers:
 editor: TBD
 creation-date: yyyy-mm-dd
 last-updated: yyyy-mm-dd
-status: accepted
+status: draft
 see-also:
   - KEP-1
   - KEP-2

--- a/keps/0001-kubernetes-enhancement-proposal-process.md
+++ b/keps/0001-kubernetes-enhancement-proposal-process.md
@@ -164,7 +164,7 @@ Metadata items:
     KEP filename.  See the template for instructions and details.
 * **status** Required
   * The current state of the KEP.
-  * Must be one of `accepted`, `implementable`, `implemented`, `deferred`, `rejected`, `withdrawn`, or `replaced`.
+  * Must be one of `draft`, `implementable`, `implemented`, `deferred`, `rejected`, `withdrawn`, or `replaced`.
 * **authors** Required
   * A list of authors for the KEP.
     This is simply the github ID.
@@ -222,9 +222,9 @@ Metadata items:
 
 A KEP has the following states
 
-- `accepted`: The KEP has been proposed and is actively being defined.
+- `draft`: The KEP has been proposed and is actively being defined.
   This is the starting state while the KEP is being fleshed out and actively defined and discussed.
-  The owning SIG has accepted that this is work that needs to be done.
+  The owning SIG has agreed that this is work that needs to be done, but is not ready for implementation.
 - `implementable`: The approvers have approved this KEP for implementation.
 - `implemented`: The KEP has been implemented and is no longer actively changed.
 - `deferred`: The KEP is proposed but not actively being worked on.

--- a/keps/0002-controller-manager.md
+++ b/keps/0002-controller-manager.md
@@ -15,7 +15,7 @@ reviewers:
 approvers:
   - "@thockin"
 editor: TBD
-status: approved
+status: draft
 replaces:
   - contributors/design-proposals/cloud-provider/cloud-provider-refactoring.md
 ```

--- a/keps/sig-cluster-lifecycle/0003-cluster-api.md
+++ b/keps/sig-cluster-lifecycle/0003-cluster-api.md
@@ -5,7 +5,7 @@
 ---
 kep-number: 3
 title: Kubernetes Cluster Management API
-status: accepted
+status: draft
 authors:
     - "@roberthbailey"
     - "@pipejakob"


### PR DESCRIPTION
This PR is a proposal to make the initial state of a KEP more clear.
There have been misunderstandings on the means because of the way
accepted has been used elsewhere on the project.

For example, some reviewing the Application object/CRD PR though expected meant implementable or that this was the accepted design direction that would be expected to implement. Since this is a new process I would argue the naming should follow the [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) and attempt to be intuitive even to those not familiar with the process (which is most people at the moment).

This proposed change moves the term to draft which is used buy other projects
such as the IETF standards track.

/cc @jdumars @bgrant0607 @jbeda 

/sig architecture

