### PR TITLE
fix a typo in the Contributor Guide

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -59,7 +59,7 @@ If you haven’t set up your environment, please find resources [here](/contribu
 
 Kubernetes is a community project. Consequently, it is wholly dependent on its community to provide a productive, friendly and collaborative environment.
 
-Read and review the [Community Expectations](community-expectations.md) for an understand of code and review expectations. 
+Read and review the [Community Expectations](community-expectations.md) for an understanding of code and review expectations.
 
 ## Thanks
 


### PR DESCRIPTION
fixes a small typo in the Contributors Guide
also, it's my first upstream PR :)

```release-note
NONE
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->