### PR TITLE
Fix a broken link for a file moved to guide from devel

### DIFF
--- a/contributors/devel/issues.md
+++ b/contributors/devel/issues.md
@@ -1,1 +1,1 @@
-+**NOTE:** This document has moved to [a new location](/community/contributors/guide/issue-triage.md)
++**NOTE:** This document has moved to [a new location](/contributors/guide/issue-triage.md)


### PR DESCRIPTION
Fix a broken link. This is the only broken link that I found after checking all the files that are moved to guide. 

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->