### PR TITLE
This commit removes the duplication of thanks from the Contributor Guide

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -61,10 +61,6 @@ Kubernetes is a community project. Consequently, it is wholly dependent on its c
 
 Read and review the [Community Expectations](community-expectations.md) for an understand of code and review expectations. 
 
-## Thanks
-
-Many thanks in advance to everyone who contributes their time and effort to making Kubernetes both a successful system as well as a successful community. The strength of our software shines in the strengths of each individual community member. Thanks!
-
 # Your First Contribution
 
 Have you ever wanted to contribute to the coolest cloud technology? We will help you understand the organization of the Kubernetes project and direct you to the best places to get started. You'll be able to pick up issues, write code to fix them, and get your work reviewed and merged.


### PR DESCRIPTION
Thanks were expressed twice in the Contributor Guide. To remove clutter, this pull request removes this section from the main README but leaves it in community-expectations.md. In the future, code review documentation will be added as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->