### PR TITLE
Add the requirement that GA/stable APIs must have conformance tests

### DIFF
--- a/contributors/devel/api_changes.md
+++ b/contributors/devel/api_changes.md
@@ -766,7 +766,9 @@ feedback
   - Object Versioning: API version `vX` where `X` is an integer (e.g. `v1`)
   - Availability: in official Kubernetes releases, and enabled by default
   - Audience: all users
-  - Completeness: same as beta
+  - Completeness: must have conformance tests, approved by SIG Architecture,
+in the appropriate conformance profile (e.g., non-portable and/or optional
+features may not be in the default profile)
   - Upgradeability: only [strictly compatible](#on-compatibility) changes
 allowed in subsequent software releases
   - Cluster Reliability: high


### PR DESCRIPTION
Add the requirement that GA/stable APIs must have conformance tests, if/as appropriate.

The intent is to stop the bleeding on features progressing to GA without conformance tests. There are some details to work out, but I don't think they belong in this doc. I'm just trying to capture the intent here.

cc @kubernetes/sig-architecture-api-reviews @jagosan @WilliamDenniss 