### PR TITLE
sig-volume: fix owner link for pkg/volume owners

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -38,7 +38,7 @@ The following subprojects are owned by sig-storage:
     - https://raw.githubusercontent.com/kubernetes-incubator/nfs-provisioner/master/OWNERS
 - **volumes**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volumes/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/OWNERS
 
 ## GitHub Teams
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1401,7 +1401,7 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes-incubator/nfs-provisioner/master/OWNERS
     - name: volumes
       owners:
-      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volumes/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/OWNERS
   - name: Testing
     dir: sig-testing
     mission_statement: >


### PR DESCRIPTION
The actual path in the Kubernetes repo is pkg/volume, not pkg/volumes.