### PR TITLE
Make ical instructions clearer

### DIFF
--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -4,7 +4,7 @@ We have PUBLIC and RECORDED [weekly meeting](https://zoom.us/my/kubernetescommun
  
 Map that to your local time with this [timezone table](https://www.google.com/search?q=1800+in+utc)
 
-See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles) , or paste this [iCal url](https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics) into any iCal client.
+See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles) , or paste this [iCal url](https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics) into any [iCal client](https://en.wikipedia.org/wiki/ICalendar).
 
 All meetings are archived on the [Youtube Channel](https://www.youtube.com/watch?v=onlFHICYB4Q&list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ)
 

--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -6,9 +6,6 @@ Map that to your local time with this [timezone table](https://www.google.com/se
 
 See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles) , or paste this [iCal url](https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics) into any iCal client.
 
-To be added to the calendar items, join the Google group
-[kubernetes-community-video-chat](https://groups.google.com/forum/#!forum/kubernetes-community-video-chat) for further instructions.
-
 All meetings are archived on the [Youtube Channel](https://www.youtube.com/watch?v=onlFHICYB4Q&list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ)
 
 Quick links:

--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -4,7 +4,7 @@ We have PUBLIC and RECORDED [weekly meeting](https://zoom.us/my/kubernetescommun
  
 Map that to your local time with this [timezone table](https://www.google.com/search?q=1800+in+utc)
 
-See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles) , or paste this [iCal url](https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics) into any [iCal client](https://en.wikipedia.org/wiki/ICalendar).
+See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles) , or paste this [iCal url](https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics) into any [iCal client](https://en.wikipedia.org/wiki/ICalendar). Do NOT copy the meetings over to a your perosnal calendar, you will miss meeting updates. Instead use your client's calendaring feature to say you are attending the meeting so that any changes made to meetings will be reflected on your personal calendar. 
 
 All meetings are archived on the [Youtube Channel](https://www.youtube.com/watch?v=onlFHICYB4Q&list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ)
 


### PR DESCRIPTION
This clarifies how best to subscribe to the community meeting. Unfortunately ical usage depends on the client, so we don't want to cover every case here, so we link to wikipedia. 

Perhaps a page or videos for each specific client might be a good idea if we want some follow up work.