### PR TITLE
List desired cloud provider git repositories as subprojects

### DIFF
--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -25,15 +25,48 @@
 {{- if .Label }}
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2F{{.Label}})
 {{- end }}
+{{- if .Subprojects }}
+
+## Subprojects
+
+The following subprojects are owned by wg-{{.Label}}:
+
+{{- range .Subprojects }}
+- **{{.Name}}**
+{{- if .Description }}
+  - Description: {{ .Description }}
+{{- end }}
+  - Owners:
+{{- range .Owners }}
+    - {{.}}
+{{- end }}
+{{- if .Meetings }}
+  - Meetings:
+{{- range .Meetings }}
+    - {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
+{{- if .ArchiveURL }}
+      - [Meeting notes and Agenda]({{.ArchiveURL}}).
+{{- end }}
+{{- if .RecordingsURL }}
+      - [Meeting recordings]({{.RecordingsURL}}).
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{ if .Contact.GithubTeams }}
 ## GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
 {{- range .Contact.GithubTeams }}
-| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
+| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | [link](https://groups.google.com/forum/#!forum/kubernetes-{{.Name}}) | {{.Description}} |
 {{- end }}
 {{  end }}

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1643,6 +1643,7 @@ workinggroups:
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-app-def
   - name: Cloud Provider
     dir: wg-cloud-provider
+    label: cloud-provider
     mission_statement: >
       Charter can be found [here](https://docs.google.com/document/d/1m4Kvnh_u_9cENEE9n1ifYowQEFSgiHnbw43urGJMB64/edit#)
     leads:
@@ -1663,6 +1664,31 @@ workinggroups:
     contact:
       slack: wg-cloud-provider
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-cloud-provider
+    subprojects:
+    - name: aws-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/aws-cloud-provider/master/OWNERS
+    - name: azure-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/azure-cloud-provider/master/OWNERS
+    - name: cloudstack-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/cloudstack-cloud-provider/master/OWNERS
+    - name: gcp-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/gcp-cloud-provider/master/OWNERS
+    - name: openstack-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/openstack-cloud-provider/master/OWNERS
+    - name: ovirt-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/ovirt-cloud-provider/master/OWNERS
+    - name: photon-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/photon-cloud-provider/master/OWNERS
+    - name: vsphere-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/vsphere-cloud-provider/master/OWNERS
   - name: Multitenancy
     dir: wg-multitenancy
     mission_statement: >

--- a/wg-cloud-provider/README.md
+++ b/wg-cloud-provider/README.md
@@ -21,6 +21,35 @@ Charter can be found [here](https://docs.google.com/document/d/1m4Kvnh_u_9cENEE9
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/wg-cloud-provider)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-cloud-provider)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fcloud-provider)
+
+## Subprojects
+
+The following subprojects are owned by wg-cloud-provider:
+- **aws-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/aws-cloud-provider/master/OWNERS
+- **azure-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/azure-cloud-provider/master/OWNERS
+- **cloudstack-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/cloudstack-cloud-provider/master/OWNERS
+- **gcp-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/gcp-cloud-provider/master/OWNERS
+- **openstack-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/openstack-cloud-provider/master/OWNERS
+- **ovirt-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/ovirt-cloud-provider/master/OWNERS
+- **photon-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/photon-cloud-provider/master/OWNERS
+- **vsphere-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/vsphere-cloud-provider/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 


### PR DESCRIPTION
This is a statement of intent to create new Git repositories for the
cloud providers to extract from `kubernetes/kubernetes`. Handling
repositories for newly donated cloud providers will be handled
separately
