### PR TITLE
sig-network: Fix OWNERS links

### DIFF
--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -30,7 +30,6 @@ Covers networking in Kubernetes.
 The following subprojects are owned by sig-network:
 - **services**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cmd/kube-proxy/OWNERS
     - https://raw.githubusercontent.com/kubernetes/pkg/proxy/OWNERS
     - https://raw.githubusercontent.com/kubernetes/pkg/controller/endpoint/OWNERS
     - https://raw.githubusercontent.com/kubernetes/pkg/controller/service/OWNERS
@@ -50,7 +49,7 @@ The following subprojects are owned by sig-network:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
 - **network-policy**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/networking/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
 
 ## GitHub Teams
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -922,7 +922,6 @@ sigs:
     subprojects:
     - name: services
       owners:
-      - https://raw.githubusercontent.com/kubernetes/cmd/kube-proxy/OWNERS
       - https://raw.githubusercontent.com/kubernetes/pkg/proxy/OWNERS
       - https://raw.githubusercontent.com/kubernetes/pkg/controller/endpoint/OWNERS
       - https://raw.githubusercontent.com/kubernetes/pkg/controller/service/OWNERS
@@ -942,7 +941,7 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
     - name: network-policy
       owners:
-      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/networking/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
   - name: Node
     dir: sig-node
     mission_statement: >


### PR DESCRIPTION
There is no cmd/kube-proxy/OWNERS file anymore and pkg/api module
moved to the separate repository.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->