### PR TITLE
Quick fixes

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -101,7 +101,7 @@ For Pull Requests, the automatically assigned reviewer will add a SIG label if y
 
 For Issues, we are still working on a more automated workflow. Since SIGs do not directly map onto Kubernetes subrepositories, it may be difficult to find which SIG your contribution belongs in. Here is the [list of SIGs](/sig-list.md). Determine which is most likely related to your contribution.
 
-*Example:* if you are filing a cni issue, you should choose the [Network SIG](http://git.k8s.io/community/sig-network). Add the SIG label in a comment like so:
+*Example:* if you are filing a CNI issue (that's Container Networking Interface), you should choose the [Network SIG](http://git.k8s.io/community/sig-network). Add the SIG label in a comment like so:
 ```
 /sig network
 ```

--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -101,7 +101,7 @@ For Pull Requests, the automatically assigned reviewer will add a SIG label if y
 
 For Issues, we are still working on a more automated workflow. Since SIGs do not directly map onto Kubernetes subrepositories, it may be difficult to find which SIG your contribution belongs in. Here is the [list of SIGs](/sig-list.md). Determine which is most likely related to your contribution.
 
-*Example:* if you are filing a CNI issue (that's Container Networking Interface), you should choose the [Network SIG](http://git.k8s.io/community/sig-network). Add the SIG label in a comment like so:
+*Example:* if you are filing a CNI issue (that's [Container Networking Interface](https://github.com/containernetworking/cni)), you should choose the [Network SIG](http://git.k8s.io/community/sig-network). Add the SIG label in a comment like so:
 ```
 /sig network
 ```

--- a/contributors/guide/issue-triage.md
+++ b/contributors/guide/issue-triage.md
@@ -36,7 +36,7 @@ a bot to manage labelling and triaging. The bot has a set of
 [commands and permissions](https://git.k8s.io/test-infra/commands.md)
 and this document will cover the basic ones.
 
-## Determine if it?s a support request
+## Determine if it's a support request
 
 Sometimes users ask for support requests in issues; these are usually requests
 from people who need help configuring some aspect of Kubernetes. These should be

--- a/mentoring/README.md
+++ b/mentoring/README.md
@@ -24,8 +24,10 @@ Long Term Contributor Ladder Growth
 * [Group Mentoring Cohorts](/mentoring/group-mentoring.md)
 
 Students
-* [Outreachy](/sig-cli/outreachy.md)
 * [Google Summer of Code](google-summer-of-code.md)
+
+Groups Traditionally Underrepresented in Tech
+* [Outreachy](/sig-cli/outreachy.md)
 
 #### Inspiration and Thanks
 This is not an out of the box program but was largely inspired by the following:  


### PR DESCRIPTION
Hi, these are a few quick fixes to the documentation.

`contributors/guide/README.md`
→ Took me ages to find out what cni stood for, so I thought I'd add it to the guide for clarity.

`contributors/guide/issue-triage.md`
→ Typo.

`mentoring/README.md`
→ The previous information was inaccurate. Outreachy isn't targeted at students, it's targeted at groups traditionally underrepresented in tech. (Meaning cis/trans women, trans men, and genderqueer people.. but I'm not sure we wanna go into that much detaill.)