### PR TITLE
Makes SIGs responsible for implementations of `CloudProvider`

### DIFF
--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -25,6 +25,13 @@ Covers maintaining, supporting, and using Kubernetes hosted on AWS Cloud.
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-aws)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Faws)
 
+## Subprojects
+
+The following subprojects are owned by sig-aws:
+- **aws-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/aws-cloud-provider/master/OWNERS
+
 ## GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -28,9 +28,9 @@ Covers maintaining, supporting, and using Kubernetes hosted on AWS Cloud.
 ## Subprojects
 
 The following subprojects are owned by sig-aws:
-- **aws-cloud-provider**
+- **cloud-provider-aws**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/aws-cloud-provider/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS
 
 ## GitHub Teams
 

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -25,6 +25,13 @@ A Special Interest Group for building, deploying, maintaining, supporting, and u
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-azure)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fazure)
 
+## Subprojects
+
+The following subprojects are owned by sig-azure:
+- **azure-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/azure-cloud-provider/master/OWNERS
+
 ## GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -28,9 +28,9 @@ A Special Interest Group for building, deploying, maintaining, supporting, and u
 ## Subprojects
 
 The following subprojects are owned by sig-azure:
-- **azure-cloud-provider**
+- **cloud-provider-azure**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/azure-cloud-provider/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
 
 ## GitHub Teams
 

--- a/sig-gcp/README.md
+++ b/sig-gcp/README.md
@@ -22,6 +22,13 @@ A Special Interest Group for building, deploying, maintaining, supporting, and u
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fgcp)
 
+## Subprojects
+
+The following subprojects are owned by sig-gcp:
+- **gcp-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/gcp-cloud-provider/master/OWNERS
+
 ## GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.

--- a/sig-gcp/README.md
+++ b/sig-gcp/README.md
@@ -25,9 +25,9 @@ A Special Interest Group for building, deploying, maintaining, supporting, and u
 ## Subprojects
 
 The following subprojects are owned by sig-gcp:
-- **gcp-cloud-provider**
+- **cloud-provider-gcp**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/gcp-cloud-provider/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
 
 ## GitHub Teams
 

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -28,9 +28,9 @@ Coordinates the cross-community efforts of the OpenStack and Kubernetes communit
 ## Subprojects
 
 The following subprojects are owned by sig-openstack:
-- **openstack-cloud-provider**
+- **cloud-provider-openstack**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/openstack-cloud-provider/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
 
 ## GitHub Teams
 

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -25,6 +25,13 @@ Coordinates the cross-community efforts of the OpenStack and Kubernetes communit
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fopenstack)
 
+## Subprojects
+
+The following subprojects are owned by sig-openstack:
+- **openstack-cloud-provider**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/openstack-cloud-provider/master/OWNERS
+
 ## GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -364,6 +364,11 @@ sigs:
       teams:
       - name: sig-aws-misc
         description: General Discussion
+    subprojects:
+    - name: aws-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/aws-cloud-provider/master/OWNERS
+
   - name: Azure
     dir: sig-azure
     mission_statement: >
@@ -395,6 +400,11 @@ sigs:
       teams:
       - name: sig-azure-misc
         description: General Discussion
+    subprojects:
+    - name: azure-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/azure-cloud-provider/master/OWNERS
+
   - name: Big Data
     dir: sig-big-data
     mission_statement: >
@@ -770,6 +780,11 @@ sigs:
         description: Design Proposals
       - name: sig-gcp-test-failures
         description: Test Failures and Triage
+    subprojects:
+    - name: gcp-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/gcp-cloud-provider/master/OWNERS
+
   - name: Instrumentation
     dir: sig-instrumentation
     mission_statement: >
@@ -1093,6 +1108,11 @@ sigs:
         description: Design Proposals
       - name: sig-openstack-test-failures
         description: Test Failures and Triage
+    subprojects:
+    - name: openstack-cloud-provider
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/openstack-cloud-provider/master/OWNERS
+
   - name: Product Management
     dir: sig-product-management
     mission_statement: >
@@ -1665,31 +1685,7 @@ workinggroups:
     contact:
       slack: wg-cloud-provider
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-cloud-provider
-    subprojects:
-    - name: aws-cloud-provider
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/aws-cloud-provider/master/OWNERS
-    - name: azure-cloud-provider
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/azure-cloud-provider/master/OWNERS
-    - name: cloudstack-cloud-provider
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/cloudstack-cloud-provider/master/OWNERS
-    - name: gcp-cloud-provider
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/gcp-cloud-provider/master/OWNERS
-    - name: openstack-cloud-provider
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/openstack-cloud-provider/master/OWNERS
-    - name: ovirt-cloud-provider
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/ovirt-cloud-provider/master/OWNERS
-    - name: photon-cloud-provider
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/photon-cloud-provider/master/OWNERS
-    - name: vsphere-cloud-provider
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/vsphere-cloud-provider/master/OWNERS
+
   - name: Multitenancy
     dir: wg-multitenancy
     mission_statement: >

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -365,9 +365,9 @@ sigs:
       - name: sig-aws-misc
         description: General Discussion
     subprojects:
-    - name: aws-cloud-provider
+    - name: cloud-provider-aws
       owners:
-      - https://raw.githubusercontent.com/kubernetes/aws-cloud-provider/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS
 
   - name: Azure
     dir: sig-azure
@@ -401,9 +401,9 @@ sigs:
       - name: sig-azure-misc
         description: General Discussion
     subprojects:
-    - name: azure-cloud-provider
+    - name: cloud-provider-azure
       owners:
-      - https://raw.githubusercontent.com/kubernetes/azure-cloud-provider/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
 
   - name: Big Data
     dir: sig-big-data
@@ -781,9 +781,9 @@ sigs:
       - name: sig-gcp-test-failures
         description: Test Failures and Triage
     subprojects:
-    - name: gcp-cloud-provider
+    - name: cloud-provider-gcp
       owners:
-      - https://raw.githubusercontent.com/kubernetes/gcp-cloud-provider/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
 
   - name: Instrumentation
     dir: sig-instrumentation
@@ -1109,9 +1109,9 @@ sigs:
       - name: sig-openstack-test-failures
         description: Test Failures and Triage
     subprojects:
-    - name: openstack-cloud-provider
+    - name: cloud-provider-openstack
       owners:
-      - https://raw.githubusercontent.com/kubernetes/openstack-cloud-provider/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
 
   - name: Product Management
     dir: sig-product-management

--- a/wg-cloud-provider/README.md
+++ b/wg-cloud-provider/README.md
@@ -23,34 +23,6 @@ Charter can be found [here](https://docs.google.com/document/d/1m4Kvnh_u_9cENEE9
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-cloud-provider)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fcloud-provider)
 
-## Subprojects
-
-The following subprojects are owned by wg-cloud-provider:
-- **aws-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/aws-cloud-provider/master/OWNERS
-- **azure-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/azure-cloud-provider/master/OWNERS
-- **cloudstack-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloudstack-cloud-provider/master/OWNERS
-- **gcp-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/gcp-cloud-provider/master/OWNERS
-- **openstack-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/openstack-cloud-provider/master/OWNERS
-- **ovirt-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/ovirt-cloud-provider/master/OWNERS
-- **photon-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/photon-cloud-provider/master/OWNERS
-- **vsphere-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/vsphere-cloud-provider/master/OWNERS
-
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->


### PR DESCRIPTION
Make the existing SIGs
- SIG AWS
- SIG Azure
- SIG GCP
- SIG OpenStack

the "owners" for the repositories which will be created to host provider
specific code. Other SIGs will be charted as needed/desired for other
providers at a later time.
