### PR TITLE
Add subprojects for sig-aws

### DIFF
--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -31,6 +31,22 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following subprojects are owned by sig-aws:
+- **aws-cloudprovider**
+  - Description: Cloudprovider implementation for AWS
+  - Owners:
+    - https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/OWNERS
+- **aws-docker-credentialprovider**
+  - Description: Credential provider implementation for AWS (for ECR)
+  - Owners:
+    - https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/aws/OWNERS
+- **aws-ebs**
+  - Description: Support for EBS volumes
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/aws_ebs/OWNERS
+- **aws-encryption-provider**
+  - Description: Implements apiserver encryption, backed by AWS KMS
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/aws-encryption-provider/master/OWNERS
 - **cloud-provider-aws**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -402,6 +402,22 @@ sigs:
       - name: sig-aws-misc
         description: General Discussion
     subprojects:
+    - name: aws-cloudprovider
+      description: Cloudprovider implementation for AWS
+      owners:
+      - https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/OWNERS
+    - name: aws-docker-credentialprovider
+      description: Credential provider implementation for AWS (for ECR)
+      owners:
+      - https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/aws/OWNERS
+    - name: aws-ebs
+      description: Support for EBS volumes
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/aws_ebs/OWNERS
+    - name: aws-encryption-provider
+      description: Implements apiserver encryption, backed by AWS KMS
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-sigs/aws-encryption-provider/master/OWNERS
     - name: cloud-provider-aws
       owners:
       - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS


### PR DESCRIPTION
Specifically: cloudprovider, credentialprovider (for ECR), volume
provider for EBS.