### PR TITLE
E2e local

### DIFF
--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -427,7 +427,7 @@ go run hack/e2e.go -- --provider=local -v --test
 To control the tests that are run:
 
 ```sh
-go run hack/e2e.go -- --provider=local -v --test --test_args="--ginkgo.focus=\"Secrets\""
+go run hack/e2e.go -- --provider=local -v --test --test_args="--ginkgo.focus=Secrets"
 ```
 
 ### Version-skewed and upgrade testing

--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -427,7 +427,7 @@ go run hack/e2e.go -- --provider=local -v --test
 To control the tests that are run:
 
 ```sh
-go run hack/e2e.go -- -v --test --test_args="--ginkgo.focus=\"Secrets\""
+go run hack/e2e.go -- --provider=local -v --test --test_args="--ginkgo.focus=\"Secrets\""
 ```
 
 ### Version-skewed and upgrade testing


### PR DESCRIPTION
The example for e2e testing with a local cluster does not work as-is for two different reasons:
- missing --provider parameter
- incorrect quoting of ginkgo.focus value
