### PR TITLE
Correcting an outdated URL in contributor cheatsheet

### DIFF
--- a/contributors/guide/contributor-cheatsheet.md
+++ b/contributors/guide/contributor-cheatsheet.md
@@ -13,7 +13,7 @@ A list of common resources when contributing to Kubernetes.
 - [Gubernator Dashboard - k8s.reviews](https://k8s-gubernator.appspot.com/pr)
 - [reviewable.kubernetes.io](https://reviewable.kubernetes.io/reviews#-)
 - [Submit Queue](https://submit-queue.k8s.io)
-- [Bot commands](https://git.k8s.io/test-infra/commands.md)
+- [Bot commands](https://go.k8s.io/bot-commands)
 - [Release Buckets](http://gcsweb.k8s.io/gcs/kubernetes-release/)
 - Developer Guide
   - [Cherry Picking Guide](/contributors/devel/cherry-picks.md) - [Queue](http://cherrypick.k8s.io/#/queue)


### PR DESCRIPTION
What this PR does / why we need it:
Previously the URL in [contributor cheatsheet](https://github.com/kubernetes/community/pull/1883/files#diff-44d578a3dd781a55fe797ae8cea800ea) to the bot commands page was outdated and still referred to the [old page](https://git.k8s.io/test-infra/commands.md). This PR makes a small change so that the URL points directly to the [new page](https://prow.k8s.io/command-help), thus less clicks and frustration for future readers.

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
None

Special notes for your reviewer:
None

Release note:
Fixed outdated URL to bot commands in contributor cheatsheet.
