### PR TITLE
Fix link to CLA, explicitly state weekday

### DIFF
--- a/events/2018/05-contributor-summit/README.md
+++ b/events/2018/05-contributor-summit/README.md
@@ -12,12 +12,12 @@ In some sense, the summit is a real-life extension of the community meetings and
 
 ## Registration
 
-- [Sign the CLA](/community/CLA.md) if you have not done so already.
+- [Sign the CLA](../../../CLA.md) if you have not done so already.
 - [Fill out this Google Form](https://goo.gl/forms/TgoUiqbqZLkyZSZw1)
 
 ## When and Where
 
-- May 1, 2018 (before Kubecon EU)
+- Tuesday, May 1, 2018 (before Kubecon EU)
 - Bella Center
 - Copenhagen, Denmark
 

--- a/events/2018/05-contributor-summit/README.md
+++ b/events/2018/05-contributor-summit/README.md
@@ -12,7 +12,7 @@ In some sense, the summit is a real-life extension of the community meetings and
 
 ## Registration
 
-- [Sign the CLA](../../../CLA.md) if you have not done so already.
+- [Sign the CLA](/CLA.md) if you have not done so already.
 - [Fill out this Google Form](https://goo.gl/forms/TgoUiqbqZLkyZSZw1)
 
 ## When and Where


### PR DESCRIPTION
Fix link to CLA (unfortunately didn't find a way to use absolute links), explicitly state that May 1st is Tuesday to avoid confusion.