### PR TITLE
Update seccomp design doc to enable default seccomp profile

### DIFF
--- a/contributors/design-proposals/node/seccomp.md
+++ b/contributors/design-proposals/node/seccomp.md
@@ -197,7 +197,7 @@ profiles to be opaque to kubernetes for now.
 
 The following format is scoped as follows:
 
-1.  `docker/default` - the default profile for the container runtime, can be
+1.  `runtime/default` - the default profile for the container runtime, can be
     overwritten by the following two.
 2.  `unconfined` - unconfined profile, ie, no seccomp sandboxing
 3.  `localhost/<profile-name>` - the profile installed to the node's local seccomp profile root


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
Updates kubernetes/kubernetes#39845
Feature issue kubernetes/features#135

This PR updates the seccomp design doc to indicate that we are enabling a default seccomp profile: docker/default. It pulls a few pieces from #660, but does not include the seccomp spec. The reasoning here is that we can simply enable docker/default as the first step and see how it works. If strong needs of a different default k8s seccomp profile come up, we can add that later.