### PR TITLE
Update sig.yaml with subprojects of SIG multicluster

### DIFF
--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -31,6 +31,22 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fmulticluster)
 
+## Subprojects
+
+The following subprojects are owned by sig-multicluster:
+- **federation-v1**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/federation/master/OWNERS
+- **federation-v2**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/federation-v2/master/OWNERS
+- **cluster-registry**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/cluster-registry/master/OWNERS
+- **kubemci**
+  - Owners:
+    - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS
+
 ## GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -945,6 +945,19 @@ sigs:
         description: Test Failures and Triage
       - name: sig-mutlicluster-proposals
         description: Design Proposals
+    subprojects:
+    - name: federation-v1
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/federation/master/OWNERS
+    - name: federation-v2
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-sigs/federation-v2/master/OWNERS
+    - name: cluster-registry
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/cluster-registry/master/OWNERS
+    - name: kubemci
+      owners:
+      - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS
   - name: Network
     dir: sig-network
     mission_statement: >


### PR DESCRIPTION
Updates the sigs.yaml file with information about SIG multicluster's subprojects.

Note: the README file for this SIG already contains manually entered information about the subprojects which we would like to maintain - for now I've left it alone but am happy to shift around as folks want.

Note: I've opened https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/159 to add an OWNERS file to that repo so that it can be tracked correctly in sigs.yaml.