### PR TITLE
Fix for duplicate title on Contributors guide README

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -1,7 +1,3 @@
----
-title: Kubernetes Contributor Guide
----
-
 # Kubernetes Contributor Guide
 
 ## Disclaimer


### PR DESCRIPTION
Removed duplicate title on contributors guide readme page