### PR TITLE
add docs for The 1:1 Hour

### DIFF
--- a/mentoring/the1-on-1hour.md
+++ b/mentoring/the1-on-1hour.md
@@ -1,0 +1,28 @@
+The 1:1 Hour
+=======
+
+One mentor. One mentee. One Hour.
+
+In this mentorship opportunity, you'll be paired with someone in the ecosystem that can help drive your upstream Kubernetes experience forward with a quick burst of information. The mentee controls the content that will be served during that hour. This is open for new AND current contributors of all [levels](/community-membership.md).
+
+Activities that you can select from include:
+* pair programming
+* live code review how-to (for those wishing to be a reviewer or be a better reviewer)
+* live docs review how-to
+* live code review of a proposed solution you are working on 
+* codebase tour of a certain area
+* guidance on your contributor path (advice on becoming an approver, etc.)
+* AMA session (ask anything!)
+
+We will attempt to match you with the closest mentor of your area of interested or activity. 
+
+## Sign up!
+[Fill out this form](https://goo.gl/forms/9WllkPFTRB999vcc2) and we'll be in touch! 
+
+## Mentors
+
+If you are interested in signing up to be a mentor for this, please see the [mentor guidelines](mentorguidelines.md).
+
+### Notes
+Please pardon our dust as we build out the process for this and recruit more mentors. 
+


### PR DESCRIPTION
adding the documentation for The 1:1 Hour - a mentoring program. The last link will be dead until I upload the mentoring guidelines. 

/sig contributor-experience
/hold