### PR TITLE
Adds new contributor playground [WIP]

### DIFF
--- a/contributors/new-contributor-playground/OWNERS
+++ b/contributors/new-contributor-playground/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - parispittman
+  - guineveresaenger
+  - jberkus
+  - errordeveloper
+  - tpepper
+  - spiffxp
+approvers:
+  - parispittman
+  - guineveresaenger
+  - jberkus
+  - errordeveloper
+labels:
+  - new-contributor-track

--- a/contributors/new-contributor-playground/OWNERS
+++ b/contributors/new-contributor-playground/OWNERS
@@ -11,4 +11,4 @@ approvers:
   - jberkus
   - errordeveloper
 labels:
-  - new-contributor-track
+  - area/new-contributor-track

--- a/contributors/new-contributor-playground/README.md
+++ b/contributors/new-contributor-playground/README.md
@@ -1,0 +1,9 @@
+# Welcome to KubeCon Copenhagen's New Contributor Track!
+
+Hello new contributors!
+
+This subfolder of kubernetes/community will be used as a safe space for participants in the New Contributor Onboarding Track to familiarize themselves with (some of) the Kubernetes Project's review and pull request processes.
+
+The label associated with this track is `new-contributor-track`.
+
+*If you are not currently attending or organizing this event, please DO NOT create issues or pull requests against this section of the community repo.*


### PR DESCRIPTION
This folder is meant as a location for participants of the new contributor track at KubeCon Copenhagen 2018 to safely try out submitting pull requests and familiarizing themselves with the workflow.

This PR also attempts to create the label `new-contributor-track` in a new OWNERS file (which has some shady membership level promotions as well to enable the teachers of the track to be Approvers). Please advise on details of new label creation, overstepping of boundaries or stepping on toes!

/assign @spiffxp 
/assign @parispittman 

/sig contributor-experience