### PR TITLE
Remove contributor page

### DIFF
--- a/contributors/devel/coding-conventions.md
+++ b/contributors/devel/coding-conventions.md
@@ -1,3 +1,0 @@
-This document has been moved to https://git.k8s.io/community/contributors/guide/coding-conventions.md
-
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/contributors/devel/faster_reviews.md
+++ b/contributors/devel/faster_reviews.md
@@ -1,4 +1,0 @@
-The contents of this file have been moved to  https://git.k8s.io/community/contributors/guide/pull-requests.md.
- <!--
- This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.
- -->

--- a/contributors/devel/go-code.md
+++ b/contributors/devel/go-code.md
@@ -1,3 +1,0 @@
-This document's content has been rolled into https://git.k8s.io/community/contributors/guide/coding-conventions.md
-
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/contributors/devel/owners.md
+++ b/contributors/devel/owners.md
@@ -1,4 +1,0 @@
-This document has been moved to https://git.k8s.io/community/contributors/guide/owners.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.
-

--- a/contributors/devel/pull-requests.md
+++ b/contributors/devel/pull-requests.md
@@ -1,4 +1,0 @@
-This file has been moved to  https://git.k8s.io/community/contributors/guide/pull-requests.md.
-<!--
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.
--->

--- a/contributors/devel/release/OWNERS
+++ b/contributors/devel/release/OWNERS
@@ -1,8 +1,0 @@
-reviewers:
-  - saad-ali
-  - pwittrock
-  - steveperry-53
-  - chenopis
-  - spiffxp
-approvers:
-  - sig-release-leads

--- a/contributors/devel/release/README.md
+++ b/contributors/devel/release/README.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/ephemera/README.md
-
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/contributors/devel/release/issues.md
+++ b/contributors/devel/release/issues.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/ephemera/issues.md
-
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/contributors/devel/release/patch-release-manager.md
+++ b/contributors/devel/release/patch-release-manager.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/release-process-documentation/release-team-guides/patch-release-manager-playbook.md
-
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/contributors/devel/release/patch_release.md
+++ b/contributors/devel/release/patch_release.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/ephemera/patch_release.md
-
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/contributors/devel/release/scalability-validation.md
+++ b/contributors/devel/release/scalability-validation.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/ephemera/scalability-validation.md
-
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/contributors/devel/release/testing.md
+++ b/contributors/devel/release/testing.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/ephemera/testing.md
-
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/contributors/devel/scalability-good-practices.md
+++ b/contributors/devel/scalability-good-practices.md
@@ -1,4 +1,0 @@
-This document has been moved to https://git.k8s.io/community/contributors/guide/scalability-good-practices.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.
-

--- a/contributors/devel/security-release-process.md
+++ b/contributors/devel/security-release-process.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/security-release-process-documentation/security-release-process.md
-
-This file is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.


### PR DESCRIPTION
Now that the release team contact info page has moved here: https://git.k8s.io/sig-release/ephemera/README.md and Kubernetes 1.10 has been released, I am submitting this PR to remove the page. (Since it said to delete once K8s 1.10 is out.) 😄 