### PR TITLE
Added link to kubernetes/community

### DIFF
--- a/contributors/new-contributor-playground/README.md
+++ b/contributors/new-contributor-playground/README.md
@@ -2,8 +2,9 @@
 
 Hello new contributors!
 
-This subfolder of kubernetes/community will be used as a safe space for participants in the New Contributor Onboarding Track to familiarize themselves with (some of) the Kubernetes Project's review and pull request processes.
+This subfolder of [kubernetes/community](https://github.com/kubernetes/community) will be used as a safe space for participants in the New Contributor Onboarding Track to familiarize themselves with (some of) the Kubernetes Project's review and pull request processes.
 
 The label associated with this track is `area/new-contributor-track`.
 
 *If you are not currently attending or organizing this event, please DO NOT create issues or pull requests against this section of the community repo.*
+


### PR DESCRIPTION
When navigating the readme you can now click to be redirected to the repository k/community
