### PR TITLE
Add China to the list of events

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -208,7 +208,7 @@ If you haven't noticed by now, we have a large, lively, and friendly open-source
 
 ## Events
 
-Kubernetes is the main focus of CloudNativeCon/KubeCon, held twice per year in EMEA and in North America. Information about these and other community events is available on the CNCF [events](https://www.cncf.io/events/) pages.
+Kubernetes is the main focus of KubeCon + CloudNativeCon, held three times per year in China, Europe and in North America. Information about these and other community events is available on the CNCF [events](https://www.cncf.io/events/) pages.
 
 ### Meetups
 


### PR DESCRIPTION
KubeCon + CloudNativeCon is now held thrice a year.
China is added to the list of events.

Signed-off-by: Marius Gerling <marius@gerl1ng.de>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->