### PR TITLE
Link to Playlist view of Youtube videos

### DIFF
--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -6,7 +6,7 @@ Map that to your local time with this [timezone table](https://www.google.com/se
 
 See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles) , or paste this [iCal url](https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics) into any [iCal client](https://en.wikipedia.org/wiki/ICalendar). Do NOT copy the meetings over to a your perosnal calendar, you will miss meeting updates. Instead use your client's calendaring feature to say you are attending the meeting so that any changes made to meetings will be reflected on your personal calendar. 
 
-All meetings are archived on the [Youtube Channel](https://www.youtube.com/watch?v=onlFHICYB4Q&list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ)
+All meetings are archived on the [Youtube Channel](https://www.youtube.com/playlist?list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ)
 
 Quick links:
 


### PR DESCRIPTION
The previous version of the Youtube link auto-played the most recent video, and tucked the historical recordings off to the side.

This version of the Youtube link focuses on the historical list of recordings and avoids potentially intrusive auto-play.
