### PR TITLE
Remove confusing aggregator list comment

### DIFF
--- a/contributors/devel/api_changes.md
+++ b/contributors/devel/api_changes.md
@@ -601,7 +601,6 @@ Due to the fast changing nature of the project, the following content is probabl
   to generate protobuf IDL and marshallers.
 * You must add the new version  to
   [cmd/kube-apiserver/app#apiVersionPriorities](https://github.com/kubernetes/kubernetes/blob/v1.8.0-alpha.2/cmd/kube-apiserver/app/aggregator.go#L172)
-  to let the aggregator list it. This list will be removed before release 1.8.
 * You must setup storage for the new version in
   [pkg/registry/group_name/rest](https://github.com/kubernetes/kubernetes/blob/v1.8.0-alpha.2/pkg/registry/authentication/rest/storage_authentication.go)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

The line deleted explicitly tells that list of versions will be removed after 1.8 which is not case. So, removing it.