### PR TITLE
remove extra parenthesis

### DIFF
--- a/committee-steering/governance/README.md
+++ b/committee-steering/governance/README.md
@@ -72,4 +72,4 @@ See [frequently asked questions]
 [Short Template]: sig-governance-template-short.md
 [frequently asked questions]: FAQ.md
 [sigs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml
-[sig-architecture example]: ../../sig-architecture/charter.md)
+[sig-architecture example]: ../../sig-architecture/charter.md


### PR DESCRIPTION
I don't think this is a `sigs.yaml` thing. 

I've never seen this anchor footnote thing before. It's super awesome.