### PR TITLE
Add SIG VMware ML and cloud-provider-vsphere subproject

### DIFF
--- a/sig-vmware/README.md
+++ b/sig-vmware/README.md
@@ -27,6 +27,33 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fvmware)
 
+## Subprojects
+
+The following subprojects are owned by sig-vmware:
+- **cloud-provider-vsphere**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/OWNERS
+
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+The google groups contain the archive of Github team notifications.
+Mentioning a team on Github will CC its group.
+Monitor these for Github activity if you are not a member of the team.
+
+| Team Name | Details | Google Groups | Description |
+| --------- |:-------:|:-------------:|  ----------- |
+| @kubernetes/sig-vmware-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-api-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-vmware-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-bugs) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware-bugs) | Bug Triage and Troubleshooting |
+| @kubernetes/sig-vmware-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-feature-requests) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware-feature-requests) | Feature Requests |
+| @kubernetes/sig-vmware-members | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-members) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware-members) | Release Team Members |
+| @kubernetes/sig-vmware-misc | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-misc) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware-misc) | General Discussion |
+| @kubernetes/sig-vmware-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-pr-reviews) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware-pr-reviews) | PR Reviews |
+| @kubernetes/sig-vmware-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-proposals) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware-proposals) | Design Proposals |
+| @kubernetes/sig-vmware-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-test-failures) | [link](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware-test-failures) | Test Failures and Triage |
+
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1622,6 +1622,27 @@ sigs:
     contact:
       slack: sig-vmware
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-vmware
+      teams:
+      - name: sig-vmware-api-reviews
+        description: API Changes and Reviews
+      - name: sig-vmware-bugs
+        description: Bug Triage and Troubleshooting
+      - name: sig-vmware-feature-requests
+        description: Feature Requests
+      - name: sig-vmware-members
+        description: Release Team Members
+      - name: sig-vmware-misc
+        description: General Discussion
+      - name: sig-vmware-pr-reviews
+        description: PR Reviews
+      - name: sig-vmware-proposals
+        description: Design Proposals
+      - name: sig-vmware-test-failures
+        description: Test Failures and Triage
+    subprojects:
+    - name: cloud-provider-vsphere
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/OWNERS      
   - name: Windows
     dir: sig-windows
     mission_statement: >


### PR DESCRIPTION
SIG VMware wants to create a subproject for the extraction of the in-tree vSphere cloud provider, this PR depends on the creation of the repo itself.

/cc: @calebamiles 