### PR TITLE
Fix name of linux foundation bot: thelinuxfoundation

### DIFF
--- a/org-owners-guide.md
+++ b/org-owners-guide.md
@@ -70,7 +70,7 @@ Each organization should have the following teams:
   - `foo-reviewers`: granted read access to the `foo` repo; intended to be used as
     a notification mechanism for interested/active contributors for the `foo` repo
 - a `bots` team
-  - should contain bots such as @k8s-ci-robot and @linuxfoundation that are
+  - should contain bots such as @k8s-ci-robot and @thelinuxfoundation that are
     necessary for org and repo automation
 - an `owners` team
   - should be populated by everyone who has `owner` privileges to the org

--- a/setting-up-cla-check.md
+++ b/setting-up-cla-check.md
@@ -21,7 +21,7 @@ the Linux Foundation CNCF CLA check for your repositories, please read on.
       - Pull request: checked
       - Issue comment: checked
       - Active: checked
-1. Add the [@linuxfoundation](https://github.com/linuxfoundation) GitHub user as an **Owner**
+1. Add the [@thelinuxfoundation](https://github.com/thelinuxfoundation) GitHub user as an **Owner**
    to your organization or repo to ensure the CLA status can be applied on PR's
 1. After you send an invite, contact the [Linux Foundation](mailto:helpdesk@rt.linuxfoundation.org); and cc [Chris Aniszczyk](mailto:caniszczyk@linuxfoundation.org), [Ihor Dvoretskyi](mailto:ihor@cncf.io), [Eric Searcy](mailto:eric@linuxfoundation.org) (to ensure that the invite gets accepted).
 1. Finally, open up a test PR to check that:


### PR DESCRIPTION
linuxfoundation appears to be the org, thelinuxfoundation is the bot.