### PR TITLE
Use singular form of DST

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -16,7 +16,7 @@ The documentation follows a template and uses the values from [`sigs.yaml`](/sig
 
 **Time Zone gotcha**:
 Time zones make everything complicated.
-And Daylight Savings time makes it even more complicated.
+And Daylight Saving time makes it even more complicated.
 Meetings are specified with a time zone and we generate a link to http://www.thetimezoneconverter.com/ so that people can easily convert it to their local time zone.
 To make this work you need to specify the time zone in a way that that web site recognizes.
 Practically, that means US pacific time must be `PT (Pacific Time)`.


### PR DESCRIPTION
This is only a nit, but DST is generally Daylight Saving Time, not Daylight Saving**s** Time.

Wikipedia does [call out](https://en.wikipedia.org/wiki/Daylight_saving_time) that _savings_ is common in the U.S., so maybe this is a non-issue. I'd still rather see it be correct.