### PR TITLE
Fixed link to owners in the maintainer section

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -222,7 +222,7 @@ The following apply to the subproject for which one would be an owner.
 
 **Status:** Removed
 
-The Maintainer role has been removed and replaced with a greater focus on [owner](#owner)s.
+The Maintainer role has been removed and replaced with a greater focus on [OWNERS].
 
 [code reviews]: contributors/devel/collab.md
 [community expectations]: contributors/guide/community-expectations.md


### PR DESCRIPTION
In the maintainers section of community-membership, it previously had a link that didn't point to anything (it was just a matter of upper/lower case). I just corrected it so it actually points to the OWNERS page.  Since none of the other links to owners corrected its case i.e OWNERS vs owners, I removed the `(#owners)` part. 