### PR TITLE
contribx: link charter doc in readme

### DIFF
--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -54,7 +54,8 @@ if [[ ${mismatches} -gt "0" ]]; then
   fi
   echo "${mismatches} ${noun} detected."
   echo "Do not manually edit sig-list.md or README.md files inside the sig folders."
-  echo "Instead make your changes to sigs.yaml and then run \`make\`.";
+  echo "Instead make your changes to sigs.yaml, then run \`make\`, and then"
+  echo "commit your changes to sigs.yaml and any generated docs.";
   echo "${break}"
   exit 1;
 fi

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -8,7 +8,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Contributor Experience Special Interest Group
 
-Developing and sustaining a healthy community of contributors is critical to scaling the project and growing the ecosystem. We need to ensure our contributors are happy and productive, we need to break the commit-rate ceiling we hit in July 2015, and we need to get the monotonically growing PR merge latency and numbers of open PRs and issues under control.
+Developing and sustaining a healthy community of contributors is critical to scaling the project and growing the ecosystem. We need to ensure our contributors are happy and productive, and that there are not bottlenecks hindering the project in, for example: feature velocity, community scaling, pull request latency, and absolute numbers of open pull requests and open issues.
 
 The [charter](charter.md) defines the scope and governance of the Contributor Experience Special Interest Group.
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -746,11 +746,13 @@ sigs:
   - name: Contributor Experience
     dir: sig-contributor-experience
     mission_statement: >
-      Developing and sustaining a healthy community of contributors is critical
-      to scaling the project and growing the ecosystem. We need to ensure our
-      contributors are happy and productive, we need to break the commit-rate
-      ceiling we hit in July 2015, and we need to get the monotonically growing
-      PR merge latency and numbers of open PRs and issues under control.
+      Developing and sustaining a healthy community of contributors
+      is critical to scaling the project and growing the ecosystem.
+      We need to ensure our contributors are happy and productive,
+      and that there are not bottlenecks hindering the project in,
+      for example: feature velocity, community scaling, pull request
+      latency, and absolute numbers of open pull requests and open
+      issues.
     charter_link: charter.md
     label: contributor-experience
     leadership:


### PR DESCRIPTION
The main readme for the SIG Contributor Experience covers at a high
level some of the information that is detailed in the new charter
document and is a bit out of date relative to it.  This freshens things a little.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->