### PR TITLE
system:node-bootstrapper is not a group name

### DIFF
--- a/keps/sig-cluster-lifecycle/draft-20180130-kubeadm-join-master.md
+++ b/keps/sig-cluster-lifecycle/draft-20180130-kubeadm-join-master.md
@@ -280,7 +280,7 @@ existing `kubeadm join` flow:
       in `kube-system` namespace.
 
       > This requires to grant access to the above configMap for
-      `system:node-bootstrapper` group (or to provide the same information
+      `system:bootstrappers` group (or to provide the same information
       provided in a file like in 1.).
 
    2. Check if the cluster is ready for joining a new master node:


### PR DESCRIPTION
`system:node-bootstrapper` is a ClusterRole not a group.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community#your-first-contribution
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->