### PR TITLE
SIG Service Catalog's charter

### DIFF
--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -8,7 +8,9 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 -->
 # Service Catalog Special Interest Group
 
-To develop a Kubernetes API for the CNCF service broker and Kubernetes broker implementation.
+Service Catalog is a Kubernetes extension project that implements the [Open Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI). It allows application developers the ability to provision and consume cloud services natively from within Kubernetes.
+
+The [charter](https://github.com/kubernetes/community/blob/master/sig-service-catalog/charter.md) defines the scope and governance of the Service Catalog Special Interest Group.
 
 ## Meetings
 * Regular SIG Meeting: [Mondays at 13:00 PT (Pacific Time)](https://zoom.us/j/7201225346) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -40,6 +40,7 @@ The following, non-exhaustive, items are out of scope:
     if they are unresponsive for > 3 months or are not proactively working
     with other chairs to fulfill responsibilities. Use lazy consensus amongst chairs with
     fallback on majority vote.
+  - Chairs may propose changes to this charter at any time.
 
 - Emeritus Chairs ([Inspired by the Helm Project](http://technosophos.com/2018/01/11/introducing-helm-emeritus-core-maintainers.html))
   - A chair who steps down may be given the title of Emeritus Chair. This title confers

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -24,8 +24,10 @@ The following, non-exhaustive, items are out of scope:
 - Maintainers
   - Responsible for approving, and reviewing, pull requests.
   - Responsible for technical planning and stewardship of the project.
-  - New maintainers are nominated by a chair and require unanimous consent by all chairs.
-  - Maintainers can be “retired” at the suggestion of a chair, and approved unanimously by the other chairs.
+  - New maintainers may be nominated by a chair, to accepted via lazy two-thirds
+    resolution amongst the chairs.
+  - Maintainers may be nominated for removal from their position by a chair,
+    to accepted via lazy two-thirds resolution amongst the chairs.
 
 - Chairs
   - All maintainer’s roles.
@@ -33,14 +35,16 @@ The following, non-exhaustive, items are out of scope:
     in nature, such as organizing the weekly meetings.
   - A chair does not have more rights, or votes, than a maintainer.
   - Responsible for reporting the SIG’s status to the appropriate Kubernetes leadership teams.
-  - Chairs MAY decide to step down at anytime and MAY propose a replacement, ideally from existing
-    maintainers. Use lazy consensus amongst chairs with fallback on majority vote to accept proposal.
-  - Chairs MAY select additional chairs through a super-majority vote amongst chairs.
-  - Chairs MUST remain active in the role and MAY removed from the position
-    if they are unresponsive for > 3 months or are not proactively working
-    with other chairs to fulfill responsibilities. Use lazy consensus amongst chairs with
-    fallback on majority vote.
-  - Chairs may propose changes to this charter at any time.
+  - All decisions amongst chairs are made using lazy consensus with a fallback to a 2/3 majority vote (lazy two-thirds resolution).
+    This process is used for all decisions, such as changing chairs/maintainers or modifying this charter.
+  - Chairs may nominate a new chair at any time, to be accepted via lazy two-thirds resolution amongst the chairs.
+  - Chairs may decide to step down at any time. Before stepping down, the chair
+    may propose and vote on their replacement via lazy two-thirds resolution amongst the chairs.
+  - Chairs must remain active in the role and may be removed from the position
+    via lazy two-thirds resolution amongst the chairs, if they are unresponsive
+    for > 3 months or are not proactively working with other chairs to fulfill responsibilities.
+  - Chairs may propose changes to this charter at any time, to be accepted via
+    lazy two-thirds resolution amongst the chairs.
 
 - Emeritus Chairs ([Inspired by the Helm Project](http://technosophos.com/2018/01/11/introducing-helm-emeritus-core-maintainers.html))
   - A chair who steps down may be given the title of Emeritus Chair. This title confers

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -67,7 +67,7 @@ The following, non-exhaustive, items are out of scope:
 - [Working groups](https://docs.google.com/document/d/1fghxARW-doHrNmBYCijhODsGoIFawpeU4X0end-XnUI/edit#) can be initiated by any member. To create a new one, add the topic
   to the weekly call’s agenda for discussion.
   - These are not the same as cross-SIG working groups.
-  - Working groups exist for an undefined period of time, so that interested members
+  - Working groups exist for an unspecified period of time, so that interested members
     can meet to discuss and solve problems for our SIG.
 
 ### Project management

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -35,9 +35,7 @@ The following, non-exhaustive, items are out of scope:
   - Responsible for reporting the SIG’s status to the appropriate Kubernetes leadership teams.
   - Chairs MAY decide to step down at anytime and MAY propose a replacement, ideally from existing
     maintainers. Use lazy consensus amongst chairs with fallback on majority vote to accept proposal.
-    This SHOULD be supported by a majority of SIG members.
   - Chairs MAY select additional chairs through a super-majority vote amongst chairs.
-    This SHOULD be supported by a majority of SIG members.
   - Chairs MUST remain active in the role and MAY removed from the position
     if they are unresponsive for > 3 months or are not proactively working
     with other chairs to fulfill responsibilities. Use lazy consensus amongst chairs with

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -43,6 +43,15 @@ The following, non-exhaustive, items are out of scope:
     with other chairs to fulfill responsibilities. Use lazy consensus amongst chairs with
     fallback on majority vote.
 
+- Emeritus Chairs ([Inspired by the Helm Project](http://technosophos.com/2018/01/11/introducing-helm-emeritus-core-maintainers.html))
+  - A chair who step down MAY be given the title of Emeritus Chair. This title confers
+    honor on the recipient and allows them to remain associated with the SIG in acknowledgement
+    of their significant contributions.
+  - Those who attain this title are no longer expected to attend the weekly meetings,
+    share in the issue queue triage rotation, vote on policy or architectural issues, or review pull requests.
+  - They are listed in our documentation as Emeritus Chairs, and we will continue to invite
+    them to participate in related events, such as KubeCon.
+
 - Security Contacts
   - MUST be a contact point for the Product Security Team to reach out to for triaging and handling of incoming issues.
   - MUST be a maintainer.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -33,6 +33,15 @@ The following, non-exhaustive, items are out of scope:
     in nature, such as organizing the weekly meetings.
   - A chair does not have more rights, or votes, than a maintainer.
   - Responsible for reporting the SIG’s status to the appropriate Kubernetes leadership teams.
+  - Chairs MAY decide to step down at anytime and MAY propose a replacement, ideally from existing
+    maintainers. Use lazy consensus amongst chairs with fallback on majority vote to accept proposal.
+    This SHOULD be supported by a majority of SIG members.
+  - Chairs MAY select additional chairs through a super-majority vote amongst chairs.
+    This SHOULD be supported by a majority of SIG members.
+  - Chairs MUST remain active in the role and MAY removed from the position
+    if they are unresponsive for > 3 months or are not proactively working
+    with other chairs to fulfill responsibilities. Use lazy consensus amongst chairs with
+    fallback on majority vote.
 
 - Security Contacts
   - MUST be a contact point for the Product Security Team to reach out to for triaging and handling of incoming issues.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -108,7 +108,7 @@ The following, non-exhaustive, items are out of scope:
   - Chairs have access to manage this repository.
 - [Helm Repository](https://svc-catalog-charts.storage.googleapis.com)
   - Charts are manually published after each release.
-  - Managed by Vic Iglesias (Google).
+  - Managed by Vic Iglesias (Google), @viglesias on the kubernetes slack.
 - [svc-cat.io](https://svc-cat.io)
   - Published on pushes to master.
   - Site hosted with [Netlify](https://app.netlify.com/sites/svc-cat/overview).

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -42,7 +42,7 @@ The following, non-exhaustive, items are out of scope:
     fallback on majority vote.
 
 - Emeritus Chairs ([Inspired by the Helm Project](http://technosophos.com/2018/01/11/introducing-helm-emeritus-core-maintainers.html))
-  - A chair who step down MAY be given the title of Emeritus Chair. This title confers
+  - A chair who steps down may be given the title of Emeritus Chair. This title confers
     honor on the recipient and allows them to remain associated with the SIG in acknowledgement
     of their significant contributions.
   - Those who attain this title are no longer expected to attend the weekly meetings,
@@ -51,9 +51,9 @@ The following, non-exhaustive, items are out of scope:
     them to participate in related events, such as KubeCon.
 
 - Security Contacts
-  - MUST be a contact point for the Product Security Team to reach out to for triaging and handling of incoming issues.
-  - MUST be a maintainer.
-  - MUST accept the Kubernetes [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy).
+  - Are a contact point for the Product Security Team to reach out to for triaging and handling of incoming issues.
+  - Must be a maintainer.
+  - Must accept the Kubernetes [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy).
   - Defined in [SECURITY_CONTACTS](https://github.com/kubernetes-incubator/service-catalog/blob/master/SECURITY_CONTACTS) file.
 
 ## Organizational management

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -1,0 +1,104 @@
+# SIG Service Catalog Charter
+Service Catalog is a Kubernetes extension project that implements the [Open Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI).
+It allows application developers the ability to provision and consume cloud services natively from within Kubernetes.
+
+This charter adheres to the conventions described in the [Kubernetes Charter README](https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md).
+
+## Scope
+
+### In scope
+
+This SIG’s main goals are:
+- Support, and adhere to, the Platform requirements of the OSBAPI specification.
+- Provide a UX for Kubernetes users that is consistent with both the OSB API specification and traditional Kubernetes user interactions.
+- Align with the OSBAPI specification as changes are made.
+- Provide feedback (bugs or feature requests) to the OSBAPI WG.
+
+### Out of scope
+
+The following, non-exhaustive, items are out of scope:
+- Operation of OSBAPI Service Brokers.
+
+## Roles
+
+- Maintainers
+  - Responsible for approving, and reviewing, pull requests.
+  - Responsible for technical planning and stewardship of the project.
+  - New maintainers are nominated by a chair and require unanimous consent by all chairs.
+  - Maintainers can be “retired” at the suggestion of a chair, and approved unanimously by the other chairs.
+
+- Chairs
+  - All maintainer’s roles.
+  - Responsible for project administration activities within the SIG and are non-technical
+    in nature, such as organizing the weekly meetings.
+  - A chair does not have more rights, or votes, than a maintainer.
+  - Responsible for reporting the SIG’s status to the appropriate Kubernetes leadership teams.
+
+## Organizational management
+
+- SIG meets every week on Zoom at 1 PM PST on Mondays
+    - Agenda [here](https://docs.google.com/document/d/17xlpkoEbPR5M6P5VDzNx17q6-IPFxKyebEekCGYiIKM/edit#).
+    - Anyone is free to add new agenda items to the doc.
+    - Recordings of the calls are made available [here](https://goo.gl/ZmLNX9).
+- SIG members explicitly representing the group at conferences (SIG progress reports, deep dives, etc.)
+  should make their slides available for perusal and feedback at least 2 week in advance.
+- [Working groups](https://docs.google.com/document/d/1fghxARW-doHrNmBYCijhODsGoIFawpeU4X0end-XnUI/edit#) can be initiated by any member. To create a new one, add the topic
+  to the weekly call’s agenda for discussion.
+  - These are not the same as cross-SIG working groups.
+  - Working groups exist for an undefined period of time, so that interested members
+    can meet to discuss and solve problems for our SIG.
+
+### Project management
+- Milestones are defined by SIG maintainers.
+- Anyone is free to request for a discussion of the milestones/plans during
+  a weekly call.
+- Weekly releases are typically done on Thursdays, and any member who has
+  maintainer rights is free to initiate it. _Friday releases are strongly discouraged._
+- Major releases are planned and discussed among the SIG members during
+  regular weekly calls.
+- The release process is defined [here](https://github.com/kubernetes-incubator/service-catalog/wiki/Release-Process).
+- Anyone can request to work on an issue by commenting on it with `#dibs`.
+
+
+### Technical processes
+- All technical decisions are made either through issues, pull requests or
+  discussions during the weekly SIG meeting. Major decisions should be documented
+  in an issue or pull request.
+- There is no requirement that all pull requests have an associated issue.
+  However, if the PR represents a significant design decision then it is
+  recommended that it be discussed among the group to avoid unnecessary
+  coding that might not be accepted.
+- While everyone is encouraged to contribute to the discussion of
+  any topic, ultimately any changes made to the codebase must be
+  approved by the maintainers.
+- Pull requests are required to have at least 2 maintainers approve them using the `LGTM 1` and `LGTM 2` labels.
+- Pull requests that are labeled with `do not merge` or have an on-going
+  discussion must not be merged until all concerns are addressed.
+- Disagreements are mainly resolved via consensus. In the event that a common
+  decision cannot be made, then a vote among the maintainers will be taken.
+  Simple majority (>50%) wins.
+
+### Assets
+- [Source Repository](https://github.com/kubernetes-incubator/service-catalog)
+- [Image Repository](https://quay.io/organization/kubernetes-service-catalog)
+  - Canary builds are published on pushes to master.
+  - Release builds (and latest) are published on tags.
+  - Chairs have access to manage this repository.
+- [Helm Repository](https://svc-catalog-charts.storage.googleapis.com)
+  - Charts are manually published after each release.
+  - Managed by Vic Iglesias (Google).
+- [svc-cat.io](https://svc-cat.io)
+  - Published on pushes to master.
+  - Site hosted with [Netlify](https://app.netlify.com/sites/svc-cat/overview).
+  - Chairs and interested maintainers have access to manage this site.
+- [CLI Binary Hosting](https://svc-cat.io/docs/install/#manual)
+  - Canary builds are published on pushes to master.
+  - Release builds (and latest) are published on tags.
+  - Files hosted on Azure blob storage.
+  - Azure account managed by Carolyn Van Slyck (Microsoft) and Aaron Schelsinger (Microsoft).
+- [Travis](https://travis-ci.org/kubernetes-incubator/service-catalog)
+  - Runs the CI builds.
+  - Maintainers have access.
+- [Jenkins](https://service-catalog-jenkins.appspot.com/)
+  - Runs end-to-end tests on a live cluster.
+  - Server managed by Michael Kibbe (Google).

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -34,6 +34,12 @@ The following, non-exhaustive, items are out of scope:
   - A chair does not have more rights, or votes, than a maintainer.
   - Responsible for reporting the SIG’s status to the appropriate Kubernetes leadership teams.
 
+- Security Contacts
+  - MUST be a contact point for the Product Security Team to reach out to for triaging and handling of incoming issues.
+  - MUST be a maintainer.
+  - MUST accept the Kubernetes [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy).
+  - Defined in [SECURITY_CONTACTS](https://github.com/kubernetes-incubator/service-catalog/blob/master/SECURITY_CONTACTS) file.
+
 ## Organizational management
 
 - SIG meets every week on Zoom at 1 PM PST on Mondays

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -11,7 +11,7 @@ This charter adheres to the conventions described in the [Kubernetes Charter REA
 This SIG’s main goals are:
 - Support, and adhere to, the Platform requirements of the OSBAPI specification.
 - Provide a UX for Kubernetes users that is consistent with both the OSB API specification and traditional Kubernetes user interactions.
-- Align with the OSBAPI specification as changes are made.
+- Align with the [OSBAPI specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md) as changes are made.
 - Provide feedback (bugs or feature requests) to the OSBAPI WG.
 
 ### Out of scope

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -122,7 +122,7 @@ The following, non-exhaustive, items are out of scope:
   - Canary builds are published on pushes to master.
   - Release builds (and latest) are published on tags.
   - Files hosted on Azure blob storage.
-  - Azure account managed by Carolyn Van Slyck (Microsoft) and Aaron Schelsinger (Microsoft).
+  - Azure account managed by Carolyn Van Slyck (Microsoft) and Aaron Schlesinger (Microsoft).
 - [Travis](https://travis-ci.org/kubernetes-incubator/service-catalog)
   - Runs the CI builds.
   - Maintainers have access.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -34,6 +34,7 @@ The following, non-exhaustive, items are out of scope:
 
 - Chairs
   - All maintainer’s roles.
+  - Chairs are listed in our [SIG definition](https://github.com/kubernetes/community/tree/master/sig-service-catalog#chairs).
   - Responsible for project administration activities within the SIG and are non-technical
     in nature, such as organizing the weekly meetings.
   - A chair does not have more rights, or votes, than a maintainer.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -9,9 +9,9 @@ This charter adheres to the conventions described in the [Kubernetes Charter REA
 ### In scope
 
 This SIG’s main goals are:
-- Support, and adhere to, the Platform requirements of the OSBAPI specification.
+- Support, and adhere to, the Platform requirements of the [OSBAPI specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md).
 - Provide a UX for Kubernetes users that is consistent with both the OSB API specification and traditional Kubernetes user interactions.
-- Align with the [OSBAPI specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md) as changes are made.
+- Align with the OSBAPI specification as changes are made.
 - Provide feedback (bugs or feature requests) to the OSBAPI WG.
 
 ### Out of scope

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -161,8 +161,7 @@ roles. We do not have the Tech Lead role, and have a honorary Emeritus Chair rol
 - While everyone is encouraged to contribute to the discussion of any topic,
   ultimately any changes made to the codebase must be approved by the
   maintainers.
-- Pull requests are required to have at least 2 maintainers approve them using
-  the `LGTM 1` and `LGTM 2` labels.
+- Pull requests are required to have at least 2 maintainers approve them.
 - Pull requests that are labeled with `do-not-merge/hold` or have an on-going
   discussion must not be merged until all concerns are addressed.
 - Disagreements are resolved via lazy consensus. In the event that a common

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -1,16 +1,21 @@
 # SIG Service Catalog Charter
-Service Catalog is a Kubernetes extension project that implements the [Open Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI).
-It allows application developers the ability to provision and consume cloud services natively from within Kubernetes.
+Service Catalog is a Kubernetes extension project that implements the [Open
+Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI). It allows
+application developers the ability to provision and consume cloud services
+natively from within Kubernetes.
 
-This charter adheres to the conventions described in the [Kubernetes Charter README](https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md).
+This charter adheres to the conventions described in the [Kubernetes Charter
+README](https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md).
 
 ## Scope
 
 ### In scope
 
 This SIG’s main goals are:
-- Support, and adhere to, the Platform requirements of the [OSBAPI specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md).
-- Provide a UX for Kubernetes users that is consistent with both the OSB API specification and traditional Kubernetes user interactions.
+- Support, and adhere to, the Platform requirements of the [OSBAPI
+  specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md).
+- Provide a UX for Kubernetes users that is consistent with both the OSB API
+  specification and traditional Kubernetes user interactions.
 - Align with the OSBAPI specification as changes are made.
 - Provide feedback (bugs or feature requests) to the OSBAPI WG.
 
@@ -25,8 +30,8 @@ The following, non-exhaustive, items are out of scope:
   - Maintainer is equivalent to the standard Kubernetes definition of Approver.
   - Responsible for approving, and reviewing, pull requests.
   - Responsible for technical planning and stewardship of the project.
-  - New maintainers may be nominated by a chair, and accepted via lazy two-thirds
-    resolution amongst the chairs.
+  - New maintainers may be nominated by a chair, and accepted via lazy
+    two-thirds resolution amongst the chairs.
   - Maintainers may be nominated for removal from their position by a chair,
     and accepted via lazy two-thirds resolution amongst the chairs.
   - Maintainers may propose changes to this charter at any time, by submitting a
@@ -35,72 +40,91 @@ The following, non-exhaustive, items are out of scope:
 
 - Chairs
   - All maintainer’s roles.
-  - Chairs are listed in our [SIG definition](https://github.com/kubernetes/community/tree/master/sig-service-catalog#chairs).
-  - Responsible for project administration activities within the SIG and are non-technical
-    in nature, such as organizing the weekly meetings.
+  - Chairs are listed in our [SIG
+    definition](https://github.com/kubernetes/community/tree/master/sig-service-catalog#chairs).
+  - Responsible for project administration activities within the SIG and are
+    non-technical in nature, such as organizing the weekly meetings.
   - A chair does not have more rights, or votes, than a maintainer.
-  - Responsible for reporting the SIG’s status to the appropriate Kubernetes leadership teams.
-  - All decisions amongst chairs are made using lazy consensus with a fallback to a 2/3 majority vote (lazy two-thirds resolution).
-    This process is used for all decisions, such as changing chairs/maintainers or modifying this charter.
-  - Chairs may nominate a new chair at any time, to be accepted via lazy two-thirds resolution amongst the chairs.
+  - Responsible for reporting the SIG’s status to the appropriate Kubernetes
+    leadership teams.
+  - All decisions amongst chairs are made using lazy consensus with a fallback
+    to a 2/3 majority vote (lazy two-thirds resolution).
+    This process is used for all decisions, such as changing chairs/maintainers
+    or modifying this charter.
+  - Chairs may nominate a new chair at any time, to be accepted via lazy
+    two-thirds resolution amongst the chairs.
   - Chairs may decide to step down at any time.
   - Chairs must remain active in the role and may be removed from the position
     via lazy two-thirds resolution amongst the chairs, if they are unresponsive
-    for > 3 months or are not proactively working with other chairs to fulfill responsibilities.
+    for > 3 months or are not proactively working with other chairs to fulfill
+    responsibilities.
 
-- Emeritus Chairs ([Inspired by the Helm Project](http://technosophos.com/2018/01/11/introducing-helm-emeritus-core-maintainers.html))
-  - A chair who steps down may choose to take an Emeritus Chair title. This confers
-    honor on the recipient and allows them to remain associated with the SIG in acknowledgement
-    of their significant contributions.
-  - Those who attain this title are no longer expected to attend the weekly meetings,
-    share in the issue queue triage rotation, vote on policy or architectural issues, or review pull requests.
-  - They are listed in our documentation as Emeritus Chairs, and we will continue to invite
-    them to participate in related events, such as KubeCon.
+- Emeritus Chairs ([Inspired by the Helm
+  Project](http://technosophos.com/2018/01/11/introducing-helm-emeritus-core-maintainers.html))
+  - A chair who steps down may choose to take an Emeritus Chair title. This
+    confers honor on the recipient and allows them to remain associated with the
+    SIG in acknowledgement of their significant contributions.
+  - Those who attain this title are no longer expected to attend the weekly
+    meetings, share in the issue queue triage rotation, vote on policy or
+    architectural issues, or review pull requests.
+  - They are listed in our documentation as Emeritus Chairs, and we will
+    continue to invite them to participate in related events, such as KubeCon.
 
 - Security Contacts
-  - Are a contact point for the Product Security Team to reach out to for triaging and handling of incoming issues.
+  - Are a contact point for the Product Security Team to reach out to for
+    triaging and handling of incoming issues.
   - Must be a maintainer.
-  - Must accept the Kubernetes [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy).
-  - Defined in [SECURITY_CONTACTS](https://github.com/kubernetes-incubator/service-catalog/blob/master/SECURITY_CONTACTS) file.
+  - Must accept the Kubernetes [Embargo
+    Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy).
+  - Defined in
+    [SECURITY_CONTACTS](https://github.com/kubernetes-incubator/service-catalog/blob/master/SECURITY_CONTACTS)
+    file.
 
 ## Organizational management
 
 - SIG meets every week on Zoom at 1 PM PST on Mondays
-    - Agenda [here](https://docs.google.com/document/d/17xlpkoEbPR5M6P5VDzNx17q6-IPFxKyebEekCGYiIKM/edit#).
+    - Agenda
+      [here](https://docs.google.com/document/d/17xlpkoEbPR5M6P5VDzNx17q6-IPFxKyebEekCGYiIKM/edit#).
     - Anyone is free to add new agenda items to the doc.
     - Recordings of the calls are made available [here](https://goo.gl/ZmLNX9).
-- SIG members explicitly representing the group at conferences (SIG progress reports, deep dives, etc.)
-  should make their slides available for perusal and feedback at least 2 week in advance.
-- [Working groups](https://docs.google.com/document/d/1fghxARW-doHrNmBYCijhODsGoIFawpeU4X0end-XnUI/edit#) can be initiated by any member. To create a new one, add the topic
-  to the weekly call’s agenda for discussion.
+- SIG members explicitly representing the group at conferences (SIG progress
+  reports, deep dives, etc.) should make their slides available for perusal and
+  feedback at least 2 week in advance.
+- [Working
+  groups](https://docs.google.com/document/d/1fghxARW-doHrNmBYCijhODsGoIFawpeU4X0end-XnUI/edit#)
+  can be initiated by any member. To create a new one, add the topic to the
+  weekly call’s agenda for discussion.
   - These are not the same as cross-SIG working groups.
-  - Working groups exist for an unspecified period of time, so that interested members
-    can meet to discuss and solve problems for our SIG.
+  - Working groups exist for an unspecified period of time, so that interested
+    members can meet to discuss and solve problems for our SIG.
 
 ### Project management
 - Milestones are defined by SIG maintainers.
 - Anyone is free to request for a discussion of the milestones/plans during
   a weekly call.
 - Weekly releases are typically done on Thursdays, and any member who has
-  maintainer rights is free to initiate it. _Friday releases are strongly discouraged._
-- Major releases are planned and discussed among the SIG members during
-  regular weekly calls.
-- The release process is defined [here](https://github.com/kubernetes-incubator/service-catalog/wiki/Release-Process).
+  maintainer rights is free to initiate it. _Friday releases are strongly
+  discouraged._
+- Major releases are planned and discussed among the SIG members during regular
+  weekly calls.
+- The release process is defined
+  [here](https://github.com/kubernetes-incubator/service-catalog/wiki/Release-Process).
 - Anyone can request to work on an issue by commenting on it with `#dibs`.
 
 
 ### Technical processes
 - All technical decisions are made either through issues, pull requests or
-  discussions during the weekly SIG meeting. Major decisions should be documented
-  in an issue or pull request.
+  discussions during the weekly SIG meeting. Major decisions should be
+  documented in an issue or pull request.
 - There is no requirement that all pull requests have an associated issue.
   However, if the PR represents a significant design decision then it is
-  recommended that it be discussed among the group to avoid unnecessary
-  coding that might not be accepted.
-- While everyone is encouraged to contribute to the discussion of
-  any topic, ultimately any changes made to the codebase must be
-  approved by the maintainers.
-- Pull requests are required to have at least 2 maintainers approve them using the `LGTM 1` and `LGTM 2` labels.
+  recommended that it be discussed among the group to avoid unnecessary coding
+  that might not be accepted.
+- While everyone is encouraged to contribute to the discussion of any topic,
+  ultimately any changes made to the codebase must be approved by the
+  maintainers.
+- Pull requests are required to have at least 2 maintainers approve them using
+  the `LGTM 1` and `LGTM 2` labels.
 - Pull requests that are labeled with `do-not-merge/hold` or have an on-going
   discussion must not be merged until all concerns are addressed.
 - Disagreements are mainly resolved via consensus. In the event that a common
@@ -124,7 +148,8 @@ The following, non-exhaustive, items are out of scope:
   - Canary builds are published on pushes to master.
   - Release builds (and latest) are published on tags.
   - Files hosted on Azure blob storage.
-  - Azure account managed by Carolyn Van Slyck (Microsoft) and Aaron Schlesinger (Microsoft).
+  - Azure account managed by Carolyn Van Slyck (Microsoft) and Aaron Schlesinger
+    (Microsoft).
 - [Travis](https://travis-ci.org/kubernetes-incubator/service-catalog)
   - Runs the CI builds.
   - Maintainers have access.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -25,10 +25,10 @@ The following, non-exhaustive, items are out of scope:
   - Maintainer is equivalent to the standard Kubernetes definition of Approver.
   - Responsible for approving, and reviewing, pull requests.
   - Responsible for technical planning and stewardship of the project.
-  - New maintainers may be nominated by a chair, to accepted via lazy two-thirds
+  - New maintainers may be nominated by a chair, and accepted via lazy two-thirds
     resolution amongst the chairs.
   - Maintainers may be nominated for removal from their position by a chair,
-    to accepted via lazy two-thirds resolution amongst the chairs.
+    and accepted via lazy two-thirds resolution amongst the chairs.
   - Maintainers may propose changes to this charter at any time, by submitting a
     pull request and then notifying the SIG mailing list, to be accepted via
     lazy two-thirds resolution amongst the chairs.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -61,7 +61,7 @@ The following, non-exhaustive, items are out of scope:
     Approver](https://github.com/kubernetes/community/blob/master/community-membership.md#approver).
   - Responsible for reviewing pull requests, and approving pull requests for merge.
   - Responsible for technical planning and stewardship of the project.
-  - New maintainers may be nominated by a chair, and accepted via lazy
+  - New maintainers may be nominated by another maintainer, and accepted via lazy
     two-thirds resolution amongst the chairs.
   - Maintainers may be nominated for removal from their position by a chair,
     and accepted via lazy two-thirds resolution amongst the chairs.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -28,6 +28,9 @@ The following, non-exhaustive, items are out of scope:
     resolution amongst the chairs.
   - Maintainers may be nominated for removal from their position by a chair,
     to accepted via lazy two-thirds resolution amongst the chairs.
+  - Maintainers may propose changes to this charter at any time, by submitting a
+    pull request and then notifying the SIG mailing list, to be accepted via
+    lazy two-thirds resolution amongst the chairs.
 
 - Chairs
   - All maintainer’s roles.
@@ -43,8 +46,6 @@ The following, non-exhaustive, items are out of scope:
   - Chairs must remain active in the role and may be removed from the position
     via lazy two-thirds resolution amongst the chairs, if they are unresponsive
     for > 3 months or are not proactively working with other chairs to fulfill responsibilities.
-  - Chairs may propose changes to this charter at any time, to be accepted via
-    lazy two-thirds resolution amongst the chairs.
 
 - Emeritus Chairs ([Inspired by the Helm Project](http://technosophos.com/2018/01/11/introducing-helm-emeritus-core-maintainers.html))
   - A chair who steps down may choose to take an Emeritus Chair title. This confers

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -42,7 +42,7 @@ The following, non-exhaustive, items are out of scope:
     lazy two-thirds resolution amongst the chairs.
 
 - Chairs
-  - All maintainer’s roles.
+  - Chairs are expected to perform the role of maintainer, in addition to their chair responsibilities.
   - Chairs are listed in our [SIG
     definition](https://github.com/kubernetes/community/tree/master/sig-service-catalog#chairs).
   - Responsible for project administration activities within the SIG and are

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -6,9 +6,10 @@ README](https://github.com/kubernetes/community/blob/master/committee-steering/g
 ## Scope
 
 Service Catalog is a Kubernetes extension project that implements the [Open
-Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI). It allows
-application developers to provision and consume cloud services natively from
-within Kubernetes.
+Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI). It enables
+application developers to provision cloud services from within Kubernetes and
+integrates configuration and discovery of those services into Kubernetes
+resources.
 
 ### In scope
 

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -1,17 +1,18 @@
 # SIG Service Catalog Charter
-Service Catalog is a Kubernetes extension project that implements the [Open
-Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI). It allows
-application developers the ability to provision and consume cloud services
-natively from within Kubernetes.
 
 This charter adheres to the conventions described in the [Kubernetes Charter
 README](https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md).
 
 ## Scope
 
-See the [service-catalog SIG definition](https://github.com/kubernetes/community/tree/master/sig-service-catalog).
+Service Catalog is a Kubernetes extension project that implements the [Open
+Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI). It allows
+application developers to provision and consume cloud services natively from
+within Kubernetes.
 
 ### In scope
+
+See the [service-catalog SIG entry](https://github.com/kubernetes/community/tree/master/sig-service-catalog).
 
 This SIG’s main goals are:
 - Support, and adhere to, the Platform requirements of the [OSBAPI
@@ -20,11 +21,6 @@ This SIG’s main goals are:
   specification and traditional Kubernetes user interactions.
 - Align with the OSBAPI specification as changes are made.
 - Provide feedback (bugs or feature requests) to the [OSBAPI WG]](https://www.openservicebrokerapi.org/).
-
-### Out of scope
-
-The following, non-exhaustive, items are out of scope:
-- Operation of OSBAPI Service Brokers.
 
 ### Code, Binaries and services
 
@@ -53,6 +49,11 @@ The following, non-exhaustive, items are out of scope:
 - [Jenkins](https://service-catalog-jenkins.appspot.com/)
   - Runs end-to-end tests on a live cluster.
   - Server managed by Michael Kibbe (Google).
+
+### Out of scope
+
+The following, non-exhaustive, items are out of scope:
+- Operation of OSBAPI Service Brokers.
 
 ## Roles
 

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -133,6 +133,7 @@ The following, non-exhaustive, items are out of scope:
 
 ### Assets
 - [Source Repository](https://github.com/kubernetes-incubator/service-catalog)
+  - See [OWNERS](https://raw.githubusercontent.com/kubernetes-incubator/service-catalog/master/OWNERS) for who has access.
 - [Image Repository](https://quay.io/organization/kubernetes-service-catalog)
   - Canary builds are published on pushes to master.
   - Release builds (and latest) are published on tags.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -9,7 +9,7 @@ README](https://github.com/kubernetes/community/blob/master/committee-steering/g
 
 ## Scope
 
-See the [service-catalog entry in sigs.yaml](https://github.com/kubernetes/community/blob/master/sigs.yaml#L1485).
+See the [service-catalog SIG definition](https://github.com/kubernetes/community/tree/master/sig-service-catalog).
 
 ### In scope
 

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -133,7 +133,7 @@ The following, non-exhaustive, items are out of scope:
 ### Project management
 - [Milestones](https://github.com/kubernetes-incubator/service-catalog/milestones)
   are defined by SIG maintainers.
-- Anyone is free to request for a discussion of the milestones/plans during
+- Anyone is free to request a discussion of the milestones/plans during
   a weekly call.
 - Weekly releases are typically done on Thursdays, and any member who has
   maintainer rights is free to initiate it. _Friday releases are strongly

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -26,6 +26,34 @@ This SIG’s main goals are:
 The following, non-exhaustive, items are out of scope:
 - Operation of OSBAPI Service Brokers.
 
+### Code, Binaries and services
+
+- [Source Repository](https://github.com/kubernetes-incubator/service-catalog)
+  - See [OWNERS](https://raw.githubusercontent.com/kubernetes-incubator/service-catalog/master/OWNERS) for who has access.
+- [Image Repository](https://quay.io/organization/kubernetes-service-catalog)
+  - Canary builds are published on pushes to master.
+  - Release builds (and latest) are published on tags.
+  - Chairs have access to manage this repository.
+- [Helm Repository](https://svc-catalog-charts.storage.googleapis.com)
+  - Charts are manually published after each release.
+  - Managed by Vic Iglesias (Google), @viglesias on the kubernetes slack.
+- [svc-cat.io](https://svc-cat.io)
+  - Published on pushes to master.
+  - Site hosted with [Netlify](https://app.netlify.com/sites/svc-cat/overview).
+  - Chairs and interested maintainers have access to manage this site.
+- [CLI Binary Hosting](https://svc-cat.io/docs/install/#manual)
+  - Canary builds are published on pushes to master.
+  - Release builds (and latest) are published on tags.
+  - Files hosted on Azure blob storage.
+  - Azure account managed by Carolyn Van Slyck (Microsoft) and Aaron Schlesinger
+    (Microsoft).
+- [Travis](https://travis-ci.org/kubernetes-incubator/service-catalog)
+  - Runs the CI builds.
+  - Maintainers have access.
+- [Jenkins](https://service-catalog-jenkins.appspot.com/)
+  - Runs end-to-end tests on a live cluster.
+  - Server managed by Michael Kibbe (Google).
+
 ## Roles
 
 - Maintainers
@@ -135,30 +163,3 @@ The following, non-exhaustive, items are out of scope:
 - Disagreements are resolved via lazy consensus. In the event that a common
   decision cannot be made, then a vote among the maintainers will be taken.
   Simple majority (>50%) wins.
-
-### Assets
-- [Source Repository](https://github.com/kubernetes-incubator/service-catalog)
-  - See [OWNERS](https://raw.githubusercontent.com/kubernetes-incubator/service-catalog/master/OWNERS) for who has access.
-- [Image Repository](https://quay.io/organization/kubernetes-service-catalog)
-  - Canary builds are published on pushes to master.
-  - Release builds (and latest) are published on tags.
-  - Chairs have access to manage this repository.
-- [Helm Repository](https://svc-catalog-charts.storage.googleapis.com)
-  - Charts are manually published after each release.
-  - Managed by Vic Iglesias (Google), @viglesias on the kubernetes slack.
-- [svc-cat.io](https://svc-cat.io)
-  - Published on pushes to master.
-  - Site hosted with [Netlify](https://app.netlify.com/sites/svc-cat/overview).
-  - Chairs and interested maintainers have access to manage this site.
-- [CLI Binary Hosting](https://svc-cat.io/docs/install/#manual)
-  - Canary builds are published on pushes to master.
-  - Release builds (and latest) are published on tags.
-  - Files hosted on Azure blob storage.
-  - Azure account managed by Carolyn Van Slyck (Microsoft) and Aaron Schlesinger
-    (Microsoft).
-- [Travis](https://travis-ci.org/kubernetes-incubator/service-catalog)
-  - Runs the CI builds.
-  - Maintainers have access.
-- [Jenkins](https://service-catalog-jenkins.appspot.com/)
-  - Runs end-to-end tests on a live cluster.
-  - Server managed by Michael Kibbe (Google).

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -22,6 +22,7 @@ The following, non-exhaustive, items are out of scope:
 ## Roles
 
 - Maintainers
+  - Maintainer is equivalent to the standard Kubernetes definition of Approver.
   - Responsible for approving, and reviewing, pull requests.
   - Responsible for technical planning and stewardship of the project.
   - New maintainers may be nominated by a chair, to accepted via lazy two-thirds

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -132,7 +132,7 @@ The following, non-exhaustive, items are out of scope:
   the `LGTM 1` and `LGTM 2` labels.
 - Pull requests that are labeled with `do-not-merge/hold` or have an on-going
   discussion must not be merged until all concerns are addressed.
-- Disagreements are mainly resolved via consensus. In the event that a common
+- Disagreements are resolved via lazy consensus. In the event that a common
   decision cannot be made, then a vote among the maintainers will be taken.
   Simple majority (>50%) wins.
 

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -9,6 +9,8 @@ README](https://github.com/kubernetes/community/blob/master/committee-steering/g
 
 ## Scope
 
+See the [service-catalog entry in sigs.yaml](https://github.com/kubernetes/community/blob/master/sigs.yaml#L1485).
+
 ### In scope
 
 This SIG’s main goals are:

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -61,7 +61,7 @@ This SIG's charter deviates from the
 [sig-governance](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md)
 roles. We do not have the Tech Lead role, and have a honorary Emeritus Chair role.
 
-- Maintainers
+- [Maintainers](https://github.com/orgs/kubernetes-incubator/teams/maintainers-service-catalog/members)
   - Maintainer is equivalent to the standard [Kubernetes definition of
     Approver](https://github.com/kubernetes/community/blob/master/community-membership.md#approver).
   - Responsible for reviewing pull requests, and approving pull requests for merge.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -101,7 +101,7 @@ The following, non-exhaustive, items are out of scope:
   any topic, ultimately any changes made to the codebase must be
   approved by the maintainers.
 - Pull requests are required to have at least 2 maintainers approve them using the `LGTM 1` and `LGTM 2` labels.
-- Pull requests that are labeled with `do not merge` or have an on-going
+- Pull requests that are labeled with `do-not-merge/hold` or have an on-going
   discussion must not be merged until all concerns are addressed.
 - Disagreements are mainly resolved via consensus. In the event that a common
   decision cannot be made, then a vote among the maintainers will be taken.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -56,6 +56,9 @@ The following, non-exhaustive, items are out of scope:
 - Operation of OSBAPI Service Brokers.
 
 ## Roles
+This SIG's charter deviates from the
+[sig-governance](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md)
+roles. We do not have the Tech Lead role, and have a honorary Emeritus Chair role.
 
 - Maintainers
   - Maintainer is equivalent to the standard [Kubernetes definition of

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -78,7 +78,7 @@ The following, non-exhaustive, items are out of scope:
   - Are a contact point for the Product Security Team to reach out to for
     triaging and handling of incoming issues.
   - Must be a maintainer.
-  - Must accept the Kubernetes [Embargo
+  - Must accept and adhere to the Kubernetes [Embargo
     Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy).
   - Defined in
     [SECURITY_CONTACTS](https://github.com/kubernetes-incubator/service-catalog/blob/master/SECURITY_CONTACTS)

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -61,6 +61,7 @@ The following, non-exhaustive, items are out of scope:
     via lazy two-thirds resolution amongst the chairs, if they are unresponsive
     for > 3 months or are not proactively working with other chairs to fulfill
     responsibilities.
+  - There is no set number of Chairs.
 
 - Emeritus Chairs ([Inspired by the Helm
   Project](http://technosophos.com/2018/01/11/introducing-helm-emeritus-core-maintainers.html))

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -103,7 +103,8 @@ The following, non-exhaustive, items are out of scope:
     members can meet to discuss and solve problems for our SIG.
 
 ### Project management
-- Milestones are defined by SIG maintainers.
+- [Milestones](https://github.com/kubernetes-incubator/service-catalog/milestones)
+  are defined by SIG maintainers.
 - Anyone is free to request for a discussion of the milestones/plans during
   a weekly call.
 - Weekly releases are typically done on Thursdays, and any member who has

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -47,7 +47,7 @@ The following, non-exhaustive, items are out of scope:
     lazy two-thirds resolution amongst the chairs.
 
 - Emeritus Chairs ([Inspired by the Helm Project](http://technosophos.com/2018/01/11/introducing-helm-emeritus-core-maintainers.html))
-  - A chair who steps down may be given the title of Emeritus Chair. This title confers
+  - A chair who steps down may choose to take an Emeritus Chair title. This confers
     honor on the recipient and allows them to remain associated with the SIG in acknowledgement
     of their significant contributions.
   - Those who attain this title are no longer expected to attend the weekly meetings,

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -29,8 +29,9 @@ The following, non-exhaustive, items are out of scope:
 ## Roles
 
 - Maintainers
-  - Maintainer is equivalent to the standard Kubernetes definition of Approver.
-  - Responsible for approving, and reviewing, pull requests.
+  - Maintainer is equivalent to the standard [Kubernetes definition of
+    Approver](https://github.com/kubernetes/community/blob/master/community-membership.md#approver).
+  - Responsible for reviewing pull requests, and approving pull requests for merge.
   - Responsible for technical planning and stewardship of the project.
   - New maintainers may be nominated by a chair, and accepted via lazy
     two-thirds resolution amongst the chairs.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -43,8 +43,7 @@ The following, non-exhaustive, items are out of scope:
   - All decisions amongst chairs are made using lazy consensus with a fallback to a 2/3 majority vote (lazy two-thirds resolution).
     This process is used for all decisions, such as changing chairs/maintainers or modifying this charter.
   - Chairs may nominate a new chair at any time, to be accepted via lazy two-thirds resolution amongst the chairs.
-  - Chairs may decide to step down at any time. Before stepping down, the chair
-    may propose and vote on their replacement via lazy two-thirds resolution amongst the chairs.
+  - Chairs may decide to step down at any time.
   - Chairs must remain active in the role and may be removed from the position
     via lazy two-thirds resolution amongst the chairs, if they are unresponsive
     for > 3 months or are not proactively working with other chairs to fulfill responsibilities.

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -19,7 +19,7 @@ This SIG’s main goals are:
 - Provide a UX for Kubernetes users that is consistent with both the OSB API
   specification and traditional Kubernetes user interactions.
 - Align with the OSBAPI specification as changes are made.
-- Provide feedback (bugs or feature requests) to the OSBAPI WG.
+- Provide feedback (bugs or feature requests) to the [OSBAPI WG]](https://www.openservicebrokerapi.org/).
 
 ### Out of scope
 

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -99,8 +99,9 @@ The following, non-exhaustive, items are out of scope:
   - Those who attain this title are no longer expected to attend the weekly
     meetings, share in the issue queue triage rotation, vote on policy or
     architectural issues, or review pull requests.
-  - They are listed in our documentation as Emeritus Chairs, and we will
-    continue to invite them to participate in related events, such as KubeCon.
+  - They are [listed in our documentation](https://svc-cat.io/community/#leadership)
+    as Emeritus Chairs, and we will continue to invite them to participate in
+    related events, such as KubeCon.
 
 - Security Contacts
   - Are a contact point for the Product Security Team to reach out to for

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -123,7 +123,7 @@ The following, non-exhaustive, items are out of scope:
   reports, deep dives, etc.) should make their slides available for perusal and
   feedback at least 2 week in advance.
 - [Working
-  groups](https://docs.google.com/document/d/1fghxARW-doHrNmBYCijhODsGoIFawpeU4X0end-XnUI/edit#)
+  groups](https://github.com/kubernetes-incubator/service-catalog/wiki/Working-Groups)
   can be initiated by any member. To create a new one, add the topic to the
   weekly call’s agenda for discussion.
   - These are not the same as cross-SIG working groups.

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1501,9 +1501,10 @@ sigs:
   - name: Service Catalog
     dir: sig-service-catalog
     mission_statement: >
-      To develop a Kubernetes API for the CNCF service broker and Kubernetes
-      broker implementation.
-    charter_link:
+      Service Catalog is a Kubernetes extension project that
+      implements the [Open Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI).
+      It allows application developers the ability to provision and consume cloud services natively from within Kubernetes.
+    charter_link: https://github.com/kubernetes/community/blob/master/sig-service-catalog/charter.md
     label: service-catalog
     leadership:
       chairs:


### PR DESCRIPTION
Draft of the SIG Service Catalog charter. Announcement on SIG mailing list to follow.

The first commit contains the current working rules that the chairs have been following so far. Proposed changes are included in separate commits.

/cc @arschles @pmorie @vaikas-google @duglin