### PR TITLE
Add active chairs to catalog's OWNERS

### DIFF
--- a/sig-service-catalog/OWNERS
+++ b/sig-service-catalog/OWNERS
@@ -1,6 +1,12 @@
 reviewers:
   - sig-service-catalog-leads
+  - pmorie
+  - duglin
+  - arschles
 approvers:
   - sig-service-catalog-leads
+  - pmorie
+  - duglin
+  - arschles
 labels:
   - sig/service-catalog


### PR DESCRIPTION
Adding the current active chairs per @fejta's suggestion. Until our leads team is created in GH, this will help us collaborate on our SIG work in this repo.