### PR TITLE
update link to Kubernetes client libraries overview page

### DIFF
--- a/contributors/devel/client-libraries.md
+++ b/contributors/devel/client-libraries.md
@@ -1,3 +1,3 @@
 ## Kubernetes API client libraries
 
-This document has been moved to https://kubernetes.io/docs/reference/client-libraries/.
+This document has been moved to https://kubernetes.io/docs/reference/using-api/client-libraries/.


### PR DESCRIPTION
fix broken link to Kubernetes client libraries overview page