### PR TITLE
Bump required Go version for Kubernetes 1.11+

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -136,7 +136,7 @@ development environment, please [set one up](http://golang.org/doc/code.html).
 | 1.8            | 1.8.3       |
 | 1.9            | 1.9.1       |
 | 1.10           | 1.9.1       |
-| 1.11+          | 1.10.1      |
+| 1.11+          | 1.10.2      |
 
 Ensure your GOPATH and PATH have been configured in accordance with the Go
 environment instructions.


### PR DESCRIPTION
This PR is to bump the required Go version for developing/testing against Kubernetes 1.11+ as suggested in the contribution docs.

The `minimum_go_version` for running tests is at least 1.10.2, and will fail otherwise. See: https://github.com/kubernetes/kubernetes/blob/24ab69d358faeb3452bb76813fddd62afeefacb6/hack/lib/golang.sh#L338-L344