### PR TITLE
Add an initial security section

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -191,8 +191,9 @@ sig-testing is responsible for that official infrastructure and CI.  The associa
 
 ## Security
 
+- [Security Release Page](https://git.k8s.io/sig-release/security-release-process-documentation/security-release-process.md) - outlines the procedures for the handling of security issues.
+- [Security and Disclosure Information](https://kubernetes.io/docs/reference/issues-security/security/) - check this page if you wish to report a security vulnerability.
 
-* Please help write this section.
 
 ## Documentation
 


### PR DESCRIPTION
The contributor guide currently has an empty section for security. I wanted to at least add a pointer to where people can find more information.

From what I can gather the Security Release Process page appears to be the entry point where we want to send people, so adding a link to that, and then one to the page for where to report security issues because I figure that never hurts.

Security folks, is there any other information you think we should add to this section? The target user is new contributors.  

/cc @philips @jessfraz @cjcullen @tallclair @liggitt 