### PR TITLE
Add non-developers contribution section and an owner for it

### DIFF
--- a/contributors/guide/OWNERS
+++ b/contributors/guide/OWNERS
@@ -3,6 +3,8 @@ reviewers:
   - guineveresaenger
   - idvoretskyi
   - tpepper
+  - kbarnard10
+  - justaugustus
 approvers:
   - castrojo
   - parispittman

--- a/contributors/guide/non-code-contributions.md
+++ b/contributors/guide/non-code-contributions.md
@@ -1,0 +1,40 @@
+# Non-code Contributions
+
+This section is new and in progress. Expect this document to change often.
+
+If you are interested in helping define and structure this work, [check the weekly meeting notes](https://docs.google.com/document/d/1gdFWfkrapQclZ4-z4Lx2JwqKsJjXXUOVoLhBzZiZgSk/edit#) for information on how to get involved. You can also find us in the SIG Contributor Experience [slack channel](https://kubernetes.slack.com/messages/sig-contribex).
+
+New contributors welcome!
+
+*   Plan of attack
+    *   Identify Non-Dev focused roles
+        *   Tasks tied to these roles
+        *   Examples:
+            *   Technical project leadership
+                *   SIG contribution
+            *   Leading contributor communities
+            *   Promotion of people and projects
+                *   Recognition
+            *   Managing communication tools
+                *   Zoom, Slack, Discourse, ...
+            *   Writing articles/blogs
+                *   Capture it somewhere, not sure where yet
+                *   Feed into Kube.weekly?
+            *   Creating artwork
+                *   Conference specific, project specific
+            *   Answering questions from community members
+            *   Updating documentation
+                *   "Everybody owns docs" can equal "nobody owns docs"
+                *   Strengthen the entry point for doc ownership
+                *   Get specific enough so that someone would have an entrypoint to get started and take ownership
+                *   Funneling more people to SIG-Docs
+            *   Operations or "Tech" that is generally not considered "dev"
+                *   e.g. ansible
+            *   This! (Onboarding and enabling new people)
+                *   You only get one chance to see this onboarding process for the first time, so a steady stream a fresh eyes is important.
+        *   Let's just ask the SIGs!
+        *   Chat with Paris regarding alternate entry paths, as may have come up during mentoring efforts.
+        *   Follow up on Contrib-Ex call
+    *   Identify Non-Dev tasks in primarily Dev roles
+        *   Is it a dis-service to suggest Docs are Non-Dev?
+            *   New functionality vs Updates/common documentation


### PR DESCRIPTION
This adds a skeleton section to the contributor guide for a non-developer section. I've put it in it's own document with a link from the guide so that the team can iterate quickly on one file. 

@kbarnard10 is already an org member so I've added her as a reviewer to the guide since she is working on this.

/sig contributor-experience
/area contributor-guide