### PR TITLE
steering: governance: define chair removal process

### DIFF
--- a/committee-steering/governance/sig-governance-template-short.md
+++ b/committee-steering/governance/sig-governance-template-short.md
@@ -10,11 +10,12 @@ Membership for roles tracked in: <link to OWNERS file>
   - Chairs *MAY* decide to step down at anytime and propose a replacement.  Use lazy consensus amongst
     chairs with fallback on majority vote to accept proposal.  This *SHOULD* be supported by a majority of
     SIG Members.
-  - Chairs *MAY* select additional chairs through a [super-majority] vote amongst chairs.  This
+  - Chairs *MAY* select additional chairs through a [super-majority] vote amongst chairs. This
     *SHOULD* be supported by a majority of SIG Members.
   - Chairs *MUST* remain active in the role and are automatically removed from the position if they are
     unresponsive for > 3 months and *MAY* be removed if not proactively working with other chairs to fulfill
-    responsibilities.
+    responsibilities.  Removal of a chair can be done either through a voluntary step down as outlined
+    above OR by a consensus of other chairs and SIG subproject owners.
   - Number: 2-3
   - Defined in [sigs.yaml]
 


### PR DESCRIPTION
As outlined by [Brian Grant](https://github.com/kubernetes/community/pull/2040#discussion_r189472207)
there isn't a process for a SIG Chair to be removed. I think the best
course is to suggest an unresponsive chair be encouraged to step down
and if that fails a consensus is reached amongst existing chairs and
subproject owners.