### PR TITLE
update urls

### DIFF
--- a/contributors/devel/update-release-docs.md
+++ b/contributors/devel/update-release-docs.md
@@ -1,3 +1,3 @@
-This document relates to the release process and can be found [here](https://git.k8s.io/sig-release/release-process-documentation/documentation-guides/update-release-docs-new.md).
+This document relates to the release process and can be found [here](https://git.k8s.io/sig-release/release-team/role-handbooks/documentation-guides/update-release-docs-new.md).
 
 *This file is a redirect stub. It should be deleted within 3 months from the current date, or by the release date of k8s v1.12, whichever comes sooner.*

--- a/contributors/devel/updating-docs-for-feature-changes.md
+++ b/contributors/devel/updating-docs-for-feature-changes.md
@@ -1,3 +1,3 @@
-This document relates to the release process and can be found [here](https://git.k8s.io/sig-release/release-process-documentation/documentation-guides/updating-docs-for-feature-changes.md).
+This document relates to the release process and can be found [here](https://git.k8s.io/sig-release/release-team/role-handbooks/documentation-guides/updating-docs-for-feature-changes.md).
 
 *This file is a redirect stub. It should be deleted within 3 months from the current date, or by the release date of k8s v1.12, whichever comes sooner.*


### PR DESCRIPTION
A recent commit in the sig-release repo moved some documentes.  These
tombstoned redircts in the community repo haven't yet expired so should
conntinue to work and need updated links.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->