### PR TITLE
Fix a mismatch in contributors/devel/running-locally.md

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -121,10 +121,10 @@ Note the difference between a [container](https://kubernetes.io/docs/user-guide/
 and a [pod](https://kubernetes.io/docs/user-guide/pods/). Since you only asked for the former, Kubernetes will create a wrapper pod for you.
 However you cannot view the nginx start page on localhost. To verify that nginx is running you need to run `curl` within the docker container (try `docker exec`).
 
-You can control the specifications of a pod via a user defined manifest, and reach nginx through your browser on the port specified therein:
+You can control the specifications of a pod via a user defined manifest, and reach nginx through your browser on the port specified there in:
 
 ```sh
-cluster/kubectl.sh create -f test/fixtures/doc-yaml/user-guide/pod.yaml
+cluster/kubectl.sh create -f test/fixtures/doc-yaml/user-guide/multi-pod.yaml
 ```
 
 Congratulations!


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
What this **PR dose/why we need it**

This PR is related with issue #2351 
I just simply changed the` running-locally.md` file. If needed, I will also add a `pod.yaml` file