### PR TITLE
Update kubernetes.io urls in contributor guide

### DIFF
--- a/contributors/guide/coding-conventions.md
+++ b/contributors/guide/coding-conventions.md
@@ -113,7 +113,7 @@ subdirectories).
 /docs/user-guide or /docs/admin, depending on whether it is a feature primarily
 intended for users that deploy applications or cluster administrators,
 respectively. Actual application examples belong in /examples.
-    - Examples should also illustrate [best practices for configuration and using the system](https://kubernetes.io/docs/user-guide/config-best-practices/)
+    - Examples should also illustrate [best practices for configuration and using the system](https://kubernetes.io/docs/concepts/configuration/overview/)
 
   - Third-party code
 

--- a/contributors/guide/issue-triage.md
+++ b/contributors/guide/issue-triage.md
@@ -51,7 +51,7 @@ issue to yourself and then `/close`.
 
 Support requests should be directed to the following:
 
-* [User documentation](https://kubernetes.io/docs/) and
+* [User documentation](https://kubernetes.io/docs/home/) and
 [troubleshooting guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/)
 
 * [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes) and
@@ -85,7 +85,7 @@ Members of the Kubernetes community use Stack Overflow to field support
 requests. Before posting a new question, please search Stack Overflow for answers 
 to similar questions, and also familiarize yourself with:
 
-  * [user documentation](http://kubernetes.io/docs/)
+  * [user documentation](https://kubernetes.io/docs/home/)
   * [troubleshooting guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/)
 
 Again, thanks for using Kubernetes.


### PR DESCRIPTION
Just a couple small changes -- The current links point to redirects, this just points them to their actual target.