### PR TITLE
README: fix typo in Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ lead to many relevant technical topics.
 
 ## Contribute
 
-The [Contributor Guide](contributors/guide/README.md) provides detailed instruction on how to get your ideas and bug fixes seen and accepted, including:
+The [Contributor Guide](contributors/guide/README.md) provides detailed instructions on how to get your ideas and bug fixes seen and accepted, including:
 1. How to [file an issue]
 1. How to [find something to work on]
 1. How to [open a pull request]


### PR DESCRIPTION
Came across this while adding a `CONTRIBUTING.md` to [publishing bot](https://github.com/kubernetes/publishing-bot/issues/72).
/shrug

/cc guineveresaenger cblecker 
/assign cblecker 