### PR TITLE
Grant sig-auth leads approval of sig-auth KEPs

### DIFF
--- a/keps/sig-auth/OWNERS
+++ b/keps/sig-auth/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-auth-leads
+approvers:
+  - sig-auth-leads
+labels:
+  - sig/auth


### PR DESCRIPTION
Owners file copied from sig-node, s/node/auth/

/sig auth