### PR TITLE
fix a mis-placed section in schedule-DS-pod-by-scheduler.md

### DIFF
--- a/contributors/design-proposals/scheduling/schedule-DS-pod-by-scheduler.md
+++ b/contributors/design-proposals/scheduling/schedule-DS-pod-by-scheduler.md
@@ -45,21 +45,20 @@ This option is to leverage NodeAffinity feature to avoid introducing schedulerâ€
 
 1. DS controller filter nodes by nodeSelector, but does NOT check against schedulerâ€™s predicates (e.g. PodFitHostResources)
 2. For each node, DS controller creates a Pod for it with the following NodeAffinity
+    ```yaml
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - nodeSelectorTerms:
+          matchExpressions:
+          - key: kubernetes.io/hostname
+            operator: in
+            values:
+            - dest_hostname
+    ```
 3. When sync Pods, DS controller will map nodes and pods by this NodeAffinity to check whether Pods are started for nodes
 4. In scheduler, DaemonSet Pods will stay pending if scheduling predicates fail. To avoid this, an appropriate priority must
  be set to all critical DaemonSet Pods. Scheduler will preempt other pods to ensure critical pods were scheduled even when
  the cluster is under resource pressure.
-
-```yaml
-nodeAffinity:
-  requiredDuringSchedulingIgnoredDuringExecution:
-  - nodeSelectorTerms:
-      matchExpressions:
-      - key: kubernetes.io/hostname
-        operator: in
-        values:
-        - dest_hostname
-```
 
 ## Reference
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
This PR is to fix an issue that `NodeAffinity` section is mis-placed, and also add 4 spaces to make it indented properly.