### PR TITLE
Mention fejta bot in the triage guidelines

### DIFF
--- a/contributors/guide/issue-triage.md
+++ b/contributors/guide/issue-triage.md
@@ -226,3 +226,11 @@ order to work on it.
 A triage engineer should add these labels appropriately. Kubernetees GitHub
 Org members can search [open issues per these labels](https://github.com/kubernetes/kubernetes/labels?utf8=%E2%9C%93&q=triage%2F+kind%2Fsupport+is%3Aopen) to find ones that can be
 quickly closed.
+
+Also note that, `fejta-bot` will add `lifecycle/stale` label to issues with no
+activity for 90 days. Such issues will be eventually auto closed if the label is
+not removed with the `/remove-lifecycle stale` label or prevented with the
+`/lifecycle frozen` label. Refer to the `fejta-bot` added comments in the issue
+for more details. It is fine to add any of the `triage/*` labels described in
+this issue triage guidelines to issues triaged by the `fejta-bot` for a better
+understanding of the issue and closing of it.


### PR DESCRIPTION
Since the fejta bot now actively triaging and closing issues, we should
mention it in the triage guidelines and if it has any impact on the usage of
the guidelines for closing issues. It should be helpful to anyone referencing
the guidelines specially to the new triagers.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->