### PR TITLE
Mention possibility to use -v flag when running godep-restore.sh

### DIFF
--- a/contributors/devel/godep.md
+++ b/contributors/devel/godep.md
@@ -63,6 +63,13 @@ simply `make clean` or `rm -rf _output`, and run it again.
 
 Now you should have a clean copy of all of the Kubernetes dependencies.
 
+Downloading dependencies might take a while, so if you want to see progress
+information use the `-v` flag:
+
+```sh
+hack/run-in-gopath.sh hack/godep-restore.sh -v
+```
+
 ## Making changes
 
 The most common things people need to do with deps are add and update them.


### PR DESCRIPTION
The documentation at [godep.md](https://github.com/kubernetes/community/blob/master/contributors/devel/godep.md) explains the use of the `hack/run-in-gopath.sh hack/godep-restore.sh` command for restoring dependencies.

This is fine, but the `hack/run-in-gopath.sh hack/godep-restore.sh` command shows no progress information and often takes a lot of time.

So it's good to mention that if you want to see what is happening, you can use the `-v` flag to turn on the verbose mode of `godep restore`.

This pull request is about adding a sentence at the end of section [Restoring deps](https://github.com/kubernetes/community/blob/master/contributors/devel/godep.md) explaining the possible use of the `-v` flag.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->