### PR TITLE
Update sigs.yaml to indicate that cluster-api-provider-gcp is owned by sig cluster lifecycle

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -47,6 +47,9 @@ The following subprojects are owned by sig-cluster-lifecycle:
 - **cluster-api**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
+- **cluster-api-provider-gcp**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
 - **cluster-api-provider-openstack**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -695,6 +695,9 @@ sigs:
     - name: cluster-api
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
+    - name: cluster-api-provider-gcp
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
     - name: cluster-api-provider-openstack
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Fixes: https://github.com/kubernetes/community/issues/2419

/assign @spiffxp