### PR TITLE
commitee-steering: link SIG Charter to SIG Governance

### DIFF
--- a/committee-steering/governance/sig-charter-template.md
+++ b/committee-steering/governance/sig-charter-template.md
@@ -61,6 +61,6 @@ Pick one:
 1. SIG Technical Leads
 2. Federation of Subprojects
 
-[sig-governance]: sig-governance.md
+[sig-governance]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md
 [sigs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml#L1454
 [Kubernetes Charter README]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

This was a relative link before but as people copy the charter that
won't work. Make it a full URL instead.