### PR TITLE
Advocate for running conformance tests in multiple architectures

### DIFF
--- a/contributors/devel/conformance-tests.md
+++ b/contributors/devel/conformance-tests.md
@@ -34,6 +34,7 @@ especially in the Nucleus or Application layers as described
 (example: the default list of admission plugins should not have to be tweaked for passing conformance).
 - cannot rely on any binaries that are not required for the
 linux kernel or for a kubelet to run (i.e. git)
+- any container images used in the test must support all architectures for which kubernetes releases are built
 
 ### Conformance Test Version Skew Policy
 


### PR DESCRIPTION
We have been talking about and progressing towards multi-arch support for a long while now: https://github.com/kubernetes/kubernetes/issues/38067

We have active work being done to ensure that container images used in e2e test suite can run across multiple architectures. So we should make sure we don't add to this debt.

- https://github.com/kubernetes/kubernetes/issues/66626
- https://github.com/kubernetes/kubernetes/issues/66618
