### PR TITLE
Expand requirements for new cloud providers

### DIFF
--- a/keps/sig-cloud-provider/providers/0004-cloud-provider-template.md
+++ b/keps/sig-cloud-provider/providers/0004-cloud-provider-template.md
@@ -67,6 +67,21 @@ For [repository requirements](https://github.com/kubernetes/community/blob/maste
 
 There must be a reasonable amount of user feedback about running Kubernetes for this cloud provider. You may want to link to sources that indicate this such as github issues, product data, customer tesitimonials, etc.
 
+### Testgrid Integration
+
+Your cloud provider is reporting conformance test results to TestGrid as per the [Reporting Conformance Test Results to Testgrid KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0003-testgrid-conformance-e2e.md).
+
+### CNCF Certified Kubernetes
+
+Your cloud provider is accepted as part of the [Certified Kubernetes Conformance Program](https://github.com/cncf/k8s-conformance).
+
+### Documentation
+
+There is documentation on running Kubernetes on your cloud provider as per the [cloud provider documentation KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0004-cloud-provider-documentation.md).
+
+### Technical Leads are members of the Kubernetes Organization
+
+All proposed technical leads for this provider must be members of the Kubernetes organization. Membership is used as a signal for technical ability, commitment to the project, and compliance to the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) which we believe are important traits for subproject technical leads. Learn more about Kubernetes community membership [here](https://github.com/kubernetes/community/blob/master/community-membership.md).
 
 ## Proposal
 

--- a/keps/sig-cloud-provider/providers/0020-cloud-provider-alibaba-cloud.md
+++ b/keps/sig-cloud-provider/providers/0020-cloud-provider-alibaba-cloud.md
@@ -45,13 +45,13 @@ Cloud Provider of Alibaba Cloud  implements interoperability between Kubernetes 
 
 - Help on the improvement for decoupling cloud provider specifics from Kubernetes implementation.
 
-   
+
 
 ### Non-Goals
 
-The networking and storage support of Alibaba Cloud for Kubernetes will be provided by other projects. 
+The networking and storage support of Alibaba Cloud for Kubernetes will be provided by other projects.
 
-E.g. 
+E.g.
 
 * [Flannel network for Alibaba Cloud VPC](https://github.com/coreos/flannel)
 * [FlexVolume for Alibaba Cloud](https://github.com/AliyunContainerService/flexvolume)
@@ -59,7 +59,7 @@ E.g.
 
 ## Prerequisites
 
-1. The VPC network is supported in this project. The support for classic network or none ECS environment will be out-of-scope. 
+1. The VPC network is supported in this project. The support for classic network or none ECS environment will be out-of-scope.
 2. When using the instance profile for authentication, an instance role is required to attach to the ECS instance firstly.
 3. Kubernetes version v1.7 or higher
 
@@ -72,6 +72,22 @@ The repo requirements is mainly a copy from [cloudprovider KEP](https://github.c
 ### User Experience Reports
 As a CNCF Platinum member, Alibaba Cloud is dedicated in providing users with highly secure , stable and efficient cloud service.
 Usage of aliyun container services can be seen from github issues in the existing alicloud controller manager repo: https://github.com/AliyunContainerService/alicloud-controller-manager/issues
+
+### Testgrid Integration
+
+TODO
+
+### CNCF Certified Kubernetes
+
+TODO
+
+### Documentation
+
+TODO
+
+### Technical Leads are members of the Kubernetes Organization
+
+TODO
 
 ## Proposal
 

--- a/keps/sig-cloud-provider/providers/0021-cloud-provider-digitalocean.md
+++ b/keps/sig-cloud-provider/providers/0021-cloud-provider-digitalocean.md
@@ -56,6 +56,22 @@ The existing repository hosting the [DigitalOcean cloud controller manager](http
 
 DigitalOcean recently announced a [Kubernetes offering](https://www.digitalocean.com/products/kubernetes/). Many users have already signed up for early access. DigitalOcean is also a gold member of the CNCF.
 
+### Testgrid Integration
+
+TODO
+
+### CNCF Certified Kubernetes
+
+TODO
+
+### Documentation
+
+TODO
+
+### Technical Leads are members of the Kubernetes Organization
+
+TODO
+
 ## Proposal
 
 ### Subproject Leads

--- a/keps/sig-cloud-provider/providers/0022-cloud-provider-baiducloud.md
+++ b/keps/sig-cloud-provider/providers/0022-cloud-provider-baiducloud.md
@@ -38,7 +38,7 @@ Baidu is a gold member of CNCF and we have a large team working on Kubernetes an
 
 - Building, deploying, maintaining, supporting, and using Kubernetes on Baidu Cloud Container Engine(CCE) and Baidu Private Cloud(BPC). Both of the project are built on Kubernetes and related CNCF project.
 
-- Designing, discussing, and maintaining the cloud-provider-baidu repository under Github Kubernetes project. 
+- Designing, discussing, and maintaining the cloud-provider-baidu repository under Github Kubernetes project.
 
 ### Non-Goals
 
@@ -65,6 +65,21 @@ CCE-ticket-2: User want to modify the image repository's username.
 ![CCE-ticket-3](http://agroup-bos.su.bcebos.com/7a4506fcb1fbeeb15c86060cfbb6e69d090c8984)
 CCE-ticket-3: User want to have multi-tenant ability in a shared large CCE cluster.
 
+### Testgrid Integration
+
+TODO
+
+### CNCF Certified Kubernetes
+
+TODO
+
+### Documentation
+
+TODO
+
+### Technical Leads are members of the Kubernetes Organization
+
+TODO
 
 ## Proposal
 


### PR DESCRIPTION
This ensures that new (out-of-tree) providers are up to the same technical standards & meets the same requirements as existing in-tree providers. 

cc @calebamiles 