### PR TITLE
Add contributor site to sigs.yaml

### DIFF
--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -50,9 +50,10 @@ The following subprojects are owned by sig-contributor-experience:
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
     - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
-- **contributors-guide**
+- **contributors-documentation**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
 - **devstats**
   - Owners:
     - Phillels

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -818,9 +818,10 @@ sigs:
       owners:
       - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
       - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
-    - name: contributors-guide
+    - name: contributors-documentation
       owners:
       - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
+      - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
     - name: devstats
       owners:
       - Phillels


### PR DESCRIPTION
Rename "contributor-guide" subproject to "contributor-documentation" per @parispittman 's recommendation to generalize the title.

Add contributor-site repo under "contributor-documentation". 

Fixes #2472 