### PR TITLE
Add/correct i18n subprojects for SIG Docs

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -38,9 +38,15 @@ The following subprojects are owned by sig-docs:
 - **kubernetes-bootcamp**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes-bootcamp/master/OWNERS
-- **kubernetes-docs-cn**
+- **kubernetes-docs-ja**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes-docs-cn/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes-docs-ja/master/OWNERS
+- **kubernetes-docs-ko**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes-docs-ko/master/OWNERS
+- **kubernetes-docs-zh**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes-docs-zh/master/OWNERS
 - **reference-docs**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/reference-docs/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -880,9 +880,15 @@ sigs:
     - name: kubernetes-bootcamp
       owners:
       - https://raw.githubusercontent.com/kubernetes/kubernetes-bootcamp/master/OWNERS
-    - name: kubernetes-docs-cn
+    - name: kubernetes-docs-ja
       owners:
-      - https://raw.githubusercontent.com/kubernetes/kubernetes-docs-cn/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/kubernetes-docs-ja/master/OWNERS
+    - name: kubernetes-docs-ko
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/kubernetes-docs-ko/master/OWNERS
+    - name: kubernetes-docs-zh
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/kubernetes-docs-zh/master/OWNERS
     - name: reference-docs
       owners:
       - https://raw.githubusercontent.com/kubernetes-incubator/reference-docs/master/OWNERS


### PR DESCRIPTION
Fixes #2470 

This PR:
- Updates the name and path of the Chinese i18n subproject to `kubernetes-docs-zh`.
- Adds subprojects for Japanese and Korean i18n.