### PR TITLE
Add kubeadm-dind-cluster as a subproject of sig-cluster-lifecycle.

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -47,12 +47,12 @@ The following subprojects are owned by sig-cluster-lifecycle:
 - **cluster-api**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
-- **cluster-api-provider-gcp**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
 - **cluster-api-provider-aws**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
+- **cluster-api-provider-gcp**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
 - **cluster-api-provider-openstack**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
@@ -72,6 +72,9 @@ The following subprojects are owned by sig-cluster-lifecycle:
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
+- **kubeadm-dind-cluster**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/OWNERS
 - **kubernetes-anywhere**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -692,12 +692,12 @@ sigs:
     - name: cluster-api
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
-    - name: cluster-api-provider-gcp
-      owners:
-      - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
     - name: cluster-api-provider-aws
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
+    - name: cluster-api-provider-gcp
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
     - name: cluster-api-provider-openstack
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
@@ -717,6 +717,9 @@ sigs:
       owners:
       - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
+    - name: kubeadm-dind-cluster
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/OWNERS
     - name: kubernetes-anywhere
       owners:
       - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Fixes #2471

Note that I also re-ordered a couple of subprojects to keep the overall list alphabetical. 

/cc @timothysc @luxas 