### PR TITLE
Add a resources needed section to the KEP template

### DIFF
--- a/keps/0000-kep-template.md
+++ b/keps/0000-kep-template.md
@@ -166,3 +166,9 @@ Why should this KEP _not_ be implemented.
 ## Alternatives [optional]
 
 Similar to the `Drawbacks` section the `Alternatives` section is used to highlight and record other possible approaches to delivering the value proposed by a KEP.
+
+## Infrastructure Needed [optional]
+
+Use this section if you need things from the project/SIG.
+Examples include a new subproject, repos requested, github details.
+Listing these here allows a SIG to get the process for these resources started right away.


### PR DESCRIPTION
I got a KEP accepted and ended up asking for a repo/org access later on. This adds an optional section to the KEP to ask for these upfront so people can think ahead of time if they need to ask for resources from their SIG so that these expectations are discussed up front. 