### PR TITLE
Centralize list of administrators and moderators

### DIFF
--- a/communication/K8sYoutubeCollaboration.md
+++ b/communication/K8sYoutubeCollaboration.md
@@ -40,4 +40,4 @@ Collaboration should simplify things for everyone, but with privilege comes resp
 
 Your community managers are happy to help with any questions that you may have and will do their best to help if anything goes wrong. Please get in touch via [SIG Contributor Experience](https://git.kubernetes.io/community/sig-contributor-experience).
 
- 
+- Check the [centralized list of administrators](./moderators.md) for contact information.

--- a/communication/moderation.md
+++ b/communication/moderation.md
@@ -3,6 +3,8 @@
 This page describes the rules and best practices for people chosen to moderate Kubernetes communications channels. 
 This includes, Slack and the mailing lists and _any communication tool_ used in an official manner by the project. 
 
+- Check the [centralized list of administrators](./moderators.md) for contact information.
+
 ## Roles and Responsibilities
 
 As part of volunteering to become a moderator you are now representative of the Kubernetes community and it is your responsibility to remain aware of your contributions in this space. 

--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -1,0 +1,59 @@
+# Community Moderators
+
+The following people are responsible for moderating/administrating Kuberentes communication channels and their home time zone. 
+See our [moderation guidelines](./moderating.md) for policies and recommendations.
+
+## Mailing Lists
+
+### kubernetes-dev
+
+### Administrators
+
+- Sarah Novotny (@sarahnovotny) - PT
+- Brian Grant (@bgrant0607) - PT
+
+### Moderators
+
+- Paris Pittman (@parispittman) - PT
+- Jorge Castro (@castrojo) - ET
+- Jaice Singer DuMars - (@jdumars) - PT
+- Louis Taylor (@kragniz)- CET
+- Nikhita Raghunath (@nikhita) - IT
+
+
+## discuss.kubernetes.io
+
+### Administrators
+
+- Paris Pittman (@parispittman) - PT
+- Jorge Castro (@castrojo) - ET 
+- Bob Killen (@mrbobbytables) - ET
+- Jeffrey Sica (@jeefy) - ET
+
+### Additional Moderators
+
+- Ihor Dvoretskyi (@idvoretskyi) - CET
+
+## YouTube Channel
+
+- Paris Pittman (@parispittman) - PT
+- Sarah Novotny (@sarahnovotny) - PT
+- Bob Hrdinsky - PT
+- Ihor Dvoretskyi (@idvoretskyi) - CET
+- Jeffrey Sica (@jeefy) - ET
+- Jorge Castro (@castrojo) - ET
+- Joe Beda - (@joebeda) - PT
+- Jaice Singer DuMars - (@jdumars) - PT
+
+## Slack
+
+- Chris Aniszczyk (@caniszczyk) - CT
+- Ihor Dvoretskyi (@idvoretskyi) - CET
+- Jaice Singer DuMars (@jdumars) - PT
+- Jorge Castro (@castrojo) - ET
+- Paris Pittman (@parispittman) - PT
+
+## Zoom
+
+- Paris Pittman (@parispittman) - PT
+- Jorge Castro (@castrojo) - ET

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -10,12 +10,8 @@ Chat is searchable and public. Do not make comments that you would not say on a 
 Kubernetes adheres to Cloud Native Compute Foundation's [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) throughout the project, and includes all communication mediums.
 
 ## ADMINS
-(by Slack ID and timezone)
-* caniszczyk - CT
-* idvoretskyi - CET
-* jdumars - ET
-* jorge - CT
-* paris - PT
+
+- Check the [centralized list of administrators](./moderators.md) for contact information.
 
 Slack Admins should make sure to mention this in the “What I do” section of their Slack profile, as well as for which time zone.
 

--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -32,8 +32,7 @@ Contact [SIG Contributor Experience](https://github.com/kubernetes/community/tre
 
 ## Admins
 
-- @parispittman
-- @castrojo
+- Check the [centralized list of administrators](./moderators.md) for contact information.
 
 Each SIG should have at least one person with a paid Zoom account. 
 See the [SIG Creation procedure](https://github.com/kubernetes/community/blob/master/sig-governance.md#sig-creation-procedure) document on how to set up an initial account. 


### PR DESCRIPTION
This gives us one list of all the moderators/admins on community properties in one place. 

Fixes #2490 

/sig contributor-experience
/hold 