### PR TITLE
add proposal about container-level serviceaccount

### DIFF
--- a/contributors/design-proposals/auth/bound-service-account-tokens.md
+++ b/contributors/design-proposals/auth/bound-service-account-tokens.md
@@ -67,7 +67,9 @@ tokens will be drop in replacements for the current service account tokens.
 Tokens issued from this API may be bound to a Kubernetes object in the same
 namespace as the service account. The name, group, version, kind and uid of the
 object will be embedded as claims in the issued token. A token bound to an
-object will only be valid for as long as that object exists.
+object will only be valid for as long as that object exists. The token will contain
+which container the request comes from if ContainerName was specified. ContainerName
+will only be valid when BoundObjectReference.Kind is 'Pod'.
 
 Only a subset of object kinds will support object binding. Initially the only
 kinds that will be supported are:
@@ -105,6 +107,10 @@ type TokenRequestSpec struct {
   // BoundObjectRef is a reference to an object that the token will be bound to.
   // The token will only be valid for as long as the bound object exists.
   BoundObjectRef *BoundObjectReference
+
+  // ContainerName indicates which container the request comes from. Valid
+  // when BoundObjectRef is Pod.
+  ContainerName string
 }
 
 type BoundObjectReference struct {
@@ -165,6 +171,7 @@ type TokenReviewSpec struct {
 >       "apiVersion": "v1",
 >       "name": "pod-foo-346acf"
 >     }
+>     "containerName": "foo-container",
 >   }
 > }
 {
@@ -180,6 +187,7 @@ type TokenReviewSpec struct {
       "apiVersion": "v1",
       "name": "pod-foo-346acf"
     }
+    "containerName": "foo-container"
   },
   "status": {
     "token":
@@ -209,6 +217,7 @@ The token payload will be:
       "uid": "a4bb8aa4-0168-11e8-92e5-42010af00002",
       "name": "pod-foo-346acf"
     }
+    "containerName": "foo-container"
   }
 }
 ```

--- a/contributors/design-proposals/auth/bound-service-account-tokens.md
+++ b/contributors/design-proposals/auth/bound-service-account-tokens.md
@@ -108,7 +108,7 @@ type TokenRequestSpec struct {
   // The token will only be valid for as long as the bound object exists.
   BoundObjectRef *BoundObjectReference
 
-  // ContainerName indicates which container the request comes from. Valid
+  // ContainerName indicates which container the token will be bound to. Valid
   // when BoundObjectRef is Pod.
   ContainerName string
 }

--- a/contributors/design-proposals/storage/svcacct-token-volume-source.md
+++ b/contributors/design-proposals/storage/svcacct-token-volume-source.md
@@ -80,8 +80,8 @@ type ServiceAccountTokenProjection struct {
   ExpirationSeconds int64
   // Path is the relative path of the file to project the token into.
   Path string
-  // IsContainerLevel determines if the token should include information about
-  // which container the request comes from.
+  // If true, the token this volume contains would include informations about
+  // which container the token will mount on.
   IsContainerLevel bool
 }
 ```
@@ -91,7 +91,7 @@ sourced from the TokenRequest API into volumes created from
 ProjectedVolumeSources. As the token approaches expiration, the kubelet volume
 plugin will proactively rotate the service account token. The kubelet will start
 trying to rotate the token if the token is older than 80 percent of its time to
-live or if the token is older than 24 hours. If IsContainerLevel is specified, the
+live or if the token is older than 24 hours. If IsContainerLevel is true, the
 volume should be used by single container exclusively.
 
 To replace the current service account token secrets, we also need to inject the

--- a/contributors/design-proposals/storage/svcacct-token-volume-source.md
+++ b/contributors/design-proposals/storage/svcacct-token-volume-source.md
@@ -80,6 +80,9 @@ type ServiceAccountTokenProjection struct {
   ExpirationSeconds int64
   // Path is the relative path of the file to project the token into.
   Path string
+  // IsContainerLevel determines if the token should include information about
+  // which container the request comes from.
+  IsContainerLevel bool
 }
 ```
 
@@ -88,7 +91,8 @@ sourced from the TokenRequest API into volumes created from
 ProjectedVolumeSources. As the token approaches expiration, the kubelet volume
 plugin will proactively rotate the service account token. The kubelet will start
 trying to rotate the token if the token is older than 80 percent of its time to
-live or if the token is older than 24 hours.
+live or if the token is older than 24 hours. If IsContainerLevel is specified, the
+volume should be used by single container exclusively.
 
 To replace the current service account token secrets, we also need to inject the
 clusters CA certificate bundle. Initially we will deploy to data in a configmap


### PR DESCRIPTION
add description about container-level serviceaccount, it could be useful when user want to
give containers different api-server access. The basic idea is make serviceaccount token acquired
by token projected volume contains container name. Authorizer would use this info with pod-name, pod-uid together to confirm which <pod, container> the request comes from.
ref:
https://github.com/kubernetes/kubernetes/issues/66020
https://github.com/kubernetes/kubernetes/pull/61858