### PR TITLE
Ensure cloud-provider-foo subprojects have only one parent

### DIFF
--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -39,9 +39,6 @@ The following subprojects are owned by sig-cloud-provider:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cloud/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/cloudprovider/OWNERS
-- **cloud-provider-azure**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
 - **cloud-provider-gcp**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS

--- a/sig-gcp/README.md
+++ b/sig-gcp/README.md
@@ -29,9 +29,6 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following subprojects are owned by sig-gcp:
-- **cloud-provider-gcp**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
 - **gcp-compute-persistent-disk-csi-driver**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/master/OWNERS

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -29,13 +29,6 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fopenstack)
 
-## Subprojects
-
-The following subprojects are owned by sig-openstack:
-- **cloud-provider-openstack**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
-
 ## GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -593,9 +593,6 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cloud/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/cloudprovider/OWNERS
-    - name: cloud-provider-azure
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
     - name: cloud-provider-gcp
       owners:
       - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
@@ -922,9 +919,6 @@ sigs:
       - name: sig-gcp-test-failures
         description: Test Failures and Triage
     subprojects:
-    - name: cloud-provider-gcp
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
     - name: gcp-compute-persistent-disk-csi-driver
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/master/OWNERS
@@ -1268,9 +1262,6 @@ sigs:
       - name: sig-openstack-test-failures
         description: Test Failures and Triage
     subprojects:
-    - name: cloud-provider-openstack
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
   - name: PM
     dir: sig-pm
     mission_statement: >


### PR DESCRIPTION
Subprojects are about ensuring that code ownership ultimately
lands with a single SIG. There were a few cloud-provider-foo
subprojects that listed dual ownership due to ongoing
discussion of the future of some SIGs. I asked the SIG chairs
involved to make a decision about which SIG these subprojects
should fall to until that discussion is resolved.

cloud-provider-azure -> sig-azure
cloud-provider-gcp -> sig-cloud-provider
cloud-provider-openstack -> sig-cloud-provider

Fixes kubernetes/community#2516