### PR TITLE
Update SIG Autoscaling in sigs.yaml

### DIFF
--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -8,7 +8,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Autoscaling Special Interest Group
 
-Covers autoscaling of clusters, horizontal and vertical autoscaling of pods, setting initial resources for pods, topics related to monitoring pods and gathering their metrics (e.g. Heapster)
+Covers development and maintenance of componets for automated scaling in Kubernetes.  This includes automated vertical and horizontal pod autoscaling, initial resource estimation, cluster-proportional system component autoscaling, and autoscaling of Kubernetes clusters themselves.
 
 ## Meetings
 * Regular SIG Meeting: [Mondays at 14:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly/triweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=UTC).
@@ -30,12 +30,28 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following subprojects are owned by sig-autoscaling:
-- **autoscaler**
+- **scale-client**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/client-go/master/scale/OWNERS
+- **cluster-autoscaler**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
-- **metrics**
+- **vertical-pod-autoscaler**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+- **horizontal-pod-autoscaler**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
+- **cluster-proportional-vertical-autoscaler**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
+- **cluster-proportional-autoscaler**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
+- **addon-resizer**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
 
 ## GitHub Teams
 

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -42,6 +42,9 @@ The following subprojects are owned by sig-instrumentation:
 - **metrics-server**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/metrics-server/master/OWNERS
+- **metrics**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
 
 ## GitHub Teams
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -305,10 +305,10 @@ sigs:
   - name: Autoscaling
     dir: sig-autoscaling
     mission_statement: >
-      Covers autoscaling of clusters, horizontal and vertical autoscaling of pods,
-      setting initial resources for pods, topics related to monitoring pods and
-      gathering their metrics (e.g. Heapster)
-    charter_link:
+      Covers development and maintenance of componets for automated scaling in
+      Kubernetes.  This includes automated vertical and horizontal pod
+      autoscaling, initial resource estimation, cluster-proportional system
+      component autoscaling, and autoscaling of Kubernetes clusters themselves.
     label: autoscaling
     leadership:
       chairs:
@@ -345,12 +345,28 @@ sigs:
       - name: sig-autoscaling-test-failures
         description: Test Failures and Triage
     subprojects:
-    - name: autoscaler
+    - name: scale-client
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/client-go/master/scale/OWNERS # doesn't exist yet
+    - name: cluster-autoscaler
       owners:
       - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
-    - name: metrics
+    - name: vertical-pod-autoscaler
       owners:
-      - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+    - name: horizontal-pod-autoscaler
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
+    - name: cluster-proportional-vertical-autoscaler
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
+    - name: cluster-proportional-autoscaler
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
+    - name: addon-resizer
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
   - name: AWS
     dir: sig-aws
     mission_statement: >
@@ -1010,6 +1026,9 @@ sigs:
     - name: metrics-server
       owners:
       - https://raw.githubusercontent.com/kubernetes-incubator/metrics-server/master/OWNERS
+    - name: metrics
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
   - name: Multicluster
     dir: sig-multicluster
     mission_statement: >


### PR DESCRIPTION
This updates the mission statement for SIG Autoscaling to correspond to
the scope of SIG Autoscaling in the charter.

It also ensures that SIG Autoscaling has the right subprojects listed (cluster
autoscaler, vertical pod autoscaler, horizontal-pod-autoscaler, and
scale-client, cluster proportional autoscalers, addon-resizer), moving the
metrics project to SIG instrumentation where it belongs.