### PR TITLE
Refering to OWNERS_ALIASES from the assigning bulletpoint

### DIFF
--- a/contributors/guide/owners.md
+++ b/contributors/guide/owners.md
@@ -101,8 +101,8 @@ aspects of this process may be configured on a per-repo basis.
 - Phase 2: Humans approve the PR
   - The PR **author** `/assign`'s all suggested **approvers** to the PR, and optionally notifies
     them (eg: "pinging @foo for approval")
-  - Only people listed in the relevant OWNERS files, either directly or through an alias, can act
-    as **approvers**, including the individual who opened the PR
+  - Only people listed in the relevant OWNERS files, either directly or through an alias, as [described
+    above](#owners_aliases), can act as **approvers**, including the individual who opened the PR.
   - **Approvers** look for holistic acceptance criteria, including dependencies with other features,
     forwards/backwards compatibility, API and flag definitions, etc
   - If the code changes look good to them, an **approver** types `/approve` in a PR comment or


### PR DESCRIPTION
In the description of how to assign reviewers to a pr it is not
explicitly mentioned, that the aliases used in OWNERS files should
be resolved before assigning.

Signed-off-by: Gergely Csatari <gergely.csatari@nokia.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->