### PR TITLE
Prune sig-testing github teams

### DIFF
--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -59,13 +59,8 @@ Monitor these for Github activity if you are not a member of the team.
 
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
-| @kubernetes/sig-testing-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-testing-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-testing-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-testing-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-testing-feature-requests) | Feature Requests |
-| @kubernetes/sig-testing-misc | [link](https://github.com/orgs/kubernetes/teams/sig-testing-misc) | General Discussion |
+| @kubernetes/sig-testing | [link](https://github.com/orgs/kubernetes/teams/sig-testing) | General Discussion |
 | @kubernetes/sig-testing-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-pr-reviews) | PR Reviews |
-| @kubernetes/sig-testing-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-testing-proposals) | Design Proposals |
-| @kubernetes/sig-testing-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-testing-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1643,20 +1643,10 @@ sigs:
       slack: sig-testing
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-testing
       teams:
-      - name: sig-testing-api-reviews
-        description: API Changes and Reviews
-      - name: sig-testing-bugs
-        description: Bug Triage and Troubleshooting
-      - name: sig-testing-feature-requests
-        description: Feature Requests
-      - name: sig-testing-misc
+      - name: sig-testing
         description: General Discussion
       - name: sig-testing-pr-reviews
         description: PR Reviews
-      - name: sig-testing-proposals
-        description: Design Proposals
-      - name: sig-testing-test-failures
-        description: Test Failures and Triage
     subprojects:
     - name: test-infra
       owners:


### PR DESCRIPTION
I anticipate it will be some time before a team structure for all sigs is driven to conclusion https://github.com/kubernetes/community/issues/2323

In the meantime, I'd like to go ahead and prune sig-testing's teams manually:
- Rename sig-testing-misc to sig-testing
- Leave sig-testing-pr-reviews since I recall seeing that used when devstats was tracking this stuff

Everyone who's a member of the other teams is already a member of sig-testing-misc, so there will be no team membership changes.

NOTE: merging this does not actually remove the teams, it's something I will manually do as a request to kubernetes/org