### PR TITLE
Rewrite 2018 voting guideline

### DIFF
--- a/events/elections/2018/README.md
+++ b/events/elections/2018/README.md
@@ -2,63 +2,91 @@
 
 ## Purpose
 
-The role of this election is to fill out the three(3) seats due for reelection this year on the [Kubernetes Steering Committee](https://github.com/kubernetes/steering).
+The role of this election is to fill out the three (3) seats due for
+reelection this year on the [Kubernetes Steering Committee]. Each elected
+member will serve a two year term.
 
-## Voting
+## Background
 
-This election will  shape the future of Kubernetes as a project and community. You will be voting on three (3) seats up for election.
-Every elected community member will serve a two year term.
+This election will shape the future of Kubernetes as a community and project.
+While SIGs and WGs help shape the technical direction of the project, the
+[Steering Committee Charter] covers the health of the project and community
+as a whole. Some examples of responsibilities to consider as you are deciding
+whether to run or who to vote for:
 
-The candidates you are voting on will be meeting regularly to strategically grow the project with contributors in mind. Most of the technical decisions, architecture planning, and the like come out of SIGs and other working groups.
-Some examples of responsibilities to consider as you are voting:  
--  Define, evolve, and defend the vision, values, mission, and scope of the project - to establish and maintain the soul of Kubernetes.
--  Charter and refine policy for defining new community groups (including Special Interest Groups, Working Groups, and Committees), and establish transparency and accountability policies for such groups.  
--  Define, evolve, and defend a Code of Conduct, which must include a neutral, unbiased process for resolving conflict
+- Define, evolve, and defend the vision, values, mission, and scope of the
+  project.
+- Define and evolve project governance structures and policies, including how
+  contributors become committers/maintainers, approvers, reviewers, members,
+  etc.
+- Charter and refine policy for defining new community groups (including
+  Special Interest Groups, Working Groups, and Committees), and establish
+  transparency and accountability policies for such groups
 
-Full scope of responsibilities, goals, and/or future election timelines, see [steering committee charter](https://github.com/kubernetes/steering/blob/master/charter.md).
+For more context, please see the [current steering committee backlog] or a
+previous [governance meeting video] which led to this whole process.
 
-For more context, please see the [current issues](https://github.com/kubernetes/steering/blob/master/backlog.md) that need to be resolved or a previous governance [meeting video](https://www.youtube.com/watch?v=ltRKXLl0RaE&list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ&index=23) which led to this whole process.
+## Eligibility
 
-## Process
+Please refer to the [Steering Committee Election Charter] for:
 
-Elections will be held using time-limited [Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) ranking on [CIVS](http://civs.cs.cornell.edu/) using the [Schulze method](https://en.wikipedia.org/wiki/Schulze_method). 
-The top vote getters, modulo the corporate diversity requirement of no more than 1/3 of the committee from a single company, will be elected to the respective positions.
+- [elegibility for candidacy]
+- [eligibility for voting]
 
-You will be ranking your choices of the candidates with an option for "no opinion". In the event of a tie, a coin will be flipped.
+### Schedule
 
-The election will open for voting on September 19, 2018 at 04:00pm UTC and end two weeks after on October 3, 2018 at 01:00am UTC. You will receive an email to the address on file at the start of the election from Jorge Castro (jorge@heptio), Community Manager, please whitelist if necessary. Detailed voting instructions will be addressed in email and the CIVS polling page.
+| Date         | Event                    |
+| ------------ | ------------------------ |
+| August 15    | Announcement of Election |
+| September 14 | All candidate bios / statements of intent due. Voting exemption forms due. |
+| September 19 | Election Begins |
+| October 3    | Election Closes |
+| October 4    | Announcement of Results |
+
+## Candidacy Process
+
+Candidates must submit a pull request with a biography in this directory with
+their platform and intent to run. This statement is **limited to 300 words**
+and must follow the format of `firstnamelastname.md`. Please refer to the
+[2017 candidate bios] for examples.
+
+## Voting Process
+
+Elections will be held using time-limited [Condorcet] ranking on [CIVS]
+using the [Schulze method]. The top vote getters will be elected to the open
+seats.
+
+Employer diversity is encouraged, and thus [maximal representation] will be
+enforced as spelled out in the [Steering Committee Election Charter].
+
+You will be ranking your choices of the candidates with an option for
+"no opinion". In the event of a tie, a coin will be flipped.
+
+The election will open for voting on September 19, 2018 at 04:00pm UTC and
+end two weeks after on October 3, 2018 at 01:00am UTC. You will receive an
+email to the address on file at the start of the election from Jorge Castro
+(jorge@heptio), Community Manager, please whitelist if necessary. Detailed
+voting instructions will be addressed in email and the CIVS polling page.
 
 ### Officers
 
-The Steering Committee has selected the following people as [election officers](https://github.com/kubernetes/community/tree/master/events/elections#election-officers):
+The Steering Committee has selected the following people as [election officers]:
 - Paris Pittman, @parispittman, Google
 - Ihor Dvoretskyi, @idvoretskyi, CNCF
 - Jorge Castro, @castrojo, Heptio
 
-### Schedule
-
-August 15 - Announcement of Election
-September 14 - All candidate bios / statement of intents due. Voting exemption forms due.
-September 19 - Election Begins
-October 3 - Election Closes
-October 4 - Announcement of Results
-
-### Eligibility  
-Members of Standing are defined by the union of:
-- SIG Chairs/Leads
-- Approvers and reviewers in any Kubernetes owned repositories
-- Anyone with write access to a Kubernetes owned repository
-- Active members of our community with at least [50 contributions to core Kubernetes](https://k8s.devstats.cncf.io/d/13/developer-activity-counts-by-repository-group?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All)
-  - People who have non-code contributions can submit a [voting exemption form](URL TBD) to account for contributions not measured by devstats.
-
-Candidates must submit a pull request with a biography in this directory with their platform and intent to run. This statement is **limited to 300 words** and must follow the format of `firstnamelastname.md`. See [last year's submissions](https://github.com/kubernetes/community/tree/master/events/elections/2017) for some examples. 
+Please direct any questions via email to <elections@k8s.io>.
 
 ### Decision
-The newly elected body will be announced in the weekly [Kubernetes Community Meeting](https://github.com/kubernetes/community/blob/master/events/community-meeting.md) on October 4, 2018.
 
-Following the meeting, the raw voting results and winners will be published on the [Kubernetes Blog](http://blog.kubernetes.io/).
+The newly elected body will be announced in the weekly [Kubernetes Community Meeting]
+on October 4, 2018.
 
-For more information, definitions, and/or detailed election process, see full [steering committee charter](https://github.com/kubernetes/steering/blob/master/charter.md).
+Following the meeting, the raw voting results and winners will be published on the
+[Kubernetes Blog]
+
+For more information, definitions, and/or detailed election process, please refer to
+the [Steering Committee Election Charter]
 
 ## Nominees
 
@@ -67,7 +95,24 @@ Name | Organization/Company | GitHub
 [Jane Container](janecontainer.md) | ContainerCo | [@github](link this) |
 
 <strong>Note:</strong>The steering committee members and election officers have
-recused themselves from any form of electioneering, including
-campaigning, nominating, endorsing, or even asking people to run.
+recused themselves from any form of electioneering, including campaigning,
+nominating, endorsing, or even asking people to run.
 
-Please direct any questions via email to <elections@k8s.io>.
+
+[Kubernetes Steering Committee]: https://github.com/kubernetes/steering
+[Steering Committee Charter]: https://github.com/kubernetes/steering/blob/master/charter.md
+[current steering committee backlog]: https://github.com/kubernetes/steering/projects/1
+[governance meeting video]: https://www.youtube.com/watch?v=ltRKXLl0RaE&list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ&index=23
+
+[Steering Committee Election Charter]: https://git.k8s.io/steering/elections.md
+[eligibility for voting]: https://github.com/kubernetes/steering/blob/master/elections.md#elegibility-for-voting
+[eligibility for candidacy]: https://github.com/kubernetes/steering/blob/master/elections.md#elegibility-for-candidacy
+
+[Condorcet]: https://en.wikipedia.org/wiki/Condorcet_method
+[CIVS]: http://civs.cs.cornell.edu/
+[Schulze method]: https://en.wikipedia.org/wiki/Schulze_method
+
+[2017 candidate bios]: https://github.com/kubernetes/community/tree/master/events/elections/2017
+[election officers]: https://github.com/kubernetes/community/tree/master/events/elections#election-officers
+[Kubernetes Community Meeting]: https://github.com/kubernetes/community/blob/master/events/community-meeting.md
+[Kubernetes Blog]: http://blog.kubernetes.io/

--- a/events/elections/2018/README.md
+++ b/events/elections/2018/README.md
@@ -37,7 +37,7 @@ Please refer to the [Steering Committee Election Charter] for:
 
 | Date         | Event                    |
 | ------------ | ------------------------ |
-| August 20    | Announcement of Election |
+| August 21    | Announcement of Election |
 | September 14 | All candidate bios / statements of intent due. Voting exemption forms due. |
 | September 19 | Election Begins |
 | October 3    | Election Closes |

--- a/events/elections/2018/README.md
+++ b/events/elections/2018/README.md
@@ -4,7 +4,7 @@
 
 The role of this election is to fill out the three (3) seats due for
 reelection this year on the [Kubernetes Steering Committee]. Each elected
-member will serve a two year term.
+member will serve a two (2) year term.
 
 ## Background
 
@@ -37,7 +37,7 @@ Please refer to the [Steering Committee Election Charter] for:
 
 | Date         | Event                    |
 | ------------ | ------------------------ |
-| August 15    | Announcement of Election |
+| August 20    | Announcement of Election |
 | September 14 | All candidate bios / statements of intent due. Voting exemption forms due. |
 | September 19 | Election Begins |
 | October 3    | Election Closes |
@@ -45,10 +45,44 @@ Please refer to the [Steering Committee Election Charter] for:
 
 ## Candidacy Process
 
-Candidates must submit a pull request with a biography in this directory with
-their platform and intent to run. This statement is **limited to 300 words**
-and must follow the format of `firstnamelastname.md`. Please refer to the
-[2017 candidate bios] for examples.
+**Nomination**
+
+If you want to stand for election, send an email to kubernetes-dev@googlegroups.com
+with the subject line "Steering Committee Nomination: Your Name (@yourgithub)".
+
+If you want to nominate someone else, you may do so, but PLEASE talk to them
+first.
+
+If you wish to accept a nomination from someone else, reply to the nomination
+email saying something like "I accept the nomination"
+
+**Endorsement**
+
+Once nominated, you must get the endorsement of three (3) different eligible
+voters from three (3) different employers.  If you are eligible to vote
+yourself, you count as one of the three.
+
+Eligible voters may endorse candidates of their choosing by replying to the
+candidate's nomination email saying something like "I endorse this nominee"
+or "+1".
+
+**Running**
+
+Eligible candidates must submit a pull request with a biography in this
+directory with their platform and intent to run. This statement is
+**limited to 300 words** and must follow the format of `firstnamelastname.md`.
+Please refer to the [2017 candidate bios] for examples.
+
+**Campaigning**
+
+Please refer to the [Steering Committee Election Charter] and understand
+that we care deeply about [limiting corporate campaigning]. The election
+officers and members of the steering committee [pledge to recuse] themselves
+from any form of electioneering.
+
+You should be running as a "brand free" individual, based on your contribution
+to the project as a member of this community, outside of whatever corporate
+roles you may hold.
 
 ## Voting Process
 
@@ -94,11 +128,6 @@ Name | Organization/Company | GitHub
 --- | --- | -- |
 [Jane Container](janecontainer.md) | ContainerCo | [@github](link this) |
 
-<strong>Note:</strong>The steering committee members and election officers have
-recused themselves from any form of electioneering, including campaigning,
-nominating, endorsing, or even asking people to run.
-
-
 [Kubernetes Steering Committee]: https://github.com/kubernetes/steering
 [Steering Committee Charter]: https://github.com/kubernetes/steering/blob/master/charter.md
 [current steering committee backlog]: https://github.com/kubernetes/steering/projects/1
@@ -107,6 +136,8 @@ nominating, endorsing, or even asking people to run.
 [Steering Committee Election Charter]: https://git.k8s.io/steering/elections.md
 [eligibility for voting]: https://github.com/kubernetes/steering/blob/master/elections.md#elegibility-for-voting
 [eligibility for candidacy]: https://github.com/kubernetes/steering/blob/master/elections.md#elegibility-for-candidacy
+[limiting corporate campaigning]: https://github.com/kubernetes/steering/blob/master/elections.md#limiting-corporate-campaigning
+[pledge to recuse]: https://github.com/kubernetes/steering/blob/master/elections.md#steering-committee-and-election-officer-recusal
 
 [Condorcet]: https://en.wikipedia.org/wiki/Condorcet_method
 [CIVS]: http://civs.cs.cornell.edu/

--- a/events/elections/README.md
+++ b/events/elections/README.md
@@ -69,28 +69,27 @@ eligibility for voting, eligibility for candidacy, maximal representation, etc.
 
 - Select Election Officers
 - Select criteria for who can vote in the upcoming election
-- Must refrain from endorsing or otherwise advocating for any candidate
-- Is allowed to vote in the election
+- [Recuses themselves from public election activities][election-recusal]
 - Announces results of the election to the community
 - Commit the results of the election to the Kubernetes Community repository
 
 ### Election Officers
 
 - Recommend election dates to be approved by the Steering Committee
-- Must be a Kubernetes Member of Standing
+- Must be [eligible to vote]
 - Cannot be running for office in the current election
 - Cannot be a current member of the steering committee
 - Generates the voter guide
 - Tracks candidates
-- Monitors kubernetes-dev for nominations
+- Monitors kubernetes-dev for nominations and endorsements
   - Keeps track of nominees in a spreadsheet
-  - Ensures that each nominee has the required nominations from three different employers (as stated in the charter)
-  - All nominations are conducted in the public, so sharing this sheet during the nomination process is encouraged
+  - Ensures that each nominee has the required endorsements from three different employers (as stated in the charter)
+  - All nominations and endorsements are conducted in the public, so sharing this sheet during the nomination process is encouraged
 - Accepts/Reviews pull requests for the candidate platforms
   - The community generally assists in helping with PRs to give the candidates a quick response time
 - Update the community regularly via the community meeting
 - Post on behalf of the steering committee if necessary
-- Posting deadlines and reminders to kubernetes-dev, twitter, and slack.
+- Posting deadlines and reminders to the kubernetes blog, kubernetes-dev, twitter, and slack.
 - Reissues ballots from CIVS to voters who might have not received their ballot.
 - Miscellaneous election related tasks as decided by the steering committee.
 - Must refrain from endorsing or otherwise advocating for any candidate.
@@ -99,3 +98,6 @@ eligibility for voting, eligibility for candidacy, maximal representation, etc.
 - It is impossible for the election officers to see the results of the election until the election ends; for purposes of transparency with the community it is encouraged to release some statistics during the election (ie. “65% of the community has voted so far!”)
 - Ensure that the election results are handed over to the steering committee.
 - Is allowed to vote in the election
+
+[eligibile to vote]: https://github.com/kubernetes/steering/blob/master/elections.md#elegibility-for-voting
+[election-recusal]: https://github.com/kubernetes/steering/blob/master/elections.md#steering-committee-and-election-officer-recusal

--- a/events/elections/README.md
+++ b/events/elections/README.md
@@ -1,6 +1,9 @@
 ## Kubernetes Elections
 
-This document will outline how to conduct a Kubernetes Steering Committee Election. See the [Steering Committee Charter](https://git.k8s.io/steering/charter.md) for more information of how the committee decides when to have an election, the method, and the maximal representation.
+This document will outline how to conduct a Kubernetes Steering Committee
+Election. See the [Steering Committee Election Charter](https://git.k8s.io/steering/elections.md)
+for more information of how the committee decides when to have elections,
+eligibility for voting, eligibility for candidacy, maximal representation, etc.
 
 ## Steering Committee chooses Election Officers
 
@@ -17,9 +20,9 @@ This document will outline how to conduct a Kubernetes Steering Committee Electi
 - Voter Registration Deadline
 - Link to voter registration process (doesn’t exist yet)
 - Election period start
-  - It takes time to create the poll in CIVS, so don’t give a specific hour, instead say “Morning of the 10th” or something vague. 
+  - It takes time to create the poll in CIVS, so don’t give a specific hour, instead say “Morning of the 10th” or something vague.
 - Election period stop
-  - CIVS needs to be manually stopped, so an actual person needs to click for the poll to stop, so this needs to be a human friendly time. 
+  - CIVS needs to be manually stopped, so an actual person needs to click for the poll to stop, so this needs to be a human friendly time.
 - Results announcement date
 - Draft dates will then be passed to the Steering Committee for final approval
 
@@ -27,10 +30,10 @@ This document will outline how to conduct a Kubernetes Steering Committee Electi
 
 1. Election officers prepare the election repository
    - Make github.com/kubernetes/community/elections/$YEAR
-   - Make github.com/kubernetes/community/elections/$YEAR/README.md, this is the voter’s guide. 
-     - Copy over the voter’s guide from the previous year. The voter’s guide is the single source of truth for the election that year! All announcements and notices should link to this document. 
+   - Make github.com/kubernetes/community/elections/$YEAR/README.md, this is the voter’s guide.
+     - Copy over the voter’s guide from the previous year. The voter’s guide is the single source of truth for the election that year! All announcements and notices should link to this document.
      - Update with new dates, candidates, and procedures (if necessary).
-   - Announce to the candidates to submit PRs with their platform statement (if they desire), 300 word limit. Each platform document lives in the elections/$YEAR directory, with the voter’s guide (README.md) acting as the index. 
+   - Announce to the candidates to submit PRs with their platform statement (if they desire), 300 word limit. Each platform document lives in the elections/$YEAR directory, with the voter’s guide (README.md) acting as the index.
 
 2. Announce voting schedule to community
 
@@ -52,13 +55,13 @@ This document will outline how to conduct a Kubernetes Steering Committee Electi
   - Enable detailed ballot reporting.
   - Allow voters to select “no opinion” for some choices.
 - Click create poll, this will send elections@kubernetes.io an email with instructions.
-- It will send you a link to “Poll Control”, bookmark this generated page as this is where you will add voters and also resend ballots to people if their ballot gets lost or filtered. 
+- It will send you a link to “Poll Control”, bookmark this generated page as this is where you will add voters and also resend ballots to people if their ballot gets lost or filtered.
 - This page is where the “Start Poll” and “Stop Poll” buttons are, start the poll.
 - Paste in the registered voters and click add voters.
   - It will mail the ballots to the participants.
-  - It does duplicate detection so multiple entries are fine. 
-- Leave the poll open for the duration of voting. 
-  - Remember to send a 24 hour reminder before closing the poll. 
+  - It does duplicate detection so multiple entries are fine.
+- Leave the poll open for the duration of voting.
+  - Remember to send a 24 hour reminder before closing the poll.
 
 ## Roles and Responsibilities:
 
@@ -87,12 +90,12 @@ This document will outline how to conduct a Kubernetes Steering Committee Electi
   - The community generally assists in helping with PRs to give the candidates a quick response time
 - Update the community regularly via the community meeting
 - Post on behalf of the steering committee if necessary
-- Posting deadlines and reminders to kubernetes-dev, twitter, and slack. 
+- Posting deadlines and reminders to kubernetes-dev, twitter, and slack.
 - Reissues ballots from CIVS to voters who might have not received their ballot.
 - Miscellaneous election related tasks as decided by the steering committee.
 - Must refrain from endorsing or otherwise advocating for any candidate.
-- Must refrain from discussing the election specifics during the election period. 
+- Must refrain from discussing the election specifics during the election period.
 - Guard the privacy of the email addresses of voters
-- It is impossible for the election officers to see the results of the election until the election ends; for purposes of transparency with the community it is encouraged to release some statistics during the election (ie. “65% of the community has voted so far!”) 
-- Ensure that the election results are handed over to the steering committee. 
+- It is impossible for the election officers to see the results of the election until the election ends; for purposes of transparency with the community it is encouraged to release some statistics during the election (ie. “65% of the community has voted so far!”)
+- Ensure that the election results are handed over to the steering committee.
 - Is allowed to vote in the election

--- a/events/elections/README.md
+++ b/events/elections/README.md
@@ -67,37 +67,42 @@ eligibility for voting, eligibility for candidacy, maximal representation, etc.
 
 ### Steering Committee
 
+- [Recuses themselves from public election activities][election-recusal]
 - Select Election Officers
 - Select criteria for who can vote in the upcoming election
-- [Recuses themselves from public election activities][election-recusal]
 - Announces results of the election to the community
 - Commit the results of the election to the Kubernetes Community repository
 
 ### Election Officers
 
-- Recommend election dates to be approved by the Steering Committee
 - Must be [eligible to vote]
 - Cannot be running for office in the current election
 - Cannot be a current member of the steering committee
-- Generates the voter guide
-- Tracks candidates
-- Monitors kubernetes-dev for nominations and endorsements
-  - Keeps track of nominees in a spreadsheet
-  - Ensures that each nominee has the required endorsements from three different employers (as stated in the charter)
+- [Recuse themselves from public election activities][election-recusal] except those required to run the election
+  - May vote
+  - May answer questions about general election specifics, ie:
+    - Where do I find the schedule?
+    - How do I vote?
+  - Will not answer questions about specific candidates, or anything that could be construed as endorsing, ie:
+    - How is $candidate doing so far? (PS - we don't know anyway)
+    - Who are your favorite candidates?
+- Recommend election dates to be approved by the Steering Committee
+- Generate the voter guide
+- Track candidates
+- Monitor kubernetes-dev for nominations and endorsements
+  - Keep track of nominees in a spreadsheet
+  - Ensure that each nominee has the required endorsements from three different employers (as stated in the charter)
   - All nominations and endorsements are conducted in the public, so sharing this sheet during the nomination process is encouraged
-- Accepts/Reviews pull requests for the candidate platforms
+- Accept/Review pull requests for the candidate platforms
   - The community generally assists in helping with PRs to give the candidates a quick response time
 - Update the community regularly via the community meeting
 - Post on behalf of the steering committee if necessary
-- Posting deadlines and reminders to the kubernetes blog, kubernetes-dev, twitter, and slack.
-- Reissues ballots from CIVS to voters who might have not received their ballot.
+- Post deadlines and reminders to the kubernetes blog, kubernetes-dev, twitter, and slack.
+- Reissue ballots from CIVS to voters who might have not received their ballot.
 - Miscellaneous election related tasks as decided by the steering committee.
-- Must refrain from endorsing or otherwise advocating for any candidate.
-- Must refrain from discussing the election specifics during the election period.
 - Guard the privacy of the email addresses of voters
 - It is impossible for the election officers to see the results of the election until the election ends; for purposes of transparency with the community it is encouraged to release some statistics during the election (ie. “65% of the community has voted so far!”)
 - Ensure that the election results are handed over to the steering committee.
-- Is allowed to vote in the election
 
 [eligibile to vote]: https://github.com/kubernetes/steering/blob/master/elections.md#elegibility-for-voting
 [election-recusal]: https://github.com/kubernetes/steering/blob/master/elections.md#steering-committee-and-election-officer-recusal


### PR DESCRIPTION
This points to kubernetes/steering as the source of truth
for eligibility requirements for voting and candidacy

I also word wrapped the 2018 voting guide to 80 chars, which
makes for an awful diff, so I'll explain what I changed as
notes in the PR

I swear I didn't sneak in a "all votes secretly go to Aaron"
policy. Promise.  Really.

I would like for this to supersede https://github.com/kubernetes/community/pull/2542

/sig contributor-experience
/committee steering