### PR TITLE
improve conformance test document

### DIFF
--- a/contributors/devel/conformance-tests.md
+++ b/contributors/devel/conformance-tests.md
@@ -62,6 +62,9 @@ Conformance tests can be run against clusters that have not been created with
 credentials.
 
 ```sh
+# build test binaries, ginkgo, and kubectl first:
+make WHAT=test/e2e/e2e.test && make WHAT=ginkgo && make WHAT=cmd/kubectl
+
 # setup for conformance tests
 export KUBECONFIG=/path/to/kubeconfig
 export KUBERNETES_CONFORMANCE_TEST=y


### PR DESCRIPTION
missing a critical part in run conformance test section:
user need to build e2e test binaries, kubectl, ginkgo before
launch test.

@BenTheElder 

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->