### PR TITLE
Remove unnecessary discription of provider "local"

### DIFF
--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -424,8 +424,6 @@ Then point the tests at a custom host directly:
 
 ```sh
 export KUBECONFIG=/path/to/kubeconfig
-export KUBE_MASTER_IP="127.0.0.1:<PORT>"
-export KUBE_MASTER=local
 go run hack/e2e.go -- --provider=local --test
 ```
 


### PR DESCRIPTION
As detect-master method[1] of the provider "local", the variables
of KUBE_MASTER and KUBE_MASTER_IP are hardcoded. Then it is not
necessary to specify them on user side. In addition, the original
description shows KUBE_MASTER=local, but that is completely wrong
that should be localhost as the code[1].
This patch removes this unnecessary discription.

[1]: https://github.com/kubernetes/kubernetes/blob/2bdae8f3d047f1042822f4ab1aff1bf5a6c8b6bf/cluster/local/util.sh#L21
