### PR TITLE
Move k/utils to sig-arch, add k/contrib to sig-arch

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -94,9 +94,6 @@ The following subprojects are owned by sig-api-machinery:
     - https://raw.githubusercontent.com/kubernetes-incubator/client-python/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/client-go/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/OWNERS
-- **universal-utils**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
 
 ## GitHub Teams
 

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -45,6 +45,12 @@ The following subprojects are owned by sig-architecture:
 - **architecture-tracking**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/architecture-tracking/master/OWNERS
+- **universal-utils**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
+- **contrib**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/contrib/master/OWNERS
 
 ## GitHub Teams
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -107,9 +107,6 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes-incubator/client-python/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/client-go/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/OWNERS
-    - name: universal-utils # There is no reason why this is in api-machinery
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
   - name: Apps
     dir: sig-apps
     mission_statement: >
@@ -250,6 +247,12 @@ sigs:
     - name: architecture-tracking
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/architecture-tracking/master/OWNERS
+    - name: universal-utils
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
+    - name: contrib # solely to steward moving code _out_ of here to more appropriate places
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/contrib/master/OWNERS
   - name: Auth
     dir: sig-auth
     mission_statement: >


### PR DESCRIPTION
Per discussion in https://github.com/kubernetes/utils/issues/44 I'm
suggesting a move of the kubernetes/utils subproject to sig-arch

I also think sig-arch should own deciding where to move code that
currently lives in k/contrib. This is the last repo not yet included in
sigs.yaml (ref: https://github.com/kubernetes/community/issues/2464)

I have added each of these as their own subprojects. Another approach
could be to make a "code-organization" subproject, and place both of
these repos under that

WDYT?

/sig contributor-experience
/sig architecture
/cc @thockin @lavalamp

/hold
for comment