### PR TITLE
Removing extra words (use)

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -59,7 +59,7 @@ You must also set your [git e-mail](https://help.github.com/articles/setting-you
 to match this e-mail address as well.
 
 If you've already submitted a PR you can correct your user.name and user.email
-and then use use `git commit --amend --reset-author` and then `git push --force` to
+and then use `git commit --amend --reset-author` and then `git push --force` to
 correct the PR.
 
 #### 5. Look for an email indicating successful signup.


### PR DESCRIPTION
The word 'use' was used twice. Removed the extra word.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->