### PR TITLE
Adding kube-storage-version-migrator repo

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -44,6 +44,7 @@ The following subprojects are owned by sig-api-machinery:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
 - **universal-machinery**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/apimachinery/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -57,6 +57,7 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/OWNERS # if not us, who?
+      - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
     - name: universal-machinery # i.e., both client and server
       owners:
       - https://raw.githubusercontent.com/kubernetes/apimachinery/master/OWNERS


### PR DESCRIPTION
It will be a subproject of sig-apimachinery.

@deads2k @lavalamp I checked how kubebuilder opened its own repo. They updated these sig files and then sent an email to kubernetes-sig-architecture@ to create the repo.