### PR TITLE
syntax fix for testing doc

### DIFF
--- a/contributors/devel/testing.md
+++ b/contributors/devel/testing.md
@@ -57,7 +57,7 @@ make test  # Run all unit tests.
 If any unit test fails with a timeout panic (see [#1594](https://github.com/kubernetes/community/issues/1594)) on the testing package, you can increase the `KUBE_TIMEOUT` value as shown below.
 
 ```sh
-make test KUBE_TIMEOUT=-timeout 300s
+make test KUBE_TIMEOUT="-timeout 300s"
 ```
 
 ### Set go flags during unit tests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Small syntax fix for the timeout flag, should have quotes around `-timeout 300s`.
