### PR TITLE
Add repo for serverside apply test cases & code

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -80,6 +80,7 @@ The following subprojects are owned by sig-api-machinery:
     - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
     - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/structured-merge-diff/master/OWNERS
 - **kubernetes-clients**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-client/community/master/OWNERS
@@ -107,7 +108,7 @@ Monitor these for Github activity if you are not a member of the team.
 
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
-| @kubernetes/sig-api-machinery-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-api-reviews) | API Changes and Reviews |
+| @kubernetes/sig-api-machinery-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-api-reviews) | API Changes and Reviews (API Machinery APIs, NOT all APIs) |
 | @kubernetes/sig-api-machinery-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-bugs) | Bug Triage and Troubleshooting |
 | @kubernetes/sig-api-machinery-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-feature-requests) | Feature Requests |
 | @kubernetes/sig-api-machinery-misc | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-misc) | General Discussion |

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -30,7 +30,7 @@ sigs:
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery
       teams:
       - name: sig-api-machinery-api-reviews
-        description: API Changes and Reviews
+        description: API Changes and Reviews (API Machinery APIs, NOT all APIs)
       - name: sig-api-machinery-bugs
         description: Bug Triage and Troubleshooting
       - name: sig-api-machinery-feature-requests
@@ -93,6 +93,7 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
       - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes-sigs/structured-merge-diff/master/OWNERS
     - name: kubernetes-clients
       owners:
       - https://raw.githubusercontent.com/kubernetes-client/community/master/OWNERS


### PR DESCRIPTION
I need a place to put the following things.
* test vectors for apply (framework started in https://github.com/kubernetes/kubernetes/pull/67098)
* home for current apply code (move begun in https://github.com/kubernetes/kubernetes/pull/67101)
* home for subsequent apply code (building on this https://github.com/kubernetes/kubernetes/pull/67458)

I could put this in staging (as in the above PRs) but it's not necessary, and I prefer the versioning story if I don't.

This is part of what the Apply working group needs to do; since WGs don't own code, API Machinery will own this code, under the "idl-schema-client-pipeline" subproject.