### PR TITLE
Add Japanese l10n repo owners for sig-docs

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -65,6 +65,7 @@ Monitor these for Github activity if you are not a member of the team.
 | @kubernetes/sig-docs-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers) | Documentation Maintainers |
 | @kubernetes/sig-docs-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-docs-pr-reviews) | Documentation PR Reviewers |
 | @kubernetes/sig-docs-ko-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ko-owners) | Korean L10n Repository Owners |
+| @kubernetes/sig-docs-ja-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ja-owners) | Japanese L10n Repository Owners |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -882,6 +882,8 @@ sigs:
         description: Documentation PR Reviewers
       - name: sig-docs-ko-owners
         description: Korean L10n Repository Owners
+      - name: sig-docs-ja-owners
+        description: Japanese L10n Repository Owners
     subprojects:
     - name: kubernetes-docs-ja
       owners:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Add sig-docs-ja-owners team.