### PR TITLE
Change k8s.io/api owners from apimachinery to architecture

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -77,8 +77,6 @@ The following subprojects are owned by sig-api-machinery:
     - https://raw.githubusercontent.com/kubernetes/code-generator/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/code-generator/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kube-openapi/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
     - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
 - **kubernetes-clients**
   - Owners:

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -33,6 +33,10 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following subprojects are owned by sig-architecture:
+- **api**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
 - **kubernetes-template-project**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -90,8 +90,6 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes/code-generator/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/code-generator/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kube-openapi/master/OWNERS
-      - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
-      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
       - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
     - name: kubernetes-clients
       owners:
@@ -236,6 +234,10 @@ sigs:
       - name: sig-architecture-test-failures
         description: Test Failures and Triage
     subprojects:
+    - name: api
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
     - name: kubernetes-template-project
       owners:
       - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/67672#issuecomment-415560829
/cc dims

/assign lavalamp 
/sig api-machinery

/assign bgrant0607 jdumars 
/sig architecture

