### PR TITLE
Adding more details into the non-code contributor guide roles

### DIFF
--- a/contributors/guide/non-code-contributions.md
+++ b/contributors/guide/non-code-contributions.md
@@ -1,40 +1,87 @@
 # Non-code Contributions
 
-This section is new and in progress. Expect this document to change often.
+*This section is new and in progress. Expect this document to change often.*
 
-If you are interested in helping define and structure this work, [check the weekly meeting notes](https://docs.google.com/document/d/1gdFWfkrapQclZ4-z4Lx2JwqKsJjXXUOVoLhBzZiZgSk/edit#) for information on how to get involved. You can also find us in the SIG Contributor Experience [slack channel](https://kubernetes.slack.com/messages/sig-contribex).
+*If you are interested in helping define and structure this work, [check the weekly meeting notes](https://docs.google.com/document/d/1gdFWfkrapQclZ4-z4Lx2JwqKsJjXXUOVoLhBzZiZgSk/edit#) for information on how to get involved. You can also find us in the SIG Contributor Experience [Slack channel](https://kubernetes.slack.com/messages/sig-contribex).*
 
-New contributors welcome!
+*All contributors welcome, new and old!*
 
-*   Plan of attack
-    *   Identify Non-Dev focused roles
-        *   Tasks tied to these roles
-        *   Examples:
-            *   Technical project leadership
-                *   SIG contribution
-            *   Leading contributor communities
-            *   Promotion of people and projects
-                *   Recognition
-            *   Managing communication tools
-                *   Zoom, Slack, Discourse, ...
-            *   Writing articles/blogs
-                *   Capture it somewhere, not sure where yet
-                *   Feed into Kube.weekly?
-            *   Creating artwork
-                *   Conference specific, project specific
-            *   Answering questions from community members
-            *   Updating documentation
-                *   "Everybody owns docs" can equal "nobody owns docs"
-                *   Strengthen the entry point for doc ownership
-                *   Get specific enough so that someone would have an entrypoint to get started and take ownership
-                *   Funneling more people to SIG-Docs
-            *   Operations or "Tech" that is generally not considered "dev"
-                *   e.g. ansible
-            *   This! (Onboarding and enabling new people)
-                *   You only get one chance to see this onboarding process for the first time, so a steady stream a fresh eyes is important.
-        *   Let's just ask the SIGs!
-        *   Chat with Paris regarding alternate entry paths, as may have come up during mentoring efforts.
-        *   Follow up on Contrib-Ex call
-    *   Identify Non-Dev tasks in primarily Dev roles
-        *   Is it a dis-service to suggest Docs are Non-Dev?
-            *   New functionality vs Updates/common documentation
+### What is this?
+
+The list below is meant to help non-code contributors find areas of the Kubernetes project where their expertise can be best utilized. The goal of this is to both provide a starting guide for anyone looking to become a contributor not necessarily writing code, and also to fill any needs that the SIGs have that might not currently be filled by code-focused contributors.
+
+This list is meant to be used by both new contributors looking for a good entrance into the project, and current contributors who would live to do something different.
+
+Are you interested in any of the roles below? Come chat with us [on Slack](https://kubernetes.slack.com/messages/sig-contribex)!
+
+#### Project general roles
+These are roles that either span the project as a whole, or span several areas of the project. Most of the roles below can be considered "good-first-roles".
+
+- Community education
+  - Answering questions on Discuss, Slack, StackOverflow, etc
+  - K8s Office Hours
+  - Meet Our Contributors
+  - Onboarding new contributors
+    - Capturing the experiences of “Fresh Eyes” in the project
+  - Getting more people to SIG-Docs
+- Outward facing community work (might be more CNCF-oriented)
+  - Hosting meetups and general evangelism
+  - Presentation of work to meetups
+  - Design
+    - Web Development
+    - Artistic contributions
+      - Conference-specific or Project-specific
+- Non-Documentation writing
+  - Blogging about early experiences
+  - Operational manuals
+    - Walkthroughs
+    - How-tos about integration experiences, tools, etc
+    - Playbooks for Ansible, Chef, Salt, etc
+  - Indexing of blogs, videos, etc
+  - Maintaining content for the new Contributor Site
+- Management of communication tools (at the discretion of project maintainers)
+  - Mailing list moderation
+  - Slack or Discourse management
+  - Calendar management
+  - Analysis of our comm tools/metrics
+- Volunteer management
+  - Finding/Funneling contributors to the right SIGs or WGs
+  - Recognition of those who contribute a lot
+  - Recognition of projects and growth efforts
+- Issue Triage
+  - Issue triage & labeling
+
+#### SIG-specific roles
+These are roles that are important to each and every SIG within the Kubernetes project. If you are interested in a specific topic within the project, you can contribute in several different ways for that specific SIG.
+
+- Documentation
+  - Common documentation for the SIG expertise area
+  - Updates
+    - Reviewing/logging technical ownership for documentation that might need updating
+  - Translation
+- Release roles
+  - All roles have shadows for onboarding new members
+- Project management
+  - Confirming ownership of tasks, issues, objects, etc
+    - Rectifying “owned by everyone, so owned by no-one”
+- Pull requests
+  - PR triage & labeling
+  - Editing PR text: release note, statement
+
+#### Non-Code Tasks in Primarily-Code roles
+These are roles that are not code-based, but require knowledge of either general coding, or specific domain knowledge of the Kubernetes code base.
+
+- Documentation
+  - Documenting new features
+- Some release roles
+  - Managing release notes
+- Github management (Tags, repos, etc)
+
+#### Post-Code Roles
+These are roles that are not code-based, but require knowledge of either general coding, or specific domain knowledge of the Kubernetes code base.
+
+- Technical project leadership
+  - Specifically, SIG-Architecture and Steering Committee
+- Some release roles
+  - Release Lead, Features Lead, etc
+- Mentoring new contributors


### PR DESCRIPTION
Creating a more thorough list of possible roles for the non-code contributor guide, for issue #2325.

This list was discussed during the SIG-ContribX meeting on August 29.

Signed-off-by: <jrosland@vmware.com>