### PR TITLE
generator: remove github team google groups note from all SIG READMEs

### DIFF
--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -88,10 +88,6 @@ The following subprojects are owned by sig-{{.Label}}:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 {{- range .Contact.GithubTeams }}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -99,10 +99,6 @@ The following subprojects are owned by sig-api-machinery:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-api-machinery-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-api-reviews) | API Changes and Reviews |

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -74,10 +74,6 @@ The following subprojects are owned by sig-apps:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-apps-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-api-reviews) | API Changes and Reviews |

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -61,10 +61,6 @@ The following subprojects are owned by sig-architecture:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-architecture-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-api-reviews) | API Changes and Reviews |

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -42,10 +42,6 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-auth-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-api-reviews) | API Changes and Reviews |

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -58,10 +58,6 @@ The following subprojects are owned by sig-autoscaling:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-autoscaling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-api-reviews) | API Changes and Reviews |

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -49,10 +49,6 @@ The following subprojects are owned by sig-aws:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-aws-misc | [link](https://github.com/orgs/kubernetes/teams/sig-aws-misc) | General Discussion |

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -48,10 +48,6 @@ The following subprojects are owned by sig-azure:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-azure | [link](https://github.com/orgs/kubernetes/teams/sig-azure) | General Discussion |

--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -34,10 +34,6 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-big-data-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-api-reviews) | API Changes and Reviews |

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -49,10 +49,6 @@ The following subprojects are owned by sig-cli:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-cli-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-api-reviews) | API Changes and Reviews |

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -54,10 +54,6 @@ The following subprojects are owned by sig-cloud-provider:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-cloud-provider-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-api-reviews) | API Changes and Reviews |

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -89,10 +89,6 @@ The following subprojects are owned by sig-cluster-lifecycle:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-cluster-lifecycle | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle) | Notify group |

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -73,10 +73,6 @@ The following subprojects are owned by sig-contributor-experience:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-contributor-experience-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-bugs) | Bug Triage and Troubleshooting |

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -56,10 +56,6 @@ The following subprojects are owned by sig-docs:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-docs-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers) | Documentation Maintainers |

--- a/sig-gcp/README.md
+++ b/sig-gcp/README.md
@@ -41,10 +41,6 @@ The following subprojects are owned by sig-gcp:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-gcp-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-api-reviews) | API Changes and Reviews |

--- a/sig-ibmcloud/README.md
+++ b/sig-ibmcloud/README.md
@@ -33,10 +33,6 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-ibmcloud-misc | [link](https://github.com/orgs/kubernetes/teams/sig-ibmcloud-misc) | General Discussion |

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -51,10 +51,6 @@ The following subprojects are owned by sig-instrumentation:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-instrumentation-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-api-reviews) | API Changes and Reviews |

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -52,10 +52,6 @@ The following subprojects are owned by sig-multicluster:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-multicluster-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-api-reviews) | API Changes and Reviews |

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -60,10 +60,6 @@ The following subprojects are owned by sig-network:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-network-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-api-reviews) | API Changes and Reviews |

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -61,10 +61,6 @@ The following subprojects are owned by sig-node:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-node-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) | API Changes and Reviews |

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -34,10 +34,6 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-openstack-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-openstack-api-reviews) | API Changes and Reviews |

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -47,10 +47,6 @@ The following subprojects are owned by sig-release:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-release-admins | [link](https://github.com/orgs/kubernetes/teams/sig-release-admins) | Release Team Admins |

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -46,10 +46,6 @@ The following subprojects are owned by sig-scalability:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-scalability-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-api-reviews) | API Changes and Reviews |

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -53,10 +53,6 @@ The following subprojects are owned by sig-scheduling:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-scheduling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-api-reviews) | API Changes and Reviews |

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -44,10 +44,6 @@ The following subprojects are owned by sig-service-catalog:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-service-catalog-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-api-reviews) | API Changes and Reviews |

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -63,10 +63,6 @@ The following subprojects are owned by sig-storage:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-storage-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-api-reviews) | API Changes and Reviews |

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -53,10 +53,6 @@ The following subprojects are owned by sig-testing:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-testing | [link](https://github.com/orgs/kubernetes/teams/sig-testing) | General Discussion |

--- a/sig-vmware/README.md
+++ b/sig-vmware/README.md
@@ -46,10 +46,6 @@ The following subprojects are owned by sig-vmware:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-vmware-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-api-reviews) | API Changes and Reviews |

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -33,10 +33,6 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-windows-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-windows-bugs) | Bug Triage and Troubleshooting |


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/community/pull/2500
For https://github.com/kubernetes/community/issues/2324

/cc cblecker spiffxp 
/assign cblecker 

/sig contributor-experience
/area github-management