### PR TITLE
Fix conformance test instructions for building Ginkgo

### DIFF
--- a/contributors/devel/conformance-tests.md
+++ b/contributors/devel/conformance-tests.md
@@ -63,7 +63,7 @@ credentials.
 
 ```sh
 # build test binaries, ginkgo, and kubectl first:
-make WHAT=test/e2e/e2e.test && make WHAT=ginkgo && make WHAT=cmd/kubectl
+make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
 
 # setup for conformance tests
 export KUBECONFIG=/path/to/kubeconfig


### PR DESCRIPTION
I think this may have been relying on this feature which was moved/removed:  https://github.com/kubernetes/kubernetes/commit/4bf2ef646f5937c2d6eb49093fad15cfe65e7aae#diff-b67911656ef5d18c4ae36cb6741b7965L103