### PR TITLE
include projects in wording

### DIFF
--- a/github-management/kubernetes-repositories.md
+++ b/github-management/kubernetes-repositories.md
@@ -23,7 +23,7 @@ To facilitate contributions and collaboration from the broader Kubernetes commun
 
 ## SIG repositories
 
-SIG repositories serve as temporary homes for SIG-sponsored experimental projects or prototypes of new core functionality, or as permanent homes for SIG-specific tools.
+SIG repositories serve as temporary homes for SIG-sponsored experimental projects or prototypes of new core functionality, or as permanent homes for SIG-specific projects and tools.
 
 ### Goals
 


### PR DESCRIPTION
To cover projects like cri-o, which arguably isn't so much a tool as it is a runtime project.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>