### PR TITLE
fix yaml formatting in kep 26 frontmatter

### DIFF
--- a/keps/sig-apps/0026-ttl-after-finish.md
+++ b/keps/sig-apps/0026-ttl-after-finish.md
@@ -7,10 +7,10 @@ owning-sig: sig-apps
 participating-sigs:
   - sig-api-machinery
 reviewers:
-  - @enisoc
-  - @tnozicka
+  - "@enisoc"
+  - "@tnozicka"
 approvers:
-  - @kow3ns
+  - "@kow3ns"
 editor: TBD
 creation-date: 2018-08-16
 last-updated: 2018-08-16


### PR DESCRIPTION
This resolved the issue with the frontmatter for kep-26 failing to render for both github and hugo (contributor site).  This is due to the `@` symbol being a reserved [yaml indicator](http://yaml.org/refcard.html) and must be quoted when it is used as the leading character in a string. 

/cc @castrojo 