### PR TITLE
Fixed typo in sig storage contributing docs

### DIFF
--- a/sig-storage/contributing.md
+++ b/sig-storage/contributing.md
@@ -4,7 +4,7 @@ We recommend the following presentations, docs, and videos to help get familiar 
 
 | Date | Title | Link | Description |
 | --- | --- | --- | --- |
-| - | Persistent Volume Framework | [Doc](http://kubernetes.io/docs/user-guide/persistent-volumes/) | Public user docs for Kubenretes Persistent Volume framework.
+| - | Persistent Volume Framework | [Doc](http://kubernetes.io/docs/user-guide/persistent-volumes/) | Public user docs for Kubernetes Persistent Volume framework.
 | 2018 May 03 | SIG Storage Intro | [Video](https://www.youtube.com/watch?v=GvrTl2T-Tts&list=PLj6h78yzYM2N8GdbjmhVU65KYm_68qBmo&index=164&t=0s) | An overview of SIG Storage By Saad Ali at Kubecon EU 2018. |
 | 2018 May 04 | Kubernetes Storage Lingo 101 | [Video](https://www.youtube.com/watch?v=uSxlgK1bCuA&t=0s&index=300&list=PLj6h78yzYM2N8GdbjmhVU65KYm_68qBmo) | An overview of various terms used in Kubernetes storage and what they mean by Saad Ali at Kubecon EU 2018.|
 | 2017 May 18 | Storage Classes & Dynamic Provisioning in Kubernetes |[Video](https://youtu.be/qktFhjJmFhg)| Intro to the basic Kubernetes storage concepts for users (direct volume reference, PV/PVC, and dynamic provisioning). |


### PR DESCRIPTION
**What and Why**  
I was reading the contribution documentation for the storage sig and noticed a small typo where "Kubernetes" was accidentally misspelled.  

I've made this mistake countless times so I figured I'd fix it while I was in the area.

**Related issues**  
https://github.com/kubernetes/community/issues/2644  