### PR TITLE
Match other staging repos, both OWNERS files listed

### DIFF
--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -45,6 +45,7 @@ The following subprojects are owned by sig-instrumentation:
 - **metrics**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/metrics/OWNERS
 
 ## GitHub Teams
 

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -45,6 +45,7 @@ The following subprojects are owned by sig-storage:
     - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
 - **external-storage**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1051,6 +1051,7 @@ sigs:
     - name: metrics
       owners:
       - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/metrics/OWNERS
   - name: Multicluster
     dir: sig-multicluster
     mission_statement: >
@@ -1636,6 +1637,7 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
     - name: external-storage
       owners:
       - https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/OWNERS


### PR DESCRIPTION
As I was reviewing other staging repos, I noticed two of them
weren't listed here in sigs.yaml. I don't really know whether
listing both the staging OWNERS and published OWNERS is any
better or worse than just listing one, so I leaned in the
direction of consistency