### PR TITLE
Update `profiling to services to APIserver`

### DIFF
--- a/contributors/devel/profiling.md
+++ b/contributors/devel/profiling.md
@@ -16,7 +16,7 @@ m.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 m.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 ```
 
-to the `init(c *Config)` method in 'pkg/master/master.go' and import 'net/http/pprof' package.
+to the `New(delegationTarget genericapiserver.DelegationTarget) (*Master, error)` method in 'pkg/master/master.go' and import 'net/http/pprof' package.
 
 In most use cases to use profiler service it's enough to do 'import _ net/http/pprof', which automatically registers a handler in the default http.Server. Slight inconvenience is that APIserver uses default server for intra-cluster communication, so plugging profiler to it is not really useful. In 'pkg/kubelet/server/server.go' more servers are created and started as separate goroutines. The one that is usually serving external traffic is secureServer. The handler for this traffic is defined in 'pkg/master/master.go' and stored in Handler variable. It is created from HTTP multiplexer, so the only thing that needs to be done is adding profiler handler functions to this multiplexer. This is exactly what lines after TL;DR do.
 


### PR DESCRIPTION
the current description for `Adding profiling to services to APIserver` is just outdated, there is no  `init(c *Config)` method in 'pkg/master/master.go'  now, this document should have been describing how to do it 4 years ago, see https://github.com/kubernetes/kubernetes/blob/6d94dd1a05b72b397458b642186864a033885b49/pkg/master/master.go and https://github.com/kubernetes/kubernetes/blob/f407700af91de685ce5aa7570f9f3d24b2c5790b/pkg/master/master.go

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->