### PR TITLE
Add meeting recordings for wg-multitenancy and fix charters

### DIFF
--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -10,7 +10,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 Service Catalog is a Kubernetes extension project that implements the [Open Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI). It allows application developers the ability to provision and consume cloud services natively from within Kubernetes.
 
-The [charter](https://github.com/kubernetes/community/blob/master/sig-service-catalog/charter.md) defines the scope and governance of the Service Catalog Special Interest Group.
+The [charter](charter.md) defines the scope and governance of the Service Catalog Special Interest Group.
 
 ## Meetings
 * Regular SIG Meeting: [Mondays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1537,7 +1537,7 @@ sigs:
       Service Catalog is a Kubernetes extension project that
       implements the [Open Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI).
       It allows application developers the ability to provision and consume cloud services natively from within Kubernetes.
-    charter_link: https://github.com/kubernetes/community/blob/master/sig-service-catalog/charter.md
+    charter_link: charter.md
     label: service-catalog
     leadership:
       chairs:
@@ -1939,7 +1939,7 @@ workinggroups:
       understand the needs of other parts of the ecosystem on this layer, and improve the interoperability
       of application management tools through better separation of concerns, common conventions,
       and common principles.
-    charter_link: https://docs.google.com/document/d/1TzRwzWYRulx4o8Fii8k7ToIx4LR4MSncxxLdJ9TkOAs/edit#
+    charter_link:
     leadership:
       chairs:
       - name: Antoine Legrand

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2009,6 +2009,7 @@ workinggroups:
       frequency: biweekly
       url: https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit
       archive_url: https://docs.google.com/document/d/1fj3yzmeU2eU8ZNBCUJG97dk_wC7228-e_MmdcmTNrZY/edit?usp=sharing
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP1tBA0W8zEe6UwPsabGQk-j
     contact:
       slack: wg-multitenancy
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy

--- a/wg-app-def/README.md
+++ b/wg-app-def/README.md
@@ -10,8 +10,6 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 Improve UX of declarative primitives in the API and/or primary client libraries and tools, understand the needs of other parts of the ecosystem on this layer, and improve the interoperability of application management tools through better separation of concerns, common conventions, and common principles.
 
-The [charter](https://docs.google.com/document/d/1TzRwzWYRulx4o8Fii8k7ToIx4LR4MSncxxLdJ9TkOAs/edit#) defines the scope and governance of the App Def Working Group.
-
 ## Meetings
 * Regular WG Meeting: [Wednesdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1Pxc-qwAt4FvuISZ_Ib5KdUwlynFkGueuzPx5Je_lbGM/edit).

--- a/wg-multitenancy/README.md
+++ b/wg-multitenancy/README.md
@@ -13,6 +13,7 @@ Define the models of multitenancy that Kubernetes will support. Discuss and exec
 ## Meetings
 * Regular WG Meeting: [Wednesdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1fj3yzmeU2eU8ZNBCUJG97dk_wC7228-e_MmdcmTNrZY/edit?usp=sharing).
+  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP1tBA0W8zEe6UwPsabGQk-j).
 
 ## Organizers
 


### PR DESCRIPTION
The links are taken from the meeting notes document: https://docs.google.com/document/d/1fj3yzmeU2eU8ZNBCUJG97dk_wC7228-e_MmdcmTNrZY/edit?usp=sharing.

/assign @jessfraz @davidopp 