### PR TITLE
Extend subproject and repo generation for generator app

### DIFF
--- a/generator/app.go
+++ b/generator/app.go
@@ -84,12 +84,23 @@ type GithubTeams struct {
 	Description string
 }
 
+// Repo represents a specific repo or subdirectories owned by the group
+type Repo struct {
+	Name        string
+	Description string
+	URL         string
+	Owners      []string
+}
+
 // Subproject represents a specific subproject owned by the group
 type Subproject struct {
 	Name        string
 	Description string
+	Label       string
+	Repos       []Repo
 	Owners      []string
 	Meetings    []Meeting
+	Contact     *Contact
 }
 
 // LeadershipGroup represents the different groups of leaders within a group
@@ -109,6 +120,7 @@ type Group struct {
 	Leadership       LeadershipGroup `yaml:"leadership"`
 	Meetings         []Meeting
 	Contact          Contact
+	Repos            []Repo
 	Subprojects      []Subproject
 	StakeholderSIGs  []string `yaml:"stakeholder_sigs,omitempty"`
 }

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -1,19 +1,23 @@
 {{- template "header" }}
 # {{.Name}} Special Interest Group
+{{ if .MissionStatement }}
 
 {{ .MissionStatement }}
+{{end}}
 {{- if .CharterLink }}
+
 The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}} Special Interest Group.
 {{ end }}
 {{ if .Meetings -}}
 ## Meetings
+
 {{- range .Meetings }}
-* {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
+- {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}))
 {{- if .ArchiveURL }}
-  * [Meeting notes and Agenda]({{.ArchiveURL}}).
+  - [Meeting notes and Agenda]({{.ArchiveURL}})
 {{- end }}
 {{- if .RecordingsURL }}
-  * [Meeting recordings]({{.RecordingsURL}}).
+  - [Meeting recordings]({{.RecordingsURL}})
 {{- end }}
 {{- end }}
 
@@ -24,66 +28,42 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{- if .Leadership.Chairs }}
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 {{ range .Leadership.Chairs }}
-* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+- {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
 {{- end }}
 {{- end }}
 {{- if .Leadership.TechnicalLeads }}
 
 ### Technical Leads
+
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 {{ range .Leadership.TechnicalLeads }}
-* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+- {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
 {{- end }}
 {{- end }}
 {{- if .Leadership.EmeritusLeads }}
 
 ## Emeritus Leads
+
 {{ range .Leadership.EmeritusLeads }}
-* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+- {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
 {{- end }}
 {{- end }}
 {{- end }}
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
-* [Mailing list]({{.Contact.MailingList}})
+
+- [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+- [Mailing list]({{.Contact.MailingList}})
 {{- if .Label }}
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2F{{.Label}})
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2F{{.Label}})
 {{- end }}
-{{- if .Subprojects }}
 
-## Subprojects
-
-The following subprojects are owned by sig-{{.Label}}:
-
-{{- range .Subprojects }}
-- **{{.Name}}**
-{{- if .Description }}
-  - Description: {{ trimSpace .Description }}
-{{- end }}
-  - Owners:
-{{- range .Owners }}
-    - {{.}}
-{{- end }}
-{{- if .Meetings }}
-  - Meetings:
-{{- range .Meetings }}
-    - {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
-{{- if .ArchiveURL }}
-      - [Meeting notes and Agenda]({{.ArchiveURL}}).
-{{- end }}
-{{- if .RecordingsURL }}
-      - [Meeting recordings]({{.RecordingsURL}}).
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
 {{ if .Contact.GithubTeams }}
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -92,5 +72,79 @@ Note that the links to display team membership will only work if you are a membe
 | --------- |:-------:| ----------- |
 {{- range .Contact.GithubTeams }}
 | @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
+{{- end }}
+
+{{- if .Repos }}
+
+## Repos / Directories
+
+The following repos / directories are owned by sig-{{.Label}}:
+
+{{- range .Repos }}
+- {{ .Name }} ({{ .Description }})
+{{- if .URL }}
+  - {{ .URL }}
+{{- end }}
+{{- if .Owners }}
+  - OWNERS:
+{{- range .Owners }}
+    - {{.}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .Subprojects }}
+
+## Subprojects
+
+The following subprojects are owned by sig-{{.Label}}:
+{{- range .Subprojects }}
+
+### {{ .Name }}
+
+{{- if .Description }}
+- Description: {{ trimSpace .Description }}
+{{- end }}
+{{- if .Contact }}
+- Contact
+{{- if .Contact.Slack }}
+  - [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+{{- end }}
+{{- if .Contact.MailingList }}
+  - [Mailing list]({{.Contact.MailingList}})
+{{- end }}
+{{- if .Label }}
+  - [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3A{{.Label}})
+{{- end }}
+{{- end }}
+{{- if .Repos }}
+- Repos
+{{- range .Repos }}
+  - {{ .Name }} ({{ .Description }})
+{{- if .URL }}
+    - {{ .URL }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .Owners }}
+- OWNERS:
+{{- range .Owners }}
+  - {{.}}
+{{- end }}
+{{- end }}
+{{- if .Meetings }}
+- Meetings:
+{{- range .Meetings }}
+  - {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}))
+{{- if .ArchiveURL }}
+    - [Meeting notes and Agenda]({{.ArchiveURL}})
+{{- end }}
+{{- if .RecordingsURL }}
+    - [Meeting recordings]({{.RecordingsURL}})
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{  end }}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -8,99 +8,32 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # API Machinery Special Interest Group
 
+
 Covers all aspects of API server, API registration and discovery, generic API CRUD semantics, admission control, encoding/decoding, conversion, defaulting, persistence layer (etcd), OpenAPI, CustomResourceDefinition, garbage collection, and client libraries.
 
+
 ## Meetings
-* Regular SIG Meeting: [Wednesdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://goo.gl/0lbiM9).
-  * [Meeting recordings](https://www.youtube.com/watch?v=Lj1ScbXpnpY&list=PL69nYSiGNLP21oW3hbLyjjj4XhrwKxH2R).
+- Regular SIG Meeting: [Wednesdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://goo.gl/0lbiM9)
+  - [Meeting recordings](https://www.youtube.com/watch?v=Lj1ScbXpnpY&list=PL69nYSiGNLP21oW3hbLyjjj4XhrwKxH2R)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Daniel Smith (**[@lavalamp](https://github.com/lavalamp)**), Google
-* David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
+- Daniel Smith (**[@lavalamp](https://github.com/lavalamp)**), Google
+- David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-api-machinery)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapi-machinery)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-api-machinery)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fapi-machinery)
 
-The following subprojects are owned by sig-api-machinery:
-- **server-binaries**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-apiserver/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-controller-manager/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/controller-manager/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/master/OWNERS
-- **control-plane-features**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
-- **universal-machinery**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/apimachinery/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apimachinery/OWNERS
-- **server-frameworks**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/apiserver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/OWNERS
-- **server-crd**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/apiextensions-apiserver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiextensions-apiserver/OWNERS
-- **server-api-aggregation**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kube-aggregator/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/kube-aggregator/OWNERS
-- **server-sdk**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/sample-apiserver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-apiserver/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/sample-controller/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-controller/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-incubator/apiserver-builder/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/OWNERS
-- **idl-schema-client-pipeline**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/gengo/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/code-generator/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/code-generator/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kube-openapi/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/structured-merge-diff/master/OWNERS
-- **kubernetes-clients**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-client/csharp/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/go-base/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/go/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/haskell/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/java/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/javascript/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/python-base/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/ruby/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-incubator/client-python/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/client-go/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/OWNERS
-- **yaml**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/yaml/master/OWNERS
-- **component-base**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/component-base/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -115,9 +48,89 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-api-machinery-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-proposals) | Design Proposals |
 | @kubernetes/sig-api-machinery-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-test-failures) | Test Failures and Triage |
 
-<!-- BEGIN CUSTOM CONTENT -->
-## Additional links
+## Subprojects
 
-* [YouTube Playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP21oW3hbLyjjj4XhrwKxH2R) - find meeting recordings here
+The following subprojects are owned by sig-api-machinery:
+
+### server-binaries
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-apiserver/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-controller-manager/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/controller-manager/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/master/OWNERS
+
+### control-plane-features
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
+
+### universal-machinery
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/apimachinery/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apimachinery/OWNERS
+
+### server-frameworks
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/apiserver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/OWNERS
+
+### server-crd
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/apiextensions-apiserver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+
+### server-api-aggregation
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kube-aggregator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/kube-aggregator/OWNERS
+
+### server-sdk
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/sample-apiserver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-apiserver/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/sample-controller/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-controller/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-incubator/apiserver-builder/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/OWNERS
+
+### idl-schema-client-pipeline
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/gengo/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/code-generator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/code-generator/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kube-openapi/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/structured-merge-diff/master/OWNERS
+
+### kubernetes-clients
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-client/csharp/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/go-base/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/go/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/haskell/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/java/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/javascript/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/python-base/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/ruby/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-incubator/client-python/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/client-go/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/OWNERS
+
+### yaml
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/yaml/master/OWNERS
+
+### component-base
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/component-base/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/OWNERS
+
+<!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -8,70 +8,36 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Apps Special Interest Group
 
+
 Covers deploying and operating applications in Kubernetes. We focus on the developer and devops experience of running applications in Kubernetes. We discuss how to define and run apps in Kubernetes, demo relevant tools and projects, and discuss areas of friction that can lead to suggesting improvements or feature requests.
+
+
 
 The [charter](charter.md) defines the scope and governance of the Apps Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Mondays at 9:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#).
-  * [Meeting recordings](https://www.youtube.com/watch?v=hn23Z-vL_cM&list=PL69nYSiGNLP2LMq7vznITnpd2Fk1YIZF3).
+- Regular SIG Meeting: [Mondays at 9:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#)
+  - [Meeting recordings](https://www.youtube.com/watch?v=hn23Z-vL_cM&list=PL69nYSiGNLP2LMq7vznITnpd2Fk1YIZF3)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Matt Farina (**[@mattfarina](https://github.com/mattfarina)**), Samsung SDS
-* Adnan Abdulhussein (**[@prydonius](https://github.com/prydonius)**), Bitnami
-* Kenneth Owens (**[@kow3ns](https://github.com/kow3ns)**), Google
+- Matt Farina (**[@mattfarina](https://github.com/mattfarina)**), Samsung SDS
+- Adnan Abdulhussein (**[@prydonius](https://github.com/prydonius)**), Bitnami
+- Kenneth Owens (**[@kow3ns](https://github.com/kow3ns)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-apps)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapps)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-apps)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fapps)
 
-The following subprojects are owned by sig-apps:
-- **examples**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/examples/master/OWNERS
-- **kompose**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kompose/master/OWNERS
-- **workloads-api**
-  - Description: The core workloads API, which is composed of the CronJob, DaemonSet, Deployment, Job, ReplicaSet, ReplicationController, and StatefulSet kinds
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cronjob/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/daemon/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/deployment/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/disruption/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/history/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/job/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replicaset/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/statefulset/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/apps/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/core/v1/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/batch/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/extensions/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/apps/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/batch/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/extensions/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/apps/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/core/v1/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/batch/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/extensions/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/apps/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/daemonset/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/deployment/OWNERS
-- **application**
-  - Description: Application metadata descriptor CRD
-  - Owners:
-    - https://github.com/kubernetes-sigs/application/blob/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -85,6 +51,50 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-apps-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-pr-reviews) | PR Reviews |
 | @kubernetes/sig-apps-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-apps-proposals) | Design Proposals |
 | @kubernetes/sig-apps-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-apps-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-apps:
+
+### examples
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/examples/master/OWNERS
+
+### kompose
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kompose/master/OWNERS
+
+### workloads-api
+- Description: The core workloads API, which is composed of the CronJob, DaemonSet, Deployment, Job, ReplicaSet, ReplicationController, and StatefulSet kinds
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cronjob/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/daemon/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/deployment/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/disruption/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/history/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/job/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replicaset/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/statefulset/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/apps/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/core/v1/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/batch/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/extensions/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/apps/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/batch/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/extensions/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/apps/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/core/v1/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/batch/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/extensions/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/apps/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/daemonset/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/deployment/OWNERS
+
+### application
+- Description: Application metadata descriptor CRD
+- OWNERS:
+  - https://github.com/kubernetes-sigs/application/blob/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -8,68 +8,36 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Architecture Special Interest Group
 
+
 The Architecture SIG maintains and evolves the design principles of Kubernetes, and provides a consistent body of expertise necessary to ensure architectural consistency over time.
+
+
 
 The [charter](charter.md) defines the scope and governance of the Architecture Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Thursdays at 19:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=19:00&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1BlmHq5uPyBUDlppYqAAzslVbAO8hilgjqZUTaNXUhKM/edit).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2m6198LaLN6YahX7EEac5g).
+- Regular SIG Meeting: [Thursdays at 19:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=19:00&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1BlmHq5uPyBUDlppYqAAzslVbAO8hilgjqZUTaNXUhKM/edit)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2m6198LaLN6YahX7EEac5g)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Brian Grant (**[@bgrant0607](https://github.com/bgrant0607)**), Google
-* Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Google
-* Matt Farina (**[@mattfarina](https://github.com/mattfarina)**), Samsung SDS
+- Brian Grant (**[@bgrant0607](https://github.com/bgrant0607)**), Google
+- Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Google
+- Matt Farina (**[@mattfarina](https://github.com/mattfarina)**), Samsung SDS
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-architecture)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Farchitecture)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-architecture)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Farchitecture)
 
-The following subprojects are owned by sig-architecture:
-- **architecture-and-api-governance**
-  - Description: [Described below](#architecture-and-api-governance)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/contributors/design-proposals/architecture/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/architecture-tracking/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
-- **conformance-definition**
-  - Description: [Described below](#conformance-definition)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
-- **kep-adoption-and-reviews**
-  - Description: [Described below](#kep-adoption-and-reviews)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/keps/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/enhancements/master/keps/OWNERS
-- **code-organization**
-  - Description: [Described below](#code-organization)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/contrib/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/vendor/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/OWNERS
-- **klog**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
-- **steering**
-  - Description: Placeholder until sigs.yaml supports committees as first-class groups. These repos are owned by the kubernetes steering committee, which is a wholly separate entity from SIG Architecture
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -83,6 +51,50 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-architecture-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-pr-reviews) | PR Reviews |
 | @kubernetes/sig-architecture-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-proposals) | Design Proposals |
 | @kubernetes/sig-architecture-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-architecture:
+
+### architecture-and-api-governance
+- Description: [Described below](#architecture-and-api-governance)
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/contributors/design-proposals/architecture/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/architecture-tracking/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
+
+### conformance-definition
+- Description: [Described below](#conformance-definition)
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
+
+### kep-adoption-and-reviews
+- Description: [Described below](#kep-adoption-and-reviews)
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/keps/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/enhancements/master/keps/OWNERS
+
+### code-organization
+- Description: [Described below](#code-organization)
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/contrib/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/vendor/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/OWNERS
+
+### klog
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
+
+### steering
+- Description: Placeholder until sigs.yaml supports committees as first-class groups. These repos are owned by the kubernetes steering committee, which is a wholly separate entity from SIG Architecture
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -8,122 +8,46 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Auth Special Interest Group
 
+
 Covers improvements to Kubernetes authorization, authentication, and cluster security policy.
 
 "All I want is a secure system where it's easy to do anything I want. Is that so much to ask?" - [xkcd](https://xkcd.com/2044 "xkcd")
 
+
+
 The [charter](charter.md) defines the scope and governance of the Auth Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Wednesdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1woLGRoONE3EBVx-wTb4pvp4CI7tmLZ6lS26VTbosLKM/edit#).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0VMOZ-V7-5AchXTHAQFzJw).
+- Regular SIG Meeting: [Wednesdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1woLGRoONE3EBVx-wTb4pvp4CI7tmLZ6lS26VTbosLKM/edit#)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0VMOZ-V7-5AchXTHAQFzJw)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Mike Danese (**[@mikedanese](https://github.com/mikedanese)**), Google
-* Mo Khan (**[@enj](https://github.com/enj)**), Red Hat
-* Tim Allclair (**[@tallclair](https://github.com/tallclair)**), Google
+- Mike Danese (**[@mikedanese](https://github.com/mikedanese)**), Google
+- Mo Khan (**[@enj](https://github.com/enj)**), Red Hat
+- Tim Allclair (**[@tallclair](https://github.com/tallclair)**), Google
 
 ## Emeritus Leads
 
-* Eric Chiang (**[@ericchiang](https://github.com/ericchiang)**), Red Hat
-* Eric Tune (**[@erictune](https://github.com/erictune)**), Google
-* David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
-* Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**), Google
+
+- Eric Chiang (**[@ericchiang](https://github.com/ericchiang)**), Red Hat
+- Eric Tune (**[@erictune](https://github.com/erictune)**), Google
+- David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
+- Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-auth)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-auth)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fauth)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-auth)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-auth)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fauth)
 
-The following subprojects are owned by sig-auth:
-- **audit-logging**
-  - Description: Kubernetes API support for audit logging.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/auditregistration/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/apis/audit/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/audit/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/audit/OWNERS
-- **authenticators**
-  - Description: Kubernetes API support for authentication.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authenticator/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authenticator/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/plugin/pkg/client/auth/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/tools/auth/OWNERS
-- **authorizers**
-  - Description: Kubernetes API support for authorization.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/rbac/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authorizer/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/cmd/auth/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/rbac/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/rbac/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/rbac/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/rbac/OWNERS
-- **certificates**
-  - Description: Certificates APIs and client infrastructure to support PKI.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/certificates/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/certificates/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/cert/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/certificate/OWNERS
-- **encryption-at-rest**
-  - Description: API storage support for storing data encrypted at rest in etcd.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/OWNERS
-- **node-identity-and-isolation**
-  - Description: Node identity management (co-owned with sig-lifecycle), and authorization restrictions for isolating workloads on separate nodes (co-owned with sig-node).
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/approver/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/certificate/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/noderestriction/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/node/OWNERS
-- **policy-management**
-  - Description: API validation and policies enforced during admission, such as PodSecurityPolicy. Excludes run-time policies like NetworkPolicy and Seccomp.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/imagepolicy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/policy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/security/podsecuritypolicy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/policy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/imagepolicy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/policy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/imagepolicy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/security/podsecuritypolicy/OWNERS
-- **service-accounts**
-  - Description: Infrastructure implementing Kubernetes service account based workload identity.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/serviceaccount/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/token/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/serviceaccount/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/serviceaccount/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -137,6 +61,97 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-auth-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-pr-reviews) | PR Reviews |
 | @kubernetes/sig-auth-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-auth-proposals) | Design Proposals |
 | @kubernetes/sig-auth-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-auth-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-auth:
+
+### audit-logging
+- Description: Kubernetes API support for audit logging.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/auditregistration/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/apis/audit/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/audit/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/audit/OWNERS
+
+### authenticators
+- Description: Kubernetes API support for authentication.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authenticator/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authenticator/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/plugin/pkg/client/auth/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/tools/auth/OWNERS
+
+### authorizers
+- Description: Kubernetes API support for authorization.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/rbac/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authorizer/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/cmd/auth/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/rbac/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/rbac/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/rbac/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/rbac/OWNERS
+
+### certificates
+- Description: Certificates APIs and client infrastructure to support PKI.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/certificates/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/certificates/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/cert/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/certificate/OWNERS
+
+### encryption-at-rest
+- Description: API storage support for storing data encrypted at rest in etcd.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/OWNERS
+
+### node-identity-and-isolation
+- Description: Node identity management (co-owned with sig-lifecycle), and authorization restrictions for isolating workloads on separate nodes (co-owned with sig-node).
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/approver/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/certificate/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/noderestriction/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/node/OWNERS
+
+### policy-management
+- Description: API validation and policies enforced during admission, such as PodSecurityPolicy. Excludes run-time policies like NetworkPolicy and Seccomp.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/imagepolicy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/policy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/security/podsecuritypolicy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/policy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/imagepolicy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/policy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/imagepolicy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/security/podsecuritypolicy/OWNERS
+
+### service-accounts
+- Description: Infrastructure implementing Kubernetes service account based workload identity.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/serviceaccount/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/token/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/serviceaccount/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/serviceaccount/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -8,53 +8,33 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Autoscaling Special Interest Group
 
+
 Covers development and maintenance of components for automated scaling in Kubernetes.  This includes automated vertical and horizontal pod autoscaling, initial resource estimation, cluster-proportional system component autoscaling, and autoscaling of Kubernetes clusters themselves.
+
+
 
 The [charter](charter.md) defines the scope and governance of the Autoscaling Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Mondays at 14:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly/triweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1RvhQAEIrVLHbyNnuaT99-6u9ZUMp7BfkPupT2LAZK7w/edit).
+- Regular SIG Meeting: [Mondays at 14:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly/triweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1RvhQAEIrVLHbyNnuaT99-6u9ZUMp7BfkPupT2LAZK7w/edit)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Marcin Wielgus (**[@mwielgus](https://github.com/mwielgus)**), Google
+- Marcin Wielgus (**[@mwielgus](https://github.com/mwielgus)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-autoscaling)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fautoscaling)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-autoscaling)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fautoscaling)
 
-The following subprojects are owned by sig-autoscaling:
-- **scale-client**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/client-go/master/scale/OWNERS
-- **cluster-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
-- **vertical-pod-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
-- **horizontal-pod-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
-- **cluster-proportional-vertical-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
-- **cluster-proportional-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
-- **addon-resizer**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -68,6 +48,39 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-autoscaling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-pr-reviews) | PR Reviews |
 | @kubernetes/sig-autoscaling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-proposals) | Design Proposals |
 | @kubernetes/sig-autoscaling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-autoscaling:
+
+### scale-client
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/client-go/master/scale/OWNERS
+
+### cluster-autoscaler
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+
+### vertical-pod-autoscaler
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+
+### horizontal-pod-autoscaler
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
+
+### cluster-proportional-vertical-autoscaler
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
+
+### cluster-proportional-autoscaler
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
+
+### addon-resizer
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Concerns

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -8,48 +8,35 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # AWS Special Interest Group
 
+
 Covers maintaining, supporting, and using Kubernetes hosted on AWS Cloud.
+
+
 
 The [charter](charter.md) defines the scope and governance of the AWS Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Fridays at 9:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit).
+- Regular SIG Meeting: [Fridays at 9:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Justin Santa Barbara (**[@justinsb](https://github.com/justinsb)**)
-* Kris Nova (**[@kris-nova](https://github.com/kris-nova)**), Heptio
-* Nishi Davidson (**[@d-nishi](https://github.com/d-nishi)**), AWS
+- Justin Santa Barbara (**[@justinsb](https://github.com/justinsb)**)
+- Kris Nova (**[@kris-nova](https://github.com/kris-nova)**), Heptio
+- Nishi Davidson (**[@d-nishi](https://github.com/d-nishi)**), AWS
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-aws)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-aws)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Faws)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-aws)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-aws)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Faws)
 
-The following subprojects are owned by sig-aws:
-- **cloud-provider-aws**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS
-- **aws-alb-ingress-controller**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/OWNERS
-- **aws-iam-authenticator**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-iam-authenticator/master/OWNERS
-- **aws-encryption-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-encryption-provider/master/OWNERS
-- **aws-ebs-csi-driver**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -57,6 +44,30 @@ Note that the links to display team membership will only work if you are a membe
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-aws-misc | [link](https://github.com/orgs/kubernetes/teams/sig-aws-misc) | General Discussion |
+
+## Subprojects
+
+The following subprojects are owned by sig-aws:
+
+### cloud-provider-aws
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS
+
+### aws-alb-ingress-controller
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/OWNERS
+
+### aws-iam-authenticator
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-iam-authenticator/master/OWNERS
+
+### aws-encryption-provider
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-encryption-provider/master/OWNERS
+
+### aws-ebs-csi-driver
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Participate

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -8,46 +8,43 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Azure Special Interest Group
 
+
 A Special Interest Group for building, deploying, maintaining, supporting, and using Kubernetes on Azure.
+
+
 
 The [charter](charter.md) defines the scope and governance of the Azure Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Wednesdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1SpxvmOgHDhnA72Z0lbhBffrfe9inQxZkU9xqlafOW9k/edit).
-  * [Meeting recordings](https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4).
+- Regular SIG Meeting: [Wednesdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1SpxvmOgHDhnA72Z0lbhBffrfe9inQxZkU9xqlafOW9k/edit)
+  - [Meeting recordings](https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**), VMware
-* Dave Strebel (**[@dstrebel](https://github.com/dstrebel)**), Microsoft
+- Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**), VMware
+- Dave Strebel (**[@dstrebel](https://github.com/dstrebel)**), Microsoft
 
 ### Technical Leads
+
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Kal Khenidak (**[@khenidak](https://github.com/khenidak)**), Microsoft
-* Pengfei Ni (**[@feiskyer](https://github.com/feiskyer)**), Microsoft
+- Kal Khenidak (**[@khenidak](https://github.com/khenidak)**), Microsoft
+- Pengfei Ni (**[@feiskyer](https://github.com/feiskyer)**), Microsoft
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-azure)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-azure)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fazure)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-azure)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-azure)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fazure)
 
-The following subprojects are owned by sig-azure:
-- **cloud-provider-azure**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
-- **cluster-api-provider-azure**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -55,6 +52,18 @@ Note that the links to display team membership will only work if you are a membe
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-azure | [link](https://github.com/orgs/kubernetes/teams/sig-azure) | General Discussion |
+
+## Subprojects
+
+The following subprojects are owned by sig-azure:
+
+### cloud-provider-azure
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
+
+### cluster-api-provider-azure
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -8,28 +8,33 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Big Data Special Interest Group
 
+
 Covers deploying and operating big data applications (Spark, Kafka, Hadoop, Flink, Storm, etc) on Kubernetes. We focus on integrations with big data applications and architecting the best ways to run them on Kubernetes.
 
+
 ## Meetings
-* Regular SIG Meeting: [Wednesdays at 17:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit).
-  * [Meeting recordings](https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit).
+- Regular SIG Meeting: [Wednesdays at 17:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit)
+  - [Meeting recordings](https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Anirudh Ramanathan (**[@foxish](https://github.com/foxish)**), Rockset
-* Erik Erlandson (**[@erikerlandson](https://github.com/erikerlandson)**), Red Hat
-* Yinan Li (**[@liyinan926](https://github.com/liyinan926)**), Google
+- Anirudh Ramanathan (**[@foxish](https://github.com/foxish)**), Rockset
+- Erik Erlandson (**[@erikerlandson](https://github.com/erikerlandson)**), Red Hat
+- Yinan Li (**[@liyinan926](https://github.com/liyinan926)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-big-data)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fbig-data)
 
-## GitHub Teams
+- [Slack](https://kubernetes.slack.com/messages/sig-big-data)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-big-data)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fbig-data)
+
+
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -8,58 +8,49 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # CLI Special Interest Group
 
+
 Covers kubectl and related tools. We focus on the development and standardization of the CLI framework and its dependencies, the establishment of conventions for writing CLI commands, POSIX compliance, and improving the command line tools from a developer and devops user experience and usability perspective.
+
+
 
 The [charter](charter.md) defines the scope and governance of the CLI Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Wednesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF).
+- Regular SIG Meeting: [Wednesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Maciej Szulik (**[@soltysh](https://github.com/soltysh)**), Red Hat
-* Sean Sullivan (**[@seans3](https://github.com/seans3)**), Google
+- Maciej Szulik (**[@soltysh](https://github.com/soltysh)**), Red Hat
+- Sean Sullivan (**[@seans3](https://github.com/seans3)**), Google
 
 ### Technical Leads
+
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Maciej Szulik (**[@soltysh](https://github.com/soltysh)**), Red Hat
-* Phillip Wittrock (**[@pwittrock](https://github.com/pwittrock)**), Google
+- Maciej Szulik (**[@soltysh](https://github.com/soltysh)**), Red Hat
+- Phillip Wittrock (**[@pwittrock](https://github.com/pwittrock)**), Google
 
 ## Emeritus Leads
 
-* Fabiano Franz (**[@fabianofranz](https://github.com/fabianofranz)**), Red Hat
-* Tony Ado (**[@AdoHe](https://github.com/AdoHe)**), Alibaba
+
+- Fabiano Franz (**[@fabianofranz](https://github.com/fabianofranz)**), Red Hat
+- Tony Ado (**[@AdoHe](https://github.com/AdoHe)**), Alibaba
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-cli)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cli)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcli)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-cli)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cli)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fcli)
 
-The following subprojects are owned by sig-cli:
-- **kubectl**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubectl/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/OWNERS
-- **kustomize**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/OWNERS
-- **cli-sdk**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cli-runtime/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cli-runtime/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/sample-cli-plugin/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-cli-plugin/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -74,6 +65,26 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-cli-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-pr-reviews) | PR Reviews |
 | @kubernetes/sig-cli-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cli-proposals) | Design Proposals |
 | @kubernetes/sig-cli-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cli-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-cli:
+
+### kubectl
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubectl/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/OWNERS
+
+### kustomize
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/OWNERS
+
+### cli-sdk
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/cli-runtime/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cli-runtime/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/sample-cli-plugin/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-cli-plugin/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -8,58 +8,36 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Cloud Provider Special Interest Group
 
+
 Ensures that the Kubernetes ecosystem is evolving in a way that is neutral to all (public and private) cloud providers. It will be responsible for establishing standards and requirements that must be met by all providers to ensure optimal integration with Kubernetes.
+
+
 
 The [charter](CHARTER.md) defines the scope and governance of the Cloud Provider Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Wednesdays at 1:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=1:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1OZE-ub-v6B8y-GuaWejL-vU_f9jsjBbrim4LtTfxssw/edit#heading=h.w7i4ksrweimp).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3dXLcYbRKCbpPCN-8CDFAB).
+- Regular SIG Meeting: [Wednesdays at 1:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=1:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1OZE-ub-v6B8y-GuaWejL-vU_f9jsjBbrim4LtTfxssw/edit#heading=h.w7i4ksrweimp)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3dXLcYbRKCbpPCN-8CDFAB)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Andrew Sy Kim (**[@andrewsykim](https://github.com/andrewsykim)**), DigitalOcean
-* Chris Hoge (**[@hogepodge](https://github.com/hogepodge)**), OpenStack Foundation
-* Jago Macleod (**[@jagosan](https://github.com/jagosan)**), Google
+- Andrew Sy Kim (**[@andrewsykim](https://github.com/andrewsykim)**), DigitalOcean
+- Chris Hoge (**[@hogepodge](https://github.com/hogepodge)**), OpenStack Foundation
+- Jago Macleod (**[@jagosan](https://github.com/jagosan)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-cloud-provider)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cloud-provider)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcloud-provider)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-cloud-provider)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cloud-provider)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fcloud-provider)
 
-The following subprojects are owned by sig-cloud-provider:
-- **kubernetes-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cloud/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/cloudprovider/OWNERS
-- **cloud-provider-alibaba-cloud**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-alibaba-cloud/master/OWNERS
-- **cloud-provider-gcp**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
-- **cloud-provider-openstack**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
-- **cloud-provider-vsphere**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/OWNERS
-- **cloud-provider-extraction**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-cloud-provider/cloud-provider-extraction/OWNERS
-  - Meetings:
-    - Weekly Sync removing the in-tree cloud providers led by @cheftako and @d-nishi: [Thursdays at 13:30 PT (Pacific Time)](https://docs.google.com/document/d/1KLsGGzNXQbsPeELCeF_q-f0h0CEGSe20xiwvcR2NlYM/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:30&tz=PT%20%28Pacific%20Time%29).
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -74,6 +52,40 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-cloud-provider-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-pr-reviews) | PR Reviews |
 | @kubernetes/sig-cloud-provider-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-proposals) | Design Proposals |
 | @kubernetes/sig-cloud-provider-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-cloud-provider:
+
+### kubernetes-cloud-provider
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cloud/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/cloudprovider/OWNERS
+
+### cloud-provider-alibaba-cloud
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-alibaba-cloud/master/OWNERS
+
+### cloud-provider-gcp
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
+
+### cloud-provider-openstack
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
+
+### cloud-provider-vsphere
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/OWNERS
+
+### cloud-provider-extraction
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-cloud-provider/cloud-provider-extraction/OWNERS
+- Meetings:
+  - Weekly Sync removing the in-tree cloud providers led by @cheftako and @d-nishi: [Thursdays at 13:30 PT (Pacific Time)](https://docs.google.com/document/d/1KLsGGzNXQbsPeELCeF_q-f0h0CEGSe20xiwvcR2NlYM/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:30&tz=PT%20%28Pacific%20Time%29))
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -8,98 +8,52 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Cluster Lifecycle Special Interest Group
 
+
 The Cluster Lifecycle SIG examines how we should change Kubernetes to make it easier to manage and operate with a focus on cluster deployment and upgrades.
 
+
 ## Meetings
-* Regular SIG Meeting: [Tuesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1Gmc7LyCIL_148a9Tft7pdhdee0NBHdOfHS1SAF0duI4/edit).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
-* kubeadm Office Hours: [Wednesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/130_kiXjG7graFNSnIAgtMS1G8zPDwpkshgfRYS0nggo/edit).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
-* Cluster API office hours: [Wednesdays at 10:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/16ils69KImmE94RlmzjWDrkmFZysgB2J4lGnYMRN89WM/edit#).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
-* Cluster API Provider Implementers' office hours (EMEA): [Wednesdays at 15:00 CEST (Central European Summer Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=CEST%20%28Central%20European%20Summer%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1IZ2-AZhe4r3CYiJuttyciS7bGZTTx4iMppcA8_Pr3xE/edit).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
-* Cluster API Provider Implementers' office hours (US West Coast): [Tuesdays at 12:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1IZ2-AZhe4r3CYiJuttyciS7bGZTTx4iMppcA8_Pr3xE/edit).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
-* Cluster API (AWS implementation) office hours: [Mondays at 10:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/10dq54Fd-xa6P5Iy3p46VY1YTFqugGMd1PygDIpuRw6c/edit).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
-* kops Office Hours: [Fridays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/12QkyL0FkNbWPcLFxxRGSPt_tNPBHbmni3YLY-lHny7E/edit).
-* Kubespray Office Hours: [Wednesdays at 07:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1oDI1rTwla393k6nEMkqz0RU9rUl3J1hov0kQfNcl-4o/edit).
+- Regular SIG Meeting: [Tuesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1Gmc7LyCIL_148a9Tft7pdhdee0NBHdOfHS1SAF0duI4/edit)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4)
+- kubeadm Office Hours: [Wednesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/130_kiXjG7graFNSnIAgtMS1G8zPDwpkshgfRYS0nggo/edit)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4)
+- Cluster API office hours: [Wednesdays at 10:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/16ils69KImmE94RlmzjWDrkmFZysgB2J4lGnYMRN89WM/edit#)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4)
+- Cluster API Provider Implementers' office hours (EMEA): [Wednesdays at 15:00 CEST (Central European Summer Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=CEST%20%28Central%20European%20Summer%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1IZ2-AZhe4r3CYiJuttyciS7bGZTTx4iMppcA8_Pr3xE/edit)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4)
+- Cluster API Provider Implementers' office hours (US West Coast): [Tuesdays at 12:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1IZ2-AZhe4r3CYiJuttyciS7bGZTTx4iMppcA8_Pr3xE/edit)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4)
+- Cluster API (AWS implementation) office hours: [Mondays at 10:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/10dq54Fd-xa6P5Iy3p46VY1YTFqugGMd1PygDIpuRw6c/edit)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4)
+- kops Office Hours: [Fridays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/12QkyL0FkNbWPcLFxxRGSPt_tNPBHbmni3YLY-lHny7E/edit)
+- Kubespray Office Hours: [Wednesdays at 07:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1oDI1rTwla393k6nEMkqz0RU9rUl3J1hov0kQfNcl-4o/edit)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Robert Bailey (**[@roberthbailey](https://github.com/roberthbailey)**), Google
-* Lucas Käldström (**[@luxas](https://github.com/luxas)**), Luxas Labs (occasionally contracting for Weaveworks)
-* Timothy St. Clair (**[@timothysc](https://github.com/timothysc)**), Heptio
+- Robert Bailey (**[@roberthbailey](https://github.com/roberthbailey)**), Google
+- Lucas Käldström (**[@luxas](https://github.com/luxas)**), Luxas Labs (occasionally contracting for Weaveworks)
+- Timothy St. Clair (**[@timothysc](https://github.com/timothysc)**), Heptio
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-cluster-lifecycle)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcluster-lifecycle)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-cluster-lifecycle)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fcluster-lifecycle)
 
-The following subprojects are owned by sig-cluster-lifecycle:
-- **bootkube**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/bootkube/master/OWNERS
-- **cluster-api**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
-- **cluster-api-provider-aws**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
-- **cluster-api-provider-digitalocean**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS
-- **cluster-api-provider-gcp**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
-- **cluster-api-provider-openstack**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
-- **kops**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS
-- **kube-aws**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/kube-aws/master/OWNERS
-- **kube-deploy**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kube-deploy/master/OWNERS
-- **kube-up**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS
-- **kubeadm**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
-- **kubeadm-dind-cluster**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/OWNERS
-- **kubernetes-anywhere**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS
-- **kubespray**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS
-- **minikube**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/minikube/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -108,6 +62,72 @@ Note that the links to display team membership will only work if you are a membe
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-cluster-lifecycle | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle) | Notify group |
 | @kubernetes/sig-cluster-lifecycle-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-pr-reviews) | PR Reviews |
+
+## Subprojects
+
+The following subprojects are owned by sig-cluster-lifecycle:
+
+### bootkube
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/bootkube/master/OWNERS
+
+### cluster-api
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
+
+### cluster-api-provider-aws
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
+
+### cluster-api-provider-digitalocean
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS
+
+### cluster-api-provider-gcp
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
+
+### cluster-api-provider-openstack
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
+
+### kops
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS
+
+### kube-aws
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/kube-aws/master/OWNERS
+
+### kube-deploy
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kube-deploy/master/OWNERS
+
+### kube-up
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS
+
+### kubeadm
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
+
+### kubeadm-dind-cluster
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/OWNERS
+
+### kubernetes-anywhere
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS
+
+### kubespray
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS
+
+### minikube
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/minikube/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-cluster-ops/README.md
+++ b/sig-cluster-ops/README.md
@@ -8,25 +8,30 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Cluster Ops Special Interest Group
 
+
 Promote operability and interoperability of Kubernetes clusters. We focus on shared operations practices for Kubernetes clusters with a goal to make Kubernetes broadly accessible with a common baseline reference. We also organize operators as a sounding board and advocacy group.
 
+
 ## Meetings
-* Regular SIG Meeting: [Thursdays at 20:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=20:00&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1IhN5v6MjcAUrvLd9dAWtKcGWBWSaRU8DNyPiof3gYMY/edit#).
-  * [Meeting recordings](https://www.youtube.com/watch?v=7uyy37pCk4U&list=PL69nYSiGNLP3b38liicqy6fm2-jWT4FQR).
+- Regular SIG Meeting: [Thursdays at 20:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=20:00&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1IhN5v6MjcAUrvLd9dAWtKcGWBWSaRU8DNyPiof3gYMY/edit#)
+  - [Meeting recordings](https://www.youtube.com/watch?v=7uyy37pCk4U&list=PL69nYSiGNLP3b38liicqy6fm2-jWT4FQR)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Rob Hirschfeld (**[@zehicle](https://github.com/zehicle)**), RackN
-* Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Google
+- Rob Hirschfeld (**[@zehicle](https://github.com/zehicle)**), RackN
+- Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-cluster-ops)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-ops)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcluster-ops)
+
+- [Slack](https://kubernetes.slack.com/messages/sig-cluster-ops)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-ops)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fcluster-ops)
+
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -8,71 +8,48 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Contributor Experience Special Interest Group
 
+
 Developing and sustaining a healthy community of contributors is critical to scaling the project and growing the ecosystem. We need to ensure our contributors are happy and productive, and that there are not bottlenecks hindering the project in, for example: feature velocity, community scaling, pull request latency, and absolute numbers of open pull requests and open issues.
+
+
 
 The [charter](charter.md) defines the scope and governance of the Contributor Experience Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Wednesdays at 9:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/).
-  * [Meeting recordings](https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr).
+- Regular SIG Meeting: [Wednesdays at 9:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/)
+  - [Meeting recordings](https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Elsie Phillips (**[@Phillels](https://github.com/Phillels)**), CoreOS
-* Paris Pittman (**[@parispittman](https://github.com/parispittman)**), Google
+- Elsie Phillips (**[@Phillels](https://github.com/Phillels)**), CoreOS
+- Paris Pittman (**[@parispittman](https://github.com/parispittman)**), Google
 
 ### Technical Leads
+
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
-* Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**)
+- Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
+- Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**)
 
 ## Emeritus Leads
 
-* Garrett Rodrigues (**[@grodrigues3](https://github.com/grodrigues3)**), Google
+
+- Garrett Rodrigues (**[@grodrigues3](https://github.com/grodrigues3)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-contribex)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-contribex)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-contribex)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-contribex)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fcontributor-experience)
 
-The following subprojects are owned by sig-contributor-experience:
-- **community**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/OWNERS
-- **community-management**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/communication/OWNERS https://raw.githubusercontent.com/kubernetes/community/master/events/OWNERS
-- **github-management**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
-- **contributors-documentation**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
-- **devstats**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
-- **k8s.io**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/k8s.io/master/OWNERS
-- **mentoring**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
-- **repo-infra**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -85,6 +62,45 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-contributor-experience-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-pr-reviews) | PR Reviews |
 | @kubernetes/sig-contributor-experience-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-proposals) | Design Proposals |
 | @kubernetes/sig-contributor-experience-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-contributor-experience:
+
+### community
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/OWNERS
+
+### community-management
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/communication/OWNERS https://raw.githubusercontent.com/kubernetes/community/master/events/OWNERS
+
+### github-management
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
+
+### contributors-documentation
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
+
+### devstats
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
+
+### k8s.io
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/k8s.io/master/OWNERS
+
+### mentoring
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
+
+### repo-infra
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -8,44 +8,36 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Docs Special Interest Group
 
+
 Covers documentation, doc processes, and doc publishing for Kubernetes.
 
+
 ## Meetings
-* Regular SIG Meeting: [Tuesdays at 17:30 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly - except fourth Tuesday every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:30&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1Ds87eRiNZeXwRBEbFr6Z7ukjbTow5RQcNZLaSvWWQsE/edit).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8).
-* APAC SIG Meeting: [Wednesdays at 02:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (monthly - fourth Wednesday every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=02:00&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1Ds87eRiNZeXwRBEbFr6Z7ukjbTow5RQcNZLaSvWWQsE/edit).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8).
+- Regular SIG Meeting: [Tuesdays at 17:30 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly - except fourth Tuesday every month) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:30&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1Ds87eRiNZeXwRBEbFr6Z7ukjbTow5RQcNZLaSvWWQsE/edit)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8)
+- APAC SIG Meeting: [Wednesdays at 02:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (monthly - fourth Wednesday every month) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=02:00&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1Ds87eRiNZeXwRBEbFr6Z7ukjbTow5RQcNZLaSvWWQsE/edit)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Andrew Chen (**[@chenopis](https://github.com/chenopis)**), Google
-* Zach Corleissen (**[@zacharysarah](https://github.com/zacharysarah)**), Linux Foundation
-* Jennifer Rondeau (**[@bradamant3](https://github.com/bradamant3)**), Heptio
+- Andrew Chen (**[@chenopis](https://github.com/chenopis)**), Google
+- Zach Corleissen (**[@zacharysarah](https://github.com/zacharysarah)**), Linux Foundation
+- Jennifer Rondeau (**[@bradamant3](https://github.com/bradamant3)**), Heptio
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-docs)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fdocs)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-docs)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fdocs)
 
-The following subprojects are owned by sig-docs:
-- **reference-docs**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/reference-docs/master/OWNERS
-- **website**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
-- **website-metadata**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/website-metadata/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -57,6 +49,22 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-docs-ko-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ko-owners) | Korean localization |
 | @kubernetes/sig-docs-ja-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ja-owners) | Japanese localization |
 | @kubernetes/sig-docs-zh-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-zh-owners) | Chinese localization |
+
+## Subprojects
+
+The following subprojects are owned by sig-docs:
+
+### reference-docs
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/reference-docs/master/OWNERS
+
+### website
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
+
+### website-metadata
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/website-metadata/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-gcp/README.md
+++ b/sig-gcp/README.md
@@ -8,35 +8,30 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # GCP Special Interest Group
 
+
 A Special Interest Group for building, deploying, maintaining, supporting, and using Kubernetes on the Google Cloud Platform.
 
+
 ## Meetings
-* Regular SIG Meeting: [Thursdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1mtmwZ4oVSSWhbEw8Lfzvc7ig84qxUpdK6uHyJp8rSGU/edit).
+- Regular SIG Meeting: [Thursdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1mtmwZ4oVSSWhbEw8Lfzvc7ig84qxUpdK6uHyJp8rSGU/edit)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Adam Worrall (**[@abgworrall](https://github.com/abgworrall)**), Google
+- Adam Worrall (**[@abgworrall](https://github.com/abgworrall)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-gcp)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fgcp)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-gcp)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-gcp)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fgcp)
 
-The following subprojects are owned by sig-gcp:
-- **gcp-compute-persistent-disk-csi-driver**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/master/OWNERS
-- **gcp-filestore-csi-driver**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/gcp-filestore-csi-driver/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -50,6 +45,18 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-gcp-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-pr-reviews) | PR Reviews |
 | @kubernetes/sig-gcp-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-proposals) | Design Proposals |
 | @kubernetes/sig-gcp-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-gcp-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-gcp:
+
+### gcp-compute-persistent-disk-csi-driver
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/master/OWNERS
+
+### gcp-filestore-csi-driver
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/gcp-filestore-csi-driver/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-ibmcloud/README.md
+++ b/sig-ibmcloud/README.md
@@ -8,27 +8,32 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # IBMCloud Special Interest Group
 
+
 A Special Interest Group (SIG) for building, deploying, maintaining, supporting, and using Kubernetes on IBM Public and Private Clouds.
 
+
 ## Meetings
-* Regular SIG Meeting: [Wednesdays at 14:00 EST](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=EST).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1qd_LTu5GFaxUhSWTHigowHt3XwjJVf1L57kupj8lnwg/edit).
+- Regular SIG Meeting: [Wednesdays at 14:00 EST](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=EST))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1qd_LTu5GFaxUhSWTHigowHt3XwjJVf1L57kupj8lnwg/edit)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Khalid Ahmed (**[@khahmed](https://github.com/khahmed)**), IBM
-* Richard Theis (**[@rtheis](https://github.com/rtheis)**), IBM
-* Sahdev Zala (**[@spzala](https://github.com/spzala)**), IBM
+- Khalid Ahmed (**[@khahmed](https://github.com/khahmed)**), IBM
+- Richard Theis (**[@rtheis](https://github.com/rtheis)**), IBM
+- Sahdev Zala (**[@spzala](https://github.com/spzala)**), IBM
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-ibmcloud)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ibmcloud)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fibmcloud)
 
-## GitHub Teams
+- [Slack](https://kubernetes.slack.com/messages/sig-ibmcloud)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ibmcloud)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fibmcloud)
+
+
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -8,49 +8,31 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Instrumentation Special Interest Group
 
+
 Covers best practices for cluster observability through metrics, logging, and events across all Kubernetes components and development of relevant components such as Heapster and kube-state-metrics. Coordinates metric requirements of different SIGs for other components through finding common APIs.
 
+
 ## Meetings
-* Regular SIG Meeting: [Thursdays at 17:30 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:30&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/17emKiwJeqfrCsv0NZ2FtyDbenXGtTNCsDEiLbPa7x7Y/edit).
+- Regular SIG Meeting: [Thursdays at 17:30 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:30&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/17emKiwJeqfrCsv0NZ2FtyDbenXGtTNCsDEiLbPa7x7Y/edit)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Piotr Szczesniak (**[@piosz](https://github.com/piosz)**), Google
-* Frederic Branczyk (**[@brancz](https://github.com/brancz)**), Red Hat
+- Piotr Szczesniak (**[@piosz](https://github.com/piosz)**), Google
+- Frederic Branczyk (**[@brancz](https://github.com/brancz)**), Red Hat
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-instrumentation)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Finstrumentation)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-instrumentation)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Finstrumentation)
 
-The following subprojects are owned by sig-instrumentation:
-- **custom-metrics-apiserver**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/custom-metrics-apiserver/master/OWNERS
-- **heapster**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/heapster/master/OWNERS
-- **kube-state-metrics**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS
-- **metrics-server**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/metrics-server/master/OWNERS
-- **metrics**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/metrics/OWNERS
-- **mutating-trace-admission-controller**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -64,6 +46,35 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-instrumentation-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-pr-reviews) | PR Reviews |
 | @kubernetes/sig-instrumentation-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-proposals) | Design Proposals |
 | @kubernetes/sig-instrumentation-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-instrumentation:
+
+### custom-metrics-apiserver
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/custom-metrics-apiserver/master/OWNERS
+
+### heapster
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/heapster/master/OWNERS
+
+### kube-state-metrics
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS
+
+### metrics-server
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/metrics-server/master/OWNERS
+
+### metrics
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/metrics/OWNERS
+
+### mutating-trace-admission-controller
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -8,48 +8,38 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Multicluster Special Interest Group
 
+
 A Special Interest Group focused on solving common challenges related to the management of multiple Kubernetes clusters, and applications that exist therein. The SIG will be responsible for designing, discussing, implementing and maintaining API’s, tools and documentation related to multi-cluster administration and application management. This includes not only active automated approaches such as Cluster Federation, but also those that employ batch workflow-style continuous deployment systems like Spinnaker and others.  Standalone building blocks for these and other similar systems (for example a cluster registry), and proposed changes to kubernetes core where appropriate will also be in scope.
+
+
 
 The [charter](charter.md) defines the scope and governance of the Multicluster Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Tuesdays at 9:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/18mk62nOXE_MCSSnb4yJD_8UadtzJrYyJxFwbrgabHe8/edit).
-  * [Meeting recordings](https://www.youtube.com/watch?v=iWKC3FsNHWg&list=PL69nYSiGNLP0HqgyqTby6HlDEz7i1mb0-).
-* Federation v2 Working Group: [Wednesdays at 7:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=7:30&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1v-Kb1pUs3ww_x0MiKtgcyTXCAuZlbVlz4_A9wS3_HXY/edit).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3iKP5EzMbtNT2zOZv6RCrX).
+- Regular SIG Meeting: [Tuesdays at 9:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/18mk62nOXE_MCSSnb4yJD_8UadtzJrYyJxFwbrgabHe8/edit)
+  - [Meeting recordings](https://www.youtube.com/watch?v=iWKC3FsNHWg&list=PL69nYSiGNLP0HqgyqTby6HlDEz7i1mb0-)
+- Federation v2 Working Group: [Wednesdays at 7:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=7:30&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1v-Kb1pUs3ww_x0MiKtgcyTXCAuZlbVlz4_A9wS3_HXY/edit)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3iKP5EzMbtNT2zOZv6RCrX)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Christian Bell (**[@csbell](https://github.com/csbell)**), Google
-* Quinton Hoole (**[@quinton-hoole](https://github.com/quinton-hoole)**), Huawei
+- Christian Bell (**[@csbell](https://github.com/csbell)**), Google
+- Quinton Hoole (**[@quinton-hoole](https://github.com/quinton-hoole)**), Huawei
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-multicluster)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fmulticluster)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-multicluster)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fmulticluster)
 
-The following subprojects are owned by sig-multicluster:
-- **federation-v1**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/federation/master/OWNERS
-- **federation-v2**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/federation-v2/master/OWNERS
-- **cluster-registry**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cluster-registry/master/OWNERS
-- **kubemci**
-  - Owners:
-    - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -63,6 +53,26 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-multicluster-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-pr-reviews) | PR Reviews |
 | @kubernetes/sig-multicluster-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-test-failures) | Test Failures and Triage |
 | @kubernetes/sig-mutlicluster-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-mutlicluster-proposals) | Design Proposals |
+
+## Subprojects
+
+The following subprojects are owned by sig-multicluster:
+
+### federation-v1
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/federation/master/OWNERS
+
+### federation-v2
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/federation-v2/master/OWNERS
+
+### cluster-registry
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/cluster-registry/master/OWNERS
+
+### kubemci
+- OWNERS:
+  - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Subprojects

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -8,54 +8,33 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Network Special Interest Group
 
+
 Covers networking in Kubernetes.
 
+
 ## Meetings
-* Regular SIG Meeting: [Thursdays at 14:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1_w77-zG_Xj0zYvEMfQZTQ-wPP4kXkpGD8smVtW_qqWM/edit).
-  * [Meeting recordings](https://www.youtube.com/watch?v=phCA5-vWkVM&list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb).
+- Regular SIG Meeting: [Thursdays at 14:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1_w77-zG_Xj0zYvEMfQZTQ-wPP4kXkpGD8smVtW_qqWM/edit)
+  - [Meeting recordings](https://www.youtube.com/watch?v=phCA5-vWkVM&list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Tim Hockin (**[@thockin](https://github.com/thockin)**), Google
-* Dan Williams (**[@dcbw](https://github.com/dcbw)**), Red Hat
-* Casey Davenport (**[@caseydavenport](https://github.com/caseydavenport)**), Tigera
+- Tim Hockin (**[@thockin](https://github.com/thockin)**), Google
+- Dan Williams (**[@dcbw](https://github.com/dcbw)**), Red Hat
+- Casey Davenport (**[@caseydavenport](https://github.com/caseydavenport)**), Tigera
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-network)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-network)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnetwork)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-network)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-network)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fnetwork)
 
-The following subprojects are owned by sig-network:
-- **services**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
-- **kube-dns**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
-- **external-dns**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/external-dns/master/OWNERS
-- **ingress**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/ingress-gce/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/OWNERS
-- **pod-networking**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
-- **network-policy**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -69,6 +48,38 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-network-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-pr-reviews) | PR Reviews |
 | @kubernetes/sig-network-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-network-proposals) | Design Proposals |
 | @kubernetes/sig-network-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-network-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-network:
+
+### services
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
+
+### kube-dns
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
+
+### external-dns
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/external-dns/master/OWNERS
+
+### ingress
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/ingress-gce/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/OWNERS
+
+### pod-networking
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
+
+### network-policy
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Areas of Responsibility

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -8,56 +8,28 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Node Special Interest Group
 
-
 ## Meetings
-* Regular SIG Meeting: [Tuesdays at 10:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit?usp=sharing).
-  * [Meeting recordings](https://www.youtube.com/watch?v=FbKOI9-x9hI&list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG).
+- Regular SIG Meeting: [Tuesdays at 10:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit?usp=sharing)
+  - [Meeting recordings](https://www.youtube.com/watch?v=FbKOI9-x9hI&list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Dawn Chen (**[@dchen1107](https://github.com/dchen1107)**), Google
-* Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**), Red Hat
+- Dawn Chen (**[@dchen1107](https://github.com/dchen1107)**), Google
+- Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**), Red Hat
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-node)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnode)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-node)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fnode)
 
-The following subprojects are owned by sig-node:
-- **cri-o**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cri-o/master/OWNERS
-- **cri-tools**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cri-tools/master/OWNERS
-- **frakti**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/frakti/master/OWNERS
-- **kubelet**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubelet/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/OWNERS
-- **node-api**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/node-api/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/node-api/OWNERS
-- **node-feature-discovery**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/OWNERS
-- **node-problem-detector**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
-- **rktlet**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/rktlet/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -70,6 +42,44 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-node-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) | PR Reviews |
 | @kubernetes/sig-node-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-node-proposals) | Design Proposals |
 | @kubernetes/sig-node-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-node:
+
+### cri-o
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/cri-o/master/OWNERS
+
+### cri-tools
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/cri-tools/master/OWNERS
+
+### frakti
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/frakti/master/OWNERS
+
+### kubelet
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubelet/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/OWNERS
+
+### node-api
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/node-api/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/node-api/OWNERS
+
+### node-feature-discovery
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/OWNERS
+
+### node-problem-detector
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
+
+### rktlet
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/rktlet/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -8,28 +8,33 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # OpenStack Special Interest Group
 
+
 Coordinates the cross-community efforts of the OpenStack and Kubernetes communities. This includes OpenStack-related contributions to Kubernetes projects with OpenStack as: a deployment platform for Kubernetes; a service provider for Kubernetes; a collection of applications to run on Kubernetes.
 
+
 ## Meetings
-* Regular SIG Meeting: [Wednesdays at 16:00 PT (Pacific Time)](https://docs.google.com/document/d/15UwgLbEyZyXXxVtsThcSuPiJru4CuqU9p3ttZSfTaY4/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit?usp=sharing_eixpa_nl&ts=588b986f).
-  * [Meeting recordings](https://www.youtube.com/watch?v=iCfUx7ilh0E&list=PL69nYSiGNLP20iTSChQ_i2QQmTBl3M7ax).
+- Regular SIG Meeting: [Wednesdays at 16:00 PT (Pacific Time)](https://docs.google.com/document/d/15UwgLbEyZyXXxVtsThcSuPiJru4CuqU9p3ttZSfTaY4/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1iAQ3LSF_Ky6uZdFtEZPD_8i6HXeFxIeW4XtGcUJtPyU/edit?usp=sharing_eixpa_nl&ts=588b986f)
+  - [Meeting recordings](https://www.youtube.com/watch?v=iCfUx7ilh0E&list=PL69nYSiGNLP20iTSChQ_i2QQmTBl3M7ax)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Chris Hoge (**[@hogepodge](https://github.com/hogepodge)**), OpenStack Foundation
-* David Lyle (**[@dklyle](https://github.com/dklyle)**), Intel
-* Robert Morse (**[@rjmorse](https://github.com/rjmorse)**), Ticketmaster
+- Chris Hoge (**[@hogepodge](https://github.com/hogepodge)**), OpenStack Foundation
+- David Lyle (**[@dklyle](https://github.com/dklyle)**), Intel
+- Robert Morse (**[@rjmorse](https://github.com/rjmorse)**), Ticketmaster
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-openstack)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fopenstack)
 
-## GitHub Teams
+- [Slack](https://kubernetes.slack.com/messages/sig-openstack)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fopenstack)
+
+
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.

--- a/sig-pm/README.md
+++ b/sig-pm/README.md
@@ -8,36 +8,34 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # PM Special Interest Group
 
+
 Focuses on aspects of product management, such as the qualification and successful management of user requests, and aspects of project and program management such as the continued improvement of the processes used by the Kubernetes community to maintain the Kubernetes Project itself.
 Besides helping to discover both what to build and how to build it, the PM Group also helps to try and keep the wheels on this spaceship we are all building together; bringing together people who think about Kubernetes as both a vibrant community of humans and technical program is another primary focus of this group.
 Members of the Kubernetes PM Group can assume certain additional responsibilities to help maintain the Kubernetes Project itself.
 It is also important to remember that the role of managing an open source project is very new and largely unscoped for a project as large as Kubernetes; we are learning too and we are excited to learn how we can best serve the community of users and contributors.
 
+
 ## Meetings
-* Regular SIG Meeting: [Tuesdays at 18:30 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:30&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/13uHgcLf-hcR4a5QbV888fhnVsF3djBEpN8HolwS0kWM/edit?usp=sharing).
-  * [Meeting recordings](https://www.youtube.com/watch?v=VcdjaZAol2I&list=PL69nYSiGNLP3EBqpUGVsK1sMgUZVomfEQ).
+- Regular SIG Meeting: [Tuesdays at 18:30 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:30&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/13uHgcLf-hcR4a5QbV888fhnVsF3djBEpN8HolwS0kWM/edit?usp=sharing)
+  - [Meeting recordings](https://www.youtube.com/watch?v=VcdjaZAol2I&list=PL69nYSiGNLP3EBqpUGVsK1sMgUZVomfEQ)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Aparna Sinha (**[@apsinha](https://github.com/apsinha)**), Google
-* Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**), CNCF
-* Caleb Miles (**[@calebamiles](https://github.com/calebamiles)**), Google
+- Aparna Sinha (**[@apsinha](https://github.com/apsinha)**), Google
+- Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**), CNCF
+- Caleb Miles (**[@calebamiles](https://github.com/calebamiles)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-pm)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-pm)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fpm)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-pm)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-pm)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fpm)
 
-The following subprojects are owned by sig-pm:
-- **enhancements**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/enhancements/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -12,51 +12,33 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 The [charter](charter.md) defines the scope and governance of the Release Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Tuesdays at 21:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=21:00&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1Fu6HxXQu8wl6TwloGUEOXVzZ1rwZ72IAhglnaAMCPqA/edit?usp=sharing).
-  * [Meeting recordings](https://www.youtube.com/watch?v=I0KbWz8MTMk&list=PL69nYSiGNLP3QKkOsDsO6A0Y1rhgP84iZ).
+- Regular SIG Meeting: [Tuesdays at 21:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=21:00&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1Fu6HxXQu8wl6TwloGUEOXVzZ1rwZ72IAhglnaAMCPqA/edit?usp=sharing)
+  - [Meeting recordings](https://www.youtube.com/watch?v=I0KbWz8MTMk&list=PL69nYSiGNLP3QKkOsDsO6A0Y1rhgP84iZ)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Caleb Miles (**[@calebamiles](https://github.com/calebamiles)**), Google
-* Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**), VMware
-* Tim Pepper (**[@tpepper](https://github.com/tpepper)**), VMware
+- Caleb Miles (**[@calebamiles](https://github.com/calebamiles)**), Google
+- Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**), VMware
+- Tim Pepper (**[@tpepper](https://github.com/tpepper)**), VMware
 
 ## Emeritus Leads
 
-* Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Google
+
+- Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-release)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Frelease)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-release)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Frelease)
 
-The following subprojects are owned by sig-release:
-- **hyperkube**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/debian-hyperkube-base/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/hyperkube/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/hyperkube/OWNERS
-- **release-team**
-  - Description: The Kubernetes Release Team is responsible for the day to day work required to successfully create releases of Kubernetes.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
-- **publishing-bot**
-  - Description: The publishing-bot publishes the contents of staging repos that live in k8s.io/kubernetes/staging to their own repositories in kubernetes
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
-- **sig-release**
-  - Description: Documents and processes related to SIG Release
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -68,9 +50,42 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/kubernetes-milestone-maintainers | [link](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers) | Milestone Maintainers |
 | @kubernetes/kubernetes-release-managers | [link](https://github.com/orgs/kubernetes/teams/kubernetes-release-managers) | Release Managers |
 
+## Subprojects
+
+The following subprojects are owned by sig-release:
+
+### hyperkube
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/debian-hyperkube-base/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/hyperkube/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/hyperkube/OWNERS
+
+### release-team
+- Description: The Kubernetes Release Team is responsible for the day to day work required to successfully create releases of Kubernetes.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
+
+### publishing-bot
+- Description: The publishing-bot publishes the contents of staging repos that live in k8s.io/kubernetes/staging to their own repositories in kubernetes
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
+
+### sig-release
+- Description: Documents and processes related to SIG Release
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
+
 <!-- BEGIN CUSTOM CONTENT -->
+<<<<<<< HEAD
 ---
 
 _The canonical location for SIG Release information is [k/sig-release](https://github.com/kubernetes/sig-release)._
+=======
+<<<<<<< HEAD
+[SIG Release] has moved!
+=======
+>>>>>>> Extend subproject and repo generation for generator app
+>>>>>>> Extend subproject and repo generation for generator app
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -8,60 +8,35 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Scalability Special Interest Group
 
+
 SIG Scalability is responsible for defining and driving scalability goals for Kubernetes. We also coordinate and contribute to general system-wide scalability and performance improvements (not falling into the charter of other individual SIGs) by driving large architectural changes and finding bottlenecks, as well as provide guidance and consultations about any scalability and performance related aspects of Kubernetes. <br/> We are actively working on finding and removing various scalability bottlenecks which should lead us towards pushing system's scalability higher. This may include going beyond 5k nodes in the future - although that's not our priority as of now, this is very deeply in our area of interest and we are happy to guide and collaborate on any efforts towards that goal as long as they are not sacrificing on overall Kubernetes architecture (by making it non-maintainable, non-understandable, etc.).
+
+
 
 The [charter](charter.md) defines the scope and governance of the Scalability Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Thursdays at 17:30 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:30&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/a/bobsplanet.com/document/d/1hEpf25qifVWztaeZPFmjNiJvPo-5JX1z0LSvvVY5G2g/edit?usp=drive_web).
-  * [Meeting recordings](https://www.youtube.com/watch?v=NDP1uYyom28&list=PL69nYSiGNLP2X-hzNTqyELU6jYS3p10uL).
+- Regular SIG Meeting: [Thursdays at 17:30 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:30&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/a/bobsplanet.com/document/d/1hEpf25qifVWztaeZPFmjNiJvPo-5JX1z0LSvvVY5G2g/edit?usp=drive_web)
+  - [Meeting recordings](https://www.youtube.com/watch?v=NDP1uYyom28&list=PL69nYSiGNLP2X-hzNTqyELU6jYS3p10uL)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Wojciech Tyczynski (**[@wojtek-t](https://github.com/wojtek-t)**), Google
-* Shyam Jeedigunta (**[@shyamjvs](https://github.com/shyamjvs)**), AWS
+- Wojciech Tyczynski (**[@wojtek-t](https://github.com/wojtek-t)**), Google
+- Shyam Jeedigunta (**[@shyamjvs](https://github.com/shyamjvs)**), AWS
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-scalability)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scale)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscalability)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-scalability)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scale)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fscalability)
 
-The following subprojects are owned by sig-scalability:
-- **kubernetes-scalability-definition**
-  - Description: [Described below](#kubernetes-scalability-definition)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/slos/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/configs-and-limits/OWNERS
-- **kubernetes-scalability-governance**
-  - Description: [Described below](#kubernetes-scalability-governance)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/governance/OWNERS
-- **kubernetes-scalability-test-frameworks**
-  - Description: [Described below](#kubernetes-scalability-test-frameworks)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/kubemark/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubemark/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubemark/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/kubemark/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/perf-tests/master/clusterloader2/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/perf-tests/master/OWNERS
-- **kubernetes-scalability-and-performance-tests-and-validation**
-  - Description: [Described below](#kubernetes-scalability-and-performance-tests-and-validation)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/processes/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/scalability/OWNERS
-- **kubernetes-scalability-bottlenecks-detection**
-  - Description: [Described below](#kubernetes-scalability-bottlenecks-detection)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/blogs/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -75,6 +50,42 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-scalability-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-pr-reviews) | PR Reviews |
 | @kubernetes/sig-scalability-proprosals | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-proprosals) | Design Proposals |
 | @kubernetes/sig-scalability-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-scalability:
+
+### kubernetes-scalability-definition
+- Description: [Described below](#kubernetes-scalability-definition)
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/slos/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/configs-and-limits/OWNERS
+
+### kubernetes-scalability-governance
+- Description: [Described below](#kubernetes-scalability-governance)
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/governance/OWNERS
+
+### kubernetes-scalability-test-frameworks
+- Description: [Described below](#kubernetes-scalability-test-frameworks)
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/kubemark/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubemark/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubemark/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/kubemark/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/perf-tests/master/clusterloader2/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/perf-tests/master/OWNERS
+
+### kubernetes-scalability-and-performance-tests-and-validation
+- Description: [Described below](#kubernetes-scalability-and-performance-tests-and-validation)
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/processes/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/scalability/OWNERS
+
+### kubernetes-scalability-bottlenecks-detection
+- Description: [Described below](#kubernetes-scalability-bottlenecks-detection)
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/blogs/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Upcoming 2019 Meeting Dates

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -8,47 +8,29 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Scheduling Special Interest Group
 
-
 ## Meetings
-* 10AM PT Meeting: [Thursdays at 17:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly starting Thursday June 7, 2018). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC).
-* 5PM PT Meeting: [Thursdays at 24:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly starting Thursday June 14, 2018). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=24:00&tz=UTC).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/13mwye7nvrmV11q9_Eg77z-1w3X7Q1GTbslpml4J7F3A/edit).
-  * [Meeting recordings](https://www.youtube.com/watch?v=PweKj6SU7UA&list=PL69nYSiGNLP2vwzcCOhxrL3JVBc-eaJWI).
+- 10AM PT Meeting: [Thursdays at 17:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly starting Thursday June 7, 2018) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC))
+- 5PM PT Meeting: [Thursdays at 24:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly starting Thursday June 14, 2018) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=24:00&tz=UTC))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/13mwye7nvrmV11q9_Eg77z-1w3X7Q1GTbslpml4J7F3A/edit)
+  - [Meeting recordings](https://www.youtube.com/watch?v=PweKj6SU7UA&list=PL69nYSiGNLP2vwzcCOhxrL3JVBc-eaJWI)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Bobby (Babak) Salamat (**[@bsalamat](https://github.com/bsalamat)**), Google
-* Klaus Ma (**[@k82cn](https://github.com/k82cn)**), Huawei
+- Bobby (Babak) Salamat (**[@bsalamat](https://github.com/bsalamat)**), Google
+- Klaus Ma (**[@k82cn](https://github.com/k82cn)**), Huawei
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-scheduling)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscheduling)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-scheduling)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fscheduling)
 
-The following subprojects are owned by sig-scheduling:
-- **cluster-capacity**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-capacity/master/OWNERS
-- **descheduler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/descheduler/master/OWNERS
-- **kube-batch**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS
-- **scheduler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-scheduler/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/scheduler/OWNERS
-- **poseidon**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -62,6 +44,31 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-scheduling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-pr-reviews) | PR Reviews |
 | @kubernetes/sig-scheduling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-proposals) | Design Proposals |
 | @kubernetes/sig-scheduling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-scheduling:
+
+### cluster-capacity
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-capacity/master/OWNERS
+
+### descheduler
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/descheduler/master/OWNERS
+
+### kube-batch
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS
+
+### scheduler
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-scheduler/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/scheduler/OWNERS
+
+### poseidon
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -8,45 +8,45 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Service Catalog Special Interest Group
 
+
 Service Catalog is a Kubernetes extension project that implements the [Open Service Broker API](https://www.openservicebrokerapi.org/) (OSBAPI). It allows application developers the ability to provision and consume cloud services natively from within Kubernetes.
+
+
 
 The [charter](charter.md) defines the scope and governance of the Service Catalog Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Mondays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/17xlpkoEbPR5M6P5VDzNx17q6-IPFxKyebEekCGYiIKM/edit).
-  * [Meeting recordings](https://www.youtube.com/watch?v=ukPj1sFFkr0&list=PL69nYSiGNLP2k9ZXx9E1MvRSotFDoHUWs).
+- Regular SIG Meeting: [Mondays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/17xlpkoEbPR5M6P5VDzNx17q6-IPFxKyebEekCGYiIKM/edit)
+  - [Meeting recordings](https://www.youtube.com/watch?v=ukPj1sFFkr0&list=PL69nYSiGNLP2k9ZXx9E1MvRSotFDoHUWs)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Carolyn Van Slyck (**[@carolynvs](https://github.com/carolynvs)**), Microsoft
-* Michael Kibbe (**[@kibbles-n-bytes](https://github.com/kibbles-n-bytes)**), Google
-* Jonathan Berkhahn (**[@jberkhahn](https://github.com/jberkhahn)**), IBM
-* Jay Boyd (**[@jboyd01](https://github.com/jboyd01)**), Red Hat
+- Carolyn Van Slyck (**[@carolynvs](https://github.com/carolynvs)**), Microsoft
+- Michael Kibbe (**[@kibbles-n-bytes](https://github.com/kibbles-n-bytes)**), Google
+- Jonathan Berkhahn (**[@jberkhahn](https://github.com/jberkhahn)**), IBM
+- Jay Boyd (**[@jboyd01](https://github.com/jboyd01)**), Red Hat
 
 ## Emeritus Leads
 
-* Paul Morie (**[@pmorie](https://github.com/pmorie)**), Red Hat
-* Aaron Schlesinger (**[@arschles](https://github.com/arschles)**), Microsoft
-* Ville Aikas (**[@vaikas-google](https://github.com/vaikas-google)**), Google
-* Doug Davis (**[@duglin](https://github.com/duglin)**), IBM
+
+- Paul Morie (**[@pmorie](https://github.com/pmorie)**), Red Hat
+- Aaron Schlesinger (**[@arschles](https://github.com/arschles)**), Microsoft
+- Ville Aikas (**[@vaikas-google](https://github.com/vaikas-google)**), Google
+- Doug Davis (**[@duglin](https://github.com/duglin)**), IBM
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-service-catalog)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fservice-catalog)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-service-catalog)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fservice-catalog)
 
-The following subprojects are owned by sig-service-catalog:
-- **service-catalog**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/service-catalog/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -60,6 +60,14 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-service-catalog-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-pr-reviews) | PR Reviews |
 | @kubernetes/sig-service-catalog-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-proposals) | Design Proposals |
 | @kubernetes/sig-service-catalog-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-service-catalog:
+
+### service-catalog
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/service-catalog/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -8,75 +8,35 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Storage Special Interest Group
 
+
 SIG Storage is responsible for ensuring that different types of file and block storage (whether ephemeral or persistent, local or remote) are available wherever a container is scheduled (including provisioning/creating, attaching, mounting, unmounting, detaching, and deleting of volumes), storage capacity management (container ephemeral storage usage, volume resizing, etc.), influencing scheduling of containers based on storage (data gravity, availability, etc.), and generic operations on storage (snapshoting, etc.).
+
+
 
 The [charter](charter.md) defines the scope and governance of the Storage Special Interest Group.
 
 ## Meetings
-* Regular SIG Meeting: [Thursdays at 9:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1-8KEG8AjAgKznS9NFm3qWqkGyCHmvU6HVl0sk5hwoAE/edit?usp=sharing).
-  * [Meeting recordings](https://www.youtube.com/watch?v=Eh7Qa7KOL8o&list=PL69nYSiGNLP02-BMqJdfFgGxYQ4Nb-2Qq).
+- Regular SIG Meeting: [Thursdays at 9:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1-8KEG8AjAgKznS9NFm3qWqkGyCHmvU6HVl0sk5hwoAE/edit?usp=sharing)
+  - [Meeting recordings](https://www.youtube.com/watch?v=Eh7Qa7KOL8o&list=PL69nYSiGNLP02-BMqJdfFgGxYQ4Nb-2Qq)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Saad Ali (**[@saad-ali](https://github.com/saad-ali)**), Google
-* Bradley Childs (**[@childsb](https://github.com/childsb)**), Red Hat
+- Saad Ali (**[@saad-ali](https://github.com/saad-ali)**), Google
+- Bradley Childs (**[@childsb](https://github.com/childsb)**), Red Hat
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-storage)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fstorage)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-storage)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fstorage)
 
-The following subprojects are owned by sig-storage:
-- **kubernetes-csi**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-cinder/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-common/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-fc/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-iscsi/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-test/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/docs/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/driver-registrar/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/drivers/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/kubernetes-csi.github.io/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/livenessprobe/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/csi-translation-lib/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-translation-lib/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/node-driver-registrar/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-utils/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/OWNERS
-- **external-storage**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-lib-external-provisioner/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/OWNERS
-- **git-sync**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/git-sync/master/OWNERS
-- **nfs-provisioner**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/nfs-provisioner/master/OWNERS
-- **volumes**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -90,6 +50,57 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-storage-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-pr-reviews) | PR Reviews |
 | @kubernetes/sig-storage-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-storage-proposals) | Design Proposals |
 | @kubernetes/sig-storage-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-storage-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-storage:
+
+### kubernetes-csi
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-cinder/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-common/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-fc/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-iscsi/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-test/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/docs/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/driver-registrar/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/drivers/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/kubernetes-csi.github.io/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/livenessprobe/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/csi-translation-lib/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-translation-lib/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/node-driver-registrar/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-utils/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/OWNERS
+
+### external-storage
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-lib-external-provisioner/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/OWNERS
+
+### git-sync
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/git-sync/master/OWNERS
+
+### nfs-provisioner
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-incubator/nfs-provisioner/master/OWNERS
+
+### volumes
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -8,65 +8,34 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Testing Special Interest Group
 
+
 Interested in how we can most effectively test Kubernetes. We're interested specifically in making it easier for the community to run tests and contribute test results, to ensure Kubernetes is stable across a variety of cluster configurations and cloud providers.
 
+
 ## Meetings
-* Regular SIG Meeting: [Tuesdays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://bit.ly/k8s-sig-testing-notes).
-  * [Meeting recordings](https://bit.ly/k8s-sig-testing-videos).
+- Regular SIG Meeting: [Tuesdays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://bit.ly/k8s-sig-testing-notes)
+  - [Meeting recordings](https://bit.ly/k8s-sig-testing-videos)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Aaron Crickenberger (**[@spiffxp](https://github.com/spiffxp)**), Google
-* Erick Feja (**[@fejta](https://github.com/fejta)**), Google
-* Steve Kuznetsov (**[@stevekuznetsov](https://github.com/stevekuznetsov)**), Red Hat
-* Timothy St. Clair (**[@timothysc](https://github.com/timothysc)**), Heptio
+- Aaron Crickenberger (**[@spiffxp](https://github.com/spiffxp)**), Google
+- Erick Feja (**[@fejta](https://github.com/fejta)**), Google
+- Steve Kuznetsov (**[@stevekuznetsov](https://github.com/stevekuznetsov)**), Red Hat
+- Timothy St. Clair (**[@timothysc](https://github.com/timothysc)**), Heptio
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-testing)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-testing)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Ftesting)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-testing)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-testing)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Ftesting)
 
-The following subprojects are owned by sig-testing:
-- **boskos**
-  - Description: Boskos is a resource manager service that handles different kinds of resources and transitions between different states. We use it on the Kubernetes project to manage pools of GCP projects for CI/CD.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
-- **gopherage**
-  - Description: Gopherage is a tool for manipulating Go coverage files. We use it on the Kubernetes project to report on code coverage due to e2e tests
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/gopherage/OWNERS
-- **gubernator**
-  - Description: Gubernator is a frontend for displaying Kubernetes test results stored in GCS. See gubernator.k8s.io to see it in action for the Kubernetes project.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/gubernator/OWNERS
-- **kind**
-  - Description: Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
-- **prow**
-  - Description: Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
-- **testing-commons**
-  - Description: The Testing Commons is a subproject within the Kubernetes sig-testing community interested code structure, layout, and execution of common test code used throughout the kubernetes project
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/testing_frameworks/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/OWNERS
-  - Meetings:
-    - Testing Commons: [Wednesdays at 07:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:30&tz=PT%20%28Pacific%20Time%29).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit#heading=h.tnoevy5f439o).
-- **test-infra**
-  - Description: Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -75,6 +44,49 @@ Note that the links to display team membership will only work if you are a membe
 | --------- |:-------:| ----------- |
 | @kubernetes/sig-testing | [link](https://github.com/orgs/kubernetes/teams/sig-testing) | General Discussion |
 | @kubernetes/sig-testing-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-pr-reviews) | PR Reviews |
+
+## Subprojects
+
+The following subprojects are owned by sig-testing:
+
+### boskos
+- Description: Boskos is a resource manager service that handles different kinds of resources and transitions between different states. We use it on the Kubernetes project to manage pools of GCP projects for CI/CD.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
+
+### gopherage
+- Description: Gopherage is a tool for manipulating Go coverage files. We use it on the Kubernetes project to report on code coverage due to e2e tests
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/gopherage/OWNERS
+
+### gubernator
+- Description: Gubernator is a frontend for displaying Kubernetes test results stored in GCS. See gubernator.k8s.io to see it in action for the Kubernetes project.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/gubernator/OWNERS
+
+### kind
+- Description: Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
+
+### prow
+- Description: Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
+
+### testing-commons
+- Description: The Testing Commons is a subproject within the Kubernetes sig-testing community interested code structure, layout, and execution of common test code used throughout the kubernetes project
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/testing_frameworks/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/OWNERS
+- Meetings:
+  - Testing Commons: [Wednesdays at 07:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:30&tz=PT%20%28Pacific%20Time%29))
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit#heading=h.tnoevy5f439o)
+
+### test-infra
+- Description: Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -8,31 +8,29 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # UI Special Interest Group
 
+
 Covers all things UI related. Efforts are centered around Kubernetes Dashboard: a general purpose, web-based UI for Kubernetes clusters. It allows users to manage applications running in the cluster and troubleshoot them, as well as manage the cluster itself.
 
+
 ## Meetings
-* Regular SIG Meeting: [Thursdays at 18:00 CET (Central European Time)](https://groups.google.com/forum/#!forum/kubernetes-sig-ui) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:00&tz=CET%20%28Central%20European%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1PwHFvqiShLIq8ZpoXvE3dSUnOv1ts5BTtZ7aATuKd-E/edit?usp=sharing).
+- Regular SIG Meeting: [Thursdays at 18:00 CET (Central European Time)](https://groups.google.com/forum/#!forum/kubernetes-sig-ui) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:00&tz=CET%20%28Central%20European%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1PwHFvqiShLIq8ZpoXvE3dSUnOv1ts5BTtZ7aATuKd-E/edit?usp=sharing)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Dan Romlein (**[@danielromlein](https://github.com/danielromlein)**), Google
-* Sebastian Florek (**[@floreks](https://github.com/floreks)**), Fujitsu
+- Dan Romlein (**[@danielromlein](https://github.com/danielromlein)**), Google
+- Sebastian Florek (**[@floreks](https://github.com/floreks)**), Fujitsu
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-ui)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fui)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-ui)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fui)
 
-The following subprojects are owned by sig-ui:
-- **dashboard**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/dashboard/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-vmware/README.md
+++ b/sig-vmware/README.md
@@ -8,40 +8,38 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # VMware Special Interest Group
 
+
 Bring together members of the VMware and Kubernetes community to maintain, support and run Kubernetes on VMware platforms.
 
+
 ## Meetings
-* Regular SIG Meeting: [Thursdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1RV0nVtlPoAtM0DQwNYxYCC9lHfiHpTNatyv4bek6XtA/edit?usp=sharing).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIqKv-Zq8WbyibQtemChor9y).
-* Cloud Provider vSphere monthly syncup: [Wednesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (monthly - first Wednesday every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1B0NmmKVh8Ea5hnNsbUsJC7ZyNCsq_6NXl5hRdcHlJgY/edit?usp=sharing).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIpOT4bOfuO3MEMHvU1tRqyR).
-* Cluster API Provider vSphere bi-weekly syncup: [Wednesdays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1jQrQiOW75uWraPk4b_LWtCTHwT7EZwrWWwMdxeWOEvk/edit?usp=sharing).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIovV-AONxMa2cyv-_5LAYiu).
+- Regular SIG Meeting: [Thursdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1RV0nVtlPoAtM0DQwNYxYCC9lHfiHpTNatyv4bek6XtA/edit?usp=sharing)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIqKv-Zq8WbyibQtemChor9y)
+- Cloud Provider vSphere monthly syncup: [Wednesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (monthly - first Wednesday every month) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1B0NmmKVh8Ea5hnNsbUsJC7ZyNCsq_6NXl5hRdcHlJgY/edit?usp=sharing)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIpOT4bOfuO3MEMHvU1tRqyR)
+- Cluster API Provider vSphere bi-weekly syncup: [Wednesdays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1jQrQiOW75uWraPk4b_LWtCTHwT7EZwrWWwMdxeWOEvk/edit?usp=sharing)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIovV-AONxMa2cyv-_5LAYiu)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Fabio Rapposelli (**[@frapposelli](https://github.com/frapposelli)**), VMware
-* Steve Wong (**[@cantbewong](https://github.com/cantbewong)**), VMware
+- Fabio Rapposelli (**[@frapposelli](https://github.com/frapposelli)**), VMware
+- Steve Wong (**[@cantbewong](https://github.com/cantbewong)**), VMware
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-vmware)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fvmware)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-vmware)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fvmware)
 
-The following subprojects are owned by sig-vmware:
-- **cluster-api-provider-vsphere**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-vsphere/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -56,6 +54,14 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-vmware-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-pr-reviews) | PR Reviews |
 | @kubernetes/sig-vmware-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-proposals) | Design Proposals |
 | @kubernetes/sig-vmware-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-vmware-test-failures) | Test Failures and Triage |
+
+## Subprojects
+
+The following subprojects are owned by sig-vmware:
+
+### cluster-api-provider-vsphere
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-vsphere/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -8,34 +8,32 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Windows Special Interest Group
 
+
 Focuses on supporting Windows Server Containers for Kubernetes.
 
+
 ## Meetings
-* Regular SIG Meeting: [Tuesdays at 12:30 Eastern Standard Time (EST)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:30&tz=Eastern%20Standard%20Time%20%28EST%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4).
+- Regular SIG Meeting: [Tuesdays at 12:30 Eastern Standard Time (EST)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly) ([Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:30&tz=Eastern%20Standard%20Time%20%28EST%29))
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431)
+  - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4)
 
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
-* Michael Michael (**[@michmike](https://github.com/michmike)**), VMware
-* Patrick Lang (**[@patricklang](https://github.com/patricklang)**), Microsoft
+- Michael Michael (**[@michmike](https://github.com/michmike)**), VMware
+- Patrick Lang (**[@patricklang](https://github.com/patricklang)**), Microsoft
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-windows)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-windows)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fwindows)
 
-## Subprojects
+- [Slack](https://kubernetes.slack.com/messages/sig-windows)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-windows)
+- [Open Issues / PRs](https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-client+org%3Akubernetes-csi+org%3Akubernetes-incubator+org%3Akubernetes-retired+org%3Akubernetes-sigs+is%3Aopen+label%3Asig%2Fwindows)
 
-The following subprojects are owned by sig-windows:
-- **windows-testing**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/OWNERS
 
-## GitHub Teams
+### GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
@@ -45,6 +43,14 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-windows-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-windows-bugs) | Bug Triage and Troubleshooting |
 | @kubernetes/sig-windows-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-windows-feature-requests) | Feature Requests |
 | @kubernetes/sig-windows-misc | [link](https://github.com/orgs/kubernetes/teams/sig-windows-misc) | General Discussion |
+
+## Subprojects
+
+The following subprojects are owned by sig-windows:
+
+### windows-testing
+- OWNERS:
+  - https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/OWNERS
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Getting Started


### PR DESCRIPTION
Adds a `Repo` struct and additional fields to the `Subproject` and `Group` structs of the generator app.

This adds some granularity to allow you to define:
- Repos / subdirectories not owned by a SIG Subproject
- Subproject ~Chairs~Contacts
- Repo names / descriptions / URLs / OWNERS

...or decide to continue using the OWNERS files for subprojects. :)

I've created a gist that you can pull to test or view an example of the structure:
- sig.yaml: https://gist.github.com/justaugustus/6e862bdd58832315e79c12ef203e6ec8#file-sigs-yaml
- example SIG Release README.md: https://gist.github.com/justaugustus/6e862bdd58832315e79c12ef203e6ec8#file-sig-release-mock-readme-md

It also cleans up some syntax nits.

Fixes: https://github.com/kubernetes/community/issues/2619
Related: https://github.com/kubernetes/community/issues/1913

/kind feature
/sig contributor-experience

Signed-off-by: Stephen Augustus <foo@agst.us>