### PR TITLE
CLA clarification

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -38,7 +38,9 @@ person@organization.domain email address in the CNCF account registration page.
 #### 3. Complete signing process
 
 After creating your account, follow the instructions to complete the
-signing process through Hellosign.
+signing process through HelloSign.
+
+If you did not receive an email from HelloSign, [then request it here](https://identity.linuxfoundation.org/projects/cncf).
 
 #### 4. Ensure your Github e-mail address matches address used to sign CLA
 


### PR DESCRIPTION
If you have to create your Linux Foundation account when clicking the links in Step 1, then the HelloSign email is not automatically sent and you have to go back and click it again. It definitely confused me.

I was thinking about changing Step 1 to only have one link to https://identity.linuxfoundation.org/projects/cncf, since on that page there are links for individual contributor or corporation.

I also opted to not use "Log in with GitHub", but created the account first, and then later I linked my GitHub account. I do not know if the ordering matters, and this might be why I didn't receive my HelloSign email after signing up.