### PR TITLE
release docs: clarify tldr table html

### DIFF
--- a/contributors/devel/release.md
+++ b/contributors/devel/release.md
@@ -56,7 +56,7 @@ If you want your PR to get merged, it needs the following required labels and mi
 <td>Required Labels</td>
 <td>
 <ul>
-<li>/milestone {v1.y}</li>
+<!--Weeks 1-8-->
 <li>/sig {name}</li>
 <li>/kind {type}</li>
 <li>/lgtm</li>
@@ -65,6 +65,7 @@ If you want your PR to get merged, it needs the following required labels and mi
 </td>
 <td>
 <ul>
+<!--Week 9-->
 <li>/milestone {v1.y}</li>
 <li>/sig {name}</li>
 <li>/kind {type}</li>
@@ -75,6 +76,7 @@ If you want your PR to get merged, it needs the following required labels and mi
 </td>
 <td>
 <ul>
+<!--Weeks 10-12-->
 <li>/milestone {v1.y}</li>
 <li>/sig {name}</li>
 <li>/kind {bug, failing-test}</li>
@@ -85,6 +87,7 @@ If you want your PR to get merged, it needs the following required labels and mi
 </td>
 <td>
 <ul>
+<!--Weeks 12+-->
 <li>/milestone {v1.y}</li>
 <li>/sig {name}</li>
 <li>/kind {bug, failing-test}</li>


### PR DESCRIPTION
I incorrectly had indicated a milestone was required in each of the four
major phases of the release cycle, where it is not in the "normal dev"
phase.  Not sure how we got that through review.  Part of it may have
been the html table format.  To help with that, in addition to removing
the errant indication of milestone as required in that early period,
I've also added html comments in the table so the reader of the raw code
can more clearly see which section is which.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->