### PR TITLE
wg-security-audit: add OWNERS file

### DIFF
--- a/wg-security-audit/OWNERS
+++ b/wg-security-audit/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - wg-security-audit-leads
+approvers:
+  - wg-security-audit-leads
+labels:
+  - wg/security-audit


### PR DESCRIPTION
Looks like it got missed in https://github.com/kubernetes/community/pull/2767 :)

Related: https://github.com/kubernetes/test-infra/pull/9744 will add the label.

/cc @jessfraz 