### PR TITLE
Use better reference links for lazy consensus

### DIFF
--- a/committee-steering/governance/sig-governance-requirements.md
+++ b/committee-steering/governance/sig-governance-requirements.md
@@ -72,7 +72,7 @@ All technical assets *MUST* be owned by exactly 1 SIG subproject.  The following
   - *SHOULD* define target metrics for health signal (e.g. broken tests fixed within N days)
   - *SHOULD* define process for meeting target metrics (e.g. all tests run as presubmit, build cop, etc)
 
-[lazy-consensus]: http://communitymgt.wikia.com/wiki/Lazy_consensus
+[lazy-consensus]: http://en.osswiki.info/concepts/lazy_consensus
 [super-majority]: https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote
 [warnocks-dilemma]: http://communitymgt.wikia.com/wiki/Warnock%27s_Dilemma
 [slo]: https://en.wikipedia.org/wiki/Service_level_objective

--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -155,7 +155,7 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
   - after 3 or more months it *SHOULD* be retired
   - after 6 or more months it *MUST* be retired
 
-[lazy-consensus]: http://communitymgt.wikia.com/wiki/Lazy_consensus
+[lazy-consensus]: http://en.osswiki.info/concepts/lazy_consensus
 [super-majority]: https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote
 [KEP]: https://github.com/kubernetes/community/blob/master/keps/0000-kep-template.md
 [sigs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml#L1454

--- a/sig-azure/charter.md
+++ b/sig-azure/charter.md
@@ -93,7 +93,7 @@ Subprojects of the SIG MUST use the following processes unless explicitly follow
 
 Issues impacting multiple subprojects in the SIG should be resolved by SIG Technical Leads, with fallback to consensus of subproject owners.
 
-[lazy-consensus]: http://communitymgt.wikia.com/wiki/Lazy_consensus
+[lazy-consensus]: http://en.osswiki.info/concepts/lazy_consensus
 [super-majority]: https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote
 [KEP]: https://github.com/kubernetes/community/blob/master/keps/0000-kep-template.md
 [sigs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml#L1454

--- a/sig-cloud-provider/CHARTER.md
+++ b/sig-cloud-provider/CHARTER.md
@@ -39,7 +39,7 @@ Subprojects that fall under SIG Cloud Provider may also be features in Kubernete
 
 ## Subproject Retirement
 
-Subprojects representing Kubernetes providers may be retired given they do not satisfy requirements for more than 6 months. Final decisions for retirement should be supported by a majority of SIG members using [lazy consensus](http://communitymgt.wikia.com/wiki/Lazy_consensus). Once retired any code related to that provider will be archived into the kubernetes-retired organization.
+Subprojects representing Kubernetes providers may be retired given they do not satisfy requirements for more than 6 months. Final decisions for retirement should be supported by a majority of SIG members using [lazy consensus](http://en.osswiki.info/concepts/lazy_consensus). Once retired any code related to that provider will be archived into the kubernetes-retired organization.
 
 Subprojects representing Kubernetes features may be retired at any point given a lack of development or a lack of demand. Final decisions for retirement should be supported by a majority of SIG members, ideally from every provider. Once retired, any code related to that subproject will be archived into the kubernetes-retired organization.
 


### PR DESCRIPTION
As it’s been used elsewhere in this repo already

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->