### PR TITLE
Add rsync as development dependency

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -115,6 +115,11 @@ environment. Recent Linux distros should work out-of-the-box.
 macOS ships with outdated BSD-based tools. We recommend installing [macOS GNU
 tools].
 
+### rsync
+
+Kubernetes build system requires `rsync` command present in the development
+platform.
+
 ### etcd
 
 Kubernetes maintains state in [`etcd`][etcd-latest], a distributed key store.


### PR DESCRIPTION
While trying to fix https://github.com/kubernetes/kubernetes/issues/62577
I noticed my system was lacking `rsync` installed, which was required to
have `make` and `make test` working.