### PR TITLE
Update Code of Conduct page with new email

### DIFF
--- a/committee-code-of-conduct/README.md
+++ b/committee-code-of-conduct/README.md
@@ -11,4 +11,4 @@ The members and their terms are as follows:
 
 Please see the [bootstrapping document](./bootstrapping-process.md) for more information on how members are picked, their responsibilities, and how the committee will initially function.
 
-_More information on how to contact this committee and learn about its process to come in the near future. For now, any Code of Conduct or Code of Conduct Committee concerns can be directed to steering-private@kubernetes.io_
+_More information on how to contact this committee and learn about its process to come in the near future. For now, any Code of Conduct or Code of Conduct Committee concerns can be directed to <conduct@kubernetes.io>_.

--- a/communication/moderation.md
+++ b/communication/moderation.md
@@ -21,7 +21,7 @@ Moderators _MUST_:
 - Take care of spam as soon as possible, which may mean taking action by removing a member from that resource.
 - Foster a safe and productive environment by being aware of potential multiple cultural differences between Kubernetes community members.
 - Understand that you might be contacted by moderators, community managers, and other users via private email or a direct message. 
-- Report egregious behavior to steering@k8s.io.
+- Report violations of the Code of Conduct to <conduct@kubernetes.io>.
 
 Moderators _SHOULD_: 
 
@@ -34,7 +34,7 @@ Moderators _SHOULD_:
 
 ## Violations
 
-The Kubernetes [Steering Committee](https://github.com/kubernetes/steering) will have the final authority regarding escalated moderation matters.  Violations of the Code of Conduct will be handled on a case by case basis. Depending on severity this can range up to and including removal of the person from the community, though this is extremely rare.
+The Kubernetes [Code of Conduct Committee](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct) will have the final authority regarding escalated moderation matters.  Violations of the Code of Conduct will be handled on a case by case basis. Depending on severity this can range up to and including removal of the person from the community, though this is extremely rare.
 
 ## Specific Guidelines
 

--- a/communication/moderation.md
+++ b/communication/moderation.md
@@ -34,7 +34,7 @@ Moderators _SHOULD_:
 
 ## Violations
 
-The Kubernetes [Code of Conduct Committee](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct) will have the final authority regarding escalated moderation matters.  Violations of the Code of Conduct will be handled on a case by case basis. Depending on severity this can range up to and including removal of the person from the community, though this is extremely rare.
+The Kubernetes [Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) will have the final authority regarding escalated moderation matters.  Violations of the Code of Conduct will be handled on a case by case basis. Depending on severity this can range up to and including removal of the person from the community, though this is extremely rare.
 
 ## Specific Guidelines
 

--- a/contributors/guide/contributor-cheatsheet.md
+++ b/contributors/guide/contributor-cheatsheet.md
@@ -52,6 +52,7 @@ A list of common resources when contributing to Kubernetes.
 - steering@kubernetes.io - Mail the steering committee. Public address with public archive.
 - steering-private@kubernetes.io - Mail the steering committee privately, for sensitive items.
 - helpdesk@rt.linuxfoundation.org - Mail the LF helpdesk for help with CLA issues.
+- conduct@kubernetes.io - Contact the Code of Conduct committee, private mailing list.
 
 ## Other
 


### PR DESCRIPTION
Now that we have a Code of Conduct Committee for Kubernetes, people should contact our private email list going forward with any problems.