### PR TITLE
Redo devstats as a subproject

### DIFF
--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -56,7 +56,7 @@ The following subprojects are owned by sig-contributor-experience:
     - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
 - **devstats**
   - Owners:
-    - Phillels
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
 - **k8s.io**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/k8s.io/master/OWNERS

--- a/sig-contributor-experience/devstats/OWNERS
+++ b/sig-contributor-experience/devstats/OWNERS
@@ -1,0 +1,16 @@
+# see https://go.k8s.io/owners
+
+reviewers:
+  - Phillels
+  - dims
+  - jberkus
+  - nikhita
+  - parispittman
+  - spiffxp
+approvers:
+  - Phillels
+  - lukaszgryglicki
+  - jberkus
+  - spiffxp
+labels:
+  - sig/contributor-experience

--- a/sig-contributor-experience/devstats/README.md
+++ b/sig-contributor-experience/devstats/README.md
@@ -1,0 +1,18 @@
+# devstats
+
+This file documents the devstats subproject. We are responsible for
+continued advocacy of CNCF's devstats project within the kubernetes
+community. The kubernetes project has a significant number of metrics
+and workflows that are unique amongst CNCF projects, thus we are more
+actively involved in ongoing development and maintenance of meaningful
+devstats metrics and dashboards than most other CNCF projects.
+
+## Things we have done in the past
+
+- Graph of the Week at kubernetes community meetings
+  - TODO: list of meetings and graphs presented?
+- Added descriptions to each of the devstats dashboards
+- Adjusted repo groups to be generated from sigs.yaml instead of the
+  previous subjective/opaque groupings
+- Consulted with the devstats maintainers to suggest new metrics and
+  new dashboards

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -887,7 +887,7 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
     - name: devstats
       owners:
-      - Phillels
+        - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
     - name: k8s.io
       owners:
       - https://raw.githubusercontent.com/kubernetes/k8s.io/master/OWNERS


### PR DESCRIPTION
Subprojects are supposed to be based on OWNERS files, even if they
are purely non-technical with no code they should still have docs
that explain what they are and how they operate.

I added a skeleton readme for devstats, and an OWNERS file. I added
jberkus and myself as approvers in addition to Phillels as I feel
we have done substantial work with devstats, if nothing else through
graph of the week presentations at community.

/kind documentation
/sig contributor-experience