### PR TITLE
Update wg-security-audit leads; include RFP link in readme.md

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2145,8 +2145,6 @@ workinggroups:
     mission_statement: >
       Perform a security audit on k8s with a vendor and produce as artifacts 
       a threat model and whitepaper outlining everything found during the audit.
-
-      The RFP will be open between 2018/10/29 and 2019/11/26 and has been published [here](https://github.com/kubernetes/community/blob/master/wg-security-audit/RFP.md).
     charter_link:
     leadership:
       chairs:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2143,8 +2143,7 @@ workinggroups:
   - name: Security Audit
     dir: wg-security-audit
     mission_statement: >
-      Perform a security audit on k8s with a vendor and produce as artifacts 
-      a threat model and whitepaper outlining everything found during the audit.
+      Perform a security audit on k8s with a vendor and produce as artifacts a threat model and whitepaper outlining everything found during the audit.
     charter_link:
     leadership:
       chairs:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2143,7 +2143,10 @@ workinggroups:
   - name: Security Audit
     dir: wg-security-audit
     mission_statement: >
-      Perform a security audit on k8s with a vendor and produce as artifacts a threat model and whitepaper outlining everything found during the audit.
+      Perform a security audit on k8s with a vendor and produce as artifacts 
+      a threat model and whitepaper outlining everything found during the audit.
+
+      The RFP will be open between 2018/10/29 and 2019/11/26 and has been published [here](RFP.md).
     charter_link:
     leadership:
       chairs:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2146,7 +2146,7 @@ workinggroups:
       Perform a security audit on k8s with a vendor and produce as artifacts 
       a threat model and whitepaper outlining everything found during the audit.
 
-      The RFP will be open between 2018/10/29 and 2019/11/26 and has been published [here](RFP.md).
+      The RFP will be open between 2018/10/29 and 2019/11/26 and has been published [here](https://github.com/kubernetes/community/blob/master/wg-security-audit/RFP.md).
     charter_link:
     leadership:
       chairs:

--- a/wg-security-audit/README.md
+++ b/wg-security-audit/README.md
@@ -8,7 +8,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Security Audit Working Group
 
-Perform a security audit on k8s with a vendor and produce as artifacts  a threat model and whitepaper outlining everything found during the audit.
+Perform a security audit on k8s with a vendor and produce as artifacts a threat model and whitepaper outlining everything found during the audit.
 
 ## Meetings
 * Regular WG Meeting: [Mondays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1RbC4SBZBlKth7IjYv_NaEpnmLGwMJ0ElpUOmsG-bdRA/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).

--- a/wg-security-audit/README.md
+++ b/wg-security-audit/README.md
@@ -8,7 +8,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Security Audit Working Group
 
-Perform a security audit on k8s with a vendor and produce as artifacts a threat model and whitepaper outlining everything found during the audit.
+Perform a security audit on k8s with a vendor and produce as artifacts  a threat model and whitepaper outlining everything found during the audit.
 
 ## Meetings
 * Regular WG Meeting: [Mondays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1RbC4SBZBlKth7IjYv_NaEpnmLGwMJ0ElpUOmsG-bdRA/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).
@@ -24,5 +24,7 @@ Perform a security audit on k8s with a vendor and produce as artifacts a threat 
 * [Mailing list]()
 
 <!-- BEGIN CUSTOM CONTENT -->
-
+## Request For Proposals
+      
+The RFP will be open between 2018/10/29 and 2019/11/26 and has been published [here](https://github.com/kubernetes/community/blob/master/wg-security-audit/RFP.md).
 <!-- END CUSTOM CONTENT -->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
I don't think [PR 2872](https://github.com/kubernetes/community/pull/2872) used the generator to update wg leads. Including that in this PR.

We are ready to publish the RFP for the third party security audit. Added link to RFP in wg-security-audit README.md.

CC: @cblecker @joelsmith @cji  