### PR TITLE
Clarify employee CLA

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -13,6 +13,8 @@ It is important to read and understand this legal agreement.
 
 ## How do I sign?
 
+If your work is done as an employee of your company, contact your company's legal department and ask to be put on the list of approved contributors for the Kubernetes CLA. Below, we have included steps for "Corporation signup" in case your company does not have a company agreement and would like to have one.
+
 #### 1. Log in to the Linux Foundation ID Portal with Github
 
 Click one of:


### PR DESCRIPTION
Some folks may be unaware that their company has signed or needs to sign a CLA if they are contributing to Kuberentes as part of their job. This sentence prompts them to check their company legal representation first so they don't sign an individual contributor license.

Addresses https://github.com/kubernetes/community/issues/1794.