### PR TITLE
Add thockin and lavalamp to devel OWNERS

### DIFF
--- a/contributors/devel/OWNERS
+++ b/contributors/devel/OWNERS
@@ -1,14 +1,16 @@
 reviewers:
-  - grodrigues3
-  - Phillels
-  - idvoretskyi
   - calebamiles
   - cblecker
+  - grodrigues3
+  - idvoretskyi
+  - Phillels
   - spiffxp
 approvers:
-  - grodrigues3
-  - Phillels
-  - idvoretskyi
   - calebamiles
   - cblecker
+  - grodrigues3
+  - idvoretskyi
+  - lavalamp
+  - Phillels
   - spiffxp
+  - thockin


### PR DESCRIPTION
Add @thockin and @lavalamp to approvers list for `contributors/devel/`. There's a bunch of legacy docs in there, including the api conventions. Also, alpha sort list.