### PR TITLE
Update keps/OWNERS

### DIFF
--- a/keps/OWNERS
+++ b/keps/OWNERS
@@ -1,17 +1,14 @@
 reviewers:
   - sig-architecture-leads
-  - jbeda
-  - bgrant0607
-  - jdumars
   - calebamiles
   - idvoretskyi
+  - jbeda
+  - justaugustus
 approvers:
   - sig-architecture-leads
-  - jbeda
-  - bgrant0607
-  - jdumars
   - calebamiles
   - idvoretskyi
+  - jbeda
 labels:
   - kind/kep
   - sig/architecture


### PR DESCRIPTION
- Add myself as a reviewer (structure and metadata, not necessarily technical content)
- Cleanup (Brian and Jaice are covered by `sig-architecture-leads` already)

Signed-off-by: Stephen Augustus <foo@agst.us>

/sig pm
/assign @jdumars @calebamiles 