### PR TITLE
Fix typos: creats -> creates

### DIFF
--- a/contributors/design-proposals/apps/deployment.md
+++ b/contributors/design-proposals/apps/deployment.md
@@ -197,7 +197,7 @@ For example, consider the following case:
 Users can pause/cancel a rollout by doing a non-cascading deletion of the Deployment
 before it is complete. Recreating the same Deployment will resume it.
 For example, consider the following case:
-- User creats a Deployment to perform a rolling-update for 10 pods from image:v1 to
+- User creates a Deployment to perform a rolling-update for 10 pods from image:v1 to
  image:v2.
 - User then deletes the Deployment while the old and new RSs are at 5 replicas each.
   User will end up with 2 RSs with 5 replicas each.

--- a/contributors/devel/automation.md
+++ b/contributors/devel/automation.md
@@ -49,4 +49,4 @@ during the original test. It would be good to file flakes as an
 The simplest way is to comment `/retest`.
 
 Any pushes of new code to the PR will automatically trigger a new test. No human
-interraction is required. Note that if the PR has a `lgtm` label, it will be removed after the pushes.
+interaction is required. Note that if the PR has a `lgtm` label, it will be removed after the pushes.

--- a/keps/sig-cli/0024-kubectl-plugins.md
+++ b/keps/sig-cli/0024-kubectl-plugins.md
@@ -107,7 +107,7 @@ See https://github.com/kubernetes/kubernetes/issues/53640 and https://github.com
 * Relay all information given to `kubectl` (via command line args) to plugins as-is.
   Plugins receive all arguments and flags provided by users and are responsible for adjusting their behavior
   accordingly.
-* Provide a way to limit which command paths can and cannot be overriddden by plugins in the command tree.
+* Provide a way to limit which command paths can and cannot be overriden by plugins in the command tree.
 
 ### Non-Goals
 

--- a/keps/sig-cli/0024-kubectl-plugins.md
+++ b/keps/sig-cli/0024-kubectl-plugins.md
@@ -107,7 +107,7 @@ See https://github.com/kubernetes/kubernetes/issues/53640 and https://github.com
 * Relay all information given to `kubectl` (via command line args) to plugins as-is.
   Plugins receive all arguments and flags provided by users and are responsible for adjusting their behavior
   accordingly.
-* Provide a way to limit which command paths can and cannot be overriden by plugins in the command tree.
+* Provide a way to limit which command paths can and cannot be overridden by plugins in the command tree.
 
 ### Non-Goals
 


### PR DESCRIPTION
Signed-off-by: mooncake <xcoder@tenxcloud.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Fix typos: creats -> creates