### PR TITLE
Update SIG Release contact information

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -56,18 +56,14 @@ Note that the links to display team membership will only work if you are a membe
 
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
-| @kubernetes/sig-release-admins | [link](https://github.com/orgs/kubernetes/teams/sig-release-admins) | Release Team Admins |
-| @kubernetes/sig-release-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-release-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-release-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-release-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-release-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-release-feature-requests) | Feature Requests |
-| @kubernetes/sig-release-members | [link](https://github.com/orgs/kubernetes/teams/sig-release-members) | Release Team Members |
-| @kubernetes/sig-release-misc | [link](https://github.com/orgs/kubernetes/teams/sig-release-misc) | General Discussion |
-| @kubernetes/sig-release-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-release-pr-reviews) | PR Reviews |
-| @kubernetes/sig-release-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-release-proposals) | Design Proposals |
-| @kubernetes/sig-release-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-release-test-failures) | Test Failures and Triage |
+| @kubernetes/sig-release | [link](https://github.com/orgs/kubernetes/teams/sig-release) | SIG Release Members |
+| @kubernetes/sig-release-admins | [link](https://github.com/orgs/kubernetes/teams/sig-release-admins) | Admins for SIG Release repositories |
+| @kubernetes/kubernetes-milestone-maintainers | [link](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers) | Milestone Maintainers |
+| @kubernetes/kubernetes-release-managers | [link](https://github.com/orgs/kubernetes/teams/kubernetes-release-managers) | Release Managers |
 
 <!-- BEGIN CUSTOM CONTENT -->
-[SIG Release] has moved!
+---
 
-[SIG Release]: https://github.com/kubernetes/sig-release
+_The canonical location for SIG Release information is [k/sig-release](https://github.com/kubernetes/sig-release)._
+
 <!-- END CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1534,24 +1534,14 @@ sigs:
       slack: sig-release
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-release
       teams:
+      - name: sig-release
+        description: SIG Release Members
       - name: sig-release-admins
-        description: Release Team Admins
-      - name: sig-release-api-reviews
-        description: API Changes and Reviews
-      - name: sig-release-bugs
-        description: Bug Triage and Troubleshooting
-      - name: sig-release-feature-requests
-        description: Feature Requests
-      - name: sig-release-members
-        description: Release Team Members
-      - name: sig-release-misc
-        description: General Discussion
-      - name: sig-release-pr-reviews
-        description: PR Reviews
-      - name: sig-release-proposals
-        description: Design Proposals
-      - name: sig-release-test-failures
-        description: Test Failures and Triage
+        description: Admins for SIG Release repositories
+      - name: kubernetes-milestone-maintainers
+        description: Milestone Maintainers
+      - name: kubernetes-release-managers
+        description: Release Managers
     subprojects:
     - name: hyperkube
       owners:


### PR DESCRIPTION
SIG Release GitHub teams have been updated in https://github.com/kubernetes/sig-release/issues/353, so reflecting that in our contact info as well.

Signed-off-by: Stephen Augustus <foo@agst.us>

/assign @calebamiles @tpepper @jdumars 