### PR TITLE
add metadata name to HPA v2 example

### DIFF
--- a/contributors/design-proposals/autoscaling/hpa-v2.md
+++ b/contributors/design-proposals/autoscaling/hpa-v2.md
@@ -211,6 +211,8 @@ the ReplicationController being autoscaled.
 ```yaml
 kind: HorizontalPodAutoscaler
 apiVersion: autoscaling/v2alpha1
+metadata:
+  name: WebFrontend
 spec:
   scaleTargetRef:
     kind: ReplicationController


### PR DESCRIPTION
Really minor thing, but this make the example copy-pastable.