### PR TITLE
governance: add diagram for community groups

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -31,6 +31,8 @@ The project has 4 main types of groups:
 * Working Groups, WGs
 * Committees
 
+![Kubernetes Governance Diagram](kubernetes_governance_diagram.png)
+
 ## SIGs
 
 The Kubernetes project is organized primarily into Special Interest


### PR DESCRIPTION
Fixes https://github.com/kubernetes/community/issues/2675

The diagram already exists https://github.com/kubernetes/community/blob/master/kubernetes_governance_diagram.png. This PR just adds a link to it in the governance doc.

I'm not sure if the diagram is entirely accurate or if some minor things have changed. If things have changed, then we should remove this diagram and add a new one later.

/committee steering