### PR TITLE
Fixed broken links for sig-network readme.md

### DIFF
--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -35,8 +35,8 @@ The following subprojects are owned by sig-network:
 - **services**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/pkg/kubernetes/master/controller/endpoint/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/pkg/kubernetes/master/controller/service/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
 - **kube-dns**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
@@ -83,8 +83,8 @@ SIG Network is responsible for the following Kubernetes subsystems:
 
 SIG Network is responsible for a number of issues and PRs. A summary can be found through GitHub search:
 
-* [SIG Network PRs](https://github.com/issues?utf8=%E2%9C%93&q=team%3Akubernetes%2Fsig-network+is%3Aopen+is%3Apr+)
-* [SIG Network Issues](https://github.com/issues?utf8=%E2%9C%93&q=team%3A%22kubernetes%2Fsig-network%22+is%3Aopen+is%3Aissue)
+* [SIG Network PRs](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+is%3Aopen+label%3Asig%2Fnetwork)
+* [SIG Network Issues](https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3Asig%2Fnetwork)
 
 ## Documents
 


### PR DESCRIPTION
Fix for #2696 

FILE: ./sig-network/README.md
[✖] https://raw.githubusercontent.com/kubernetes/pkg/kubernetes/master/controller/endpoint/OWNERS → Status: 404
[✖] https://raw.githubusercontent.com/kubernetes/pkg/kubernetes/master/controller/service/OWNERS → Status: 404
[✖] https://github.com/issues?utf8=%E2%9C%93&q=team%3Akubernetes%2Fsig-network+is%3Aopen+is%3Apr+ → Status: 404
[✖] https://github.com/issues?utf8=%E2%9C%93&q=team%3A%22kubernetes%2Fsig-network%22+is%3Aopen+is%3Aissue → Status: 404

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->