### PR TITLE
Fix yaml formatting in kep 31 metadata

### DIFF
--- a/keps/sig-cluster-lifecycle/0031-20181022-etcdadm.md
+++ b/keps/sig-cluster-lifecycle/0031-20181022-etcdadm.md
@@ -7,11 +7,11 @@ owning-sig: sig-cluster-lifecycle
 #participating-sigs:
 #- sig-apimachinery
 reviewers:
-  - @roberthbailey
-  - @timothysc
+  - "@roberthbailey"
+  - "@timothysc"
 approvers:
-  - @roberthbailey
-  - @timothysc
+  - "@roberthbailey"
+  - "@timothysc"
 editor: TBD
 creation-date: 2018-10-22
 last-updated: 2018-10-22


### PR DESCRIPTION
This resolved an issue with the frontmatter header for kep-31 failing to render as metadata  for both github and hugo (contributor site).  This is due to the `@` symbol being a reserved [yaml indicator](http://yaml.org/refcard.html) and must be quoted when it is used as the leading character in a string. 

/cc @castrojo 