### PR TITLE
Brokenlinks for #2696

### DIFF
--- a/keps/sig-cloud-provider/providers/0004-cloud-provider-template.md
+++ b/keps/sig-cloud-provider/providers/0004-cloud-provider-template.md
@@ -69,7 +69,7 @@ There must be a reasonable amount of user feedback about running Kubernetes for 
 
 ### Testgrid Integration
 
-Your cloud provider is reporting conformance test results to TestGrid as per the [Reporting Conformance Test Results to Testgrid KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0003-testgrid-conformance-e2e.md).
+Your cloud provider is reporting conformance test results to TestGrid as per the [Reporting Conformance Test Results to Testgrid KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0018-testgrid-conformance-e2e.md).
 
 ### CNCF Certified Kubernetes
 
@@ -77,7 +77,7 @@ Your cloud provider is accepted as part of the [Certified Kubernetes Conformance
 
 ### Documentation
 
-There is documentation on running Kubernetes on your cloud provider as per the [cloud provider documentation KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0004-cloud-provider-documentation.md).
+There is documentation on running Kubernetes on your cloud provider as per the [cloud provider documentation KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0019-cloud-provider-documentation.md).
 
 ### Technical Leads are members of the Kubernetes Organization
 

--- a/keps/sig-cloud-provider/providers/0020-cloud-provider-alibaba-cloud.md
+++ b/keps/sig-cloud-provider/providers/0020-cloud-provider-alibaba-cloud.md
@@ -74,7 +74,7 @@ As a CNCF Platinum member, Alibaba Cloud is dedicated in providing users with hi
 Usage of aliyun container services can be seen from github issues in the existing alicloud controller manager repo: https://github.com/AliyunContainerService/alicloud-controller-manager/issues
 
 ### Testgrid Integration
- Alibaba cloud provider is reporting conformance test results to TestGrid as per the [Reporting Conformance Test Results to Testgrid KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0003-testgrid-conformance-e2e.md).
+ Alibaba cloud provider is reporting conformance test results to TestGrid as per the [Reporting Conformance Test Results to Testgrid KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0018-testgrid-conformance-e2e.md).
  See [report](https://k8s-testgrid.appspot.com/conformance-alibaba-cloud-provider#Alibaba%20Cloud%20Provider,%20v1.10) for more details.
 
 ### CNCF Certified Kubernetes

--- a/sig-cluster-lifecycle/charter.md
+++ b/sig-cluster-lifecycle/charter.md
@@ -34,7 +34,7 @@ The following topics fall under ownership of this SIG:
 - User interface, or user experience, issues other than cluster bootstrapping or management (see [sig-ui](../sig-ui) and  [sig-cli](../sig-cli)).
 - Node related issues (see [sig-node](../sig-node)).
 - Kubernetes control plane issues:
-   - Control plane component related issues (see [sig-apimachinery](../sig-apimachinery)).
+   - Control plane component related issues (see [sig-api-machinery](../sig-api-machinery)).
 
 ## Roles and Organization Management
 

--- a/sig-docs/migrated-from-wiki/roadmap-docs.md
+++ b/sig-docs/migrated-from-wiki/roadmap-docs.md
@@ -2,7 +2,7 @@
 
 If you'd like to help with documentation, please read the [kubernetes.io site instructions](https://git.k8s.io/kubernetes.github.io/README.md).
 
-If you'd like to contribute an example, please read the [guidelines](https://git.k8s.io/kubernetes/examples/guidelines.md).
+If you'd like to contribute an example, please read the [guidelines](https://git.k8s.io/examples/guidelines.md).
 
 Owners: @kubernetes/docs, @kubernetes/examples
 

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -35,8 +35,8 @@ The following subprojects are owned by sig-network:
 - **services**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/pkg/kubernetes/master/controller/endpoint/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/pkg/kubernetes/master/controller/service/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
 - **kube-dns**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
@@ -83,8 +83,8 @@ SIG Network is responsible for the following Kubernetes subsystems:
 
 SIG Network is responsible for a number of issues and PRs. A summary can be found through GitHub search:
 
-* [SIG Network PRs](https://github.com/issues?utf8=%E2%9C%93&q=team%3Akubernetes%2Fsig-network+is%3Aopen+is%3Apr+)
-* [SIG Network Issues](https://github.com/issues?utf8=%E2%9C%93&q=team%3A%22kubernetes%2Fsig-network%22+is%3Aopen+is%3Aissue)
+* [SIG Network PRs](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+is%3Aopen+label%3Asig%2Fnetwork)
+* [SIG Network Issues](https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3Asig%2Fnetwork)
 
 ## Documents
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1323,8 +1323,8 @@ sigs:
     - name: services
       owners:
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
-      - https://raw.githubusercontent.com/kubernetes/pkg/kubernetes/master/controller/endpoint/OWNERS
-      - https://raw.githubusercontent.com/kubernetes/pkg/kubernetes/master/controller/service/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
     - name: kube-dns
       owners:
       - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS


### PR DESCRIPTION
Fix for #2696 

FILE: ./keps/sig-cloud-provider/providers/0020-cloud-provider-alibaba-cloud.md

[✖] https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0003-testgrid-conformance-e2e.md
→ Status: 404

FILE: ./keps/sig-cloud-provider/providers/0004-cloud-provider-template.md
[✖] https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0003-testgrid-conformance-e2e.md
→ Status: 404
[✖] https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0004-cloud-provider-documentation.md
→ Status: 404

FILE: ./sig-docs/migrated-from-wiki/roadmap-docs.md
[✖] https://git.k8s.io/kubernetes/examples/guidelines.md → Status: 404

FILE: ./sig-cluster-lifecycle/charter.md
[✖] ../sig-apimachinery → Status: 400 Error: ENOENT: no such file or
directory, access
'/home/jorge/src/kubernetes/community/sig-apimachinery'