### PR TITLE
Add subproject info for k-sigs/website-metadata

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -41,6 +41,9 @@ The following subprojects are owned by sig-docs:
 - **website**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
+- **website-metadata**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/website-metadata/master/OWNERS
 
 ## GitHub Teams
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1072,6 +1072,9 @@ sigs:
     - name: website
       owners:
       - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
+    - name: website-metadata
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-sigs/website-metadata/master/OWNERS
   - name: GCP
     dir: sig-gcp
     mission_statement: >


### PR DESCRIPTION
This PR updates `sigs.yaml` with information for a new SIG Docs subproject repo: website-metadata.

This PR depends on the repository's creation.

/ref https://github.com/kubernetes/org/issues/248#issuecomment-440434544

/sig docs
/area github-repo
/assign @cblecker 
/cc @chenopis @Bradamant3 @hanjiayao @markthink @fleeto
