### PR TITLE
Provide a charter for SIG Big Data

### DIFF
--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -45,12 +45,7 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-big-data-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-big-data-test-failures) | Test Failures and Triage |
 
 <!-- BEGIN CUSTOM CONTENT -->
-## Goals
-* Design and architect ways to run big data applications effectively on Kubernetes
-* Discuss ongoing implementation efforts
-* Discuss resource sharing and multi-tenancy (in the context of big data applications)
-* Suggest Kubernetes features where we see a need
 
-## Non-goals
-* Endorsing any particular tool/framework
+SIG Big Data [Charter](charter.md)
+
 <!-- END CUSTOM CONTENT -->

--- a/sig-big-data/README.md
+++ b/sig-big-data/README.md
@@ -8,7 +8,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Big Data Special Interest Group
 
-Covers deploying and operating big data applications (Spark, Kafka, Hadoop, Flink, Storm, etc) on Kubernetes. We focus on integrations with big data applications and architecting the best ways to run them on Kubernetes.
+Serve as a community resource for advising big data and data science related software projects on techniques and best practices for integrating with Kubernetes. Represents the concerns of users from big data communities to Kubernetes for the purposes of driving new features and other enhancements, based on big data use cases.    
 
 ## Meetings
 * Regular SIG Meeting: [Wednesdays at 17:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC).

--- a/sig-big-data/charter.md
+++ b/sig-big-data/charter.md
@@ -24,7 +24,8 @@ The Big Data SIG serves as a community resource for advising big data and data s
 
 ### Out of scope
 
-Software and tooling communities that have no intersection with data science or big data.
+- Promoting or otherwise advocating for any specfic big data project
+- Software and tooling communities that have no intersection with data science or big data.
 
 ## Roles and Organization Management
 

--- a/sig-big-data/charter.md
+++ b/sig-big-data/charter.md
@@ -1,0 +1,55 @@
+# SIG Big Data Charter
+
+This charter adheres to the conventions described in the [Kubernetes Charter README] and uses
+the Roles and Organization Management outlined in [sig-governance].
+
+## Scope
+
+The Big Data SIG serves as a community resource for advising big data and data science related software projects on techniques and best practices for integrating with Kubernetes. This SIG also represents the concerns of users from big data communities to Kubernetes for the purposes of driving new features and other enhancements, based on big data use cases.
+
+### In scope
+
+#### Code, Binaries and Services
+
+- New features for supporting big data or data science use cases
+- CRDs and Operators for big data tooling
+- KEPs relating to either new features or new subprojects in support of big data
+
+#### Cross-cutting and Externally Facing Processes
+
+- Promoting best practices for Kubernetes integrations
+- Advising big data communities on Kubernetes features
+- Shepherding issues and pull requests from community members
+- Hosting demos and discussions of big data integrations for Kubernetes
+
+### Out of scope
+
+Software and tooling communities that have no intersection with data science or big data.
+
+## Roles and Organization Management
+
+This SIG adheres to the Roles and Organization Management outlined in [sig-governance]
+and opts-in to updates and modifications to [sig-governance].
+
+### Additional responsibilities of Chairs
+
+- Ensure that regular meetings have at least one SIG chair present, or that the meeting is canceled.
+- Record meeting minutes
+- Post teleconference recordings
+- Represent the SIG at events and community meetings wherever possible
+- Actively promote diversity and inclusion in the SIG
+- Uphold the Kubernetes Code of Conduct especially in terms of personal behavior and responsibility
+
+### Subproject Creation
+
+Any subprojects that are deemed necessary to promote big data or data science use cases are to
+be the responsibility of SIG Technical Leads, assembled for that purpose.
+
+### To Do
+
+- Whether or not to formalise a working definition of what conssitutes a big data or data science related project,
+and if so how to codify that definition, remains an open question.
+
+[sig-governance]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md
+[sig-subprojects]: https://github.com/kubernetes/community/blob/master/sig-YOURSIG/README.md#subprojects
+[Kubernetes Charter README]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md

--- a/sig-big-data/charter.md
+++ b/sig-big-data/charter.md
@@ -24,7 +24,7 @@ The Big Data SIG serves as a community resource for advising big data and data s
 
 ### Out of scope
 
-- Promoting or otherwise advocating for any specfic big data project
+- Promoting or otherwise advocating for any specific big data project
 - Software and tooling communities that have no intersection with data science or big data.
 
 ## Roles and Organization Management

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -576,9 +576,10 @@ sigs:
   - name: Big Data
     dir: sig-big-data
     mission_statement: >
-      Covers deploying and operating big data applications (Spark, Kafka,
-      Hadoop, Flink, Storm, etc) on Kubernetes. We focus on integrations with
-      big data applications and architecting the best ways to run them on Kubernetes.
+      Serve as a community resource for advising big data and data science related software projects
+      on techniques and best practices for integrating with Kubernetes.
+      Represents the concerns of users from big data communities to Kubernetes for the purposes of
+      driving new features and other enhancements, based on big data use cases.    
     charter_link:
     label: big-data
     leadership:


### PR DESCRIPTION
Adds a `charter.md` for the `sig-big-data` directory, and makes corresponding adjustments to `sigs.yaml` and the SIG readme.