### PR TITLE
Link to CoCC from our CoC page

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,6 @@
 # Kubernetes Community Code of Conduct
 
 Kubernetes follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
+the [Kubernetes Code of Conduct Committee](./committee-code-of-conduct) via <conduct@kubernetes.io>.


### PR DESCRIPTION
Make it easier to find out who to contact quickly, without following a bunch of links.
