### PR TITLE
Change devel guide glog references to klog

### DIFF
--- a/contributors/devel/logging.md
+++ b/contributors/devel/logging.md
@@ -1,31 +1,31 @@
 ## Logging Conventions
 
-The following conventions for the glog levels to use.
-[glog](http://godoc.org/github.com/golang/glog) is globally preferred to
+The following conventions for the klog levels to use.
+[klog](http://godoc.org/github.com/kubernetes/klog) is globally preferred to
 [log](http://golang.org/pkg/log/) for better runtime control.
 
-* glog.Errorf() - Always an error
+* klog.Errorf() - Always an error
 
-* glog.Warningf() - Something unexpected, but probably not an error
+* klog.Warningf() - Something unexpected, but probably not an error
 
-* glog.Infof() has multiple levels:
-  * glog.V(0) - Generally useful for this to ALWAYS be visible to an operator
+* klog.Infof() has multiple levels:
+  * klog.V(0) - Generally useful for this to ALWAYS be visible to an operator
     * Programmer errors
     * Logging extra info about a panic
     * CLI argument handling
-  * glog.V(1) - A reasonable default log level if you don't want verbosity.
+  * klog.V(1) - A reasonable default log level if you don't want verbosity.
     * Information about config (listening on X, watching Y)
     * Errors that repeat frequently that relate to conditions that can be corrected (pod detected as unhealthy)
-  * glog.V(2) - Useful steady state information about the service and important log messages that may correlate to significant changes in the system.  This is the recommended default log level for most systems.
+  * klog.V(2) - Useful steady state information about the service and important log messages that may correlate to significant changes in the system.  This is the recommended default log level for most systems.
     * Logging HTTP requests and their exit code
     * System state changing (killing pod)
     * Controller state change events (starting pods)
     * Scheduler log messages
-  * glog.V(3) - Extended information about changes
+  * klog.V(3) - Extended information about changes
     * More info about system state changes
-  * glog.V(4) - Debug level verbosity
+  * klog.V(4) - Debug level verbosity
     * Logging in particularly thorny parts of code where you may want to come back later and check it
-  * glog.V(5) - Trace level verbosity
+  * klog.V(5) - Trace level verbosity
     * Context to understand the steps leading up to errors and warnings
     * More information for troubleshooting reported issues
 


### PR DESCRIPTION
Following the move from `glog` to `klog` in https://github.com/kubernetes/kubernetes/pull/70889 this updates the devel logging docs to reference `klog` over `glog`.

Signed-off-by: Christopher Hein <me@christopherhein.com>

/cc @dims 