### PR TITLE
[apimachinery] Delegate Subproject Responsibility

### DIFF
--- a/sig-api-machinery/charter.md
+++ b/sig-api-machinery/charter.md
@@ -51,7 +51,9 @@ N/A
 
 ### Deviations from [sig-governance]
 
-N/A
+#### Subproject Governance
+
+SIG delegates responsibilities related to any individual subproject, such as repository creation and maintenance for that subproject, to the leads of the given subproject.
 
 ### Subproject Creation
 


### PR DESCRIPTION
This delegates SIG API Machinery responsibilities that are scoped to individual
subprojects (such as approval of subproject repository creation)
to subproject leads.