### PR TITLE
Fixes some link in sig-cli

### DIFF
--- a/sig-cli/CONTRIBUTING.md
+++ b/sig-cli/CONTRIBUTING.md
@@ -400,7 +400,7 @@ See the sig-cli [community page] for points of contact and meeting times:
 [`PTAL`]: https://en.wiktionary.org/wiki/PTAL
 [agenda]: https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit
 [bug]: #bug-lifecycle
-[communication]:  /sig-cli#contact
+[communication]:  /sig-cli/README.md#contact
 [community page]: /sig-cli
 [design proposal]: #design-proposals
 [design repo]: /contributors/design-proposals/cli
@@ -415,9 +415,9 @@ See the sig-cli [community page] for points of contact and meeting times:
 [kubectl docs]: https://kubernetes.io/docs/tutorials/object-management-kubectl/object-management/
 [kubernetes/cmd/kubectl]: https://git.k8s.io/kubernetes/cmd/kubectl
 [kubernetes/pkg/kubectl]: https://git.k8s.io/kubernetes/pkg/kubectl
-[leads]: /sig-cli#leads
+[leads]: /sig-cli/README.md#leadership
 [management overview]: https://kubernetes.io/docs/concepts/tools/kubectl/object-management-overview
-[meeting]: /sig-cli#meetings
+[meeting]: /sig-cli/README.md#meetings
 [release]: #release
 [slack-messages]: https://kubernetes.slack.com/messages/sig-cli
 [slack-signup]: http://slack.k8s.io/

--- a/sig-cli/charter.md
+++ b/sig-cli/charter.md
@@ -42,7 +42,7 @@ and opts-in to updates and modifications to [sig-governance].
 
 ### Subproject Creation
 
-Option 1: by [SIG Technical Leads](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md#L100)
+Option 1: by [SIG Technical Leads](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md#tech-lead)
 
 
 [Kubernetes Charter README]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Fixes some link in sig-cli

* On a smartphone, link with the anchor directly to [/sig-cli](https://github.com/kubernetes/community/tree/master/sig-cli)  it doesn't work, so I add README.md before the anchor
* Link to header instead of line number on `SIG Technical Leads` link