### PR TITLE
Fix typo in instrumentation.md: "into" -> "in"

### DIFF
--- a/contributors/devel/instrumentation.md
+++ b/contributors/devel/instrumentation.md
@@ -134,7 +134,7 @@ constantly create new ones, with new names. However, they have
 a reasonable upper bound for a given size of infrastructure they refer to and
 its typical frequency of changes.
 
-In general, “external” labels like pod or node name do not belong into the
+In general, “external” labels like pod or node name do not belong in the
 instrumentation itself. They are to be attached to metrics by the collecting
 system that has the external knowledge ([blog post](https://www.robustperception.io/target-labels-are-for-life-not-just-for-christmas/)).
 


### PR DESCRIPTION
Fix a little typo.