### PR TITLE
Adjust subprojects for sig-testing, sig-release

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -42,10 +42,17 @@ The following subprojects are owned by sig-release:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/debian-hyperkube-base/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/hyperkube/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/hyperkube/OWNERS
-- **release**
+- **release-team**
+  - Description: The Kubernetes Release Team is responsible for the day to day work required to successfully create releases of Kubernetes.
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/release-team/master/OWNERS
+- **publishing-bot**
+  - Description: The publishing-bot publishes the contents of staging repos that live in k8s.io/kubernetes/staging to their own repositories in kubernetes
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
 - **sig-release**
+  - Description: Documents and processes related to SIG Release
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
 

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -46,7 +46,7 @@ The following subprojects are owned by sig-release:
   - Description: The Kubernetes Release Team is responsible for the day to day work required to successfully create releases of Kubernetes.
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/release-team/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
 - **publishing-bot**
   - Description: The publishing-bot publishes the contents of staging repos that live in k8s.io/kubernetes/staging to their own repositories in kubernetes
   - Owners:

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -33,13 +33,26 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following subprojects are owned by sig-testing:
+- **boskos**
+  - Description: Boskos is a resource manager service that handles different kinds of resources and transitions between different states. We use it on the Kubernetes project to manage pools of GCP projects for CI/CD.
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
+- **gopherage**
+  - Description: Gopherage is a tool for manipulating Go coverage files. We use it on the Kubernetes project to report on code coverage due to e2e tests
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/gubernator/OWNERS
+- **gubernator**
+  - Description: Gubernator is a frontend for displaying Kubernetes test results stored in GCS. See gubernator.k8s.io to see it in action for the Kubernetes  project.
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/gubernator/OWNERS
 - **kind**
   - Description: Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
-- **repo-publishing**
+- **prow**
+  - Description: Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
 - **testing-commons**
   - Description: The Testing Commons is a subproject within the Kubernetes sig-testing community interested code structure, layout, and execution of common test code used throughout the kubernetes project
   - Owners:
@@ -49,6 +62,7 @@ The following subprojects are owned by sig-testing:
     - Testing Commons: [Wednesdays at 07:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:30&tz=PT%20%28Pacific%20Time%29).
       - [Meeting notes and Agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit#heading=h.tnoevy5f439o).
 - **test-infra**
+  - Description: Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/OWNERS
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1571,10 +1571,22 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/debian-hyperkube-base/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/hyperkube/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/hyperkube/OWNERS
-    - name: release
+    - name: release-team
+      description: >
+        The Kubernetes Release Team is responsible for the day to day work
+        required to successfully create releases of Kubernetes.
       owners:
       - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/release-team/master/OWNERS
+    - name: publishing-bot
+      description: >
+        The publishing-bot publishes the contents of staging repos that live
+        in k8s.io/kubernetes/staging to their own repositories in kubernetes
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
     - name: sig-release
+      description: >
+        Documents and processes related to SIG Release
       owners:
       - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
   - name: Scalability
@@ -1903,15 +1915,38 @@ sigs:
       - name: sig-testing-pr-reviews
         description: PR Reviews
     subprojects:
+    - name: boskos
+      description: >
+        Boskos is a resource manager service that handles different kinds of
+        resources and transitions between different states. We use it on the
+        Kubernetes project to manage pools of GCP projects for CI/CD.
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
+    - name: gopherage
+      description: >
+        Gopherage is a tool for manipulating Go coverage files. We use it on
+        the Kubernetes project to report on code coverage due to e2e tests
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/test-infra/master/gubernator/OWNERS
+    - name: gubernator
+      description: >
+        Gubernator is a frontend for displaying Kubernetes test results stored
+        in GCS. See gubernator.k8s.io to see it in action for the Kubernetes 
+        project.
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/test-infra/master/gubernator/OWNERS
     - name: kind
       description: >
         Kubernetes IN Docker. Run Kubernetes test clusters on your local
         machine using Docker containers as nodes.
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
-    - name: repo-publishing
+    - name: prow
+      description: >
+        Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it
+        in action for the Kubernetes project
       owners:
-      - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
     - name: testing-commons
       description: >
         The Testing Commons is a subproject within the Kubernetes sig-testing community
@@ -1929,6 +1964,9 @@ sigs:
         url: https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit
         archive_url: https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit#heading=h.tnoevy5f439o
     - name: test-infra
+      description: >
+        Miscellaneous tools and configuration to run the testing infrastructure
+        for the Kubernetes project
       owners:
       - https://raw.githubusercontent.com/kubernetes/test-infra/master/OWNERS
   - name: UI

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1577,7 +1577,7 @@ sigs:
         required to successfully create releases of Kubernetes.
       owners:
       - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
-      - https://raw.githubusercontent.com/kubernetes/release-team/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
     - name: publishing-bot
       description: >
         The publishing-bot publishes the contents of staging repos that live


### PR DESCRIPTION
Specifically

- add boksos, gopherage, gubernator and prow to
  sig-testing
- move sig-testing's "repo-publishing" to sig-release
  as "publishing-bot"
- rename sig-release's "release" to "release-team" and
  add the release-team/OWNERS to owners
- add descriptions to sig-release subprojects

I did the SIG Release stuff while I was there, I can punt that if it's
too scope creepy. Main thing was I looked back and publishing-bot was
added in by someone from API Machinery. Neither of the people listed as
approvers for that codebase have ever attended SIG Testing. It seems
more like up SIG Release's alley than having anything to do with
Testing.

I chose the SIG Testing subprojects based on those= which seemed like they
could conceivably be extracted into their own repos if we someday wanted to.

There are others which I might want to group together and I didn't feel
like getting mired in that right now (ie: project config sorta spans
config, jobs, testgrid; github automation spans robots, maintenance,
some prow/cmd subdirs, etc.)

/kind cleanup