### PR TITLE
Add tech_leads for sig-auth

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,9 @@ aliases:
     - mikedanese
     - enj
     - tallclair
+    - deads2k
+    - liggitt
+    - mikedanese
   sig-autoscaling-leads:
     - mwielgus
     - directxman12

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -28,12 +28,18 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Mo Khan (**[@enj](https://github.com/enj)**), Red Hat
 * Tim Allclair (**[@tallclair](https://github.com/tallclair)**), Google
 
+### Technical Leads
+The Technical Leads of the SIG establish new subprojects, decommission existing
+subprojects, and resolve cross-subproject technical issues and decisions.
+
+* David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
+* Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**), Google
+* Mike Danese (**[@mikedanese](https://github.com/mikedanese)**), Google
+
 ## Emeritus Leads
 
 * Eric Chiang (**[@ericchiang](https://github.com/ericchiang)**), Red Hat
 * Eric Tune (**[@erictune](https://github.com/erictune)**), Google
-* David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
-* Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**), Google
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/sig-auth)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -294,18 +294,22 @@ sigs:
       - name: Tim Allclair
         github: tallclair
         company: Google
+      tech_leads:
+      - name: David Eads
+        github: deads2k
+        company: Red Hat
+      - name: Jordan Liggitt
+        github: liggitt
+        company: Google
+      - name: Mike Danese
+        github: mikedanese
+        company: Google
       emeritus_leads:
       - name: Eric Chiang
         github: ericchiang
         company: Red Hat
       - name: Eric Tune
         github: erictune
-        company: Google
-      - name: David Eads
-        github: deads2k
-        company: Red Hat
-      - name: Jordan Liggitt
-        github: liggitt
         company: Google
     meetings:
     - description: Regular SIG Meeting


### PR DESCRIPTION
Seeding sig-auth tech leads following methodology discussed in https://groups.google.com/d/msg/kubernetes-sig-auth/v0-Awf0rBOg/Dk3SipCTAQAJ

Subproject approvers for more than one sig-auth subproject:
- @liggitt (6 subprojects)
- @deads2k (5 subprojects)
- @mikedanese (5 subprojects)
- @tallclair (3 subprojects)
- @smarterclayton (2 subprojects)

Will announce the proposal in the sig-auth meeting today, and in the [mailing list thread](https://groups.google.com/d/msg/kubernetes-sig-auth/v0-Awf0rBOg/Dk3SipCTAQAJ), and leave open for comment.

/assign @mikedanese @tallclair @enj 