### PR TITLE
Update SIG Storage with info around csi-translation-lib

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -53,9 +53,10 @@ The following subprojects are owned by sig-storage:
     - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/kubernetes-csi-migration-library/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/csi-translation-lib/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-translation-lib/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/node-driver-registrar/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-utils/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1857,9 +1857,10 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/OWNERS
-      - https://raw.githubusercontent.com/kubernetes-csi/kubernetes-csi-migration-library/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/csi-translation-lib/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-translation-lib/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/node-driver-registrar/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-utils/master/OWNERS


### PR DESCRIPTION
Add staging repo: staging/src/k8s.io/csi-translation-lib
Remove repo kubernetes-csi/kubernetes-csi-migration-library which will be superseded by new staging repo: staging/src/k8s.io/csi-translation-lib

Related to https://github.com/kubernetes/org/issues/321#issuecomment-452837675
Depends on https://github.com/kubernetes/kubernetes/pull/72770 where above repo is populated.

/cc @msau42 @davidz627 @leakingtapan 