### PR TITLE
Deleting stub file that is more than one year old

### DIFF
--- a/contributors/devel/adding-an-APIGroup.md
+++ b/contributors/devel/adding-an-APIGroup.md
@@ -1,4 +1,0 @@
-Adding an API Group
-===============
-
-Please refer to [api_changes.md](api_changes.md#making-a-new-api-group).


### PR DESCRIPTION
The file adding-an-APIGroup.md is a stub file with more than 90 days.

/sig contributor-experience
/kind feature

/assign @cblecker @lavalamp 

/cc @parispittman @nikhita 