### PR TITLE
Updating ways to deploy to include EKS and eksctl

### DIFF
--- a/sig-aws/kubernetes-on-aws.md
+++ b/sig-aws/kubernetes-on-aws.md
@@ -3,8 +3,10 @@ Kubernetes on Amazon Web Services
 
 This page lists different options, in alphabetic order, of starting a Kubernetes cluster on Amazon Web Services.
 
+* Amazon Elastic Container Service for Kubernetes: https://aws.amazon.com/eks/
 * Clocker: http://www.clocker.io/tutorials/kubernetes-cluster.html
-* Heptio: https://github.com/aws-quickstart/quickstart-heptio 
+* Eksctl: http://eksctl.io
+* Heptio: https://github.com/aws-quickstart/quickstart-heptio
 * Juju Charms: https://jujucharms.com/canonical-kubernetes/
 * KAT - Kubernetes cluster on AWS with Terraform: https://github.com/xuwang/kube-aws-terraform
 * Kargo: https://github.com/kubernetes-incubator/kargo


### PR DESCRIPTION
There are probable more documented ways to deploy k8s on AWS as this point, but this PR adds eks and eksctl.

Signed-off-by: Christopher Hein <me@christopherhein.com>