### PR TITLE
devel: add area/developer-guide label

### DIFF
--- a/contributors/devel/OWNERS
+++ b/contributors/devel/OWNERS
@@ -14,3 +14,5 @@ approvers:
   - Phillels
   - spiffxp
   - thockin
+labels:
+  - area/developer-guide


### PR DESCRIPTION
This PR adds the `area/developer-guide` label to the OWNERS file in `devel`, so that the label is automatically applied for PRs targeting it. This will help in triaging @eduartua's work in that area as well.

/hold
https://github.com/kubernetes/test-infra/pull/10876 will actually create that label. Hold until it is merged.