### PR TITLE
Deleting outdated stub file

### DIFF
--- a/contributors/devel/how-to-doc.md
+++ b/contributors/devel/how-to-doc.md
@@ -1,5 +1,0 @@
-# Document Conventions
-
-Updated: 11/3/2017
-
-*Users and developers who want to write documents for Kubernetes can get started [here](https://github.com/kubernetes/website).*


### PR DESCRIPTION
Ref. #3064 

how-to-doc.md is a file in /devel that is outdated. Links in other files fixed.

/sig contributor-experience
/cc @parispittman @nikhita 

/assign @cblecker @idvoretskyi 

/area developer-guide
/kind cleanup