### PR TITLE
Adds the [LinuxOnly] tag

### DIFF
--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -574,6 +574,11 @@ test suite for [Conformance Testing](conformance-tests.md). This test must
 meet a number of [requirements](conformance-tests.md#conformance-test-requirements)
 to be eligible for this tag. This tag does not supersed any other labels.
 
+  - `[LinuxOnly]`: If a test is known to be using Linux-specific features 
+(e.g.: seLinuxOptions) or is unable to run on Windows nodes, it is labeled
+`[LinuxOnly]`. When using Windows nodes, this tag should be added to the
+`skip` argument.
+
   - The following tags are not considered to be exhaustively applied, but are
 intended to further categorize existing `[Conformance]` tests, or tests that are
 being considered as candidate for promotion to `[Conformance]` as we work to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

If a test is known to be using Linux-specific features
(e.g.: seLinuxOptions) or is unable to run on Windows nodes, it is labeled
`[LinuxOnly]`. When using Windows nodes, this tag should be added to the
`skip` argument.

This tag was proposed during [1][2].

Depends-On: https://github.com/kubernetes/kubernetes/pull/73204
Related Issue: https://github.com/kubernetes/kubernetes/issues/69871

[1] https://groups.google.com/forum/#!topic/kubernetes-sig-testing/ii5584-Tkqk
[2] https://docs.google.com/document/d/1z8MQpr_jTwhmjLMUaqQyBk1EYG_Y_3D4y4YdMJ7V1Kk/edit#heading=h.ukbaidczvy3r
