### PR TITLE
Add nikhita to github admins team, adjust OWNERS

### DIFF
--- a/github-management/OWNERS
+++ b/github-management/OWNERS
@@ -1,13 +1,17 @@
-reviewers:
-  - calebamiles
-  - cblecker
-  - fejta
-  - grodrigues3
-  - idvoretskyi
-  - spiffxp
+# See the OWNERS docs at https://go.k8s.io/owners
+
 approvers:
   - cblecker
-  - grodrigues3
+  - spiffxp
+
+reviewers:
+  - calebamiles
+  - fejta
+  - idvoretskyi
+  - justaugustus
+  - mrbobbytables
+  - nikhita
+
 labels:
   - sig/contributor-experience
   - area/github-management

--- a/github-management/README.md
+++ b/github-management/README.md
@@ -31,13 +31,13 @@ This team (**[@kubernetes/owners](https://github.com/orgs/kubernetes/teams/owner
 * Caleb Miles (**[@calebamiles](https://github.com/calebamiles)**, US Pacific)
 * Christoph Blecker (**[@cblecker](https://github.com/cblecker)**, CA Pacific)
 * Erick Fejta (**[@fejta](https://github.com/fejta)**, US Pacific)
-* Garrett Rodrigues (**[@grodrigues3](https://github.com/grodrigues3)**, US Pacific)
+* Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**, Indian Standard Time)
 * Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**, UA Eastern European)
 
 This team is responsible for holding Org Owner privileges over all the active
 Kubernetes orgs, and will take action in accordance with our polices and
 procedures. All members of this team are subject to the Kubernetes
-[security embargo policy](https://git.k8s.io/sig-release/security-release-process-documentation/security-release-process.md#embargo-policy).
+[security embargo policy].
 
 Nominations to this team will come from the Contributor Experience SIG, and
 require confirmation by the Steering Committee before taking effect. Time zones
@@ -110,3 +110,5 @@ repositories and organizations:
 - [label_sync](https://git.k8s.io/test-infra/label_sync): Add, modify, delete,
   and migrate labels across an entire organization based on a defined YAML
   configuration
+
+[security embargo policy]: https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/private-distributors-list.md#embargo-policy


### PR DESCRIPTION
[kubernetes-sig-contributor-experience@ thread](https://groups.google.com/d/msg/kubernetes-sig-contribex/Oin3mGNRwNg/2gDnVdqFFAAJ) for the nomination

grodrigues3 has graciously agreed to step down for nikhita on the github admin team

I also adjusted OWNERS such that:
- I am subproject owner in lieu of grodrigues 
- the membership team are also listed as reviewers here

/hold
/committee steering
need steering signoff for the membership change
/assign @nikhita 
can you confirm you're interested in this, and accept the security embargo policy?

the OWNERS shuffle was a guess, am I doing it right?