### PR TITLE
Add mailing-list guidelines

### DIFF
--- a/communication/mailing-list-guidelines.md
+++ b/communication/mailing-list-guidelines.md
@@ -1,0 +1,201 @@
+# Mailing list guidelines
+
+The Kubernetes Mailing list or Google Groups functions as the primary means of
+asynchronous communication for the project's
+[Special Interest Groups (SIG)][sig-list] and [Working Groups (WG)][sig-list].
+
+### ATTENTION: SIG/WG Mailing list owners
+
+If you are currently a moderator of a SIG or WG Mailing List. See the new policy
+requirements here:
+
+- [Mailing list annual review](#annual-permissions-review)
+- [Mailing list moderation queue](#new-user-posting-queue)
+  - [Creating moderation queue](#create-moderation-queue)
+
+
+## Code of conduct
+
+The Kubernetes project adheres to the community [Code of Conduct] throughout all
+platforms and includes all communication mediums.
+
+## Admins
+
+Check the [centralized list of administrators][admins] for contact information.
+
+To connect: Reach out to one of the listed moderators,[Mailing list owners],
+the [sig contributor experience Mailing list] or the `#sig-contribex` slack
+channel.
+
+### Mailing list owners
+
+Mailing list owners should include the Chairs for your [SIG or WG][sig-list] and
+the below contacts:
+
+- parispittman[at]google.com
+- jorgec[at]vmware.com
+- ihor[at]cncf.io
+
+---
+
+## Moderation
+
+SIG and Working Group Mailing lists should have the [Mailing list owners] as
+co-owners to the list so that administrative functions can be managed centrally
+across the project.
+
+Moderation of the SIG/WG lists is up to that individual SIG/WG. The admins
+are there to help facilitate leadership changes, or various other administrative
+functions.
+
+Users who are violating the [Code of Conduct] or other negative activities
+(like spamming) should be moderated.
+- [Lock the thread immediately] so that people cannot reply to the thread.
+- [Delete the post].
+- In some cases you might need to ban a user from the group, follow
+  [these instructions] on how stop a member from being able to post to the group.
+  For more technical help on how to use Google Groups, check the [Groups Help]
+  page.
+
+
+### Moderator expectations and guidelines
+
+Moderators should adhere to the general Kubernetes project
+[moderation guidelines].
+
+
+#### New user posting queue
+
+New members who post to the Mailing list will automatically have their messages
+put in the [moderation queue]. Moderators of the list will receive a
+notification of their message and should process them accordingly.
+
+
+#### Annual permissions review
+
+SIG and WG Moderators must establish an annual review of their Mailing lists
+to ensure their Moderator list is current and includes [Mailing List owners].
+Many of the SIG and WG Mailing lists pre-date current communication policy and
+an annual review ensures ownership is up to date.
+
+This review does not need to occur at a specific recurring date and can be
+combined with other actions such as SIG/WG leadership changes or sub-project
+additions.
+
+
+---
+
+## Mailing list creation
+
+Create a Google Group at https://groups.google.com/forum/#!creategroup,
+following the below procedure:
+- Each SIG must have two discussion groups with the following settings.
+  - `kubernetes-sig-<foo>` (the discussion group):
+    - Anyone can view content.
+    - Anyone can join.
+    - Moderate messages from non-members of the group.
+    - Only members can view the list of members.
+  - `kubernetes-sig-<foo>-leads` (list for the leads, to be used with Zoom and
+    Calendars)
+    - Only members can view group content.
+    - Anyone can apply to join.
+    - Moderate messages from non-members of the group.
+    - Only members can view the list of members.
+- Groups should be created as e-mail lists with at least three owners and must
+  include the [Mailing list owners](#mailing-list-owners).
+-  To add the owners, visit the **Group Settings** (drop-down menu on the right
+   side), select **Direct Add Members** on the left side and add them via their
+   email address (with a suitable welcome message).
+- In **Members/All Members** select the [Mailing list owners] and assign them
+  to the **owner role**.
+- Set the following permissions to **Public**:
+  - **View topics**
+  - **Post**
+  - **Join the Group**
+- Create and share your _"meeting notes"_ Google doc with the following
+  permissions settings:
+  - **Can edit** for members of the newly created Mailing List.
+  - **Can comment** for `kubernetes-dev@googlegroups.com`
+  - **View only** for anyone with the link. **NOTE:** Depending on
+    employer organization policy, this may not be possible to configure. The
+    document should be copied over to an account without the restriction and 
+    include the owner reference at the top of the document.
+
+Familiarize yourself with the [moderation guidelines] for the project and create
+a [moderation queue]. Chairs should be cognizant that a new group will require
+an initial time investment moderation-wise as the group establishes itself.
+
+
+### Create moderation queue
+
+The moderation queue will direct all new user messages to the a moderation
+queue before being posted to the Mailing List.
+
+- From the Google Groups management page goto **Settings** -> **Moderation**.
+- Configure the following settings:
+  - **Post:**
+    - Owners of the Group
+    - Manager of the Group
+    - All Members of the Group
+  - **Post as the Group:**
+    - Owners of the Group
+    - Managers of the Group
+  - **Approve Members:**
+    - Managers of the Group
+  - **Lock Topics:**
+    - Owners of the Group
+    - Managers of the Group
+  - **Modify Members:** (should be Greyed out)
+    - Owners of the Group
+    - Managers of the Group
+  - **New Member Restrictions:**
+    - New member posts are moderated
+  - **Reject author notification:**
+    - Notify authors when moderators reject their posts -> **checked**
+    - Message:
+      ```
+      Since you're a new subscriber you're in a moderation queue, sorry for the inconvenience, a moderator will check your message shortly.
+      ```
+  - **Spam messages:**
+    - Send them to moderation queue and send notification to moderators.
+
+### Archive a mailing list
+
+To archive a mailing list, use the below procedure.
+
+- Send a final notice to the mailing list that it is closed. This notice should
+  include a brief description as to why and include links to any other relevant
+  information.
+- From the Google Groups management page goto **Information** ->
+  **General Information**.
+  - Configure the following settings:
+    - **Group description** -> Set to the same message used for the final 
+      mailing list notice.
+- From the Google Groups management page goto **Information** ->
+  **Content Control**.
+  - Configure the following settings:
+    - **Archive messages to the group** -> **checked**
+- From the Google Groups management page goto **Permissions** ->
+  **Basic permissions**.
+  - Configure the following settings:
+    - **View Topics:**
+      - Managers of the group
+      - All members of the group
+      - Anyone on the web
+    - **Post:** -> uncheck all options
+    - **Join the group:**
+      - Only invited users
+
+
+
+[mailing list owners]: #mailing-list-owners
+[moderation queue]: #create-moderation-queue
+[sig-list]: /sig-list.md
+[Code of Conduct]: /code-of-conduct.md
+[admins]: ./moderators.md#mailing-lists
+[sig contributor experience mailing list]: https://groups.google.com/forum/#!forum/kubernetes-sig-contribex
+[moderation guidelines]: ./moderation.md
+[lock the thread immediately]: https://support.google.com/groups/answer/2466386?hl=en#
+[delete the post]: https://support.google.com/groups/answer/1046523?hl=en
+[these instructions]: https://support.google.com/groups/answer/2646833?hl=en&ref_topic=2458761#
+[groups help]: https://support.google.com/groups/answer/2466386?hl=en&ref_topic=2458761

--- a/communication/moderation.md
+++ b/communication/moderation.md
@@ -1,81 +1,90 @@
 # Moderation on Kubernetes Communications Channels
 
-This page describes the rules and best practices for people chosen to moderate Kubernetes communications channels. 
-This includes, Slack and the mailing lists and _any communication tool_ used in an official manner by the project. 
+This page describes the rules and best practices for people chosen to moderate
+Kubernetes communications channels. This includes: Slack, the mailing lists
+and _any communication tool_ used in an official manner by the project.
 
-- Check the [centralized list of administrators](./moderators.md) for contact information.
+- Check the [centralized list of administrators] for contact information.
+
 
 ## Roles and Responsibilities
 
-As part of volunteering to become a moderator you are now representative of the Kubernetes community and it is your responsibility to remain aware of your contributions in this space. 
-These responsibilities apply to all Kubernetes official channels. 
+As part of volunteering to become a moderator you are now representative of the
+Kubernetes community and it is your responsibility to remain aware of your
+contributions in this space. These responsibilities apply to all Kubernetes
+official channels.
 
 Moderators _MUST_:   
 
 - Take action as specified by these Kubernetes Moderator Guidelines.
-  - You are empowered to take _immediate action_ when there is a violation. You do not need to wait for review or approval if an egregious violation has occurred. Make a judgement call based on our Code of Conduct and Values (see below). 
-  - Removing a bad actor or content from the medium is preferable to letting it sit there. 
+  - You are empowered to take _immediate action_ when there is a violation. You
+    do not need to wait for review or approval if an egregious violation has
+    occurred. Make a judgement call based on our Code of Conduct and Values
+    (see below).
+  - Removing a bad actor or content from the medium is preferable to letting it
+    sit there.
 - Abide by the documented tasks and actions required of moderators.
-- Ensure that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) is in effect on all official Kubernetes communication channels.
-- Become familiar with the [Kubernetes Community Values](https://github.com/kubernetes/steering/blob/master/values.md).
-- Take care of spam as soon as possible, which may mean taking action by removing a member from that resource.
-- Foster a safe and productive environment by being aware of potential multiple cultural differences between Kubernetes community members.
-- Understand that you might be contacted by moderators, community managers, and other users via private email or a direct message. 
+- Ensure that the Kubernetes [Code of Conduct] is in effect on all official
+  Kubernetes communication channels.
+- Become familiar with the [Kubernetes Community Values].
+- Take care of spam as soon as possible, which may mean taking action by
+  removing a member from that resource.
+- Foster a safe and productive environment by being aware of potential multiple
+  cultural differences between Kubernetes community members.
+- Understand that you might be contacted by moderators, community managers, and
+  other users via private email or a direct message.
 - Report violations of the Code of Conduct to <conduct@kubernetes.io>.
 
 Moderators _SHOULD_: 
 
-- Exercise compassion and empathy when communicating and collaborating with other community members.
-- Understand the difference between a user abusing the resource or just having difficulty expressing comments and questions in English.
+- Exercise compassion and empathy when communicating and collaborating with
+  other community members.
+- Understand the difference between a user abusing the resource or just having
+  difficulty expressing comments and questions in English.
 - Be an example and role model to others in the community.
-- Remember to check and recognize if you need take a break when you become frustrated or find yourself in a heated debate.
-- Help your colleagues if you recognize them in one of the [stages of burnout](https://opensource.com/business/15/12/avoid-burnout-live-happy).
-- Be helpful and have fun! 
+- Remember to check and recognize if you need take a break when you become
+  frustrated or find yourself in a heated debate.
+- Help your colleagues if you recognize them in one of the [stages of burnout].
+- Be helpful and have fun!
+
 
 ## Violations
 
-The Kubernetes [Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) will have the final authority regarding escalated moderation matters.  Violations of the Code of Conduct will be handled on a case by case basis. Depending on severity this can range up to and including removal of the person from the community, though this is extremely rare.
+The Kubernetes [Code of Conduct Committee] will have the final authority
+regarding escalated moderation matters. Violations of the Code of Conduct will
+be handled on a case by case basis. Depending on severity this can range up to
+and including removal of the person from the community, though this is
+extremely rare.
+
 
 ## Specific Guidelines
 
-These guidelines are for tool-specific policies that don't fit under a general umbrella. 
+These guidelines are for tool-specific policies that don't fit under a general
+umbrella.
 
-### Mailing Lists
+### Discuss guidelines
 
-### Moderating a SIG/WG list
+- [Discuss guidelines](./discuss-guidelines.md)
 
-- SIG and Working Group mailing list should have parispittman@google.com and jorgec@vmware.com as a coowner so that administrative functions can be managed centrally across the project.
-  - Moderation of the SIG/WG lists is up to that individual SIG/WG, these admins are there to help facilitate leadership changes, reset lost passwords, etc. 
+### Mailing list guidelines
 
-- Users who are violating the Code of Conduct or other negative activities (like spamming) should be moderated.
-  - [Lock the thread immediately](https://support.google.com/groups/answer/2466386?hl=en#) so that people cannot reply to the thread.
-  - [Delete the post](https://support.google.com/groups/answer/1046523?hl=en) - 
-  - In some cases you might need to ban a user from the group, follow [these instructions](https://support.google.com/groups/answer/2646833?hl=en&ref_topic=2458761#) on how stop a member from being able to post to the group. 
-
-For more technical help on how to use Google Groups, check the [Groups Help](https://support.google.com/groups/answer/2466386?hl=en&ref_topic=2458761) page.
-
-### New users posting to a SIG/WG list
-New members who post to a group will automatically have their messages put in a queue and be sent the following message automatically: "Since you're a new subscriber you're in a moderation queue, sorry for the inconvenience, a moderator will check your message shortly."
-
-Moderators will receive emails when messages are in this queue and will process them accordingly.
-
-### Discuss
-
-- [Discuss Guidelines](./discuss-guidelines.md)
+- [Mailing List guidelines](./mailing-list-guidelines.md)
 
 ### Slack
 
-- [Slack Guidelines](./slack-guidelines.md)
+- [Slack guidelines](./slack-guidelines.md)
 
 ### Zoom 
 
-- [Zoom Guidelines](./zoom-guidelines.md)
+- [Zoom guidelines](./zoom-guidelines.md)
 
 
 ### References and Resources
 
-Thanks to the following projects for making their moderation guidelines public, allowing us to build on the shoulders of giants.
-Moderators are encouraged to learn how other projects moderate and learn from them in order to improve our guidelines:
+Thanks to the following projects for making their moderation guidelines public,
+allowing us to build on the shoulders of giants. Moderators are encouraged to
+learn how other projects moderate and learn from them in order to improve our
+guidelines:
 
 - Mozilla's [Forum Moderation Guidelines](https://support.mozilla.org/en-US/kb/moderation-guidelines)
 - OASIS [How to Moderate a Mailing List](https://www.oasis-open.org/khelp/kmlm/user_help/html/mailing_list_moderation.html)
@@ -83,3 +92,9 @@ Moderators are encouraged to learn how other projects moderate and learn from th
 - [5 tips for more effective community moderation](https://www.socialmediatoday.com/social-business/5-tips-more-effective-community-moderation)
 - [8 Helpful Moderation Tips for Community Managers](https://sproutsocial.com/insights/tips-community-managers/)
 - [Setting Up Community Guidelines for Moderation](https://www.getopensocial.com/blog/community-management/setting-community-guidelines-moderation)
+
+[centralized list of administrators]: ./moderators.md#mailing-lists
+[Code of Conduct]: /code-of-conduct.md
+[Kubernetes Community Values]: /values.md
+[stages of burnout]: https://opensource.com/business/15/12/avoid-burnout-live-happy
+[Code of Conduct Committee]: /committee-code-of-conduct


### PR DESCRIPTION
This separates and adds mailing list specific communication guidelines.

Reference #2956

/cc @parispittman @castrojo 