### PR TITLE
Broken Links fix for 2696

### DIFF
--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -219,10 +219,6 @@ Commit changes made in response to review comments to the same branch on your
 fork.
 
 Very small PRs are easy to review.  Very large PRs are very difficult to review.
-At the assigned reviewer's discretion, a PR may be switched to use
-[Reviewable](https://reviewable.io) instead.  Once a PR is switched to
-Reviewable, please ONLY send or reply to comments through Reviewable.  Mixing
-code review tools can be very confusing.
 
 #### Squash and Merge
 

--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -199,7 +199,7 @@ git push -f ${your_remote_name} myfeature
 
 ### 7 Create a pull request
 
-1. Visit your fork at https://github.com/$user/kubernetes
+1. Visit your fork at `https://github.com/$user/kubernetes`
 2. Click the `Compare & Pull Request` button next to your `myfeature` branch.
 3. Check out the pull request [process](/contributors/guide/pull-requests.md) for more details and
    advice.
@@ -220,7 +220,7 @@ fork.
 
 Very small PRs are easy to review.  Very large PRs are very difficult to review.
 At the assigned reviewer's discretion, a PR may be switched to use
-[Reviewable](https://reviewable.k8s.io) instead.  Once a PR is switched to
+[Reviewable](https://reviewable.io) instead.  Once a PR is switched to
 Reviewable, please ONLY send or reply to comments through Reviewable.  Mixing
 code review tools can be very confusing.
 

--- a/sig-azure/charter.md
+++ b/sig-azure/charter.md
@@ -97,4 +97,4 @@ Issues impacting multiple subprojects in the SIG should be resolved by SIG Techn
 [super-majority]: https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote
 [KEP]: https://github.com/kubernetes/community/blob/master/keps/0000-kep-template.md
 [sigs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml#L1454
-[OWNERS]: contributors/devel/owners.md
+[OWNERS]: owners.md

--- a/sig-azure/charter.md
+++ b/sig-azure/charter.md
@@ -97,4 +97,4 @@ Issues impacting multiple subprojects in the SIG should be resolved by SIG Techn
 [super-majority]: https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote
 [KEP]: https://github.com/kubernetes/community/blob/master/keps/0000-kep-template.md
 [sigs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml#L1454
-[OWNERS]: owners.md
+[OWNERS]: OWNERS

--- a/sig-azure/charter.md
+++ b/sig-azure/charter.md
@@ -97,4 +97,4 @@ Issues impacting multiple subprojects in the SIG should be resolved by SIG Techn
 [super-majority]: https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote
 [KEP]: https://github.com/kubernetes/community/blob/master/keps/0000-kep-template.md
 [sigs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml#L1454
-[OWNERS]: OWNERS
+[OWNERS]: /contributors/guide/owners.md

--- a/sig-multicluster/CONTRIBUTING.md
+++ b/sig-multicluster/CONTRIBUTING.md
@@ -275,8 +275,8 @@ See the sig-multicluster [community page] for points of contact and meeting time
 [community page]: /sig-multicluster
 [contributors guide]: /contributors/guide
 [design proposal]: #design-proposals
-[design repo]: /contributors/design-proposals/sig-multicluster
-[design template]: /contributors/design-proposals/sig-multicluster/template.md
+[design repo]: /contributors/design-proposals/multicluster
+[design template]: /contributors/design-proposals/Design_Proposal_TEMPLATE.md
 [development guide]: /contributors/devel/development.md
 [existing issue]: #adopt-an-issue
 [feature repo]: https://github.com/kubernetes/features

--- a/sig-storage/contributing.md
+++ b/sig-storage/contributing.md
@@ -40,7 +40,7 @@ For folks looking to add support for a new storage platform in Kubernetes, you h
 - Write an in-tree volume plugin or provisioner: You can contribute a new in-tree volume plugin or provisioner, that gets built and ships with Kubernetes, for use within the Persistent Volume Framework. 
 [See the Ceph RBD volume plugin example](https://git.k8s.io/kubernetes/pkg/volume/rbd) or [the AWS Provisioner example](https://github.com/kubernetes/kubernetes/pull/29006)
 - Write a FlexVolume plugin: This is an out-of-tree volume plugin which you develop and build separately outside of Kubernetes. 
-You then install the plugin on every Kubernetes host within your cluster and then [configure the plugin in Kubernetes as a FlexVolume](https://git.k8s.io/kubernetes/examples/volumes/flexvolume)
+You then install the plugin on every Kubernetes host within your cluster and then [configure the plugin in Kubernetes as a FlexVolume](https://git.k8s.io/examples/staging/volumes/flexvolume)
 - Write a Provisioner Controller: You can write a separate controller that watches for pending claims with a specific selector label on them. 
 Once an appropriate claim is discovered, the controller then provisions the appropriate storage intended for the claim and creates a corresponding 
 persistent volume for the claim that includes the same label used in the original claim selector. This will ensure that the PV for the new 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
The following broken links are fixed in the community documentation

FILE: ./sig-azure/charter.md
[✖] contributors/devel/owners.md → Status: 400 Error: ENOENT: no such file or directory, access '/home/jorge/src/kubernetes/community/sig-azure/contributors/devel/owners.md'

FILE: ./sig-storage/contributing.md
[✖] https://git.k8s.io/kubernetes/examples/volumes/flexvolume → Status: 404

FILE: ./sig-multicluster/CONTRIBUTING.md
[✖] http://github.com/kubernetes/community/blob/master/contributors/design-proposals/sig-multicluster → Status: 404
[✖] http://github.com/kubernetes/community/blob/master/contributors/design-proposals/sig-multicluster/template.md → Status: 404

FILE: ./contributors/guide/github-workflow.md
[✖] https://github.com/$user/kubernetes → Status: 404
[✖] https://reviewable.k8s.io → Status: 0 Error: getaddrinfo ENOTFOUND reviewable.k8s.io reviewable.k8s.io:443