### PR TITLE
Add dashboard-metrics-scraper to SIG-UI charter

### DIFF
--- a/sig-ui/charter.md
+++ b/sig-ui/charter.md
@@ -10,6 +10,7 @@ SIG-UI covers GUI-related aspects of the Kubernetes project. Efforts are centere
 
 - [Kubernetes Dashboard](https://github.com/kubernetes/dashboard)
 - [Dashboard Cluster Addon](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dashboard)
+- [Dashboard Metrics Scraper](https://github.com/kubernetes-sigs/dashboard-metrics-scraper)
 
 #### Cross-cutting and Externally Facing Processes
 


### PR DESCRIPTION
Adds the [dashboard-metrics-scraper](https://github.com/kubernetes-sigs/dashboard-metrics-scraper) to our charter.

/sig ui