### PR TITLE
clarify the actual number of main types of groups

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -25,7 +25,7 @@ See [community membership]
 
 # Community groups
 
-The project has 5 main types of groups:
+The project is comprised of the following types of subgroups:
 * Special Interest Groups, SIGs
   * Subprojects
 * Working Groups, WGs


### PR DESCRIPTION
As per Brian Grant in another thread https://github.com/kubernetes/community/pull/3174#discussion_r252500194

> Yes, it is intended. They are subgroups of SIGs. Thanks.

Since subprojects (like cluster-api) are subsumed by actual SIGs like cluster-lifecyle, I think it should be 4 "main types of groups". 