### PR TITLE
Update CoC links to the Kubernetes CoC instead of the CNCF CoC

### DIFF
--- a/communication/README.md
+++ b/communication/README.md
@@ -1,6 +1,6 @@
 # Communication
 
-The Kubernetes community abides by the [CNCF code of conduct].  Here is an excerpt:
+The Kubernetes community abides by the [Kubernetes code of conduct].  Here is an excerpt:
 
 > _As contributors and maintainers of this project, and in the interest
 > of fostering an open and welcoming community, we pledge to respect
@@ -86,7 +86,7 @@ Kubernetes is the main focus of KubeCon + CloudNativeCon, held every spring in E
 
 [Blog]: https://kubernetes.io/blog/
 [calendar.google.com]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles
-[CNCF code of conduct]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
+[Kubernetes code of conduct]: /code-of-conduct.md
 [communication]: /communication.md
 [community meeting]: /communication.md#weekly-meeting
 [events]: https://www.cncf.io/events/

--- a/communication/discuss-guidelines.md
+++ b/communication/discuss-guidelines.md
@@ -16,7 +16,7 @@ _"be excellent to each other"_.
 
 ## Code of conduct
 
-Kubernetes adheres to the Cloud Native Compute Foundation's [Code of Conduct]
+Kubernetes adheres to the [Kubernetes Code of Conduct]
 throughout the project, and includes all communication mediums.
 
 
@@ -178,7 +178,7 @@ list with the new region, the moderators and their timezone.
 [Discourse]: https://discourse.org
 [KEP 0007]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-contributor-experience/0007-20180403-community-forum.md
 [archive k-users]: https://github.com/kubernetes/community/issues/2492
-[Code of Conduct]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
+[Kubernetes Code of Conduct]: /code-of-conduct.md
 [Linux Foundation Privacy Policy]: https://www.linuxfoundation.org/privacy/
 [admins]: ./moderators.md#discusskubernetesio
 [Discuss About page]: https://discuss.kubernetes.io/about

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -7,7 +7,7 @@ Chat is searchable and public. Do not make comments that you would not say on a 
 `@here` and `@channel` should be used rarely. Members will receive notifications from these commands and we are a global project - please be kind. Note: `@all` is only to be used by admins.
 
 ## CODE OF CONDUCT
-Kubernetes adheres to Cloud Native Compute Foundation's [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) throughout the project, and includes all communication mediums.
+Kubernetes adheres to the [Kubernetes Code of Conduct](/code-of-conduct.md) throughout the project, and includes all communication mediums.
 
 ## ADMINS
 

--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -16,7 +16,7 @@ moderation guidelines.
 
 ## Code of conduct
 
-The Kubernetes project adheres to the community [Code of Conduct] throughout all
+The Kubernetes project adheres to the [Kubernetes Code of Conduct] throughout all
 platforms and includes all communication mediums.
 
 
@@ -195,7 +195,7 @@ Thanks for making Kubernetes meetings work great!
 [zoom admins]: /moderators.md#zoom
 [host key]: https://support.zoom.us/hc/en-us/articles/205172555-Host-Key
 [CNCF Service Desk]: https://github.com/cncf/servicedesk
-[Code of Conduct]: /code-of-conduct.md
+[Kubernetes Code of Conduct]: /code-of-conduct.md
 [code of conduct committee]: /committee-code-of-conduct/README.md
 [SIG Creation procedure]: /sig-governance.md#sig-creation-and-maintenance-procedure
 [latest version]: https://zoom.us/download

--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -47,7 +47,7 @@ Before you can contribute, you will need to sign the [Contributor License Agreem
 
 ## Code of Conduct
 
-Please make sure to read and observe our [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Please make sure to read and observe our [Code of Conduct](/code-of-conduct.md).
 
 ## Setting up your development environment
 
@@ -208,7 +208,7 @@ To make it easier for your PR to receive reviews, consider the reviewers will ne
 * break large changes into a logical series of smaller patches which individually make easily understandable changes, and in aggregate solve a broader issue
 * label PRs with appropriate SIGs and reviewers: to do this read the messages the bot sends you to guide you through the PR process
 
-Reviewers, the people giving the review, are highly encouraged to revisit the [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) and must go above and beyond to promote a collaborative, respectful community.  
+Reviewers, the people giving the review, are highly encouraged to revisit the [Code of Conduct](/code-of-conduct.md) and must go above and beyond to promote a collaborative, respectful community.  
 When reviewing PRs from others [The Gentle Art of Patch Review](http://sage.thesharps.us/2014/09/01/the-gentle-art-of-patch-review/) suggests an iterative series of focuses which is designed to lead new contributors to positive collaboration without inundating them initially with nuances:
 
 * Is the idea behind the contribution sound?

--- a/governance.md
+++ b/governance.md
@@ -10,7 +10,7 @@ The Kubernetes community adheres to the following principles:
 
 # Code of Conduct
 
-The Kubernetes community abides by the CNCF [code of conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Here is an excerpt:
+The Kubernetes community abides by the [Kubernetes code of conduct](/code-of-conduct.md). Here is an excerpt:
 
 _As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
 


### PR DESCRIPTION
Ref: https://github.com/kubernetes/community/pull/3160

We should point to the Kubernetes Code of Conduct instead of the CNCF Code of Conduct since that's the source of truth for Kubernetes.

/sig contributor-experience
/committee conduct