### PR TITLE
devel: bump tombstone date to July or release of 1.15

### DIFF
--- a/contributors/devel/api-conventions.md
+++ b/contributors/devel/api-conventions.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md.
 
-This file is a placeholder to preserve links.  Please remove by April 24, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/api_changes.md
+++ b/contributors/devel/api_changes.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md.
 
-This file is a placeholder to preserve links.  Please remove by April 24, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/bazel.md
+++ b/contributors/devel/bazel.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-testing/bazel.md.
 
-This file is a placeholder to preserve links.  Please remove by April 30, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/cherry-picks.md
+++ b/contributors/devel/cherry-picks.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md.
 
-This file is a placeholder to preserve links.  Please remove by April 29, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/collab.md
+++ b/contributors/devel/collab.md
@@ -1,3 +1,3 @@
-This document has moved to: [here](https://git.k8s.io/community/contributors/guide/collab.md).
+This file has moved to https://git.k8s.io/community/contributors/guide/collab.md.
 
-*This file is a redirect stub. It should be deleted by 04/22/2019.*
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/component-config-conventions.md
+++ b/contributors/devel/component-config-conventions.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-architecture/component-config-conventions.md.
 
-This file is a placeholder to preserve links.  Please remove by April 24, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/conformance-tests.md
+++ b/contributors/devel/conformance-tests.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-architecture/conformance-tests.md.
 
-This file is a placeholder to preserve links.  Please remove by April 24, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/container-runtime-interface.md
+++ b/contributors/devel/container-runtime-interface.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-node/container-runtime-interface.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/controllers.md
+++ b/contributors/devel/controllers.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-api-machinery/controllers.md.
 
-This file is a placeholder to preserve links.  Please remove by April 24, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/cri-container-stats.md
+++ b/contributors/devel/cri-container-stats.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-node/cri-container-stats.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/cri-testing-policy.md
+++ b/contributors/devel/cri-testing-policy.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-node/cri-testing-policy.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/cri-validation.md
+++ b/contributors/devel/cri-validation.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-node/cri-validation.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/e2e-node-tests.md
+++ b/contributors/devel/e2e-node-tests.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-node/e2e-node-tests.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/e2e-tests.md
+++ b/contributors/devel/e2e-tests.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-testing/e2e-tests.md.
 
-This file is a placeholder to preserve links.  Please remove by April 30, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/event-style-guide.md
+++ b/contributors/devel/event-style-guide.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-instrumentation/event-style-guide.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/flaky-tests.md
+++ b/contributors/devel/flaky-tests.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-testing/flaky-tests.md.
 
-This file is a placeholder to preserve links.  Please remove by April 30, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/flexvolume.md
+++ b/contributors/devel/flexvolume.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-storage/flexvolume.md.
 
-This file is a placeholder to preserve links.  Please remove by April 29, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/generating-clientset.md
+++ b/contributors/devel/generating-clientset.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-api-machinery/generating-clientset.md.
 
-This file is a placeholder to preserve links.  Please remove by April 24, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/getting-builds.md
+++ b/contributors/devel/getting-builds.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-release/getting-builds.md.
 
-This file is a placeholder to preserve links.  Please remove by April 29, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/godep.md
+++ b/contributors/devel/godep.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-architecture/godep.md.
 
-This file is a placeholder to preserve links.  Please remove by April 24, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/gubernator.md
+++ b/contributors/devel/gubernator.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-testing/gubernator.md.
 
-This file is a placeholder to preserve links. Please remove by April 30, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/help-wanted.md
+++ b/contributors/devel/help-wanted.md
@@ -1,3 +1,3 @@
-This document has moved [here](https://git.k8s.io/community/tree/master/contributors/guide/help-wanted.md).
+This file has moved to https://git.k8s.io/community/contributors/guide/help-wanted.md.
 
-*This file is a redirect stub. It should be deleted by 04/22/2019.*
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/instrumentation.md
+++ b/contributors/devel/instrumentation.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-instrumentation/instrumentation.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/kubelet-cri-networking.md
+++ b/contributors/devel/kubelet-cri-networking.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-node/kubelet-cri-networking.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/kubemark-guide.md
+++ b/contributors/devel/kubemark-guide.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-scalability/kubemark-guide.md.
 
-This file is a placeholder to preserve links.  Please remove by April 29, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/logging.md
+++ b/contributors/devel/logging.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-instrumentation/logging.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/node-performance-testing.md
+++ b/contributors/devel/node-performance-testing.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-node/node-performance-testing.md.
 
-This file is a placeholder to preserve links.  Please remove by April 28, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/profiling.md
+++ b/contributors/devel/profiling.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-scalability/profiling.md.
 
-This file is a placeholder to preserve links.  Please remove by April 29, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/release.md
+++ b/contributors/devel/release.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-release/release.md.
 
-This file is a placeholder to preserve links.  Please remove by April 29, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/scheduler.md
+++ b/contributors/devel/scheduler.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-scheduling/scheduler.md.
 
-This file is a placeholder to preserve links.  Please remove by April 29, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/scheduler_algorithm.md
+++ b/contributors/devel/scheduler_algorithm.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-scheduling/scheduler_algorithm.md.
 
-This file is a placeholder to preserve links.  Please remove by April 29, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/staging.md
+++ b/contributors/devel/staging.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-architecture/staging.md.
 
-This file is a placeholder to preserve links.  Please remove by April 24, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/strategic-merge-patch.md
+++ b/contributors/devel/strategic-merge-patch.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-api-machinery/strategic-merge-patch.md.
 
-This file is a placeholder to preserve links.  Please remove by April 24, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.

--- a/contributors/devel/testing.md
+++ b/contributors/devel/testing.md
@@ -1,3 +1,3 @@
 This file has moved to https://git.k8s.io/community/contributors/devel/sig-testing/testing.md.
 
-This file is a placeholder to preserve links. Please remove by April 30, 2019 or the release of kubernetes 1.13, whichever comes first.
+This file is a placeholder to preserve links.  Please remove after 2019-07-01 or the release of kubernetes 1.15, whichever comes first.


### PR DESCRIPTION
Ref: https://github.com/kubernetes/community/pull/3145#discussion_r253299491, https://github.com/kubernetes/community/pull/3187

Fixes https://github.com/kubernetes/community/issues/3199

Chatted with Paris on Slack about this - we agreed that 1 July 2019 or the release of 1.15 (whichever is sooner) would be a good time to nuke all the tombstones. Rationale behind this:

v1.14 gets released on 25 March. The next release (1.15) is usually after three months so that would be late June or early July. July is also almost half a year from now so we can be sure that all references/dependencies are corrected by then.

We also wanted to be safe and choose a date farther away because there are a lot of links throughtout the ecosystem which point to the api-conventions doc (amongst others).

/cc @parispittman @eduartua @cblecker 