### PR TITLE
 devel: add OWNERS files for SIG sub-directories 

### DIFF
--- a/contributors/devel/sig-api-machinery/OWNERS
+++ b/contributors/devel/sig-api-machinery/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-api-machinery-leads
+approvers:
+  - sig-api-machinery-leads
+labels:
+  - sig/api-machinery

--- a/contributors/devel/sig-architecture/OWNERS
+++ b/contributors/devel/sig-architecture/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-architecture-leads
+  - jbeda
+approvers:
+  - sig-architecture-leads
+  - jbeda
+labels:
+  - sig/architecture

--- a/contributors/devel/sig-instrumentation/OWNERS
+++ b/contributors/devel/sig-instrumentation/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-instrumentation-leads
+approvers:
+  - sig-instrumentation-leads
+labels:
+  - sig/instrumentation

--- a/contributors/devel/sig-node/OWNERS
+++ b/contributors/devel/sig-node/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-node-leads
+approvers:
+  - sig-node-leads
+labels:
+  - sig/node

--- a/contributors/devel/sig-release/OWNERS
+++ b/contributors/devel/sig-release/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-release-leads
+approvers:
+  - sig-release-leads
+labels:
+  - sig/release

--- a/contributors/devel/sig-scalability/OWNERS
+++ b/contributors/devel/sig-scalability/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-scalability-leads
+approvers:
+  - sig-scalability-leads
+labels:
+  - sig/scalability

--- a/contributors/devel/sig-scheduling/OWNERS
+++ b/contributors/devel/sig-scheduling/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-scheduling-leads
+approvers:
+  - sig-scheduling-leads
+labels:
+  - sig/scheduling

--- a/contributors/devel/sig-storage/OWNERS
+++ b/contributors/devel/sig-storage/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-storage-leads
+approvers:
+  - sig-storage-leads
+labels:
+  - sig/storage

--- a/contributors/devel/sig-testing/OWNERS
+++ b/contributors/devel/sig-testing/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-testing-leads
+approvers:
+  - sig-testing-leads
+labels:
+  - sig/testing


### PR DESCRIPTION
~~The first commit renames the sig sub-dirs from `sig-api-machinery` -> `api-machinery` and so on, to make it consistent with the nomenclature in [design-proposals](https://github.com/kubernetes/community/tree/master/contributors/design-proposals).~~ This will break a bunch of links. This isn't a super important change, so if we really need this, it can go in another PR.

The ~~second~~ commit adds OWNERS files to the existing SIG sub-directories. The content of the OWNERS file is same as that in [design-proposals](https://github.com/kubernetes/community/tree/master/contributors/design-proposals).

/cc @parispittman @eduartua @cblecker 