### PR TITLE
Add `verify-dockerized` to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ generate-dockerized:
 verify:
 	@hack/verify.sh
 
+verify-dockerized:
+	docker run --rm -v $(shell pwd):/go/src/app:Z $(IMAGE_NAME) make -C /go/src/app verify
+
 test:
 	go test -v ./generator/...
 


### PR DESCRIPTION
The `Makefile` has `generate-dockerized` and `test-dockerized`. For
consistency, and also because its helpful for those who may not have
their Go environment properly setup, add `verify-dockerized` to the
Dockerfile. Its responsible for running `verify` in the docker
container.