### PR TITLE
Use go 1.11 for Dockerized Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_NAME=golang:1.9
+IMAGE_NAME=golang:1.11
 
 default: \
 	generate \


### PR DESCRIPTION
Previously, we used the Go 1.9 image for our dockerized targets in the
Makefile. The k8s project mandates Go 1.11 for k8s 1.13+
(https://github.com/kubernetes/community/blob/master/contributors/devel/development.md),
so there's no reason not to use Go 1.11 here.

I've verified all existing dockerized targets still work with go 1.11.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->