### PR TITLE
godep: point to list of whitelisted licenses

### DIFF
--- a/contributors/devel/sig-architecture/godep.md
+++ b/contributors/devel/sig-architecture/godep.md
@@ -259,3 +259,6 @@ or the Steering Committee (@kubernetes/steering-committee) to ensure that they
 are compatible with the Kubernetes project license. It is also important to note
 and flag if a license has changed when updating a dependency, so that these can
 also be reviewed.
+
+For reference, whitelisted licenses as per the CNCF Whitelist Policy are
+mentioned [here](https://git.k8s.io/sig-release/licensing/README.md#licenses-for-dependencies).


### PR DESCRIPTION
This PR points to the list of approved whitelisted licenses by the CNCF Governing Board, as per the [slide deck](https://docs.google.com/presentation/d/1tbH15qF7bXOp8veRKHlWSeH6w1NWkMN3qmIwB6LvvgU/edit#slide=id.p1) shared by @swinslow. (Ref: https://github.com/kubernetes/steering/issues/57#issuecomment-458968990)

https://github.com/kubernetes/sig-release/pull/504 adds the actual list to the sig-release repo.

/cc @swinslow @dims @justaugustus 
members involved in the sig-release licensing subproject

/cc @thockin @cblecker @sttts 
dep-approvers

/hold
want to make sure this is explicitly lgtm'ed by @swinslow 

/sig release
/area licensing
