### PR TITLE
Add vendor selection process writeup for security audit

### DIFF
--- a/wg-security-audit/README.md
+++ b/wg-security-audit/README.md
@@ -32,6 +32,8 @@ The RFP will be open between 2018/10/29 and 2018/11/30 and has been published [h
 
 The [RFP](https://github.com/kubernetes/community/blob/master/wg-security-audit/RFP.md) is now closed. The working group selected Trail of Atredis, a collaboration between [Trail of Bits](https://www.trailofbits.com/) and [Atredis Partners](https://www.atredis.com/) to perform the audit.
 
+You can read more about the vendor selection [here](RFP_Decision.md).
+
 ## Mailing Lists
 
 * Sensitive communications regarding the audit should be sent to the [private variant of the mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-security-audit-private).

--- a/wg-security-audit/RFP_Decision.md
+++ b/wg-security-audit/RFP_Decision.md
@@ -1,0 +1,27 @@
+# Security Audit WG - RFP Decision Process
+
+The Security Audit Working Group was tasked with leading the process of having a third party security audit conducted for the Kubernetes project. Our first steps were to select the vendors to be included in the Request for Proposal (RFP) process and create the RFP document setting out the goals of the audit. We were then responsible for evaluating the submitted proposals in order to select the vendor best suited to complete a security assessment against Kubernetes, a very complex and widely scoped project. 
+
+After publishing the initial RFP and distributing it to the eligible vendors, we had a period open for vendors to submit questions to better understand the project’s goals, which we made publicly available in the RFP document. While six (6) vendors were invited to participate, we ultimately received four (4) RFP responses, due to one vendor dropping out and two vendors partnering to submit a combined proposal. 
+
+The next stage of this project was more difficult: evaluating the responses and determining which vendor to use for the audit. With the list of eligible vendors already limited to a small set of very strong and well-known firms, it came as no surprise to us that they each had extremely compelling proposals that made choosing one over the other very difficult. The working group leads have years of experience on both sides of the table: writing proposals and conducting audits, as well as working with these vendors and their teams to assess companies we’ve worked at. To help us combine objective evaluations with our individual past experiences and knowledge of each of the vendors’ work and relevant experience (conference talks, white papers, published research and reports), we came up with a set of criteria that each of us used to rank the proposals on a scale of 1 to 5:
+
+* Personnel fit and talent
+* Relevant understanding and experience (orchestration systems, containers, hardening, etc.)
+* The individual work products requested in the RFP:
+	- Threat Model
+	- Reference architecture
+	- White paper
+	- Assessment and report
+
+While budget constraints became a part of the final selection, we wanted to leave cost out of the process as much as possible and focus on ensuring the community received the best possible audit. Based on this criteria, the scoring overall was extremely close, with the total scores all within a few points of each other.  
+
+| Vendor | Total Score |
+|--------|-------------|
+| Vendor A | 149 |
+| Vendor B | 149 |
+| Vendor C | 144 |
+| Vendor D | 135 |
+
+After narrowing it down to our top two choices and some further discussions with those vendors, we decided to select the partnership of Atredis and Trail of Bits to complete this audit. We felt very strongly that the combination of these two firms, both composed of very senior and well known staff in the information security industry, would provide the best possible results. We look forward to working with them to kick off the actual audit process soon and for other Kubernetes contributors from the various SIGs to help partner with the working group on this assessment.
+


### PR DESCRIPTION
In the interest of transparency, the Security Audit Working Group would like to document the decision process we used for evaluating the vendor proposals for the security audit. 

cc the rest of the WG: @aasmall @joelsmith 