### PR TITLE
fixing broken link to moderation guidelines

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -1,7 +1,7 @@
 # Community Moderators
 
 The following people are responsible for moderating/administrating Kubernetes communication channels and their home time zone. 
-See our [moderation guidelines](./moderating.md) for policies and recommendations.
+See our [moderation guidelines](./moderation.md) for policies and recommendations.
 
 ## Mailing Lists
 


### PR DESCRIPTION
Hi Community,

As this is my first PR I really wanted to express my excitement and enthusiasm being part of such a great community. I hope I did everything right for my first PR but bear with me while I am learning the process and how to interact with the community. 

What this PR is actually about:
When looking over the [moderators](https://github.com/kubernetes/community/blob/9dc2678523eae4cea7aee86a6938e43cc2d3033d/communication/moderators.md) page I found that the link to the `moderation guidelines` is broken. This PR is intended to fix this.

Once again, I am excited of being part in this community and hope for many more PRs (also on the technical side) to come.

Best,
Fabian