### PR TITLE
Specify need for using py2 with Bazel

### DIFF
--- a/contributors/devel/sig-testing/bazel.md
+++ b/contributors/devel/sig-testing/bazel.md
@@ -14,6 +14,10 @@ These tools are called via the `hack/update-bazel.sh` script.
 
 Instructions for installing Bazel
 can be found [here](https://www.bazel.io/versions/master/docs/install.html).
+Please note that until [this Bazel
+issue](https://github.com/bazelbuild/rules_docker/issues/454) is fixed,
+`/usr/bin/env python` must be python2 in order for all the Bazel commands listed
+below to succeed.
 
 Several convenience `make` rules have been created for common operations:
 


### PR DESCRIPTION
The default python on my system is python3. This caused me to run into
https://github.com/bazelbuild/rules_docker/issues/454 when running
`bazel build //...`. Update the documentation to indicate that
`/usr/bin/env python` must resolve to python2 in order for all of the
Bazel commands included in the documentation to work.

We can remove this comment after Bazel better supports using python3 as
the default system python. It appears from
https://github.com/bazelbuild/rules_docker/issues/580 that the
`rules_docker` folks hope to merge the fix in mid to late Q1 2019.