### PR TITLE
Add explicit links to release-engineering in sig-release

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -47,7 +47,7 @@ The following subprojects are owned by sig-release:
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/licensing/OWNERS
 - **release-engineering**
-  - Description: The Release Engineering subproject is responsible for the process/procedures/tools used to create/maintain Kubernetes release artifacts.
+  - Description: The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1586,8 +1586,10 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes/sig-release/master/licensing/OWNERS
     - name: release-engineering
       description: >
-        The Release Engineering subproject is responsible for the process/procedures/tools
-        used to create/maintain Kubernetes release artifacts.
+        The Release Engineering subproject is responsible for the
+        [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering)
+        and [tools](https://github.com/kubernetes/release) used to
+        create/maintain Kubernetes release artifacts.
       owners:
       - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1983,7 +1983,7 @@ sigs:
         frequency: weekly
         url: https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit
         archive_url: https://docs.google.com/document/d/1b9Ppm7ZT_tMWRs5Ph1zGJJKb5nF9c3ZHzMwg1olJIrc/edit
-        recordings_url: https://bit.ly/k8s-sig-testing-videos 
+        recordings_url: https://bit.ly/k8s-sig-testing-videos
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
     - name: prow


### PR DESCRIPTION
It's confusing having two links for the release-engineering subproject
without any description of each. The k/release repo houses all of the
existing tooling, such as anago, while the k/sig-release repo houses the
procedures and processes. Add these links explicitly to the description
so that newcomers have a clearer idea of where to get started.