### PR TITLE
github-management: clarify sponsorship criteria

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -50,8 +50,8 @@ remain active contributors to the community.
 - Sponsored by 2 reviewers. **Note the following requirements for sponsors**:
     - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating
       on issues, etc.
-    - Sponsors must be reviewers or approvers in at least 1 OWNERS file (in any repo in the Kubernetes GitHub
-      organization)
+    - Sponsors must be reviewers or approvers in at least 1 OWNERS file either in any repo in the [Kubernetes org],
+    or the org they are sponsoring for.
     - Sponsors must be from multiple member companies to demonstrate integration across community.
 - **[Open an issue][membership request] against the kubernetes/org repo**
    - Ensure your sponsors are @mentioned on the issue

--- a/github-management/new-membership-procedure.md
+++ b/github-management/new-membership-procedure.md
@@ -51,8 +51,8 @@ required to be eligible to sponsor a new member. These requirements are:
   then the sponsor should be a member of either that org, or main Kubernetes
   org (as members of the main org have implicit membership in other orgs).
 
-- Sponsors must be a reviewer or approver in at least one OWNERS file in any
-  Kubernetes GitHub org.
+- Sponsors must be a reviewer or approver in at least one OWNERS file in
+  either the [Kubernetes GitHub org] or the org they are sponsoring for.
 
 - Sponsors must be from multiple member companies to demonstrate integration
   across community
@@ -101,3 +101,4 @@ merge.
 [community membership]: /community-membership.md
 [k-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [kubernetes/org]: https://git.k8s.io/org/
+[Kubernetes GitHub org]: https://github.com/kubernetes


### PR DESCRIPTION
An approver/reviewer in @kubernetes, may sponsor someone for the @kubernetes org or any of the related organizations (@kubernetes-sigs, @kubernetes-csi etc); as long as it's a project they're involved with.

However, this does not work the other way around. A sponsor that is only an approver/reviewer in @kubernetes-sigs cannot sponsor someone for membership in the @kubernetes org. They are scoped just to the org they're associated with.

Hopefully this reduces some of the back and forth (example https://github.com/kubernetes/org/issues/470#issuecomment-462763752) for @mrbobbytables and @justaugustus. :smile:  

/sig contributor-experience
/area github-management

/cc @cblecker @mrbobbytables @spiffxp @justaugustus  
/assign @cblecker 