### PR TITLE
Update vertical-pod-autoscaler.md

### DIFF
--- a/contributors/design-proposals/autoscaling/vertical-pod-autoscaler.md
+++ b/contributors/design-proposals/autoscaling/vertical-pod-autoscaler.md
@@ -241,7 +241,7 @@ single field `mode` that enables the feature.
 
 ```json
 "updatePolicy" {
-  "mode": "",
+  "updateMode": "",
 }
 ```
 
@@ -249,10 +249,15 @@ Mode can be set to one of the following:
 
 1. `"Initial"`: VPA only assigns resources on Pod creation and does not
    change them during lifetime of the Pod.
-2. `"Auto"` (default): VPA assigns resources on Pod creation and
+2. `"Recreate"`: VPA assigns resources on Pod creation and
    additionally can update them during lifetime of the Pod, including evicting /
    rescheduling the Pod.
-3. `"Off"`: VPA never changes Pod resources. The recommender still sets the
+3. `"Auto"` (default): Currently this mode is equivalent to the `"Recreate"` mode.
+   VPA assigns resources on Pod creation and additionally can update them during 
+   the lifetime of the pod, using any available update method. To reiterate, 
+   this is equivalent to `"Recreate"`, which is currently the only available
+   update method.
+4. `"Off"`: VPA never changes Pod resources. The recommender still sets the
    recommended resources in the VPA object. This can be used for a “dry run”.
 
 To disable VPA updates the user can do any of the following: (1) change the


### PR DESCRIPTION
Found a little typo in the Update Policy section inside the JSON example. Also added in the 'Recreate' Update mode with a description in line with current functionality and updated the 'Auto' Update mode to reflect definition in ` autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1/types.go`

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->