### PR TITLE
Add sig-apimachinery delegates for subproject repo creation approval

### DIFF
--- a/sig-api-machinery/charter.md
+++ b/sig-api-machinery/charter.md
@@ -51,7 +51,20 @@ N/A
 
 ### Deviations from [sig-governance]
 
-N/A
+#### Sub-project Repo Creation
+
+The following individuals may approve kubernetes-sigs repo creation requests to be owned by any api-machinery
+sub-projects:
+
+- @cheftako
+- @sttts
+
+The following individuals may approve kubernetes-sigs repo creation requests to be owned by specific api-machinery
+sub-projects:
+
+- server-sdk
+  - @pwittrock
+
 
 ### Subproject Creation
 


### PR DESCRIPTION
Allow the project to scale by delegating kubernetes-sigs repo creation approval to specific sub-project owners.