### PR TITLE
Update conformance docs to use --ginkgo-parallel 

### DIFF
--- a/contributors/devel/sig-architecture/conformance-tests.md
+++ b/contributors/devel/sig-architecture/conformance-tests.md
@@ -122,7 +122,7 @@ export KUBERNETES_CONFORMANCE_TEST=y
 kubetest --provider=skeleton --test --test_args="--ginkgo.focus=\[Conformance\]"
 
 # Option B: run parallel conformance tests first, then serial conformance tests serially
-GINKGO_PARALLEL=y kubetest --provider=skeleton --test --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]"
+kubetest --ginkgo-parallel --provider=skeleton --test --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]"
 kubetest --provider=skeleton --test --test_args="--ginkgo.focus=\[Serial\].*\[Conformance\]"
 ```
 


### PR DESCRIPTION
Use the "new" `--ginkgo-parallel ` instead of the deprecated env var:

```bash
2019/02/20 14:09:10 main.go:980: Please use kubetest --ginkgo-parallel (instead of deprecated GINKGO_PARALLEL=y)
```

Tested with the latest kubetest version.