### PR TITLE
Add csi-driver-image-populator to kubernetes-csi subproject

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -38,6 +38,7 @@ The following subprojects are owned by sig-storage:
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-cinder/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-common/master/OWNERS

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -35,7 +35,6 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following subprojects are owned by sig-storage:
 - **kubernetes-csi**
   - Owners:
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-cinder/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1874,6 +1874,7 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-cinder/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
+      - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-common/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1871,7 +1871,6 @@ sigs:
     subprojects:
     - name: kubernetes-csi
       owners:
-      - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-cinder/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/486

I also went ahead and removed `csi-driver-cinder` as a repo in the subproject because that repo was deleted. Ref: https://github.com/kubernetes/org/issues/317.

/assign @kfox1111 @msau42 @saad-ali 