### PR TITLE
Add support for User Groups in sigs.yaml

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -13,6 +13,7 @@ The documentation follows a template and uses the values from [`sigs.yaml`](/sig
 - List: [`list.tmpl`](list.tmpl)
 - SIG README: [`sig_readme.tmpl`](sig_readme.tmpl)
 - WG README: [`wg_readme.tmpl`](wg_readme.tmpl)
+- UG README: [`ug_readme.tmpl`](ug_readme.tmpl)
 
 **Time Zone gotcha**:
 Time zones make everything complicated.
@@ -28,6 +29,7 @@ accompanying documentation. This takes the format of three types of doc files:
 ```
 sig-<sig-name>/README.md
 wg-<working-group-name>/README.md
+ug-<user-group-name>/README.md
 sig-list.md
 ```
 

--- a/generator/app.go
+++ b/generator/app.go
@@ -124,6 +124,7 @@ func (e *Group) DirName(prefix string) string {
 type Context struct {
 	Sigs          []Group
 	WorkingGroups []Group
+	UserGroups    []Group
 }
 
 func pathExists(path string) bool {
@@ -305,12 +306,21 @@ func main() {
 		return strings.ToLower(ctx.WorkingGroups[i].Name) <= strings.ToLower(ctx.WorkingGroups[j].Name)
 	})
 
+	sort.Slice(ctx.UserGroups, func(i, j int) bool {
+		return strings.ToLower(ctx.UserGroups[i].Name) <= strings.ToLower(ctx.UserGroups[j].Name)
+	})
+
 	err = createGroupReadme(ctx.Sigs, "sig")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	err = createGroupReadme(ctx.WorkingGroups, "wg")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = createGroupReadme(ctx.UserGroups, "ug")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/generator/list.tmpl
+++ b/generator/list.tmpl
@@ -34,3 +34,13 @@ When the need arises, a [new SIG can be created](sig-creation-procedure.md)
 {{- range .WorkingGroups}}
 |[{{.Name}}]({{.Dir}}/README.md)|{{range .StakeholderSIGs}}* {{.}}<br>{{end }}|{{range .Leadership.Chairs}}* [{{.Name}}](https://github.com/{{.GitHub}}){{if .Company}}, {{.Company}}{{end}}<br>{{end}}|* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})<br>* [Mailing List]({{.Contact.MailingList}})|{{range .Meetings}}* {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}} ({{.Frequency}})]({{.URL}})<br>{{end}}
 {{- end }}
+{{- /* TODO: remove the below condition when at least one user group has been added */}}
+{{ if .UserGroups }}
+### Master User Group List
+
+| Name | Organizers | Contact | Meetings |
+|------|------------|---------|----------|
+{{- range .UserGroups}}
+|[{{.Name}}]({{.Dir}}/README.md)|{{range .Leadership.Chairs}}* [{{.Name}}](https://github.com/{{.GitHub}}){{if .Company}}, {{.Company}}{{end}}<br>{{end}}|* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})<br>* [Mailing List]({{.Contact.MailingList}})|{{range .Meetings}}* {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}} ({{.Frequency}})]({{.URL}})<br>{{end}}
+{{- end }}
+{{  end }}

--- a/generator/ug_readme.tmpl
+++ b/generator/ug_readme.tmpl
@@ -1,0 +1,49 @@
+{{- template "header" }}
+# {{.Name}} User Group
+
+{{ .MissionStatement }}
+{{- if .CharterLink }}
+The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}} User Group.
+{{ end }}
+{{ if .Meetings -}}
+## Meetings
+{{- range .Meetings }}
+* {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
+{{- if .ArchiveURL }}
+  * [Meeting notes and Agenda]({{.ArchiveURL}}).
+{{- end }}
+{{- if .RecordingsURL }}
+  * [Meeting recordings]({{.RecordingsURL}}).
+{{- end }}
+{{- end }}
+
+{{- end }}
+{{- if .Leadership }}
+{{- if .Leadership.Chairs }}
+
+## Organizers
+{{ range .Leadership.Chairs }}
+* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+{{- end }}
+{{- end }}
+{{- end }}
+
+## Contact
+* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+* [Mailing list]({{.Contact.MailingList}})
+{{- if .Label }}
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2F{{.Label}})
+{{- end }}
+
+{{ if .Contact.GithubTeams }}
+## GitHub Teams
+
+The below teams can be mentioned on issues and PRs in order to get attention from the right people.
+Note that the links to display team membership will only work if you are a member of the org.
+
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+{{- range .Contact.GithubTeams }}
+| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
+{{- end }}
+{{  end }}

--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -37,7 +37,7 @@ make 1>/dev/null
 mismatches=0
 break=$(printf "=%.0s" $(seq 1 68))
 
-for file in $(ls ${CRT_DIR}/sig-*/README.md ${CRT_DIR}/wg-*/README.md ${CRT_DIR}/sig-list.md ${CRT_DIR}/OWNERS_ALIASES); do
+for file in $(ls ${CRT_DIR}/sig-*/README.md ${CRT_DIR}/wg-*/README.md ${CRT_DIR}/ug-*/README.md ${CRT_DIR}/sig-list.md ${CRT_DIR}/OWNERS_ALIASES); do
   real=${file#$CRT_DIR/}
   if ! diff -q ${file} ${WORKING_DIR}/${real} &>/dev/null; then
     echo "${file} does not match ${WORKING_DIR}/${real}";


### PR DESCRIPTION
Fixes https://github.com/kubernetes/community/issues/3297

User Groups were added in #3174. This PR adds support for documenting them in sigs.yaml. Ref: https://github.com/kubernetes/community/pull/2988#issuecomment-465792969.

/cc @cblecker @parispittman 
/sig contributor-experience

/cc @spiffxp 
/committee steering