### PR TITLE
Add User Groups to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more specific topics, try a SIG.
 
 ## Governance
 
-Kubernetes has three types of groups that are officially supported:
+Kubernetes has the following types of groups that are officially supported:
 
 * **Committees** are named sets of people that are chartered to take on sensitive topics.
   This group is encouraged to be as open as possible while achieving its mission but, because of the nature of the topics discussed, private communications are allowed.
@@ -30,6 +30,9 @@ Kubernetes has three types of groups that are officially supported:
 * **Working Groups** are temporary groups that are formed to address issues that cross SIG boundaries.
   Working groups do not own any code or other long term artifacts.
   Working groups can report back and act through involved SIGs.
+* **User Groups** are groups for facilitating communication and discovery of information related to
+  topics that have long term relevance to large groups of Kubernetes users.
+  They do not have ownership of parts of the Kubernetes code base.
 
 See the [full governance doc](governance.md) for more details on these groups.
 

--- a/governance.md
+++ b/governance.md
@@ -137,13 +137,13 @@ code base. As such they are neither good fits for SIGs or Working Groups.
 An example of such a topic might be continuous delivery to Kubernetes. 
 
 Though their central goal is not a a deliverable piece of work, as contributing
-members of the community working groups are expected to work with SIGs
+members of the community user groups are expected to work with SIGs
 to either identify friction or usability issues that need to be addressed,
 or to provide or improve documentation in their area of expertise. However
 these activities are covered under general code contributions to the relevant
 SIGs (e.g. SIG Docs) rather than as part of the user group. These contributions
 are expected to be more incremental and ad-hoc versus the more targeted 
-output of a working group.
+output of a user group.
 
 User groups function as a centralized resource to facilitate communication
 and discovery of information related to the topic of the user group. User


### PR DESCRIPTION
User Groups were added in #3174. The README has a tldr of community groups - so this PR documents User Groups in the README.

The TLDR is adapted from https://github.com/kubernetes/community/blob/master/governance.md#user-groups.

/committee steering
/cc @kubernetes/steering-committee 

 