### PR TITLE
generator: remove google groups note from all WG READMEs

### DIFF
--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -75,13 +75,9 @@ The following subprojects are owned by wg-{{.Label}}:
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
-| Team Name | Details | Google Groups | Description |
-| --------- |:-------:|:-------------:|  ----------- |
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
 {{- range .Contact.GithubTeams }}
-| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | [link](https://groups.google.com/forum/#!forum/kubernetes-{{.Name}}) | {{.Description}} |
+| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
 {{- end }}
 {{  end }}

--- a/wg-component-standard/README.md
+++ b/wg-component-standard/README.md
@@ -35,13 +35,9 @@ Develop a standard foundation (philosophy and libraries) for core Kubernetes com
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.
 Note that the links to display team membership will only work if you are a member of the org.
 
-The google groups contain the archive of Github team notifications.
-Mentioning a team on Github will CC its group.
-Monitor these for Github activity if you are not a member of the team.
-
-| Team Name | Details | Google Groups | Description |
-| --------- |:-------:|:-------------:|  ----------- |
-| @kubernetes/wg-component-standard | [link](https://github.com/orgs/kubernetes/teams/wg-component-standard) | [link](https://groups.google.com/forum/#!forum/kubernetes-wg-component-standard) | Component Standard Discussion |
+| Team Name | Details | Description |
+| --------- |:-------:| ----------- |
+| @kubernetes/wg-component-standard | [link](https://github.com/orgs/kubernetes/teams/wg-component-standard) | Component Standard Discussion |
 
 <!-- BEGIN CUSTOM CONTENT -->
 


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/community/pull/2606 and https://github.com/kubernetes/community/pull/2500
For https://github.com/kubernetes/community/issues/2324

/cc @cblecker @spiffxp 
/assign @cblecker 

/sig contributor-experience