### PR TITLE
Automatically add contribex label to moderation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/moderator_application.md
+++ b/.github/ISSUE_TEMPLATE/moderator_application.md
@@ -2,7 +2,9 @@
 name: Community Moderator Request
 about: Request moderator priviledges on a Kubernetes property
 title: 'REQUEST: New moderator for <your-GH-handle> of <k8s property>'
-labels: area/community-management
+labels:
+- area/community-management
+- sig/contributor-experience
 assignees: ''
 
 ---


### PR DESCRIPTION
/assign @castrojo @cblecker 

We are getting many issues for moderator request -- let's automatically apply the SIG label for those.