### PR TITLE
Revert automatically adding contribex label to moderation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/moderator_application.md
+++ b/.github/ISSUE_TEMPLATE/moderator_application.md
@@ -2,9 +2,7 @@
 name: Community Moderator Request
 about: Request moderator priviledges on a Kubernetes property
 title: 'REQUEST: New moderator for <your-GH-handle> of <k8s property>'
-labels:
-- area/community-management
-- sig/contributor-experience
+labels: area/community-management
 assignees: ''
 
 ---


### PR DESCRIPTION
This reverts commit acaa9b8bedfb5d3603a7dbd505eca00e2a836a9b, reversing changes made to 95c22eab926f81e2e9865e567497076ce8d3cb58 (reverts https://github.com/kubernetes/community/pull/3314)

GitHub doesn't allow multiple labels in issue templates and if a comma separated list is used, GitHub refuses to recognize it as a issue template in the first place. :neutral_face: 

/assign @cblecker 