### PR TITLE
Automatically add contribex label to moderation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/moderator_application.md
+++ b/.github/ISSUE_TEMPLATE/moderator_application.md
@@ -2,7 +2,7 @@
 name: Community Moderator Request
 about: Request moderator priviledges on a Kubernetes property
 title: 'REQUEST: New moderator for <your-GH-handle> of <k8s property>'
-labels: area/community-management
+labels: area/community-management, sig/contributor-experience
 assignees: ''
 
 ---


### PR DESCRIPTION
Take two of https://github.com/kubernetes/community/pull/3314

/assign @cblecker 