### PR TITLE
Update the Contributor Summit EU docs with initial information

### DIFF
--- a/events/2019/05-contributor-summit/README.md
+++ b/events/2019/05-contributor-summit/README.md
@@ -1,1 +1,59 @@
 # 2019 Kubernetes Contributor Summit EU
+
+## What
+
+This event brings together new and current Kubernetes contributors to connect and collaborate face-to-face. It is an opportunity for existing contributors to help shape the future of the project, and offers a welcoming space for new community members to learn, explore and put the contributor workflow to practice. The summit spans two days - an optional social event in the evening of Sunday, May 19th along with the main full-day event on Monday, May 20th.
+
+In some sense, the summit is a real-life extension of the community meetings and SIG meetings. There are three explicit goals:
+
+ - Onboard new contributors to be productive in our community
+ - Send contributors home with more context, knowledge, and skills about the project
+ - SIG-specific face-to-face collaboration
+
+
+## Registration
+
+ - [Sign the CLA](/CLA.md) if you have not done so already
+ - Registration form will be available soon
+
+## When and Where
+
+The Contributor Summit takes place in the days leading up to [KubeCon + CloudNativeCon Europe](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019/), make sure you plan travel accordingly.
+
+ - Sunday, May 19, 2019 - Social event (optional)
+ - Monday, May 20, 2019 - Contributor Summit
+ - Fira Gran Via, Barcelona, Spain
+ - Event website with more information: LINK TBD
+
+## Contributor Summit Team
+
+
+| Role  | Lead |
+| ------------- | ------------- |
+| Summit Lead  | Jonas Rosland (@jonasrosland)  |
+| Project Manager  | Ihor Dvoretskyi (@idvoretskyi)  |
+| Marketing & Comms  | Paris Pittman (@parispittman)  |
+| Accessibility, Inclusiveness, and Diversity  | Noah Kantrowitz (@coderanger)  |
+| Venue  | Deb Giles (@debgiles)  |
+| Social Event  | Paris Pittman (@parispittman)  |
+| Content - General  | Dawn Foster (@geekygirldawn) |
+| Content - Specific  | Guinevere Saenger (@guineveresaenger)  |
+| Registration  | Bob Killen (@mrbobbytables)  |
+| Swag   | Jorge Castro (@castrojo)
+| Photography  | Ruben Orduz (@rdodev)  |
+
+
+## Media Policy
+
+A photographer and videographer will be onsite recording sessions, collecting b-roll and other shots for KubeCon. If you would rather not be involved, please reach out to an organizer on the day of so we may accommodate you.
+
+
+## Code of Conduct
+
+This event, like all Kubernetes events, has a [Code of Conduct](/code-of-conduct.md). We will have an onsite rep with contact information to be provided here and posted during the event.
+
+
+## Misc
+We want to remove as many barriers as possible for you to attend this event. Please contact community@kubernetes.io to see if we can accommodate a request.
+
+Further details to be updated on this doc. Please check back for a complete guide.


### PR DESCRIPTION
Update the Contributor Summit EU docs with initial information such as time and date, roles and leads, and some basic venue information.

Signed-off-by: Jonas Rosland <jrosland@vmware.com>

