### PR TITLE
Add new Slack mods to the list

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -109,12 +109,13 @@ These are listed as "Communications Managers" in YouTube
 
 #### Moderators (9)
 
+- Bob Killen (@mrbobbytables) - ET
 - Ihor Dvoretskyi (@idvoretskyi) - EET
 - Jaice Singer DuMars (@jdumars) - PT
+- Jeffrey Sica (@jeefy) - ET
 - Jorge Castro (@castrojo) - ET
+- Katharine Berry (@Katharine) - PT
 - Paris Pittman (@parispittman) - PT
-- Open
-- Open
 - Open
 - Open
 


### PR DESCRIPTION
Add @Katharine (closes #3316), @mrbobbytables (closes #3310), and @jeefy (closes #3321) to the Slack moderators list.

Also increases the number of bullet points to 9 to match the number listed, assuming I can count correctly.

/sig contributor-experience
/area community-management
