### PR TITLE
Fixed url of wg's google group in community/wg-k8s-infra/charter.md

### DIFF
--- a/wg-k8s-infra/charter.md
+++ b/wg-k8s-infra/charter.md
@@ -127,5 +127,5 @@ time.
 [lazy consensus]: http://en.osswiki.info/concepts/lazy_consensus
 
 [kubernetes-dev@]: https://groups.google.com/forum/#!forum/kubernetes-dev
-[wg-k8s-infra@]: https://groups.google.com/forum/#!forum/k8s-infra-team
+[wg-k8s-infra@]: https://groups.google.com/forum/#!forum/kubernetes-wg-k8s-infra
 [kubernetes/k8s.io]: https://git.k8s.io/k8s.io


### PR DESCRIPTION
According to: https://github.com/kubernetes/k8s.io/issues/166

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->