### PR TITLE
Fix link to Embargo Policy

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -4,7 +4,7 @@
 # to for triaging and handling of incoming issues.
 #
 # The below names agree to abide by the
-# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
 # and will be removed and replaced if they violate that agreement.
 #
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE

--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -161,5 +161,5 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
 [sigs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml#L1454
 [OWNERS]: contributors/devel/owners.md
 [Kubernetes Charter README]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md
-[Embargo Policy]: https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy
+[Embargo Policy]: https://git.k8s.io/security/private-distributors-list.md#embargo-policy
 [SECURITY_CONTACTS]: https://github.com/kubernetes/kubernetes-template-project/blob/master/SECURITY_CONTACTS

--- a/github-management/README.md
+++ b/github-management/README.md
@@ -111,4 +111,4 @@ repositories and organizations:
   and migrate labels across an entire organization based on a defined YAML
   configuration
 
-[security embargo policy]: https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/private-distributors-list.md#embargo-policy
+[security embargo policy]: https://git.k8s.io/security/private-distributors-list.md#embargo-policy

--- a/sig-service-catalog/charter.md
+++ b/sig-service-catalog/charter.md
@@ -113,7 +113,7 @@ roles. We do not have the Tech Lead role, and have a honorary Emeritus Chair rol
     triaging and handling of incoming issues.
   - Must be a maintainer.
   - Must accept and adhere to the Kubernetes [Embargo
-    Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy).
+    Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy).
   - Defined in
     [SECURITY_CONTACTS](https://github.com/kubernetes-incubator/service-catalog/blob/master/SECURITY_CONTACTS)
     file.


### PR DESCRIPTION
Related kubernetes/security#2, https://github.com/kubernetes/kubernetes-template-project/pull/27

The link to the Embargo Policy 404s for all `SECURITY_CONTACTS` files in all repos, but I want to be sure to update in this repo since it has lots of process-related docs for roles which require acceptance of the embargo policy (github-management for example).

/cc @philips @joelsmith @liggitt 