### PR TITLE
Remove generated examples, its unclear what it means.

### DIFF
--- a/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md
+++ b/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md
@@ -50,8 +50,6 @@ Development would be based on a generated client using OpenAPI and [swagger-code
 
     * Proto encoding
 
-    * Generated examples
-
 ### Client Support Level
 
 * Alpha [![Client Support Level](https://img.shields.io/badge/kubernetes%20client-alpha-green.svg?style=plastic&colorA=306CE8)](/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)


### PR DESCRIPTION
As far as I can tell this qualification is poorly understood, and actually not a great goal anyway, since the generated examples (e.g. https://github.com/kubernetes-client/java/blob/master/kubernetes/docs/AppsV1Api.md#deleteCollectionNamespacedDaemonSet) aren't really that useful anyway.

There's separate requirements about docs for the `stable` status below, and this is confusing various people
(e.g. https://github.com/kubernetes-client/javascript/pull/182)

Thus, I think it makes sense to delete this requirement.

cc @lavalamp @mbohlool 