### PR TITLE
github-management: document team structure and process

### DIFF
--- a/github-management/opening-a-request.md
+++ b/github-management/opening-a-request.md
@@ -15,6 +15,10 @@ If you need help with the following:
 Please open an issue against the [kubernetes/org] repository describing your
 issue. If your request is urgent, please escalate to **[@kubernetes/owners]**.
 
+To create a new team, add a member to a team or rename a team, please
+create a PR against the [kubernetes/org] repository according to
+the [team guidance].
+
 ## Bot/Automation issues
 
 If you need help with the following:
@@ -32,3 +36,4 @@ your issue. If your request is urgent, please escalate to the
 [@kubernetes/owners]: https://github.com/orgs/kubernetes/teams/owners
 [kubernetes/test-infra]: https://github.com/kubernetes/test-infra/issues
 [test-infra on-call]: https://go.k8s.io/oncall
+[team guidance]: /github-management/org-owners-guide.md#team-guidance

--- a/github-management/org-owners-guide.md
+++ b/github-management/org-owners-guide.md
@@ -48,6 +48,8 @@ transfer in existing code.
 
 ## Team Guidance
 
+### Nomenclature
+
 Each organization should have the following teams:
 
 - teams for each repo `foo`
@@ -75,6 +77,24 @@ for all orgs going forward.  Notable discrepancies at the moment:
 - `admins-foo` and `maintainers-foo` teams as used by the kubernetes-incubator
   org. This was a mistake that swapped the usual convention, and we would like
   to rename the team
+
+### Structure and Process
+
+Guidelines on how to create and structure teams are described below:
+
+- Teams should not have any `maintainers` and everyone who should be part of
+the team should be added in the `members` list.
+  - Note that because of how the GiHub API works, org admins still need to be
+    in the `maintainers` list for the teams they are a part of.
+- The `privacy` of a team *must* be `closed`.
+- A new team can be created or a member can be added to a team by
+creating a PR against the [kubernetes/org] repo. The PR must be
+approved by the relevant `OWNERS` or the SIG leads.
+  - For example, addition of a member to `foo-maintainers` must be approved
+    by the `OWNERS` of the repo `foo` or the leads of the SIG associated
+    with the repo.
+- To rename a team, add the `previously: <old-team-name>` field to the team
+and rename the `name` of the team to the new name.
 
 ## Project Board Guidance
 
@@ -109,3 +129,4 @@ Project](https://github.com/kubernetes/kubernetes-template-project), and the
 [GitHub Administration Team]:
 /github-management/README.md#github-administration-team
 [@kubernetes/owners]: https://github.com/orgs/kubernetes/teams/owners
+[kubernetes/org]: https://github.com/kubernetes/org


### PR DESCRIPTION
Fixes https://github.com/kubernetes/community/issues/3102
and address the docs part of https://github.com/kubernetes/org/issues/563

/kind documentation
/cc @spiffxp @justaugustus @mrbobbytables @idealhack @rlenferink 
/assign @spiffxp 