### PR TITLE
Fix link in README.md

### DIFF
--- a/contributors/devel/README.md
+++ b/contributors/devel/README.md
@@ -43,7 +43,7 @@ Guide](http://kubernetes.io/docs/admin/).
 * **Coding Conventions** ([coding-conventions.md](../guide/coding-conventions.md)):
   Coding style advice for contributors.
 
-* **Document Conventions** ([how-to-doc.md](how-to-doc.md))
+* **Document Conventions** ([The Kubernetes documentation](https://github.com/kubernetes/website))
   Document style advice for contributors.
 
 * **Running a cluster locally** ([running-locally.md](running-locally.md)):
@@ -60,7 +60,7 @@ Guide](http://kubernetes.io/docs/admin/).
 * **API Conventions** ([api-conventions.md](api-conventions.md)):
   Defining the verbs and resources used in the Kubernetes API.
 
-* **API Client Libraries** ([client-libraries.md](client-libraries.md)):
+* **API Client Libraries** ([Client Libraries](https://kubernetes.io/docs/reference/using-api/client-libraries/)):
   A list of existing client libraries, both supported and user-contributed.
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

## Why

I visited [contributors/devel/README.md](https://github.com/kubernetes/community/blob/d91a9912d5712fb82293da49f9a0a53a8b4134fb/contributors/devel/README.md) from [kubernetes/kubernetes]( https://github.com/kubernetes/kubernetes/blame/eaa78b88ac25a61bfb1aa81d118c5ffeda041b64/README.md#L58).

I find some broken links.

## What

Fix links.
I got URLs from PRs below.

- Document Conventions
  - PR: Deleting outdated stub file #3137
  - https://github.com/kubernetes/community/pull/3137/files#diff-145ff4e94d6e25958957f2fb0568af8fL5
- API Client Libraries
  - PR: Deleting stub files in /devel and updating links - Umbrella issue 3064 #3086
  - https://github.com/kubernetes/community/pull/3086/files#diff-2b7114a5eb334757eb23135e4a9c5563L3