### PR TITLE
Fix links to sig creation/lifecycle doc

### DIFF
--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -197,7 +197,7 @@ Thanks for making Kubernetes meetings work great!
 [CNCF Service Desk]: https://github.com/cncf/servicedesk
 [Kubernetes Code of Conduct]: /code-of-conduct.md
 [code of conduct committee]: /committee-code-of-conduct/README.md
-[SIG Creation procedure]: /sig-governance.md#sig-creation-and-maintenance-procedure
+[SIG Creation procedure]: /sig-wg-lifecycle.md#communicate
 [latest version]: https://zoom.us/download
 [documentation on how to use their moderation tools]: https://support.zoom.us/hc/en-us/articles/201362603-Host-Controls-in-a-Meeting
 [best practices doc]: https://docs.google.com/document/d/1fudC_diqhN2TdclGKnQ4Omu4mwom83kYbZ5uzVRI07w/edit?usp=sharing

--- a/generator/list.tmpl
+++ b/generator/list.tmpl
@@ -9,7 +9,7 @@ depending on their needs and workflow.
 
 Each group's material is in its subdirectory in this project.
 
-When the need arises, a [new SIG can be created](sig-creation-procedure.md)
+When the need arises, a [new SIG can be created](sig-wg-lifecycle.md)
 
 ### Master SIG List
 

--- a/sig-list.md
+++ b/sig-list.md
@@ -16,7 +16,7 @@ depending on their needs and workflow.
 
 Each group's material is in its subdirectory in this project.
 
-When the need arises, a [new SIG can be created](sig-creation-procedure.md)
+When the need arises, a [new SIG can be created](sig-wg-lifecycle.md)
 
 ### Master SIG List
 


### PR DESCRIPTION
Follow up of the TODOs in https://github.com/kubernetes/community/pull/3287

TODO:
- [x] generator/list.tmpl -> need to change the sig creation link to sig-wg-lifecycle (doc added here)
- [x] fix all dependancies to the root /sig-goverance.md to direct to the /committee-steering/sig-governance file.
 - There are no such dependencies. 

/assign @parispittman 