### PR TITLE
Add 2fa requirement to moderator request template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/moderator_application.md
+++ b/.github/ISSUE_TEMPLATE/moderator_application.md
@@ -19,6 +19,7 @@ e.g. (at)property_user
 ### Requirements
 
 - [ ] I am a Kubernetes Org member already
+- [ ] I have enabled 2FA on my account for the property I would like to moderate (if applicable).
 - [ ] I have read and will abide by the policies mentioned in the [Moderation Guidelines](https://git.k8s.io/community/communication/moderation.md)
 - [ ] I have two sponsors that meet the sponsor requirements listed in the moderator guidelines
 - [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application


### PR DESCRIPTION
Moderators for Kubernetes communication properties should enable 2FA for any property they are going to moderate.

/cc @jeefy @castrojo 