### PR TITLE
Add multi-tenancy subproject to sig-auth

### DIFF
--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -128,6 +128,10 @@ The following subprojects are owned by sig-auth:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/token/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/serviceaccount/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/serviceaccount/OWNERS
+- **multi-tenancy**
+  - Description: Proposals and prototypes for introducing tenant model to enable multi-tenant cluster
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/OWNERS
 
 ## GitHub Teams
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -443,6 +443,11 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/token/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/serviceaccount/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/serviceaccount/OWNERS
+    - name: multi-tenancy
+      description: >
+       Proposals and prototypes for introducing tenant model to enable multi-tenant cluster
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/OWNERS
   - name: Autoscaling
     dir: sig-autoscaling
     mission_statement: >


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/528

/cc @liggitt @tallclair @mikedanese @easeway @davidopp 