### PR TITLE
Add note about updating copyright for donated repos

### DIFF
--- a/github-management/kubernetes-repositories.md
+++ b/github-management/kubernetes-repositories.md
@@ -98,6 +98,8 @@ the developers who could not be reached
      [@caniszczyk](https://github.com/caniszczyk) for review of third party deps
    * Boilerplate text across all files should attribute copyright as follows:
      `"Copyright <Project Authors>"` if no CLA was in place prior to donation
+     * If there was a CLA prior to donation, the copyright can be updated post-transfer.
+     The copyright _must_ be updated by someone from the donating organization.
 
 ## Core Repositories
 


### PR DESCRIPTION
Ref: https://groups.google.com/d/topic/kubernetes-sig-architecture/TjHLgJcDF-I/discussion

fyi @kubernetes/owners @caniszczyk 

/cc @dims @justaugustus @swinslow 
licensing subproject members

/assign @spiffxp 
github-management owner

/assign @swinslow 
/hold
Want to make sure that we get lgtm by @swinslow because this is legalese 

