### PR TITLE
Add etcdadm subproject to sig-cluster-lifecycle

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -69,6 +69,9 @@ The following subprojects are owned by sig-cluster-lifecycle:
 - **cluster-api-provider-openstack**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
+- **etcdadm**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/etcdadm/master/OWNERS
 - **kops**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -910,6 +910,9 @@ sigs:
     - name: cluster-api-provider-openstack
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
+    - name: etcdadm
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-sigs/etcdadm/master/OWNERS
     - name: kops
       owners:
       - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS


### PR DESCRIPTION
As requested in https://github.com/kubernetes/org/issues/308

/cc @cblecker 
/cc @nikhita 