### PR TITLE
added export to user and working dir examples

### DIFF
--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -22,7 +22,7 @@ Define a local working directory:
 # You must follow exactly this pattern,
 # neither `$GOPATH/src/github.com/${your github profile name/`
 # nor any other pattern will work.
-working_dir=$GOPATH/src/k8s.io
+export working_dir=$GOPATH/src/k8s.io
 ```
 
 > If you already do Go development on github, the `k8s.io` directory
@@ -31,7 +31,7 @@ working_dir=$GOPATH/src/k8s.io
 Set `user` to match your github profile name:
 
 ```sh
-user={your github profile name}
+export user={your github profile name}
 ```
 
 Both `$working_dir` and `$user` are mentioned in the figure above.


### PR DESCRIPTION
Added `export` to the examples for setting `working_dir` and `user` for clarity.