### PR TITLE
Remove youtube "Communications managers" from moderator roles.

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -109,8 +109,6 @@ Moderators seats: 10
 
 Moderators pro tempore seats: 3
 
-These are listed as "Communications Managers" in YouTube
-
 - Open
 - Open
 - Open


### PR DESCRIPTION
The "Communications manager" role is tied to google+ (which is being [shutdown for most users](https://support.google.com/plus/answer/9217723?hl=en)) and has limited functionality within youtube itself. All of its abilities that do come with the role, do not align with how we use youtube. With that, figure it should be removed.

/sig contributor-experience
/area community-management
/cc @castrojo @parispittman 