### PR TITLE
Add subprojects for committees

### DIFF
--- a/committee-product-security/README.md
+++ b/committee-product-security/README.md
@@ -23,6 +23,14 @@ The Kubernetes Product Security Committee is the body that is responsible for re
 * Private Mailing List: security@kubernetes.io
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fproduct-security)
 
+## Subprojects
+
+The following subprojects are owned by the Product Security Committee:
+- **security**
+  - Description: Policies and documentation for the Product Security Committee
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/security/master/OWNERS
+
 ## GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.

--- a/committee-steering/README.md
+++ b/committee-steering/README.md
@@ -36,6 +36,22 @@ The [charter](https://git.k8s.io/steering/charter.md) defines the scope and gove
 * Private Mailing List: steering-private@kubernetes.io
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fsteering)
 
+## Subprojects
+
+The following subprojects are owned by the Steering Committee:
+- **steering**
+  - Description: Steering Committee policy and documentation
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS
+- **kubernetes-template-project**
+  - Description: Template for starting new projects in the GitHub organizations owned by Kubernetes.
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
+- **spartakus**
+  - Description: Collection of usage information about Kubernetes clusters.
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
+
 ## GitHub Teams
 
 The below teams can be mentioned on issues and PRs in order to get attention from the right people.

--- a/generator/committee_readme.tmpl
+++ b/generator/committee_readme.tmpl
@@ -43,6 +43,35 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{- if .Label }}
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2F{{.Label}})
 {{- end }}
+{{- if .Subprojects }}
+
+## Subprojects
+
+The following subprojects are owned by the {{.Name}} Committee:
+
+{{- range .Subprojects }}
+- **{{.Name}}**
+{{- if .Description }}
+  - Description: {{ trimSpace .Description }}
+{{- end }}
+  - Owners:
+{{- range .Owners }}
+    - {{.}}
+{{- end }}
+{{- if .Meetings }}
+  - Meetings:
+{{- range .Meetings }}
+    - {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
+{{- if .ArchiveURL }}
+      - [Meeting notes and Agenda]({{.ArchiveURL}}).
+{{- end }}
+{{- if .RecordingsURL }}
+      - [Meeting recordings]({{.RecordingsURL}}).
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{ if .Contact.GithubTeams }}
 ## GitHub Teams
 

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -59,12 +59,6 @@ The following subprojects are owned by sig-architecture:
 - **klog**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
-- **steering**
-  - Description: Placeholder until sigs.yaml supports committees as first-class groups. These repos are owned by the kubernetes steering committee, which is a wholly separate entity from SIG Architecture
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
 
 ## GitHub Teams
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2629,3 +2629,8 @@ committees:
       teams:
       - name: product-security-committee
         description: General Discussion
+    subprojects:
+    - name: security
+      description: Policies and documentation for the Product Security Committee
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/security/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -278,12 +278,6 @@ sigs:
     - name: klog
       owners:
       - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
-    - name: steering
-      description: Placeholder until sigs.yaml supports committees as first-class groups. These repos are owned by the kubernetes steering committee, which is a wholly separate entity from SIG Architecture
-      owners:
-      - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS
-      - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
-      - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
 
   - name: Auth
     dir: sig-auth
@@ -2564,6 +2558,20 @@ committees:
       teams:
       - name: steering-committee
         description: General Discussion
+    subprojects:
+    - name: steering
+      description: Steering Committee policy and documentation
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS
+    - name: kubernetes-template-project
+      description: Template for starting new projects in the GitHub organizations owned by Kubernetes.
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
+    - name: spartakus
+      description: Collection of usage information about Kubernetes clusters.
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
+
   - name: Code of Conduct
     dir: committee-code-of-conduct
     mission_statement: >


### PR DESCRIPTION
Not sure if we officially say that committees can have subprojects, but I noticed steering as a subproject for sig-arch after creating https://github.com/kubernetes/community/pull/3437: https://github.com/kubernetes/community/tree/master/sig-architecture#subprojects.

Technically, committees also own repos (and thus "code") so I guess it makes sense to list these as subprojects?

/hold
/committee steering
/committee product-security
/cc @kubernetes/steering-committee @kubernetes/product-security-committee @mattfarina @jdumars 

/sig contributor-experience
/assign @spiffxp 
(generator owner)