### PR TITLE
Update security release page URL now that security docs have been moved

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -248,7 +248,7 @@ If you're looking to run e2e tests on your own infrastructure, [kubetest](https:
 
 ## Security
 
-- [Security Release Page](https://git.k8s.io/sig-release/security-release-process-documentation/security-release-process.md) - outlines the procedures for the handling of security issues.
+- [Security Release Page](https://git.k8s.io/security/security-release-process.md) - outlines the procedures for the handling of security issues.
 - [Security and Disclosure Information](https://kubernetes.io/docs/reference/issues-security/security/) - check this page if you wish to report a security vulnerability.
 
 ## Documentation


### PR DESCRIPTION
Somehow I missed this one in #3311

See https://github.com/kubernetes/security/pull/1 for background info