### PR TITLE
Add contact (slack, mailing_list, teams) to subprojects

### DIFF
--- a/generator/app.go
+++ b/generator/app.go
@@ -89,7 +89,7 @@ type GithubTeams struct {
 type Subproject struct {
 	Name        string
 	Description string
-	Contact     Contact
+	Contact     *Contact
 	Owners      []string
 	Meetings    []Meeting
 }

--- a/generator/app.go
+++ b/generator/app.go
@@ -89,6 +89,7 @@ type GithubTeams struct {
 type Subproject struct {
 	Name        string
 	Description string
+	Contact     Contact
 	Owners      []string
 	Meetings    []Meeting
 }

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -68,6 +68,18 @@ The following subprojects are owned by sig-{{.Label}}:
 {{- range .Owners }}
     - {{.}}
 {{- end }}
+{{- if .Contact.Slack }}
+  - Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+{{- end }}
+{{- if .Contact.MailingList }}
+  - [Mailing List]({{.Contact.MailingList}})
+{{- end }}
+{{- if .Contact.GithubTeams }}
+  - GitHub Teams: 
+{{- range .Contact.GithubTeams }}
+    - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }}({{.Description}}){{- end}}
+{{- end }}
+{{- end }}
 {{- if .Meetings }}
   - Meetings:
 {{- range .Meetings }}

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -68,16 +68,19 @@ The following subprojects are owned by sig-{{.Label}}:
 {{- range .Owners }}
     - {{.}}
 {{- end }}
+{{- if .Contact }}
+  - Contact
 {{- if .Contact.Slack }}
-  - Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+    - Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
 {{- end }}
 {{- if .Contact.MailingList }}
-  - [Mailing List]({{.Contact.MailingList}})
+    - [Mailing List]({{.Contact.MailingList}})
 {{- end }}
 {{- if .Contact.GithubTeams }}
-  - GitHub Teams: 
+    - GitHub Teams: 
 {{- range .Contact.GithubTeams }}
-    - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }}({{.Description}}){{- end}}
+      - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }}({{.Description}}){{- end}}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if .Meetings }}

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -48,6 +48,9 @@ The following subprojects are owned by sig-architecture:
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
+  - Slack: [#k8s-conformance](https://kubernetes.slack.com/messages/k8s-conformance)
+  - GitHub Teams:
+    - [@kubernetes/cncf-conformance-wg](https://github.com/orgs/kubernetes/teams/cncf-conformance-wg)
 - **code-organization**
   - Description: [Described below](#code-organization)
   - Owners:

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -48,9 +48,10 @@ The following subprojects are owned by sig-architecture:
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
-  - Slack: [#k8s-conformance](https://kubernetes.slack.com/messages/k8s-conformance)
-  - GitHub Teams:
-    - [@kubernetes/cncf-conformance-wg](https://github.com/orgs/kubernetes/teams/cncf-conformance-wg)
+  - Contact
+    - Slack: [#k8s-conformance](https://kubernetes.slack.com/messages/k8s-conformance)
+    - GitHub Teams:
+      - [@kubernetes/cncf-conformance-wg](https://github.com/orgs/kubernetes/teams/cncf-conformance-wg)
 - **code-organization**
   - Description: [Described below](#code-organization)
   - Owners:

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -49,6 +49,7 @@ The following subprojects are owned by sig-testing:
   - Description: Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
+  - Slack: [#kind](https://kubernetes.slack.com/messages/kind)
   - Meetings:
     - sigs.k8s.io/kind weekly meeting: [Mondays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
       - [Meeting notes and Agenda](https://docs.google.com/document/d/1b9Ppm7ZT_tMWRs5Ph1zGJJKb5nF9c3ZHzMwg1olJIrc/edit).
@@ -57,11 +58,13 @@ The following subprojects are owned by sig-testing:
   - Description: Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
+  - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
 - **testing-commons**
   - Description: The Testing Commons is a subproject within the Kubernetes sig-testing community interested code structure, layout, and execution of common test code used throughout the kubernetes project
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/testing_frameworks/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/OWNERS
+  - Slack: [#testing-commons](https://kubernetes.slack.com/messages/testing-commons)
   - Meetings:
     - Testing Commons: [Fridays at 07:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:30&tz=PT%20%28Pacific%20Time%29).
       - [Meeting notes and Agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit#heading=h.tnoevy5f439o).

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -49,7 +49,8 @@ The following subprojects are owned by sig-testing:
   - Description: Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
-  - Slack: [#kind](https://kubernetes.slack.com/messages/kind)
+  - Contact
+    - Slack: [#kind](https://kubernetes.slack.com/messages/kind)
   - Meetings:
     - sigs.k8s.io/kind weekly meeting: [Mondays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
       - [Meeting notes and Agenda](https://docs.google.com/document/d/1b9Ppm7ZT_tMWRs5Ph1zGJJKb5nF9c3ZHzMwg1olJIrc/edit).
@@ -58,13 +59,15 @@ The following subprojects are owned by sig-testing:
   - Description: Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
-  - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
+  - Contact
+    - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
 - **testing-commons**
   - Description: The Testing Commons is a subproject within the Kubernetes sig-testing community interested code structure, layout, and execution of common test code used throughout the kubernetes project
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/testing_frameworks/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/OWNERS
-  - Slack: [#testing-commons](https://kubernetes.slack.com/messages/testing-commons)
+  - Contact
+    - Slack: [#testing-commons](https://kubernetes.slack.com/messages/testing-commons)
   - Meetings:
     - Testing Commons: [Fridays at 07:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:30&tz=PT%20%28Pacific%20Time%29).
       - [Meeting notes and Agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit#heading=h.tnoevy5f439o).

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -264,6 +264,10 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
     - name: conformance-definition
       description: "[Described below](#conformance-definition)"
+      contact:
+        slack: k8s-conformance
+        teams:
+          - name: cncf-conformance-wg
       owners:
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
@@ -2001,6 +2005,8 @@ sigs:
       description: >
         Kubernetes IN Docker. Run Kubernetes test clusters on your local
         machine using Docker containers as nodes.
+      contact:
+        slack: kind
       meetings:
       - description: sigs.k8s.io/kind weekly meeting
         day: Monday
@@ -2016,6 +2022,8 @@ sigs:
       description: >
         Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it
         in action for the Kubernetes project
+      contact:
+        slack: prow
       owners:
       - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
     - name: testing-commons
@@ -2023,6 +2031,8 @@ sigs:
         The Testing Commons is a subproject within the Kubernetes sig-testing community
         interested code structure, layout, and execution of common test code used
         throughout the kubernetes project
+      contact:
+        slack: testing-commons
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/testing_frameworks/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/OWNERS


### PR DESCRIPTION
Demonstrate by adding slack channels for sig-testing subprojects
that already have their own slack channels

Add a GitHub team related to conformance to sig-arch's conformance
definition subproject

GitHub teams as implemented now are very kubernetes-org centric,
I'm not trying to change that here, would suggest a followup
change to allow for the use of github teams in other orgs
(like kubernetes-sigs)


/hold
I would rather let some other generator-related PR's get in first,
I suspect there are merge conflicts and I'd rather take the hit