### PR TITLE
devel guide: update patch release team contact for cherry picks

### DIFF
--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -40,9 +40,11 @@ branches.
    * Milestones on cherry-pick PRs should be the milestone for the target 
    release branch (for example, milestone 1.11 for a cherry-pick onto 
    release-1.11).
-   *  You can find the current release team members in the 
-   [appropriate release folder](https://git.k8s.io/sig-release/releases) for the target release.
-   You may cc them with `<@githubusername>` on your cherry-pick PR.
+   * During code freeze, to get attention on a cherry-pick by the current
+   release team members see the [appropriate release folder](https://git.k8s.io/sig-release/releases)
+   for the target release's team contact information. You may cc them with
+   `<@githubusername>` on your cherry-pick PR.
+   * For prior branches, check the [patch release schedule](https://git.k8s.io/sig-release/releases/patch-releases.md), which includes contact information for the patch release team.
 
 ## Cherry-pick Review
 


### PR DESCRIPTION
We're adding a GitHub team for the patch managers and have a group mail
alias to make it easier contacting the folks who shepherd cherry picks
across the arc of time.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->