### PR TITLE
Add cri-api as a subproject to sig-node

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -30,6 +30,9 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following subprojects are owned by sig-node:
+- **cri-api**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/cri-api/master/OWNERS
 - **cri-o**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cri-o/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1441,6 +1441,9 @@ sigs:
       - name: sig-node-test-failures
         description: Test Failures and Triage
     subprojects:
+    - name: cri-api
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/cri-api/master/OWNERS
     - name: cri-o
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/cri-o/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/642

/assign @dims @derekwaynecarr 