### PR TITLE
[WIP] Propose updates to the SIG ContribEx Charter

### DIFF
--- a/sig-contributor-experience/charter.md
+++ b/sig-contributor-experience/charter.md
@@ -75,7 +75,7 @@ CNCF in many of the noted cases above, contributes funding to our platforms, pro
 - Code for the testing and CI infrastructure - that’s SIG Testing
 - [kubernetes/community] Members are to follow those folders owners files and SIG leadership for the specific issue/PR in question.
 - User community relations and management.
-  - Slack or YouTube moderation (This should be a new SIG or the CNCF)
+  - Slack or YouTube moderation (This should be a new SIG)
 - The contributor experience for repos not included in the Kubernetes associated repositories list found in the [GitHub Project Organizational Management] subproject README.
 - Steering committee election policy updates and maintenance. (Steering Comittee handles this)
 - We do not create SIGs/WGs but can assist in the various community management needs of their micro communities that would kick off their formation and keep them going.
@@ -89,10 +89,10 @@ CNCF in many of the noted cases above, contributes funding to our platforms, pro
 - Ownership, staffing, and moderation of Kubernetes communication properties. The CNCF may delegate admin or management positions on these properties to members of Contributor Experience:
   - [discuss.kubernetes.io] - This tool is mostly self-moderating and enough Kubernetes members participate that most of these roles are administrative.
   - [Mailing lists] / Google groups (this belongs to the each SIG)
-  - [Slack] (CNCF)
-  - [/kubernetescommunity] YouTube channel (CNCF)
+  - [Slack] (This should be a new SIG)
+  - [/kubernetescommunity] YouTube channel (This should be a shared responsibility with a new SIG)
   - [Zoom] (CNCF)
-  - Ownership of the Kubernetes Gsuite (this is Steering Committee)
+  - Ownership of the Kubernetes G suite (this is Steering Committee)
 - Logistical Execution of the [Contributor Summit(s)]
   - The CNCF will provide us with an events manager who will handle the event logistics and provide guidance with the requirements we set forth. 
 
@@ -125,8 +125,8 @@ Chairs and Technical Leads
 [Google Summer of Code]: https://git.k8s.io/community/mentoring/google-summer-of-code.md
 [Outreachy]: https://git.k8s.io/community/mentoring/outreachy.md
 [Meet Our Contributors]:  https://git.k8s.io/community/mentoring/meet-our-contributors.md
-[Group Mentoring - WIP]:  https://git.k8s.io/community/mentoring/group-mentoring.md
-[The 1:1 Hour - WIP]: https://git.k8s.io/community/mentoring/the1-on-1hour.md
+[Group Mentoring]:  https://git.k8s.io/community/mentoring/group-mentoring.md
+[The 1:1 Hour]: https://git.k8s.io/community/mentoring/the1-on-1hour.md
 [kubernetes/community]: https://git.k8s.io/community/
 [Contributor Summit(s)]: https://git.k8s.io/community/events/2018/12-contributor-summit
 [contributor summits]: https://git.k8s.io/community/events/2018/12-contributor-summit

--- a/sig-contributor-experience/charter.md
+++ b/sig-contributor-experience/charter.md
@@ -1,51 +1,45 @@
 # Contributor Experience Special Interest Group Charter
 
-This charter adheres to the conventions described in the [Kubernetes Charter README] and uses the Roles and Organization Management outlined in [sig-governance].
-
 ## Scope
 
-The [Contributor Experience Special Interest Group] (SIG) is responsible for improving the experience of those who upstream contribute to the Kubernetes project. We do this by creating, and maintaining programs and processes that promote community health and reduce project friction, while retiring those programs and processes that don't. Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed.
-
-We do this by listening - whether it’s through our roadshows to SIG meetings, surveys, data, or [GitHub issues], we take in the feedback and turn it into our [project list]. We build a welcoming and inclusive community of contributors by giving them places to be heard and productive.
+Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed. The [Contributor Experience Special Interest Group] (SIG) is responsible for improving the experience of those who contribute upstream to the Kubernetes project. We do this by creating, and maintaining policies and processes that promote community health and reduce project friction. 
 
 ### In scope
 
 #### Code, Binaries and Services
 
-- [GitHub Management]
-- Establish policies, standards and procedures for the use, of all public platforms officially used by the project, including but not limited to:
-  - [discuss.kubernetes.io]
-  - [GitHub Management]
-  - [Mailing lists] / Google groups for the project as a whole (eg: kubernetes-dev@googlegroups.com) and for individual sigs and wgs where the Chairs have provided us ownership
-  - [Slack]
-  - [/kubernetescommunity] YouTube channel
-  - [Zoom]
-- Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
-- Own and execute events that are targeted to the Kubernetes contributor community, including:
-  - The weekly [Kubernetes Community meeting]
-  - Maintenance of the Kubernetes Gsuite
-    - Managing @kubernetes.io aliases for project usage
-    - Managing the Kubernetes Community Calendar
-  - Content and Format of the [Contributor Summit(s)]
-  - [Steering Committee elections] (though we do not own policy creation, see 'out of scope' below)
-  - Retrospective moderation for other SIGs upon request
-  - Other events, like other SIG face to face events, upon request and consideration
+The inscope bullets listed below have a matching bullet for out of scope
+
+- Help onboard new and current contributors into the culture, workflow, and CI of our contributor experience through the [contributor guide], other related documentation, [contributor summits] and programs tailored to onboarding.
 - Strategize, build, and execute on scalable [mentoring programs] for all contributor levels. These may include:
   - [Google Summer of Code]
   - [Outreachy]
   - [Meet Our Contributors]
-  - [Group Mentoring - WIP]
-  - [The 1:1 Hour - WIP]
+  - [Group Mentoring]
+  - [The 1:1 Hour]
   - Speed Mentoring sessions at selected KubeCon/CloundNativeCon's
-- Help onboard new and current contributors into the culture, workflow, and CI of our contributor experience through the [contributor guide], other related documentation, [contributor summits] and programs tailored to onboarding.
-- Perform issue triage on and maintain the [kubernetes/community] repository.  
-- Help SIGs with being as transparent and open as possible through creating best practices, guidelines, and general administration of YouTube, Zoom, and our mailing lists where applicable
-- Assist SIGs/WG Chairs and Technical Leads with organizational management operations as laid out in the [sig-governance] doc
-- Distribute contributor related news on various Kubernetes channels, including Cloud Native Compute Foundation ([CNCF]) for posting blogs, social media, and other platforms as needed.
-- Establish and share metrics to measure project health, community health, and general trends, including:
-  - ongoing work with the CNCF to improve [DevStats]
-  - the contributor experience survey(s)
-  - engagement on project platforms that we manage
+- Establish policies, standards and procedures for the following:
+  - [discuss.kubernetes.io]
+  - [GitHub Project Organizational Management]
+  - [Mailing lists] / Google groups for the project as a whole (eg: kubernetes-dev@googlegroups.com) and for individual sigs and wgs where the Chairs have provided us ownership
+  - [Slack]
+  - [/kubernetescommunity] YouTube channel
+  - [Zoom]
+  - Perform issue triage on and maintain the [kubernetes/community] repository.  
+  - Maintenance of the Kubernetes Gsuite
+    - Managing @kubernetes.io aliases for project usage
+    - Managing the Kubernetes Community Calendar
+  - The weekly [Kubernetes Community meeting]
+  - Content and Format of the [Contributor Summit(s)]
+  - Execution of the [Steering Committee elections]
+  - Retrospective moderation for other SIGs upon request
+  - Assist SIGs/WG Chairs and Technical Leads with organizational management operations as laid out in the [sig-governance] doc
+  - Distribute contributor related news on various Kubernetes channels, including Cloud Native Compute Foundation ([CNCF]) for posting blogs, social media, and other platforms as needed.
+  - Establish and share metrics to measure project health, community health, and general trends, including:
+    - Ongoing work with the CNCF to improve [DevStats]
+    - The contributor experience survey(s)
+- [GitHub Project Organizational Management]
+  - Work with other SIGs and interested parties in the project to execute GitHub tasks where required.
 - Research other OSS projects and consult with their leaders about contributor experience topics to make sure we are always delivering value to our contributors
 
 #### Cross-cutting and Externally Facing Processes
@@ -71,42 +65,41 @@ We cross-cut all SIGs and WGs to deliver the following processes:
 If we need funding for any reason, we approach [CNCF].
 CNCF in many of the noted cases above, contributes funding to our platforms, processes, and/or programs. They do not play a day-to-day operations role and have bestowed that to our community to run as we see fit. Since they do fund some of our initiatives, this means that they hold owner account privileges on certain platforms like Zoom and Slack. In these cases, such as Slack, there are at least two Contributor Experience [communication] subproject OWNERs listed as admins.
 
+- External communications platforms that we do not control but might have some influence over
+    - [r/kubernetes]
+    - [@kubernetesio] twitter account
+    - [Kubernetes Blog]
+
 ### Out of scope
 
 - Code for the testing and CI infrastructure - that’s SIG Testing
-- [kubernetes/community]  ownership of folders for KEPs and Design Proposals. Members are to follow those folders owners files and SIG leadership for the specific issue/PR in question.
-- User community management. We hold office hours because contributors are a large portion of the volunteers that run that program.
-  - Slack or YouTube moderation (This should be a new SIG or another group)
-- The contributor experience for repos not included in the Kubernetes associated repositories list found in the [GitHub Management] subproject README.
+- [kubernetes/community] Members are to follow those folders owners files and SIG leadership for the specific issue/PR in question.
+- User community relations and management.
+  - Slack or YouTube moderation (This should be a new SIG or the CNCF)
+- The contributor experience for repos not included in the Kubernetes associated repositories list found in the [GitHub Project Organizational Management] subproject README.
 - Steering committee election policy updates and maintenance. (Steering Comittee handles this)
 - We do not create SIGs/WGs but can assist in the various community management needs of their micro communities that would kick off their formation and keep them going.
   - We do not close down Working Groups, that is the responsibility of the sponsoring SIGs of that working group
 - We are not the [code of conduct committee] and therefore do not control incident management reporting or decisions; however, our moderation guidelines allow us to act swiftly if there is a clear violation of terms of either our code of conduct or one of our supported platforms terms of service. If there is an action that the committee needs to take that involves one of these platforms (example: the removal of someone from GitHub), we will carry that out if none of the committee members have access.
-- SIG Properties 
+- Ongoing maintenance of established SIG Resources. We are available to assist SIGs with these properties and provide guidance, but the responsibility of managing these day to day belongs to the individual SIG.
   - SIG Calendars and their settings
   - SIG Mailing List permissions, moderation, and maintenance
   - SIG YouTube playlist videos
   - SIG settings on their Zoom account
-  - We are available to assist SIGs with these properties and provide guidance, but the responsibility of managing these day to day belongs to the individual SIG
-- Ownership, staffing, and moderation of Kubernetes communication properties. The CNCF may delegate admin or management positions on these properties to members of Contributor Experience
+- Ownership, staffing, and moderation of Kubernetes communication properties. The CNCF may delegate admin or management positions on these properties to members of Contributor Experience:
   - [discuss.kubernetes.io] - This tool is mostly self-moderating and enough Kubernetes members participate that most of these roles are administrative.
-  - [Mailing lists] / Google groups (that belong to the each SIG)
-  - [Slack] - (TBD)
-  - [/kubernetescommunity] YouTube channel (CNCF) 
+  - [Mailing lists] / Google groups (this belongs to the each SIG)
+  - [Slack] (CNCF)
+  - [/kubernetescommunity] YouTube channel (CNCF)
   - [Zoom] (CNCF)
-- Communication platforms that are out of our scope for maintenance and support but we may still have some influence:
-    - [r/kubernetes]
-    - [@kubernetesio] twitter account
-    - [kubernetes blog]
+  - Ownership of the Kubernetes Gsuite (this is Steering Committee)
 - Logistical Execution of the [Contributor Summit(s)]
   - The CNCF will provide us with an events manager who will handle the event logistics and provide guidance with the requirements we set forth. 
-
 
 ## Roles and Organization Management
 
 This sig adheres to the Roles and Organization Management outlined in [sig-governance]
 and opts-in to updates and modifications to [sig-governance].
-
 
 ### Additional responsibilities of Chairs
 
@@ -140,7 +133,7 @@ Chairs and Technical Leads
 [DevStats]: https://k8s.cncf.devstats.io
 [kubernetes-sig-contribex@]: https://groups.google.com/forum/#!forum/kubernetes-sig-contribex
 [kubernetes blog]: https://www.kubernetes.io/blog
-[GitHub Management]: https://git.k8s.io/community/github-management
+[GitHub Project Organizational Management]: https://git.k8s.io/community/github-management
 [communication]: https://git.k8s.io/community/communication
 [CNCF]: https://cncf.io
 [GitHub issues]: https://github.com/kubernetes/community/issues

--- a/sig-contributor-experience/charter.md
+++ b/sig-contributor-experience/charter.md
@@ -34,7 +34,7 @@ The inscope bullets listed below have a matching bullet for out of scope
   - Execution of the [Steering Committee elections]
   - Retrospective moderation for other SIGs upon request
   - Assist SIGs/WG Chairs and Technical Leads with organizational management operations as laid out in the [sig-governance] doc
-  - Distribute contributor related news on various Kubernetes channels, including Cloud Native Compute Foundation ([CNCF]) for posting blogs, social media, and other platforms as needed.
+  - Distribute contributor related news on various Kubernetes channels, including Cloud Native Computing Foundation ([CNCF]) for posting blogs, social media, and other platforms as needed.
   - Establish and share metrics to measure project health, community health, and general trends, including:
     - Ongoing work with the CNCF to improve [DevStats]
     - The contributor experience survey(s)

--- a/sig-contributor-experience/charter.md
+++ b/sig-contributor-experience/charter.md
@@ -13,7 +13,13 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
 #### Code, Binaries and Services
 
 - [GitHub Management]
-- [Mailing lists] / Google groups for the project as a whole (eg: kubernetes-dev@googlegroups.com) that are not owned by SIGs
+- Establish policies, standards and procedures for the use, of all public platforms officially used by the project, including but not limited to:
+  - [discuss.kubernetes.io]
+  - [GitHub Management]
+  - [Mailing lists] / Google groups for the project as a whole (eg: kubernetes-dev@googlegroups.com) and for individual sigs and wgs where the Chairs have provided us ownership
+  - [Slack]
+  - [/kubernetescommunity] YouTube channel
+  - [Zoom]
 - Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
 - Own and execute events that are targeted to the Kubernetes contributor community, including:
   - The weekly [Kubernetes Community meeting]
@@ -81,17 +87,19 @@ CNCF in many of the noted cases above, contributes funding to our platforms, pro
   - SIG Mailing List permissions, moderation, and maintenance
   - SIG YouTube playlist videos
   - SIG settings on their Zoom account
-  - We are available to assist SIGs with these properties, but the responsibility of managing these day to day belongs to the individual SIG
-- Account ownership of the Kubernetes public social properties. The CNCF may delegate admin or management positions on these properties to members of Contrib Ex:
-  - Main Zoom account (CNCF)
-  - Main YouTube account (CNCF)
-  - Main Slack ownership (CNCF)
+  - We are available to assist SIGs with these properties and provide guidance, but the responsibility of managing these day to day belongs to the individual SIG
+- Ownership, staffing, and moderation of Kubernetes communication properties. The CNCF may delegate admin or management positions on these properties to members of Contributor Experience
+  - [discuss.kubernetes.io] - This tool is mostly self-moderating and enough Kubernetes members participate that most of these roles are administrative.
+  - [Mailing lists] / Google groups (that belong to the each SIG)
+  - [Slack] - (TBD)
+  - [/kubernetescommunity] YouTube channel (CNCF) 
+  - [Zoom] (CNCF)
 - Communication platforms that are out of our scope for maintenance and support but we may still have some influence:
     - [r/kubernetes]
     - [@kubernetesio] twitter account
     - [kubernetes blog]
 - Logistical Execution of the [Contributor Summit(s)]
-  - The CNCF will handle the logistical requirements of the contributor summits with our input while we will focus on the content.
+  - The CNCF will provide us with an events manager who will handle the event logistics and provide guidance with the requirements we set forth. 
 
 
 ## Roles and Organization Management

--- a/sig-contributor-experience/charter.md
+++ b/sig-contributor-experience/charter.md
@@ -12,21 +12,15 @@ We do this by listening - whether it’s through our roadshows to SIG meetings, 
 
 #### Code, Binaries and Services
 
-- Establish policies, standards and procedures for the use, [moderation], and management of all public platforms officially used by the project, including but not limited to:
-  - [discuss.kubernetes.io]
-  - [GitHub Management]
-  - [Mailing lists] / Google groups for the project as a whole (eg: kubernetes-dev@googlegroups.com) and for individual sigs and wgs where the Chairs have provided us ownership
-  - [Slack]
-  - [/kubernetescommunity] YouTube channel
-  - [Zoom]
-- Establish and staff teams responsible for the administration and moderation of these platforms
-  - Teams must be staffed by trusted contributors spanning time zones, see [moderation] for more detail
-  - They are authorized to take immediate action when dealing with code of conduct issues, see [moderators] for the full list
-  - They are expected to escalate to the project's code of conduct committee when issues rise above the level of simple moderation
+- [GitHub Management]
+- [Mailing lists] / Google groups for the project as a whole (eg: kubernetes-dev@googlegroups.com) that are not owned by SIGs
 - Work with other SIGs and interested parties in the project to execute GitHub tasks where required, see [GitHub Management] for more detail
 - Own and execute events that are targeted to the Kubernetes contributor community, including:
   - The weekly [Kubernetes Community meeting]
-  - [Contributor Summit(s)]
+  - Maintenance of the Kubernetes Gsuite
+    - Managing @kubernetes.io aliases for project usage
+    - Managing the Kubernetes Community Calendar
+  - Content and Format of the [Contributor Summit(s)]
   - [Steering Committee elections] (though we do not own policy creation, see 'out of scope' below)
   - Retrospective moderation for other SIGs upon request
   - Other events, like other SIG face to face events, upon request and consideration
@@ -76,14 +70,29 @@ CNCF in many of the noted cases above, contributes funding to our platforms, pro
 - Code for the testing and CI infrastructure - that’s SIG Testing
 - [kubernetes/community]  ownership of folders for KEPs and Design Proposals. Members are to follow those folders owners files and SIG leadership for the specific issue/PR in question.
 - User community management. We hold office hours because contributors are a large portion of the volunteers that run that program.
+  - Slack or YouTube moderation (This should be a new SIG or another group)
 - The contributor experience for repos not included in the Kubernetes associated repositories list found in the [GitHub Management] subproject README.
-- Steering committee election policy updates and maintenance.
+- Steering committee election policy updates and maintenance. (Steering Comittee handles this)
 - We do not create SIGs/WGs but can assist in the various community management needs of their micro communities that would kick off their formation and keep them going.
+  - We do not close down Working Groups, that is the responsibility of the sponsoring SIGs of that working group
 - We are not the [code of conduct committee] and therefore do not control incident management reporting or decisions; however, our moderation guidelines allow us to act swiftly if there is a clear violation of terms of either our code of conduct or one of our supported platforms terms of service. If there is an action that the committee needs to take that involves one of these platforms (example: the removal of someone from GitHub), we will carry that out if none of the committee members have access.
+- SIG Properties 
+  - SIG Calendars and their settings
+  - SIG Mailing List permissions, moderation, and maintenance
+  - SIG YouTube playlist videos
+  - SIG settings on their Zoom account
+  - We are available to assist SIGs with these properties, but the responsibility of managing these day to day belongs to the individual SIG
+- Account ownership of the Kubernetes public social properties. The CNCF may delegate admin or management positions on these properties to members of Contrib Ex:
+  - Main Zoom account (CNCF)
+  - Main YouTube account (CNCF)
+  - Main Slack ownership (CNCF)
 - Communication platforms that are out of our scope for maintenance and support but we may still have some influence:
     - [r/kubernetes]
     - [@kubernetesio] twitter account
     - [kubernetes blog]
+- Logistical Execution of the [Contributor Summit(s)]
+  - The CNCF will handle the logistical requirements of the contributor summits with our input while we will focus on the content.
+
 
 ## Roles and Organization Management
 


### PR DESCRIPTION
This is a work in progress and needs community discussion.

Things that end up not belonging to anyone end up being owned by Contrib Ex. This is a first draft at nailing down exactly what we should be responsible for and what we should not be responsible for.

Note that this effectively removes ContribEx as the default moderator of all the kubernetes properties. The project will still need this work to get done, so where appropriate I've moved that back to the SIGs, and for everything else it will require discussion or perhaps a new community structure to manage those things. 

Changes: 

- Explicitly add Kubernetes Gsuite as a responsibility
- Explicitly add CNCF as the lead owner of Zoom, YouTube, and Slack
accounts
- Begin to document responsibilities around contributor summits between
this SIG and the CNCF
- Explicitly remove moderation of social properties as a responsility
- Explicitly remove closing down working groups as a responsibility
- Explicitly remove SIG Calendar, lists, YouTube playlists, and Zoom
settings as a responsibility

/hold
/sig contributor-experience