### PR TITLE
Fix SIG Governance link

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -207,7 +207,7 @@ All contributors must sign the CNCF CLA, as described [here](CLA.md).
 [design principles]: /contributors/design-proposals/architecture/principles.md
 [scope]: https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/
 [community membership]: /community-membership.md
-[sig governance]: /committee-steering/sig-governance.md
+[sig governance]: /committee-steering/governance/sig-governance.md
 [owners]: /community-membership.md#subproject-owner
 [sig charter process]: /committee-steering/governance/README.md
 [short template]: /committee-steering/governance/sig-governance-template-short.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
Just point the SIG Governance link to the right document (looks like it got moved).