### PR TITLE
Fix a link to "communication" document

### DIFF
--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -171,7 +171,7 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
 
 [SIG PM]: https://github.com/kubernetes/community/tree/master/sig-pm
 [k/enhancements]: https://github.com/kubernetes/enhancements
-[forums provided]:
+[forums provided]: /communication/README.md
 
 [lazy-consensus]: http://en.osswiki.info/concepts/lazy_consensus
 [super-majority]: https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

The link to the `communication` document was there but missing the URL. Just added the desired URL.

Fixes #3530