### PR TITLE
Add community membership requirement

### DIFF
--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -24,6 +24,8 @@ Subproject Owner Role.  (this different from a SIG or Organization Member).
 - Initial members are defined at the founding of the SIG or Subproject as part of the acceptance
   of that SIG or Subproject.
 - Members *SHOULD* remain active and responsive in their Roles.
+- Members *MUST* be [community members] to be eligible to hold a leadership role
+  within a SIG.
 - Members taking an extended leave of 1 or more months *SHOULD*
   coordinate with other members to ensure the
   role is adequately staffed during the leave.
@@ -183,3 +185,4 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
 [Embargo Policy]: https://git.k8s.io/security/private-distributors-list.md#embargo-policy
 [SECURITY_CONTACTS]: https://github.com/kubernetes/kubernetes-template-project/blob/master/SECURITY_CONTACTS
 [sig-wg-lifecycle]: /sig-wg-lifecycle.md
+[community members]: /community-membership.md

--- a/committee-steering/governance/wg-governance.md
+++ b/committee-steering/governance/wg-governance.md
@@ -73,6 +73,8 @@ should eventually be reflected in a pull request on sigs.yaml:
 1. Who will chair the group, and ensure it continues to meet these requirements?
 1. Is diversity well-represented in the Working Group?
 
+Please note that all working group organizers and holders of other leadership roles must be [community members].
+
 Once the above questions have been answered, complete the rest of the checklist in the [SIG / WG Lifecycle] document
 
 Once merged, the Working Group is officially chartered until it either completes its stated goal, or disbands
@@ -106,3 +108,4 @@ References
 
 [SIG / WG Lifecycle]: /sig-wg-lifecycle.md
 [repositories document]: https://github.com/kubernetes/community/blob/master/github-management/kubernetes-repositories.md
+[community members]: /community-membership.md

--- a/governance.md
+++ b/governance.md
@@ -25,7 +25,7 @@ environment for our contributors and users. We want everyone in the community to
 
 # Community membership
 
-See [community membership]
+See [community membership][community members]
 
 # Community groups
 
@@ -127,15 +127,14 @@ Working groups are documented in [sigs.yaml].
 
 ## Committees
 
-Some topics, such as Security or Code of Conduct, require
-discretion. Whereas SIGs are voluntary groups which operate in the
-open and anyone can join, Committees do not have open membership and do
-not always operate in the open.  The steering committee can form
-committees as needed, for bounded or unbounded duration.  Membership
-of a committee is decided by the steering committee.  Like a SIG, a
-committee has a charter and a chair, and will report to the steering
-committee periodically, and to the community as makes sense, given the
-charter.
+Some topics, such as Security or Code of Conduct, require discretion. Whereas
+SIGs are voluntary groups which operate in the open and anyone can join,
+Committees do not have open membership and do not always operate in the open.
+The steering committee can form committees as needed, for bounded or unbounded
+duration.  Membership of a committee is decided by the steering committee,
+however, all committee members must be [community members].  Like a SIG, a
+committee has a charter and a chair, and will report to the steering committee
+periodically, and to the community as makes sense, given the charter.
 
 ## User groups
 Some topics have long term relevance to large groups of Kubernetes users, but
@@ -152,12 +151,13 @@ SIGs (e.g. SIG Docs) rather than as part of the user group. These contributions
 are expected to be more incremental and ad-hoc versus the more targeted
 output of a user group.
 
-User groups function as a centralized resource to facilitate communication
-and discovery of information related to the topic of the user group. User
-groups should not undertake to produce any deliverable, instead they should
-form working groups under the auspices of some SIG for such work. Likewise
-they shouldn't take ownership of anything in the Kubernetes process, as
-that is a role for SIGs.
+User groups function as a centralized resource to facilitate communication and
+discovery of information related to the topic of the user group. User groups
+should not undertake to produce any deliverable, instead they should form
+working groups under the auspices of some SIG for such work. Likewise they
+shouldn't take ownership of anything in the Kubernetes process, as that is a
+role for SIGs. All user group chairs, and others that hold leadership positions
+within a user group must be [community members].
 
 To facilitate discoverability and engagement,
 user groups are documented in [sigs.yaml]
@@ -206,7 +206,7 @@ All contributors must sign the CNCF CLA, as described [here](CLA.md).
 [Kubernetes code of conduct]: /code-of-conduct.md
 [design principles]: /contributors/design-proposals/architecture/principles.md
 [scope]: https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/
-[community membership]: /community-membership.md
+[community members]: /community-membership.md
 [sig governance]: /committee-steering/governance/sig-governance.md
 [owners]: /community-membership.md#subproject-owner
 [sig charter process]: /committee-steering/governance/README.md

--- a/sig-wg-lifecycle.md
+++ b/sig-wg-lifecycle.md
@@ -9,6 +9,7 @@ Out of scope for this document: [subproject] creation.
 ## [Creation]
 ### Prerequisites for a SIG
 - [ ] Read [sig-governance.md]
+- [ ] Ensure all SIG Chairs, Technical Leads, and other leadership roles are [community members]
 - [ ] Send an email to the Steering Committee <steering@kubernetes.io> to scope the SIG and get provisional approval.
 - [ ] Look at the checklist below for processes and tips that you will need to do while this is going on. It's best to collect this information upfront so you have a smoother process to launch
 - [ ] Follow the [SIG charter process] to propose and obtain approval for a charter
@@ -16,6 +17,7 @@ Out of scope for this document: [subproject] creation.
 
 ### Prerequisites for a WG
 - [ ] Read [wg-governance.md]
+- [ ] Ensure all WG Organizers, and other leadership roles are [community members]
 - [ ] Send email to [kubernetes-dev@googlegroups.com] titled "WG-Creation-Request: WG Foo" with some of the questions answered from wg-goverance.md and wait for community discourse; ask for SIG sponsorship
 - [ ] Do the first checklist item in the #GitHub section below and add a row to the WG section:
   - [ ] Label with committee/steering and wait for a simple majority
@@ -109,3 +111,4 @@ Sometimes it might be necessary to sunset a SIG or Working Group. SIGs/WGs may a
 [Thursday community updates]: /events/community-meeting.md
 [example]: https://docs.google.com/document/d/1qZcAvuWBznR_oEaPWtwm7U4JNT91m8r9YOUvInU-src/edit#heading=h.jsw0l2t0ra8
 [update meetings]: /communication/calendar-guidelines.md
+[community members]: /community-membership.md


### PR DESCRIPTION
If sig leaders are not community members, this prevents us from putting them in OWNERS files, assigning issues/PRs to them, and other common community administration tasks. Requiring folks to go through this process also ensures that leaders are established members of the community and have had their work reviewed/sponsored by others.

/committee steering
/cc @kubernetes/steering-committee 
/hold