### PR TITLE
Add legacyflag OWNERS to component-base subproject

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -101,6 +101,7 @@ The following subprojects are owned by sig-api-machinery:
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/component-base/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/legacyflag/master/OWNERS
 
 ## GitHub Teams
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -118,6 +118,7 @@ sigs:
       owners:
       - https://raw.githubusercontent.com/kubernetes/component-base/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/OWNERS
+      - https://raw.githubusercontent.com/kubernetes-sigs/legacyflag/master/OWNERS
   - name: Apps
     dir: sig-apps
     mission_statement: >


### PR DESCRIPTION
Now that repo https://github.com/kubernetes-sigs/legacyflag is created per https://github.com/kubernetes/org/issues/683 and KEP https://github.com/kubernetes/enhancements/pull/764, add OWNERS link to the component-base subproject in sigs.yaml.

/cc @nikhita @luxas @sttts