### PR TITLE
Add sig-docs-es team

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -59,6 +59,7 @@ Note that the links to display team membership will only work if you are a membe
 | @kubernetes/sig-docs-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers) | Documentation maintainers |
 | @kubernetes/sig-docs-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-docs-pr-reviews) | Documentation PR reviews |
 | @kubernetes/sig-docs-en-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-en-owners) | English content (default) |
+| @kubernetes/sig-docs-es-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-es-owners) | Spanish content |
 | @kubernetes/sig-docs-de-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-de-owners) | German content |
 | @kubernetes/sig-docs-fr-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-fr-owners) | French content |
 | @kubernetes/sig-docs-it-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-it-owners) | Italian content |

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1136,6 +1136,8 @@ sigs:
         description: Documentation PR reviews
       - name: sig-docs-en-owners
         description: English content (default)
+      - name: sig-docs-es-owners
+        description: Spanish content
       - name: sig-docs-de-owners
         description: German content
       - name: sig-docs-fr-owners


### PR DESCRIPTION
This pull requests adds the sig-docs-es team to the community repo. This team is working on the spanish localization and was added in https://github.com/kubernetes/org/pull/685.

```
❯ make WHAT=sig-docs generate | grep -v Skipping
go run ./generator/app.go
Generating sig-docs/README.md
Generating sig-list.md
Generating OWNERS_ALIASES
Finished generation!
```