### PR TITLE
Display label for user groups in the SIG list

### DIFF
--- a/generator/list.tmpl
+++ b/generator/list.tmpl
@@ -34,16 +34,15 @@ When the need arises, a [new SIG can be created](sig-wg-lifecycle.md)
 {{- range .WorkingGroups}}
 |[{{.Name}}]({{.Dir}}/README.md)|{{range .StakeholderSIGs}}* {{.}}<br>{{end }}|{{range .Leadership.Chairs}}* [{{.Name}}](https://github.com/{{.GitHub}}){{if .Company}}, {{.Company}}{{end}}<br>{{end}}|* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})<br>* [Mailing List]({{.Contact.MailingList}})|{{range .Meetings}}* {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}} ({{.Frequency}})]({{.URL}})<br>{{end}}
 {{- end }}
-{{- /* TODO: remove the below condition when at least one user group has been added */}}
-{{ if .UserGroups }}
+
 ### Master User Group List
 
-| Name | Organizers | Contact | Meetings |
-|------|------------|---------|----------|
+| Name | Label |Organizers | Contact | Meetings |
+|------|-------|------------|--------|----------|
 {{- range .UserGroups}}
-|[{{.Name}}]({{.Dir}}/README.md)|{{range .Leadership.Chairs}}* [{{.Name}}](https://github.com/{{.GitHub}}){{if .Company}}, {{.Company}}{{end}}<br>{{end}}|* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})<br>* [Mailing List]({{.Contact.MailingList}})|{{range .Meetings}}* {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}} ({{.Frequency}})]({{.URL}})<br>{{end}}
+|[{{.Name}}]({{.Dir}}/README.md)|{{.Label}}|{{range .Leadership.Chairs}}* [{{.Name}}](https://github.com/{{.GitHub}}){{if .Company}}, {{.Company}}{{end}}<br>{{end}}|* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})<br>* [Mailing List]({{.Contact.MailingList}})|{{range .Meetings}}* {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}} ({{.Frequency}})]({{.URL}})<br>{{end}}
 {{- end }}
-{{  end }}
+
 ### Master Committee List
 
 | Name |  Label | Members | Contact |

--- a/sig-list.md
+++ b/sig-list.md
@@ -69,9 +69,9 @@ When the need arises, a [new SIG can be created](sig-wg-lifecycle.md)
 
 ### Master User Group List
 
-| Name | Organizers | Contact | Meetings |
-|------|------------|---------|----------|
-|[Big Data](ug-big-data/README.md)|* [Anirudh Ramanathan](https://github.com/foxish), Rockset<br>* [Erik Erlandson](https://github.com/erikerlandson), Red Hat<br>* [Yinan Li](https://github.com/liyinan926), Google<br>|* [Slack](https://kubernetes.slack.com/messages/ug-big-data)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-ug-big-data)|* Regular User Group Meeting: [Wednesdays at 18:00 UTC (biweekly)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit)<br>
+| Name | Label |Organizers | Contact | Meetings |
+|------|-------|------------|--------|----------|
+|[Big Data](ug-big-data/README.md)|big-data|* [Anirudh Ramanathan](https://github.com/foxish), Rockset<br>* [Erik Erlandson](https://github.com/erikerlandson), Red Hat<br>* [Yinan Li](https://github.com/liyinan926), Google<br>|* [Slack](https://kubernetes.slack.com/messages/ug-big-data)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-ug-big-data)|* Regular User Group Meeting: [Wednesdays at 18:00 UTC (biweekly)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit)<br>
 
 ### Master Committee List
 


### PR DESCRIPTION
There is space for another column and it'd be nice to be consistent with other groups.

Note: we don't display label for WGs, but the columns look pretty dense already so I haven't added for it. 

xref https://github.com/kubernetes/test-infra/pull/12131

/cc @cblecker @spiffxp 