### PR TITLE
Add slack-management label

### DIFF
--- a/.github/ISSUE_TEMPLATE/slack-request.md
+++ b/.github/ISSUE_TEMPLATE/slack-request.md
@@ -2,7 +2,7 @@
 name: Slack Request
 about: Request a Channel, Bot, Token, or Webhook
 title: 'REQUEST: New Slack <[channel|bot|token|webhook]> <[channel|bot|token|webhook] name>'
-labels: area/community-management, sig/contributor-experience
+labels: area/community-management, area/slack-management, sig/contributor-experience
 assignees: ''
 ---
 <!--
@@ -30,6 +30,3 @@ The Slack username of the Channel/Bot/Token/Webhook owner or primary contact.
 
 
 **Description of Request:**
-
-
-

--- a/communication/slack-config/OWNERS
+++ b/communication/slack-config/OWNERS
@@ -2,13 +2,15 @@
 
 # These are the primary slack moderators.
 approvers:
-- katharine
-- castrojo
-- jeefy
-- mrbobbytables
-- alejandrox1
-- jdumars
-- parispitmann
-- coderanger
-- idvoretskyi
-- idealhack
+  - katharine
+  - castrojo
+  - jeefy
+  - mrbobbytables
+  - alejandrox1
+  - jdumars
+  - parispitmann
+  - coderanger
+  - idvoretskyi
+  - idealhack
+labels:
+  - area/slack-management


### PR DESCRIPTION
Adds area/slack-management label to parts of the repo that deal with it, so requests can be tagged as such.