### PR TITLE
Create YouTube and Zoom admin slack user groups

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -123,9 +123,9 @@ Moderators seats: 10
 | Jorge Castro        | @castrojo           | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Jeffrey Sica        | @jeefy              | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Bob Killen          | @mrbobbytables      | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
-| Jorge Alarcon       | @alejandroxv1       | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
+| Jorge Alarcon       | @alejandrox1        | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Jaice Singer DuMars | @jdumars            | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
-| Joe Beda            | @joebeda            | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
+| Joe Beda            | @jbeda              | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Ihor Dvoretskyi     | @ihor.dvoretskyi    | EMEA     | [EET - Eastern European Time](https://time.is/EET)      |
 | *Open*              | *Open*              |          |                                                         |
 
@@ -158,7 +158,7 @@ Moderators seats: 10
 | Jorge Castro        | @castrojo           | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Jeffrey Sica        | @jeefy              | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Bob Killen          | @mrbobbytables      | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
-| Jorge Alarcon       | @alejandroxv1       | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
+| Jorge Alarcon       | @alejandrox1        | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Katharine Berry     | @Katharine          | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Jaice Singer DuMars | @jdumars            | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Paris Pittman       | @paris              | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
@@ -177,7 +177,7 @@ Moderators pro tempore seats: 10
 | Angus Lees              | @anguslees          | APAC   | [AET - Australian Eastern Time](https://time.is/Australia) |
 | Aditya Konarde          | @aditya-konarde     | APAC   | [IST - Indian Standard Time](https://time.is/IST)          |
 | Manjunath Kumatagi      | @mkumatag           | APAC   | [IST - Indian Standard Time](https://time.is/IST)          |
-| Pandiyaraja Ramamoorthy | @pontiyaraja        | APAC   | [IST - Indian Standard Time](https://time.is/IST)          |
+| Pandiyaraja Ramamoorthy | @pontiya            | APAC   | [IST - Indian Standard Time](https://time.is/IST)          |
 | Roy Lenferink           | @rlenferink         | EMEA   | [CET - Central European Time](https://time.is/CET)         |
 | Loic Le Dru             | @lledru             | EMEA   | [CET - Central European Time](https://time.is/CET)         |
 | Puja Abbassi            | @puja108            | EMEA   | [CET - Central European Time](https://time.is/CET)         |
@@ -194,7 +194,7 @@ Administrators seats: 4
 |---------------|---------------------|----------|---------------------------------------------------------|
 | Jorge Castro  | @castrojo           | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Bob Killen    | @mrbobbytables      | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
-| Jorge Alarcon | @alejandroxv1       | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
+| Jorge Alarcon | @alejandrox1        | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Paris Pittman | @paris              | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 
 - License and main account controlled by the CNCF

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -3,3 +3,28 @@
 usergroups:
   - name: test-infra-oncall
     external: true
+  - name: youtube-admins
+    long_name: YouTube Admins
+    description: YouTube Admin group. Ping for a YouTube-specific issue
+    channels:
+      - sig-contribex
+    members:
+      - jeefy
+      - sarahnovotny
+      - paris
+      - castrojo
+      - mrbobbytables
+      - alejandrox1
+      - jdumars
+      - jbeda
+      - idvoretskyi
+  - name: zoom-admins
+    long_name: Zoom Admins
+    description: Zoom Admin group. Ping for a Zoom-specific issue
+    channels:
+      - sig-contribex
+    members:
+      - paris
+      - castrojo
+      - mrbobbytables
+      - alejandrox1

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -2,3 +2,12 @@
 # Slack user IDs.
 users:
   katharine: UBTBNJ6GL
+  jeefy: U5MCFK468
+  sarahnovotny: U0AGW7007
+  paris: U5SB22BBQ
+  castrojo: U1W1Q6PRQ
+  mrbobbytables: U511ZSKHD
+  alejandrox1: U6AS37R50
+  jdumars: U0YJS6LHL
+  jbeda: U09QZ63DX
+  idvoretskyi: U0CBHE6GM

--- a/communication/youtube-guidelines.md
+++ b/communication/youtube-guidelines.md
@@ -23,7 +23,7 @@ project, and includes all communication mediums.
 ## Admins
 
 - Check the [centralized list of administrators] for contact information.
-
+- To contact the admin group in Slack, ping `@youtube-admins` in the `#sig-contribex` Slack channel.
 
 ## Meeting Playlists
 

--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -95,6 +95,9 @@ Issues that cannot be handle via normal moderation, or with the assistance of th
 [Zoom Admins] should be escalated to the Kubernetes [Code of Conduct Committee]
 at conduct@kubernetes.io.
 
+To contact the admin group in Slack, ping `@zoom-admins` in the `#sig-contribex`
+Slack channel.
+
 
 ## Meeting recordings
 


### PR DESCRIPTION
Fixes #3577 -- instead of a combined channel, this creates two slack user groups (`@youtube-admins` and `@zoom-admins`) and updates documentation to use said user groups.

Along the way I found some inconsistencies in the `moderators.md` file that I updated.