### PR TITLE
Added SIG F2F Guidelines page

### DIFF
--- a/events/2019/05-contributor-summit/README.md
+++ b/events/2019/05-contributor-summit/README.md
@@ -8,7 +8,7 @@ In some sense, the summit is a real-life extension of the community meetings and
 
  - Onboard new contributors to be productive in our community
  - Send contributors home with more context, knowledge, and skills about the project
- - SIG-specific face-to-face collaboration
+ - [SIG-specific face-to-face collaboration](sig-f2f-guidelines.md)
 
 
 ## Registration

--- a/events/2019/05-contributor-summit/sig-f2f-guidelines.md
+++ b/events/2019/05-contributor-summit/sig-f2f-guidelines.md
@@ -1,0 +1,34 @@
+# SIG F2F Guidelines for Contributor Summit Barcelona 2019
+
+SIG Chairs should register interest in a F2F for the Contributor Summit in Barcelona on Monday, May 20th 2019. **Important: We will try to accommodate all requests, but space is limited. UPDATE: We are at room capacity and cannot accept new requests.** Details about status of accepted F2F meetings can be found in [Issue #3358](https://github.com/kubernetes/community/issues/3358)
+
+## How are SIG F2F meetings different from SIG Deep Dives and Intros being held during KubeCon?
+
+* These SIG F2F meetings should be solely focused on contributors, whereas the deep dives and intros are for discussions with consumers, users, and contributors.
+* For example, the F2F meetings would be a good place to discuss issues internal to your SIG to work on processes and other issues that have the biggest impact on contributors.
+
+## What we will provide
+
+* Tables and chairs in dedicated rooms.
+* Breakfast, lunch and other refreshments throughout the day.
+
+## What we will NOT provide
+
+* We cannot confirm access to a projector / beamer.
+* F2F meetings will not have audio or video recordings.
+* Each SIG is responsible for setting their own agenda and providing any content required.
+
+## Request Form
+
+The form is now closed, but the information requested is mentioned here for historical purposes.
+
+**Information required:**
+
+* Name of person requesting F2F.
+* Your primary email.
+* GitHub Handle.
+* SIG Name.
+* Approximate number of attendees.
+* What do you plan to do during your F2F (a couple of bullets / sentences is fine)?
+* What do you hope to walk away with after the F2F has concluded?
+


### PR DESCRIPTION
Added a new SIG F2F guidelines page to move this out of gdocs and into something more permanently discoverable. I also linked the README to this new page in the repo.

/sig contributor-experience
/area contributor-summit
/cc @jonasrosland 