### PR TITLE
Add note about deleting empty repos

### DIFF
--- a/github-management/kubernetes-repositories.md
+++ b/github-management/kubernetes-repositories.md
@@ -182,6 +182,9 @@ This maintains the complete record of issues, PRs and other contributions,
 leaves the repository read-only, and makes it clear that the repository should
 be considered retired and unmaintained.
 
+In case a repository has only the initial commits adding template files
+and no additional activity, it can be completely deleted.
+
 ## FAQ
 
 **My project is currently in kubernetes-incubator, what is going to happen to


### PR DESCRIPTION
To document cases where we might want to **delete** empty repos. Empty repos = repos which have only the initial commits adding template files and no other activity.

Example - https://github.com/kubernetes-csi/csi-lib-common
Ref: https://github.com/kubernetes/org/issues/718

Note to the reviewer: we have previously deleted repos which satisfied this criteria but this PR documents the case explicitly. 

/assign @cblecker @spiffxp 
github-management owners