### PR TITLE
Remove tombstones related to sig lifecycle

### DIFF
--- a/sig-creation-procedure.md
+++ b/sig-creation-procedure.md
@@ -1,3 +1,0 @@
-## Special Interest and Working Group creation procedure
-
-Moved to [sig-wg-lifecycle](/sig-wg-lifecycle.md)

--- a/sig-governance.md
+++ b/sig-governance.md
@@ -1,3 +1,0 @@
-This document was spread into various sections of documents in the [committee-steering] folder. This tombstone should be deleted before the 1.15 release and verified there are no dependencies. 
-
-[committee-steering]: /committee-steering


### PR DESCRIPTION
One of them explicitly says to be removed before 1.15, the other
hasn't substantively changed since Aug 30.

ref: https://github.com/kubernetes/community/issues/2857