### PR TITLE
Slack: delegate #kubernetes-docs-* to sig-docs-leads

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -131,13 +131,7 @@ channels:
   - name: kubernetes-careers
   - name: kubernetes-client
   - name: kubernetes-dev
-  - name: kubernetes-docs-de
-  - name: kubernetes-docs-es
-  - name: kubernetes-docs-fr
-  - name: kubernetes-docs-it
-  - name: kubernetes-docs-ja
-  - name: kubernetes-docs-ko
-  - name: kubernetes-docs-zh
+  # kubernetes-docs-* channels are defined in sig-docs/
   - name: kubernetes-novice
   - name: kubernetes-operators
   - name: kubernetes-ruby

--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -10,4 +10,7 @@ restrictions:
       - ".*"
   - path: template.yaml
     template: true
+  - path: "sig-docs/*.yaml"
+    channels:
+      - "^kubernetes-docs-[a-z]{2}$"
   - path: "**/*" # prevent any other file from containing anything

--- a/communication/slack-config/sig-docs/OWNERS
+++ b/communication/slack-config/sig-docs/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-docs-leads

--- a/communication/slack-config/sig-docs/docs-channels.yaml
+++ b/communication/slack-config/sig-docs/docs-channels.yaml
@@ -1,0 +1,8 @@
+channels:
+  - name: kubernetes-docs-de
+  - name: kubernetes-docs-es
+  - name: kubernetes-docs-fr
+  - name: kubernetes-docs-it
+  - name: kubernetes-docs-ja
+  - name: kubernetes-docs-ko
+  - name: kubernetes-docs-zh


### PR DESCRIPTION
Delegate the ability to manipulate the locale-specific #kubernetes-docs-* channels to sig-docs-leads.