### PR TITLE
Add csi-vsphere subproject to SIG VMware

### DIFF
--- a/sig-vmware/README.md
+++ b/sig-vmware/README.md
@@ -40,6 +40,9 @@ The following subprojects are owned by sig-vmware:
 - **cluster-api-provider-vsphere**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-vsphere/master/OWNERS
+- **vsphere-csi-driver**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/OWNERS
 
 ## GitHub Teams
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2172,6 +2172,9 @@ sigs:
     - name: cluster-api-provider-vsphere
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-vsphere/master/OWNERS
+    - name: vsphere-csi-driver
+      owners:
+      - https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/OWNERS
   - name: Windows
     dir: sig-windows
     mission_statement: >


### PR DESCRIPTION
Docs regenerated

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

During the 2019/04/04 [meeting for SIG-VMware](https://docs.google.com/document/d/1RV0nVtlPoAtM0DQwNYxYCC9lHfiHpTNatyv4bek6XtA/edit#heading=h.7ux7o2icdb49) it was agreed to adopt CSI vSphere as a subproject of the SIG. This update to sigs.yaml adds that subproject to the list.

A PR to `kubernetes/org` for creation of the repo `kubernetes-sigs/vsphere-csi-driver` is pending, and will be xref'd here once opened.

/assign @frapposelli @cantbewong 
^ SIG-VMware chairs