### PR TITLE
Add #slack-infra channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -250,6 +250,7 @@ channels:
   - name: sig-windows
   - name: skaffold
   - name: slack-admins
+  - name: slack-infra
   - name: sonobuoy
   - name: spark-operator
   - name: spinnaker


### PR DESCRIPTION
For discussion of the slack-infra work (which currently mostly happens in a private channel, which is not ideal).