### PR TITLE
Remove the deleted csi-lib-common repo

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -40,7 +40,6 @@ The following subprojects are owned by sig-storage:
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-common/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-fc/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-iscsi/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-test/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1923,7 +1923,6 @@ sigs:
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
-      - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-common/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-fc/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-iscsi/master/OWNERS
       - https://raw.githubusercontent.com/kubernetes-csi/csi-test/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/718

`kubernetes-csi-migration-library` was archived, but surprisingly it was never added to sigs.yaml (?!)

/cc @saad-ali 
/assign @cblecker 