### PR TITLE
Create issue and PR management guildlines for the sig contribex

### DIFF
--- a/sig-contributor-experience/triage-team/triage.md
+++ b/sig-contributor-experience/triage-team/triage.md
@@ -2,31 +2,31 @@
 
 ## Purpose
 
-Speed up management of issues and PRs labeled with `sig/contributor-experience`.
-
-The SIG Contributor Experience [issues](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience) and [PRs](https://github.com/kubernetes/community/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3Asig%2Fcontributor-experience+) are labeled with `sig/contributor-experience`.
-
-Following are few example searches on issue and PR:
-* [Open issues](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience)
-* [Open issues for a specific milestone](https://github.com/kubernetes/community/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Asig%2Fcontributor-experience+milestone%3AMay)
-* [Open PRs](https://github.com/kubernetes/community/pulls?utf8=%E2%9C%93&q=is%3A+pr+is%3Aopen+label%3Asig%2Fcontributor-experience+)
-* [Open PRs for a specific milestone](https://github.com/kubernetes/community/pulls?utf8=%E2%9C%93&q=is%3Apr+label%3Asig%2Fcontributor-experience+milestone%3AMay+is%3Aopen)
+Speed up management of issues and PRs under [k/community repo](https://git.k8s.io/community).
 
 ## Scope
 
-Manage incoming issues and PRs that are already identified and labeled with the `sig/contributor-experience` particularly in the [Kubernetes community repository](https://git.k8s.io/community) but in general across various Kubernetes related GitHub repositories like [Kubernetes repository](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Asig%2Fcontributor-experience).
+Incoming issues and PRs in the [Kubernetes community repository](https://git.k8s.io/community). The goal is to maintain a healthy community repository by timely handling issues and PRs. The scope may be enhanced in the future.
 
 ## People involved
 
-Everyone is welcome to help manage issues and PRs but the work and responsibilities discussed in this document is created with Triage team and Triage Captain roles in mind.
+Everyone is welcome to help manage issues and PRs, however, the work and responsibilities discussed in this document is created with `sig/contributor-experience` triage team and [OWNERS](https://git.k8s.io/community/sig-contributor-experience/OWNERS) in mind.
 
 ## Work involved
 
-The main work is to keep track of issues and PRs, ping people, add appropriate labels as needed and report the overall status to the SIG Leads.
+The main work is to keep track of issues and PRs, ping people, add labels and milestone, and discuss the overall status with the SIG leads. If you can not add or can not decide the correct label or milestone, that’s fine, contact leaders of the SIG to do so.
 
-  - Validate if an issue is a bug - Validate if the issue is indeed a bug by following these [instructions](https://git.k8s.io/community/contributors/guide/issue-triage.md#validate-if-the-issue-is-bug).
+### Issues
 
-  - Determine it belongs to contributor-experience SIG - An issue can be incorrectly labeled with the `sig/contributor-experience` label. If you think an issue does not belong to the `sig/contributor-experience`, add a comment stating so with a reason. Example response:
+#### Validate if an issue is a bug or a support request
+
+Validate if the issue is indeed a bug by following these [instructions](https://git.k8s.io/community/contributors/guide/issue-triage.md#determine-if-its-a-support-request). If it is a support request, provide a response similar to this [format](https://git.k8s.io/community/contributors/guide/issue-triage.md#user-support-response-example) and close it.
+
+#### Determine SIG
+
+In order to determine a correct SIG, charter of the SIG can be helpful. For example, you can determine if an issue belongs to one of the `sig/contributor-experience` [Subprojects](https://git.k8s.io/community/sig-contributor-experience#subprojects) by looking at the [charter](https://git.k8s.io/community/sig-contributor-experience/charter.md).
+
+An issue can have an incorrect SIG label. If you think an issue does not belong to the labeled SIG, remove the label and provide a reason by adding a comment. For example, provide this response when an issue is incorrectly labeled with the `sig/contributor-experience`:
 
 ```code
 
@@ -38,32 +38,55 @@ If you think this is incorrect, please provide a reason and add it back with /si
 
 ```
 
-  - Define priorities - Define priority of an issue or PR by following these [instructions](https://git.k8s.io/community/contributors/guide/issue-triage.md#define-priority).
+#### Determine milestone
 
-  - Verify important tasks and labels are in place - Make sure that one or more of the following tasks and labels are identified for issues and PRs. If any of these are missing, you can add one if you are authorized to do so. If you can not assign or can not decide the correct one, that’s fine, contact leaders of the SIG to do so.
+[Milestone](https://git.k8s.io/community/milestones) should be defined considering the [priority](#determine-priorities). If the priority is `priority/critical-urgent`, the milestone should be the current milestone. If priority is not critical, the milestone can be set to current or future one. Use your experience and reference of related past issues while determining a milestone.
 
-    - Issues
+#### Determine projects
 
-        - Milestone
-        - area/*
-        - kind/*
-        - good first issue
-        - help wanted
+The project is defined based off of [Subprojects](https://git.k8s.io/community/sig-contributor-experience#subprojects).
 
-    - PR
+#### Determine area
 
-        - Milestone
-        - Reviewers
-        - Assignees
-        - area/*
-        - kind/*
+An issue `area/*` label is defined around the [Subprojects](https://git.k8s.io/community/sig-contributor-experience#subprojects). e.g. `area/devstats`. Determine the area label considering Subprojects, and using your experience and reference of related past issues.
 
-  - Report - Maintain a list of issues and PRs which seem to be delaying, at risk of not making it in time, labeled with `lifecycle/stale` and `lifecycle/rotten` or in need of attention by the SIG Leads or other roles. Present this list in the weekly SIG meetings. If needed, also send the list of issues and PRs that aren't getting enough attention to the mailing list biweekly.
+#### Determine priorities
+
+WIP. For now, define priority of an issue by following these generic [instructions](https://git.k8s.io/community/contributors/guide/issue-triage.md#define-priority).
+
+#### Determine kind
+
+For the `kind/*` label, we follow the instruction as defined in the [release guidelines](https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label).
+
+#### Determine if an issue is a candidate for new contributors
+
+An issue can be a good candidate for a new contributor to work. Such issues should be labeled with `good first issue` or `help wanted` as described in more detail [here](https://git.k8s.io/community/contributors/guide/help-wanted.md).
+
+#### Discuss the work
+
+Maintain a list of issues and PRs which seem to be delaying, at risk of not making it in time, labeled with `lifecycle/stale` and `lifecycle/rotten` or in need of attention by the SIG leads or other roles. Discuss this list in the bi-weekly SIG meetings. If needed, also send the list of issues and PRs that aren't getting enough attention to the mailing list biweekly.
+
+### PRs
+
+TODO - PR specific work.
 
 ## How to Escalate
-Whenever you find out that an issue or PR is not active and it needs to be taken care, try the following escalation path:
-* Leave a comment on the GitHub issue or PR: "This issue hasn't been updated in 3 months. Are you still expecting to complete it in the current milestone?". It's helpful here to @ mention individuals you want an attention from.
-* Send a message on the SIG slack channels or mailing list about the problem: It's helpful to directly @ mention the SIG Leads / Owners, and to condense multiple issues into a list, e.g. "Hey, these three issues haven't seen any attention, are they still valid for the current or future milestone?"
-* Message individual owners and reviewers directly via Slack and/or email ID, if such an ID is available.
-* Escalate to the SIG Leads with suggestions on what to do with non-responsive issues or PR.
+
+Whenever you find out that an issue or PR is not active and it needs to be taken care, try the following escalation path.
+
+### Leave a comment in the issue or PR
+
+"This issue hasn't been updated in 3 months. Are you still expecting to complete it in the current milestone?". It's helpful here to @ mention individuals you want an attention from.
+
+### Send a message on the SIG slack channel or mailing list
+
+It's helpful to directly @ mention the SIG Leads / Owners, and to condense multiple issues into a list, e.g. "Hey, these three issues haven't seen any attention, are they still valid for the current or future milestone?"
+
+### Message individual owners and reviewers directly
+
+Send a direct message via Slack and/or email ID, if such an ID is available.
+
+### Escalate to the SIG Leads
+
+Talk to SIG leads with suggestions on what to do with non-responsive issues or PR.
 

--- a/sig-contributor-experience/triage-team/triage.md
+++ b/sig-contributor-experience/triage-team/triage.md
@@ -9,35 +9,61 @@ The SIG Contributor Experience [issues](https://github.com/kubernetes/community/
 Following are few example searches on issue and PR:
 * [Open issues](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience)
 * [Open issues for a specific milestone](https://github.com/kubernetes/community/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Asig%2Fcontributor-experience+milestone%3AMay)
-* [Open PRs](https://github.com/kubernetes/community/pulls?utf8=%E2%9C%93&q=is%3A+pr+is%3Aopen+label%3Asig%2Fcontributor-experience+) 
+* [Open PRs](https://github.com/kubernetes/community/pulls?utf8=%E2%9C%93&q=is%3A+pr+is%3Aopen+label%3Asig%2Fcontributor-experience+)
 * [Open PRs for a specific milestone](https://github.com/kubernetes/community/pulls?utf8=%E2%9C%93&q=is%3Apr+label%3Asig%2Fcontributor-experience+milestone%3AMay+is%3Aopen)
 
 ## Scope
 
-Manage incoming issues and PRs that are already identified and labeled with the `sig/contributor-experience` particularly in the [Kubernetes community repository](https://github.com/kubernetes/community) but in general across various Kubernetes related GitHub repositories like [Kubernetes repository](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Asig%2Fcontributor-experience).
+Manage incoming issues and PRs that are already identified and labeled with the `sig/contributor-experience` particularly in the [Kubernetes community repository](https://git.k8s.io/community) but in general across various Kubernetes related GitHub repositories like [Kubernetes repository](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Asig%2Fcontributor-experience).
 
 ## People involved
 
-Everyone is welcome to help manage issues and PRs but the work and responsibilities discussed in this document is created with [Triage Team](TODO-describe the team in a separate doc and add link) and [Triage Captain](TODO-describe the team in a separate doc and add link) role in mind.
+Everyone is welcome to help manage issues and PRs but the work and responsibilities discussed in this document is created with Triage team and Triage Captain roles in mind.
 
 ## Work involved
 
 The main work is to keep track of issues and PRs, ping people, add appropriate labels as needed and report the overall status to the SIG Leads.
 
-- **Validate if an issue is a bug**: Validate if the issue is indeed a bug by following these [instructions](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#validate-if-the-issue-is-bug).
+  - Validate if an issue is a bug - Validate if the issue is indeed a bug by following these [instructions](https://git.k8s.io/community/contributors/guide/issue-triage.md#validate-if-the-issue-is-bug).
 
-- **Determine it belongs to contributor-experience SIG**: An issue can be incorrectly labeled with the `sig/contributor-experience` label. If you think an issue does not belong to the `sig/contributor-experience`, add a comment stating so with a reason.
+  - Determine it belongs to contributor-experience SIG - An issue can be incorrectly labeled with the `sig/contributor-experience` label. If you think an issue does not belong to the `sig/contributor-experience`, add a comment stating so with a reason. Example response:
 
-- **Define priorities**: Define priority of an issue or PR by following these [instructions](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#define-priority).
+```code
 
-- **Verify important labels are in place**: Make sure that proper assignees are added in issue, reviewers are added to the PR and milestone is identified. If any of these labels are missing, you can add one if you are authorized to do so. If you can not assign labels or you can not decide the correct label, that’s fine, contact technical leaders of the SIG to do so.
+`/remove-sig contributor-experience`
 
-- **Report**: Maintain a list of issues and PRs which seem to be delaying, at risk of not making it in time, or in need of attention by the SIG Leads or other roles, and present it in the weekly SIG meetings.
+I don't think this is a SIG Contributor Experience issue because ....
+
+If you think this is incorrect, please provide a reason and add it back with /sig contributor-experience label as a single line comment.
+
+```
+
+  - Define priorities - Define priority of an issue or PR by following these [instructions](https://git.k8s.io/community/contributors/guide/issue-triage.md#define-priority).
+
+  - Verify important tasks and labels are in place - Make sure that one or more of the following tasks and labels are identified for issues and PRs. If any of these are missing, you can add one if you are authorized to do so. If you can not assign or can not decide the correct one, that’s fine, contact leaders of the SIG to do so.
+
+    - Issues
+
+        - Milestone
+        - area/*
+        - kind/*
+        - good first issue
+        - help wanted
+
+    - PR
+
+        - Milestone
+        - Reviewers
+        - Assignees
+        - area/*
+        - kind/*
+
+  - Report - Maintain a list of issues and PRs which seem to be delaying, at risk of not making it in time, labeled with `lifecycle/stale` and `lifecycle/rotten` or in need of attention by the SIG Leads or other roles. Present this list in the weekly SIG meetings. If needed, also send the list of issues and PRs that aren't getting enough attention to the mailing list biweekly.
 
 ## How to Escalate
 Whenever you find out that an issue or PR is not active and it needs to be taken care, try the following escalation path:
 * Leave a comment on the GitHub issue or PR: "This issue hasn't been updated in 3 months. Are you still expecting to complete it in the current milestone?". It's helpful here to @ mention individuals you want an attention from.
 * Send a message on the SIG slack channels or mailing list about the problem: It's helpful to directly @ mention the SIG Leads / Owners, and to condense multiple issues into a list, e.g. "Hey, these three issues haven't seen any attention, are they still valid for the current or future milestone?"
-* Message individual owners and reviewers directly via Slack and/or email. Individual's email addresses may be harder to find than GitHub ID, but are usually in the Git commit history. Sometimes Slack handles are hard to find. There is no master list mapping human names to GitHub ID, email or Slack ID. If you can't find contact info, asking in the SIG's Slack channel will usually get you pointed in the right direction.
+* Message individual owners and reviewers directly via Slack and/or email ID, if such an ID is available.
 * Escalate to the SIG Leads with suggestions on what to do with non-responsive issues or PR.
 

--- a/sig-contributor-experience/triage-team/triage.md
+++ b/sig-contributor-experience/triage-team/triage.md
@@ -1,0 +1,43 @@
+# Issue and PR Management
+
+## Purpose
+
+Speed up management of issues and PRs labeled with `sig/contributor-experience`.
+
+The SIG Contributor Experience [issues](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience) and [PRs](https://github.com/kubernetes/community/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3Asig%2Fcontributor-experience+) are labeled with `sig/contributor-experience`.
+
+Following are few example searches on issue and PR:
+* [Open issues](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience)
+* [Open issues for a specific milestone](https://github.com/kubernetes/community/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Asig%2Fcontributor-experience+milestone%3AMay)
+* [Open PRs](https://github.com/kubernetes/community/pulls?utf8=%E2%9C%93&q=is%3A+pr+is%3Aopen+label%3Asig%2Fcontributor-experience+) 
+* [Open PRs for a specific milestone](https://github.com/kubernetes/community/pulls?utf8=%E2%9C%93&q=is%3Apr+label%3Asig%2Fcontributor-experience+milestone%3AMay+is%3Aopen)
+
+## Scope
+
+Manage incoming issues and PRs that are already identified and labeled with the `sig/contributor-experience` particularly in the [Kubernetes community repository](https://github.com/kubernetes/community) but in general across various Kubernetes related GitHub repositories like [Kubernetes repository](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Asig%2Fcontributor-experience).
+
+## People involved
+
+Everyone is welcome to help manage issues and PRs but the work and responsibilities discussed in this document is created with [Triage Team](TODO-describe the team in a separate doc and add link) and [Triage Captain](TODO-describe the team in a separate doc and add link) role in mind.
+
+## Work involved
+
+The main work is to keep track of issues and PRs, ping people, add appropriate labels as needed and report the overall status to the SIG Leads.
+
+- **Validate if an issue is a bug**: Validate if the issue is indeed a bug by following these [instructions](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#validate-if-the-issue-is-bug).
+
+- **Determine it belongs to contributor-experience SIG**: An issue can be incorrectly labeled with the `sig/contributor-experience` label. If you think an issue does not belong to the `sig/contributor-experience`, add a comment stating so with a reason.
+
+- **Define priorities**: Define priority of an issue or PR by following these [instructions](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md#define-priority).
+
+- **Verify important labels are in place**: Make sure that proper assignees are added in issue, reviewers are added to the PR and milestone is identified. If any of these labels are missing, you can add one if you are authorized to do so. If you can not assign labels or you can not decide the correct label, that’s fine, contact technical leaders of the SIG to do so.
+
+- **Report**: Maintain a list of issues and PRs which seem to be delaying, at risk of not making it in time, or in need of attention by the SIG Leads or other roles, and present it in the weekly SIG meetings.
+
+## How to Escalate
+Whenever you find out that an issue or PR is not active and it needs to be taken care, try the following escalation path:
+* Leave a comment on the GitHub issue or PR: "This issue hasn't been updated in 3 months. Are you still expecting to complete it in the current milestone?". It's helpful here to @ mention individuals you want an attention from.
+* Send a message on the SIG slack channels or mailing list about the problem: It's helpful to directly @ mention the SIG Leads / Owners, and to condense multiple issues into a list, e.g. "Hey, these three issues haven't seen any attention, are they still valid for the current or future milestone?"
+* Message individual owners and reviewers directly via Slack and/or email. Individual's email addresses may be harder to find than GitHub ID, but are usually in the Git commit history. Sometimes Slack handles are hard to find. There is no master list mapping human names to GitHub ID, email or Slack ID. If you can't find contact info, asking in the SIG's Slack channel will usually get you pointed in the right direction.
+* Escalate to the SIG Leads with suggestions on what to do with non-responsive issues or PR.
+


### PR DESCRIPTION
These guidelines and responsibilities are focused on  issues and PRs
that are identified for sig contributor experience. Keeping it as short
as possible for easier usage. It's also  utilizing and poiting to other
existing materials on triage.
Add the triage team members and specific role descriptions in a separate
document.

Related #3364

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->