### PR TITLE
Add K8s blog teams and update charter

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -45,6 +45,9 @@ The following subprojects are owned by sig-docs:
 - **website**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
+- **kubernetes-blog**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/website/master/content/en/blog/OWNERS
 
 ## GitHub Teams
 
@@ -53,22 +56,26 @@ Note that the links to display team membership will only work if you are a membe
 
 | Team Name | Details | Description |
 | --------- |:-------:| ----------- |
+| @kubernetes/kubernetes-blog | [link](https://github.com/orgs/kubernetes/teams/kubernetes-blog) | Kubernetes blog maintainers |
 | @kubernetes/sig-docs-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers) | Documentation maintainers |
 | @kubernetes/sig-docs-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-docs-pr-reviews) | Documentation PR reviews |
+| @kubernetes/sig-docs-de-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-de-owners) | German language content |
 | @kubernetes/sig-docs-en-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-en-owners) | English content (default) |
-| @kubernetes/sig-docs-es-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-es-owners) | Spanish content |
-| @kubernetes/sig-docs-de-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-de-owners) | German content |
-| @kubernetes/sig-docs-fr-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-fr-owners) | French content |
-| @kubernetes/sig-docs-it-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-it-owners) | Italian content |
-| @kubernetes/sig-docs-ja-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ja-owners) | Japanese content |
-| @kubernetes/sig-docs-ko-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ko-owners) | Korean content |
-| @kubernetes/sig-docs-zh-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-zh-owners) | Chinese content |
+| @kubernetes/sig-docs-es-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-es-owners) | Spanish language content |
+| @kubernetes/sig-docs-fr-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-fr-owners) | French language content |
+| @kubernetes/sig-docs-id-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-id-owners) | Indonesian language content |
+| @kubernetes/sig-docs-it-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-it-owners) | Italian language content |
+| @kubernetes/sig-docs-ja-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ja-owners) | Japanese language content |
+| @kubernetes/sig-docs-ko-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ko-owners) | Korean language content |
+| @kubernetes/sig-docs-pt-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-pt-owners) | Portuguese language content |
+| @kubernetes/sig-docs-zh-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-zh-owners) | Chinese language content |
 
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 * Discuss documentation and docs issues for kubernetes.io
-* Plan docs releases for kubernetes
-* Suggest improvements to user onboarding through better documentation on Kubernetes.io
-* Identify and implement ways to get documentation feedback and metrics
-* Help community contributors get involved in kubernetes documentation
+* Content for the official Kubernetes blog
+* Lead docs releases for Kubernetes
+* Suggest improvements to user onboarding through better documentation on kubernetes.io
+* Documentation metrics and user feedback
+* Help community contributors get involved in Kubernetes documentation
 <!-- END CUSTOM CONTENT -->

--- a/sig-docs/charter.md
+++ b/sig-docs/charter.md
@@ -48,7 +48,7 @@ See Cross-cutting for limitations on how the SIG helps with related efforts on o
 - [Coordinating docs contributions for quarterly releases][docs-release]
 
 - Kubernetes blog:
-  SIG Docs hosts the Kubernetes blog and provides tooling and workflow support for publishing the blog, but does not directly review blog posts or work with blog contributors.
+  The Kubernetes blog is a subproject of SIG Docs. SIG Docs provides tooling and workflow support for publishing the blog, but does not directly review blog posts or work with blog contributors. The blog subproject provides its own approvers and reviewers, and sets independent standards for creation and review of blog content. 
 
 - Site UX:
   SIG Docs organizes and revises technical content to improve UX and technical accuracy for the current and four most previous releases, based on:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1097,26 +1097,32 @@ sigs:
       slack: sig-docs
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-docs
       teams:
+      - name: kubernetes-blog
+        description: Kubernetes blog maintainers
       - name: sig-docs-maintainers
         description: Documentation maintainers
       - name: sig-docs-pr-reviews
         description: Documentation PR reviews
+      - name: sig-docs-de-owners
+        description: German language content
       - name: sig-docs-en-owners
         description: English content (default)
       - name: sig-docs-es-owners
-        description: Spanish content
-      - name: sig-docs-de-owners
-        description: German content
+        description: Spanish language content
       - name: sig-docs-fr-owners
-        description: French content
+        description: French language content
+      - name: sig-docs-id-owners
+        description: Indonesian language content
       - name: sig-docs-it-owners
-        description: Italian content
+        description: Italian language content
       - name: sig-docs-ja-owners
-        description: Japanese content
+        description: Japanese language content
       - name: sig-docs-ko-owners
-        description: Korean content
+        description: Korean language content
+      - name: sig-docs-pt-owners
+        description: Portuguese language content
       - name: sig-docs-zh-owners
-        description: Chinese content
+        description: Chinese language content
     subprojects:
     - name: reference-docs
       owners:
@@ -1124,6 +1130,9 @@ sigs:
     - name: website
       owners:
       - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
+    - name: kubernetes-blog
+      owners:
+      - https://raw.githubusercontent.com/kubernetes/website/master/content/en/blog/OWNERS
   - name: GCP
     dir: sig-gcp
     mission_statement: >


### PR DESCRIPTION
This PR updates the list of SIG Docs subprojects and team contacts.

This is a newer version of the changes introduced in #3632. 

See:
- https://github.com/kubernetes/community/pull/3632#issuecomment-485999077
- https://github.com/kubernetes/org/issues/753
- https://github.com/kubernetes/org/issues/754

/cc @kbarnard10 @jaredbhatti @Bradamant3 