### PR TITLE
Add an OWNERs file for people responsible for representing k8s in the

### DIFF
--- a/communication/cncf-servicedesk/OWNERS
+++ b/communication/cncf-servicedesk/OWNERS
@@ -1,0 +1,23 @@
+- reviewers:
+    - bgrant0607
+    - brendandburns
+    - calebamiles
+    - castrojo
+    - cblecker
+    - derekwaynecarr
+    - dims
+    - idvoretskyi
+    - jbeda
+    - jdumars
+    - michelleN
+    - parispittman
+    - philips
+    - pwittrock
+    - sarahnovotny
+    - smarterclayton
+    - spiffxp
+    - timothysc
+- approvers:
+    - committee-steering
+- labels:
+    - committee/steering

--- a/communication/cncf-servicedesk/README.md
+++ b/communication/cncf-servicedesk/README.md
@@ -1,0 +1,3 @@
+## CNCF Service Desk
+
+This OWNERs file lists the people who have access to file tickets with the [CNCF Service Desk](https://github.com/cncf/servicedesk) on behalf of the Kubernetes project.


### PR DESCRIPTION
CNCF service desk. Fixes kubernetes/steering/#102

Signed-off-by: Jorge O. Castro <jorgec@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->