### PR TITLE
Add #release-branch-mgmt Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -198,6 +198,7 @@ channels:
   - name: rancher
   - name: random
     archived: true
+  - name: release-branch-mgmt
   - name: rktnetes
   - name: ro-users
   - name: ru-users


### PR DESCRIPTION
This channel is for release branch management specific conversations, and to connect shadows and leads together.

Adding someone new to a group conversation inevitably creates a new group chat on slack. It would be best to have one central communication channel, and so that future leads and shadows could also utilize. 
 
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

CC: @hoegaarden @chrisz100 @vivektaparia @idealhack @SlickNik 