### PR TITLE
Add Slack channel name length restriction.

### DIFF
--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -118,6 +118,7 @@ management of Slack.
 
 To add a channel, open a Pull Request (PR) updating the [slack-config].
 - Add the channel to [channels.yaml] following the [Channel Documentation].
+  - Channel names must be 21 characters or less in length (Slack limit).
   - Typical channel naming conventions follow:
     - `#kubernetes-foo`
     - `#sig-foo`


### PR DESCRIPTION
Add a note regarding channel name length to guidelines.

ref: https://github.com/kubernetes/community/pull/3655#issuecomment-487778836

/cc @Katharine 