### PR TITLE
Add Discuss Spanish Regional Category moderators

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -95,6 +95,13 @@ Regional category moderators seats (per category): 3
 | Jacopo Nardiello   | @jnardiello           | EMEA   | [CET - Central European Time](https://time.is/CET) |
 | *Open*             | *Open*                |        |                                                    |
 
+**[Spanish]**
+
+| Name               | Kubernetes Discuss ID | Region | Timezone                                           |
+|--------------------|-----------------------|--------|----------------------------------------------------|
+| Rael Garcia        | @rael                 | EMEA   | [CET - Central European Time](https://time.is/CET) |
+| *Open*             | *Open*                |        |                                                    |
+
 **[Ukrainian]**
 
 | Name             | Kubernetes Discuss ID | Region | Timezone                                           |
@@ -205,4 +212,5 @@ Administrators seats: 4
 [Chinese]: https://discuss.kubernetes.io/t/about-the-chinese-category/2881
 [German]: https://discuss.kubernetes.io/t/about-the-german-category/3152
 [Italian]: https://discuss.kubernetes.io/t/about-the-italian-category/2917/2
+[Spanish]: https://discuss.kubernetes.io/t/about-the-spanish-category/6167
 [Ukrainian]: https://discuss.kubernetes.io/t/about-the-ukrainian-category/2916


### PR DESCRIPTION
### GitHub Username

@raelga 

### Property you'd like to Moderate

- discuss.k8s.io / Spanish Regional Category

### Username on Property Requested

[@rael](https://discuss.kubernetes.io/u/rael/summary)

### Requirements

- [x] I am a Kubernetes Org member already
- [x] I have enabled 2FA on my account for the property I would like to moderate (if applicable).
- [x] I have read and will abide by the policies mentioned in the [Moderation Guidelines](https://git.k8s.io/community/communication/moderation.md)
- [x] I have two sponsors that meet the sponsor requirements listed in the moderator guidelines
- [x] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application

### Sponsors

- @mrbobbytables
- @jeefy 

### List of qualifications for this position

- Experience moderating discuss and other forum engines such as phpbb or vbulletin.
- Contributor in the sig-docs team, leading the Spanish localization effort.

### Context

As discussed in https://discuss.kubernetes.io/t/spanish-regional-discussion-category/6142, we're trying to bootstrap the Spanish category on the Discuss forum.

So far, there is no movement, so it's hard to find a second moderator, but we will be looking into it once the community starts to get some activity.

/cc @mrbobbytables 