### PR TITLE
sig-node: remove the cri-o subproject

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -33,9 +33,6 @@ The following subprojects are owned by sig-node:
 - **cri-api**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/cri-api/master/OWNERS
-- **cri-o**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cri-o/master/OWNERS
 - **cri-tools**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cri-tools/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1451,9 +1451,6 @@ sigs:
     - name: cri-api
       owners:
       - https://raw.githubusercontent.com/kubernetes/cri-api/master/OWNERS
-    - name: cri-o
-      owners:
-      - https://raw.githubusercontent.com/kubernetes-sigs/cri-o/master/OWNERS
     - name: cri-tools
       owners:
       - https://raw.githubusercontent.com/kubernetes-sigs/cri-tools/master/OWNERS


### PR DESCRIPTION
cri-o has migrated to its own GitHub org: https://github.com/cri-o/cri-o
Ref: https://github.com/kubernetes/org/issues/675

/assign @derekwaynecarr @cblecker 