### PR TITLE
Update cri-container-stats documentation

### DIFF
--- a/contributors/devel/sig-node/cri-container-stats.md
+++ b/contributors/devel/sig-node/cri-container-stats.md
@@ -115,7 +115,10 @@ behind it.*
 
 ## Status
 
-The container metrics calls are added to CRI in Kubernetes 1.7, but Kubelet does not
-yet use it to gather metrics from the runtime. We plan to enable Kubelet to
-optionally consume the container metrics from the API in 1.8.
-
+The container metrics calls were added to CRI in Kubernetes 1.7, but Kubelet did not
+yet use it to gather metrics from the runtime. In Kubernetes 1.8, Kubelet was
+given the option to [consume the container metrics using CRI
+stats](https://github.com/kubernetes/kubernetes/pull/51557). See the
+`pkg/kubelet/cadvisor.go#UsingLegacyCadvisorStats`
+[function](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cadvisor/util.go#L73)
+for more information on how Kubelet determines the proper metrics source.


### PR DESCRIPTION
Update the cri-container-stats documentation with more recent status
info. Particularly, clarify that the option to consume CRI stats has
been implemented, and link to the code that determines the consumption
option.