### PR TITLE
add node-problem-detector channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -179,6 +179,7 @@ channels:
   - name: mysql-operator
   - name: navigator
   - name: nl-users
+  - name: node-problem-detector
   - name: norw-users
   - name: office-hours
   - name: opencontainers


### PR DESCRIPTION
I am one of the maintainers of [node-problem-detector](https://github.com/kubernetes/node-problem-detector) project. In order to make the discussion more smoothly with end users,  we suggest we add a `node-problem-detector` slack channel.

/cc @Random-Liu @wangzhen127 