### PR TITLE
Archive monolith and ops-status slack channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -175,6 +175,7 @@ channels:
   - name: minikube-dev
   - name: monitoring-mixins
   - name: monolith
+    archived: true
   - name: multi-platform
   - name: mysql-operator
   - name: navigator
@@ -187,6 +188,7 @@ channels:
   - name: openstack-helm
   - name: openstack-kolla
   - name: ops-status
+    archived: true
   - name: osbkit
   - name: pharmer
   - name: pl-users


### PR DESCRIPTION
- monolith is inactive today. It was created for discussing migrating monolith apps to Kubernetes. Ref: https://groups.google.com/forum/#!forum/monolithic-apps-to-k8s.

- ops-status was meant for "operations issues that might be relevant to the K8s community".
For upstream Kubernetes ops-specific discussion, we have #testing-ops.
For general ops discussion, we have #sre.

/hold