### PR TITLE
Update kubelet cri networking

### DIFF
--- a/contributors/devel/sig-node/kubelet-cri-networking.md
+++ b/contributors/devel/sig-node/kubelet-cri-networking.md
@@ -52,5 +52,9 @@ k8s networking requirements are satisfied.
 * As more network feature arrives, CRI will evolve. 
 
 ## Related Issues
+
+Note, these issues may be resolved/closed. We still list them because they
+provide additional historical context.
+
 * Kubelet network plugin for client/server container runtimes [#28667](https://github.com/kubernetes/kubernetes/issues/28667)
 * CRI networking umbrella issue [#37316](https://github.com/kubernetes/kubernetes/issues/37316)


### PR DESCRIPTION
As the "Related Issues" are from the ~1.5 release, add copy making it
clear they may no longer be relevant, but we still include them for the
historical context they provide.