### PR TITLE
Move klog to sig-instrumentation

### DIFF
--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -61,9 +61,6 @@ The following subprojects are owned by sig-architecture:
     - Slack: [#k8s-conformance](https://kubernetes.slack.com/messages/k8s-conformance)
     - GitHub Teams:
       - [@kubernetes/cncf-conformance-wg](https://github.com/orgs/kubernetes/teams/cncf-conformance-wg)
-- **klog**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
 
 ## GitHub Teams
 

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -38,6 +38,9 @@ The following subprojects are owned by sig-instrumentation:
 - **heapster**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/heapster/master/OWNERS
+- **klog**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
 - **kube-state-metrics**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -292,9 +292,6 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
-  - name: klog
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
 - dir: sig-auth
   name: Auth
   mission_statement: >
@@ -1275,6 +1272,9 @@ sigs:
   - name: heapster
     owners:
     - https://raw.githubusercontent.com/kubernetes/heapster/master/OWNERS
+  - name: klog
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
   - name: kube-state-metrics
     owners:
     - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS


### PR DESCRIPTION
/sig instrumentation

klog was initially under sig-arch, it makes a lot of sense to move this under sig-instrumentation as that sig owns the "logging" for kubernetes.

Change-Id: I0de87dd36a09175a51c24bef4466692825207bbd

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->