### PR TITLE
revert changes to UG Big Data resource names

### DIFF
--- a/sig-list.md
+++ b/sig-list.md
@@ -71,7 +71,7 @@ When the need arises, a [new SIG can be created](sig-wg-lifecycle.md)
 
 | Name | Label |Organizers | Contact | Meetings |
 |------|-------|------------|--------|----------|
-|[Big Data](ug-big-data/README.md)|big-data|* [Erik Erlandson](https://github.com/erikerlandson), Red Hat<br>* [Anirudh Ramanathan](https://github.com/foxish), Rockset<br>* [Yinan Li](https://github.com/liyinan926), Google<br>|* [Slack](https://kubernetes.slack.com/messages/big-data-user-group)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-big-data-user-group)|* Regular User Group Meeting: [Wednesdays at 18:00 UTC (biweekly)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit)<br>
+|[Big Data](ug-big-data/README.md)|big-data|* [Erik Erlandson](https://github.com/erikerlandson), Red Hat<br>* [Anirudh Ramanathan](https://github.com/foxish), Rockset<br>* [Yinan Li](https://github.com/liyinan926), Google<br>|* [Slack](https://kubernetes.slack.com/messages/ug-big-data)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-ug-big-data)|* Regular User Group Meeting: [Wednesdays at 18:00 UTC (biweekly)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit)<br>
 
 ### Master Committee List
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2643,8 +2643,8 @@ usergroups:
     archive_url: https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit
     recordings_url: https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit
   contact:
-    slack: big-data-user-group
-    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-big-data-user-group
+    slack: ug-big-data
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-ug-big-data
     teams:
     - name: ug-big-data
       description: General Discussion

--- a/ug-big-data/README.md
+++ b/ug-big-data/README.md
@@ -22,8 +22,8 @@ Serve as a community resource for advising big data and data science related sof
 * Yinan Li (**[@liyinan926](https://github.com/liyinan926)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/big-data-user-group)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-big-data-user-group)
+* [Slack](https://kubernetes.slack.com/messages/ug-big-data)
+* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-ug-big-data)
 * [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fbig-data)
 
 


### PR DESCRIPTION
This PR is to revert changes I made in #3666; the original placeholder names I used turned out to be the ones preferred by committee.

The sigs.yaml file altered in some way that prevented me from directly reverting the original PR.