### PR TITLE
add kube-state-metrics slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -117,6 +117,7 @@ channels:
   - name: kube-router
   - name: kube-score
   - name: kube-spawn
+  - name: kube-state-metrics
   - name: kubeadm
   - name: kubeapps
   - name: kubebuilder


### PR DESCRIPTION
I am one of the maintainers of [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) project. In order to make the discussion more smoothly with end users, we suggest we add a `kube-state-metrics` slack channel.

/cc @brancz @mxinden 