### PR TITLE
Add label aliases for mlbot.net GitHub App

### DIFF
--- a/.github/issue_label_bot.yaml
+++ b/.github/issue_label_bot.yaml
@@ -1,0 +1,5 @@
+# config for: https://mlbot.net/
+label-alias:
+  bug: 'kind/bug'
+  feature_request: 'kind/feature'
+  question: 'triage/support'


### PR DESCRIPTION
ref: https://github.com/kubernetes/community/issues/3672

This is my best guess at the the bot's three different labels map to the
GitHub labels that we use.

/hold
/sig contributor-experience
Is this a thing we want to move forward with? Are these aliases correct?