### PR TITLE
Added note about the different names of LastHeartbeatTime

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -342,7 +342,9 @@ Do not use fields that you don't need - simpler is better.
 Use of the `Reason` field is encouraged.
 
 Use the `LastHeartbeatTime` with great caution - frequent changes to this field
-can cause a large fan-out effect for some resources.
+can cause a large fan-out effect for some resources. The name of this field also
+varies from resource to resource, sometimes it's called `LastProbeTime`, and other
+times it's called `LastUpdateTime`.
 
 Conditions should be added to explicitly convey properties that users and
 components care about rather than requiring those properties to be inferred from


### PR DESCRIPTION
I can only see one place in the k8s API where `LastHeartbeatTime` is used, that's in the [Node resource](https://github.com/kubernetes/api/blob/kubernetes-1.14.1/core/v1/types.go#L4164). Other names for the same field are `LastProbeTime` (eg for the [Pod resource](https://github.com/kubernetes/api/blob/kubernetes-1.14.1/core/v1/types.go#L2429)) and `LastUpdateTime` (eg for the [Deployment resource](https://github.com/kubernetes/api/blob/kubernetes-1.14.1/apps/v1/types.go#L439)).

I've added a note that mentions the alternative names in the naming conventions, but I wonder whether the canonical naming convention should be changed to perhaps `LastUpdateTime`.