### PR TITLE
Add subproject slack channels

### DIFF
--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -44,6 +44,8 @@ The following subprojects are owned by sig-apps:
 - **kompose**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kompose/master/OWNERS
+  - Contact
+    - Slack: [#kompose](https://kubernetes.slack.com/messages/kompose)
 - **workloads-api**
   - Description: The core workloads API, which is composed of the CronJob, DaemonSet, Deployment, Job, ReplicaSet, ReplicationController, and StatefulSet kinds
   - Owners:

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -69,6 +69,8 @@ The following subprojects are owned by sig-cli:
 - **kustomize**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/OWNERS
+  - Contact
+    - Slack: [#kustomize](https://kubernetes.slack.com/messages/kustomize)
 
 ## GitHub Teams
 

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -64,6 +64,8 @@ The following subprojects are owned by sig-cluster-lifecycle:
 - **bootkube**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/bootkube/master/OWNERS
+  - Contact
+    - Slack: [#bootkube](https://kubernetes.slack.com/messages/bootkube)
 - **cluster-addons**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/addon-operators/master/OWNERS
@@ -72,6 +74,8 @@ The following subprojects are owned by sig-cluster-lifecycle:
 - **cluster-api**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
+  - Contact
+    - Slack: [#cluster-api](https://kubernetes.slack.com/messages/cluster-api)
 - **cluster-api-provider-aws**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
@@ -87,15 +91,21 @@ The following subprojects are owned by sig-cluster-lifecycle:
 - **etcdadm**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/etcdadm/master/OWNERS
+  - Contact
+    - Slack: [#etcdadm](https://kubernetes.slack.com/messages/etcdadm)
 - **kops**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS
 - **kube-aws**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/kube-aws/master/OWNERS
+  - Contact
+    - Slack: [#kube-aws](https://kubernetes.slack.com/messages/kube-aws)
 - **kube-deploy**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kube-deploy/master/OWNERS
+  - Contact
+    - Slack: [#kube-deploy](https://kubernetes.slack.com/messages/kube-deploy)
 - **kube-up**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS
@@ -104,6 +114,8 @@ The following subprojects are owned by sig-cluster-lifecycle:
     - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
+  - Contact
+    - Slack: [#kubeadm](https://kubernetes.slack.com/messages/kubeadm)
 - **kubeadm-dind-cluster**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/OWNERS
@@ -113,9 +125,13 @@ The following subprojects are owned by sig-cluster-lifecycle:
 - **kubespray**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS
+  - Contact
+    - Slack: [#kubespray](https://kubernetes.slack.com/messages/kubespray)
 - **minikube**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/minikube/master/OWNERS
+  - Contact
+    - Slack: [#minikube](https://kubernetes.slack.com/messages/minikube)
 
 ## GitHub Teams
 

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -60,9 +60,13 @@ The following subprojects are owned by sig-contributor-experience:
 - **devstats**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
+  - Contact
+    - Slack: [#devstats](https://kubernetes.slack.com/messages/devstats)
 - **events**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/community/master/events/OWNERS
+  - Contact
+    - Slack: [#events](https://kubernetes.slack.com/messages/events)
   - Meetings:
     - Contributor Summit strategy, content and planning: [Mondays at 9:00 PT (Pacific Time)]() (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
 - **github-management**
@@ -82,6 +86,8 @@ The following subprojects are owned by sig-contributor-experience:
 - **slack-infra**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/slack-infra/master/OWNERS
+  - Contact
+    - Slack: [#slack-infra](https://kubernetes.slack.com/messages/slack-infra)
 
 ## GitHub Teams
 

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -41,9 +41,13 @@ The following subprojects are owned by sig-instrumentation:
 - **klog**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
+  - Contact
+    - Slack: [#klog](https://kubernetes.slack.com/messages/klog)
 - **kube-state-metrics**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS
+  - Contact
+    - Slack: [#kube-state-metrics](https://kubernetes.slack.com/messages/kube-state-metrics)
 - **metrics**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/metrics/OWNERS

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -37,6 +37,8 @@ The following subprojects are owned by sig-network:
 - **external-dns**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/external-dns/master/OWNERS
+  - Contact
+    - Slack: [#external-dns](https://kubernetes.slack.com/messages/external-dns)
 - **ingress**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/ingress-gce/master/OWNERS

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -56,6 +56,8 @@ The following subprojects are owned by sig-node:
 - **node-problem-detector**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
+  - Contact
+    - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
 - **rktlet**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/rktlet/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -179,6 +179,8 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes/examples/master/OWNERS
   - name: kompose
+    contact:
+      slack: kompose
     owners:
     - https://raw.githubusercontent.com/kubernetes/kompose/master/OWNERS
   - name: workloads-api
@@ -713,6 +715,8 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/kubectl/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/OWNERS
   - name: kustomize
+    contact:
+      slack: kustomize
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/OWNERS
 - dir: sig-cloud-provider
@@ -909,6 +913,8 @@ sigs:
       description: PR Reviews
   subprojects:
   - name: bootkube
+    contact:
+      slack: bootkube
     owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/bootkube/master/OWNERS
   - name: cluster-addons
@@ -917,6 +923,8 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/addon-operators/master/OWNERS
   - name: cluster-api
+    contact:
+      slack: cluster-api
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
   - name: cluster-api-provider-aws
@@ -932,21 +940,29 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
   - name: etcdadm
+    contact:
+      slack: etcdadm
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/etcdadm/master/OWNERS
   - name: kops
     owners:
     - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS
   - name: kube-aws
+    contact:
+      slack: kube-aws
     owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/kube-aws/master/OWNERS
   - name: kube-deploy
+    contact:
+      slack: kube-deploy
     owners:
     - https://raw.githubusercontent.com/kubernetes/kube-deploy/master/OWNERS
   - name: kube-up
     owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS
   - name: kubeadm
+    contact:
+      slack: kubeadm
     owners:
     - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
@@ -958,9 +974,13 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS
   - name: kubespray
+    contact:
+      slack: kubespray
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS
   - name: minikube
+    contact:
+      slack: minikube
     owners:
     - https://raw.githubusercontent.com/kubernetes/minikube/master/OWNERS
 - dir: sig-contributor-experience
@@ -1043,9 +1063,13 @@ sigs:
       frequency: biweekly
       url: https://docs.google.com/document/d/1gdFWfkrapQclZ4-z4Lx2JwqKsJjXXUOVoLhBzZiZgSk/edit
   - name: devstats
+    contact:
+      slack: devstats
     owners:
     - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
   - name: events
+    contact:
+      slack: events
     owners:
     - https://raw.githubusercontent.com/kubernetes/community/master/events/OWNERS
     meetings:
@@ -1069,6 +1093,8 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
   - name: slack-infra
+    contact:
+      slack: slack-infra
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/slack-infra/master/OWNERS
 - dir: sig-docs
@@ -1285,9 +1311,13 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes/heapster/master/OWNERS
   - name: klog
+    contact:
+      slack: klog
     owners:
     - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
   - name: kube-state-metrics
+    contact:
+      slack: kube-state-metrics
     owners:
     - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS
   - name: metrics
@@ -1418,6 +1448,8 @@ sigs:
       description: Test Failures and Triage
   subprojects:
   - name: external-dns
+    contact:
+      slack: external-dns
     owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/external-dns/master/OWNERS
   - name: ingress
@@ -1502,6 +1534,8 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/OWNERS
   - name: node-problem-detector
+    contact:
+      slack: node-problem-detector
     owners:
     - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
   - name: rktlet


### PR DESCRIPTION
A script of mine noticed there are a number of slack channels in https://github.com/kubernetes/community/blob/master/communication/slack-config/channels.yaml that happen to match the names of subprojects in sigs.yaml