### PR TITLE
Requesting Slack channel for Kubernetes blog

### DIFF
--- a/communication/slack-config/sig-docs/docs-channels.yaml
+++ b/communication/slack-config/sig-docs/docs-channels.yaml
@@ -9,3 +9,4 @@ channels:
   - name: kubernetes-docs-ko
   - name: kubernetes-docs-pt
   - name: kubernetes-docs-zh
+  - name: kubernetes-docs-blog

--- a/communication/slack-config/sig-docs/docs-channels.yaml
+++ b/communication/slack-config/sig-docs/docs-channels.yaml
@@ -1,4 +1,5 @@
 channels:
+  - name: kubernetes-docs-blog
   - name: kubernetes-docs-de
   - name: kubernetes-docs-es
   - name: kubernetes-docs-fr
@@ -9,4 +10,3 @@ channels:
   - name: kubernetes-docs-ko
   - name: kubernetes-docs-pt
   - name: kubernetes-docs-zh
-  - name: kubernetes-docs-blog


### PR DESCRIPTION
We are creating a subproject of SIG-Docs for the Kubernetes blog and would like to add a Slack channel for blog-specific discussions.