### PR TITLE
Requesting Slack channel for Kubernetes blog

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -134,6 +134,7 @@ channels:
   - name: kubernetes-client
   - name: kubernetes-dev
   # kubernetes-docs-* channels are defined in sig-docs/
+  - name: kubernetes-docs-blog
   - name: kubernetes-novice
   - name: kubernetes-operators
   - name: kubernetes-ruby

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -134,7 +134,6 @@ channels:
   - name: kubernetes-client
   - name: kubernetes-dev
   # kubernetes-docs-* channels are defined in sig-docs/
-  - name: kubernetes-docs-blog
   - name: kubernetes-novice
   - name: kubernetes-operators
   - name: kubernetes-ruby
@@ -229,6 +228,7 @@ channels:
     archived: true
   - name: sig-contribex
   - name: sig-docs
+  - name: sig-docs-blog
   - name: sig-docs-maintainers
   - name: sig-docs-modeling
   - name: sig-docs-release


### PR DESCRIPTION
We are creating a subproject of SIG-Docs for the Kubernetes blog and would like to add a Slack channel for blog-specific discussions.