### PR TITLE
added link to meeting recordings for sig-aws

### DIFF
--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -15,6 +15,7 @@ The [charter](charter.md) defines the scope and governance of the AWS Special In
 ## Meetings
 * Regular SIG Meeting: [Fridays at 9:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly 2019 start date: Jan. 11th). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit).
+  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29DzPOBBaJi-SO3AQ_b4HC).
 
 ## Leadership
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -557,6 +557,7 @@ sigs:
     frequency: 'biweekly 2019 start date: Jan. 11th'
     url: https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit
     archive_url: https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29DzPOBBaJi-SO3AQ_b4HC
   contact:
     slack: sig-aws
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-aws


### PR DESCRIPTION
There was no link from the sig-aws README to the meeting recordings on YouTube, so I added the link to sigs.yaml and generated the readme file to make the videos easier for people to find.