### PR TITLE
Update who must approve repo creation requests

### DIFF
--- a/github-management/kubernetes-repositories.md
+++ b/github-management/kubernetes-repositories.md
@@ -77,7 +77,8 @@ repo page.)
      repositories must use the Creative Commons License version 4.0.
    * Must adopt the CNCF CLA bot, merge bot and Kubernetes PR commands/bots.
    * All OWNERS of the project must also be active SIG members.
-   * SIG membership must vote using lazy consensus to create a new repository
+   * Must be approved by the process spelled out in the SIG's charter and a
+   publicly linkable written decision should be available for the same.
    * SIG must already have identified all of their existing subprojects and
      code, with valid OWNERS files, in
 [`sigs.yaml`](https://github.com/kubernetes/community/blob/master/sigs.yaml)


### PR DESCRIPTION
Current state of docs:

- https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md#subproject-creation
mentions that repos _may_ be created under k-sigs by a lazy consensus of subproject owners.

- Some charters like https://github.com/kubernetes/community/blob/master/sig-api-machinery/charter.md#deviations-from-sig-governance
have explicit processes setup for who can approve repo creation requests.

- https://github.com/kubernetes/community/blob/master/github-management/kubernetes-repositories.md#rules-for-new-repositories
says that repo creation requests must be approved by lazy consensus of SIG membership.

Current state of how we do things:

- We create repos if the SIG leads have approved the repo creation
request.
- We don't require a lazy consensus thread on the mailing list.

To reconcile both docs and the current state of things, this commit
updates the docs to say that repo creation requests must be approved by
lazy consensus of SIG membership _and_ must also be explicitly approved
by folks listed out the in the SIG charter.

Note that the wording says "process spelled out in the SIG charter"
because SIG charters _may_ also define a complete process on how they'd
like to handle this, not just the list of people who can approve repo
creation requests.

/assign @spiffxp @cblecker 