### PR TITLE
Add all email comms for BCN

### DIFF
--- a/events/2019/05-contributor-summit/README.md
+++ b/events/2019/05-contributor-summit/README.md
@@ -9,6 +9,7 @@ In some sense, the summit is a real-life extension of the community meetings and
  - Onboard new contributors to be productive in our community
  - Send contributors home with more context, knowledge, and skills about the project
  - [SIG-specific face-to-face collaboration](sig-f2f-guidelines.md)
+ - [All pre- and post-event email communications sent out to attendees](communications.md)
 
 
 ## Registration

--- a/events/2019/05-contributor-summit/communications.md
+++ b/events/2019/05-contributor-summit/communications.md
@@ -1,0 +1,233 @@
+# Comms used for Contributor Summit Barcelona, 2019
+
+This document contains all the email communications that were sent out for the Contributor Summit in Barcelona.
+
+---
+
+## [Kubernetes Contributor Summit EU] [Sched Invite] Email
+_Sent out as soon as an attendee is added and approved in Sched_
+
+Welcome!
+
+You have been added as an attendee to the [Kubernetes Contributor Summit in Barcelona](https://events.linuxfoundation.org/events/contributor-summit-europe-2019/).
+
+Please sign up for the sessions you plan to attend. This information will help both the session facilitators and the event team plan appropriately for the sessions.
+
+If you have any questions, please send an e-mail to community@kubernetes.io or reach out in the [#contributor-summit](https://kubernetes.slack.com/messages/contributor-summit) slack channel.
+
+See you in Barcelona!
+
+- Kubernetes Contributor Summit Events Team
+
+---
+
+## [Kubernetes Contributor Summit EU] [Registration Changes] Email
+_Sent to those needing to change from 201 to 101 workshop_
+
+Hello (Name),
+
+Thank you for signing up for the 2019 Kubernetes Contributor Summit in Barcelona. To better align contributors with the track that would best fit, we wanted to follow-up and see if you would be interested in the New Contributor Track. The current contributor track is restricted to those that are Kubernetes org members or those that are actively contributing to the upstream project.
+
+Unlike past New Contributor Tracks, the Contributor Summit in Barcelona has two options for new contributors:
+
+101 - For brand new contributors who are interested in contributing, but have little to no experience contributing to open source projects.
+
+201 - For people who have experience contributing to other open source projects, but who are new to Kubernetes.
+
+If switching is something you'd like to do, please just respond and we'll take care of it right away.
+
+If you feel you should still be in the current contributor track, please reply to this email or follow-up separately with community@kubernetes.io.
+
+Thank you.
+
+- Kubernetes Contributor Summit Events Team
+
+---
+
+## [Kubernetes Contributor Summit EU] [Current Contributors Sched Info] Email
+_Sent out three weeks in advance to current contributors_
+
+Hi (Name),
+
+Welcome to the [Barcelona Kubernetes Contributor Summit](https://events.linuxfoundation.org/events/contributor-summit-europe-2019/)!
+
+A [Sched](https://contsummiteu19.sched.com/) invite was sent out last Friday inviting you to sign-up for sessions.
+
+As a reminder, the only content for current contributors on Monday are [SIG Face-to-Face (F2F) meetings](https://contsummiteu19.sched.com/overview/type/SIG+F2F); including: CLI, Cloud Provider, Cluster Lifecycle, IBM Cloud, Instrumentation, Kubebuilder subproject (API Machinery), Networking, PM, Release, Scheduling, UI, VMware, and Windows.
+
+If you are no longer interested in attending Monday, you may update your registration by connecting with us in Kubernetes Slack [#contributor-summit](https://kubernetes.slack.com/messages/contributor-summit) (if you don’t have an account yet, join here: https://slack.k8s.io) or e-mail us at community@kubernetes.io.
+
+If you are still planning on attending Monday, please sign up in [Sched](https://contsummiteu19.sched.com/overview/type/SIG+F2F) for the F2F sessions you are interested in. This will help us plan the room selection accordingly.
+
+Thank you and see you in Barcelona!
+
+- Kubernetes Contributor Summit Events Team
+
+
+---
+
+## [Kubernetes Contributor Summit EU] [New Contributor Setup Information] Email
+_Sent out two weeks in advance to new contributors_
+
+Hi (Name),
+
+It is less than two weeks until [Kubernetes Contributor Summit](https://events.linuxfoundation.org/events/contributor-summit-europe-2019/), and we want to say, from the entire Kubernetes community, that we are so excited to be seeing so many new faces!
+
+You can find the [schedule for the event here](https://contsummiteu19.sched.com).
+
+Before we get to see each other in person, we would like to send a reminder and a few suggestions on how to get the most out of the New Contributor Workshop.
+
+**REMINDER**  
+Please follow this link for instructions to sign the [Kubernetes Contributor License Agreement](https://contsummiteu19.sched.com). Your organization may have a different, and possibly lengthy, process for this, so make sure you start and complete this task well in advance. Only folks who have signed the CLA will be able to participate in our community workflow exercises.
+
+If you run into trouble doing so, or have questions, please do not hesitate to contact the Linux Foundation Helpdesk at https://support.linuxfoundation.org/  - they are responsive and helpful.
+
+**SUGGESTIONS**  
+Familiarize yourself with git and GitHub, if you haven't already done so. [Here’s a quick tutorial to get you started](https://guides.github.com/activities/hello-world/). It's 100% okay to be both very new and very experienced at it. Just let us know and we will help you follow along!
+
+Part of the workshop will involve building and testing the Kubernetes core repository. This is very exciting and fun! If you would like to try to code along, please prepare for the vagaries of conference center wifi and complete the following steps at home before the workshop:
+Create your own fork of https://github.com/kubernetes/kubernetes
+Clone your fork into your personal laptop (this will take a minute or so!)
+Make sure you have [golang](https://golang.org/dl/) and [Docker](https://www.docker.com/get-started) installed
+
+**NCW 101 PARTICIPANTS**  
+Please look at, fork and clone the [Contributor Playground repository](https://github.com/kubernetes-sigs/contributor-playground) before attending the workshop.
+
+**NCW 201 PARTICIPANTS**  
+We are trying our best to find ways to account for variability across operating systems and individual setups. Time is limited so if you cannot follow along due to technical difficulties, we may ask folks to pair up with those whose setup is currently working.
+
+
+
+If you have any questions, please connect with us [#contributor-summit](https://kubernetes.slack.com/messages/contributor-summit) (if you don’t have an account yet, join here: https://slack.k8s.io) or at community@kubernetes.io.
+
+See you soon!
+
+- Kubernetes Contributor Summit Events Team
+
+---
+
+## [Kubernetes Contributor Summit EU] [Pre-Event Information] Email
+_Sent out one week in advance to all attendees_
+
+Hi (Name),
+
+Happy Tuesday before the main event, contributors! It's happening!!
+
+You should have gotten a detailed email last week from us regarding what you need to know as we approach the event. So we want to keep this a bit shorter, making sure you have all the information that you need to have a great time at [Kubernetes Contributor Summit Barcelona](https://events.linuxfoundation.org/events/contributor-summit-europe-2019/).
+
+### Contributor Summit Celebration
+Sunday, 19 May 2019, 17:00 - 20:00
+
+**CELEBRATION VENUE**  
+[Hotel Arts Barcelona](https://www.hotelartsbarcelona.com/en/)  
+Lokal + Terrace, Ground Floor  
+[Marina 19-21, 08005 Barcelona, Spain](https://goo.gl/maps/yABfqg3VjkJ2)
+
+Fact: 85%+ of Monday’s attendees will be there!  Join us for food, drinks, games, and get to know your fellow contributors.
+
+Pick up your Contributor Summit badge in the lobby before joining the celebration.
+
+### Contributor Summit
+Monday, 20 May 2019, 10:00 - 17:00
+
+**EVENT VENUE**  
+[Fira Gran Via](https://goo.gl/maps/9EANSD7gQQQ2)  
+Congress Center 4 & 5 (Enter through Hall 8.0)
+
+[All the slides for the workshop are available here.](https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/)
+
+**BADGE PICKUP**
+- **Contributor Summit Badge**
+  A special badge needed for the Contributor Summit can be picked up at the Contributor Celebration or at the Fira Gran Via.  A ribbon showcasing that you are a New or Existing Contributor can be picked up at the same time, and attached to your KubeCon + CloudNativeCon badge.
+- **KubeCon + CloudNativeCon Badge**
+  Available at the airport, participating hotels, and Fira Gran Via. Please see the main KubeCon + CloudNativeCon [schedule](https://kccnceu19.sched.com/overview/type/Registration+%2B+Badge+Pick-up) for detailed badge pickup information.
+
+**SCHEDULE**  
+You can find the main schedule for the event here: https://contsummiteu19.sched.com
+
+- **New Contributor Workshops**  
+  We will start at 10:00 to give everyone ample room to enjoy breakfast on their own, and pick up their event badges. The workshop will start with a “Welcome and introduction” session in room CC5.1, and then break out into the 101 workshop in CC5.1 (same room), and 201 workshop in CC4.1.
+
+- **SIG F2F Info**  
+  For current contributors, we have several SIG F2F meetings that are co-located with the Contributor Summit on Monday: SIG CLI, SIG Cloud Provider, SIG Cluster Lifecycle, SIG IBM Cloud, SIG Instrumentation, KubeBuilder (SIG API Machinery), SIG Networking, SIG PM, SIG Release, SIG Scheduling, SIG UI, SIG VMware, and SIG Windows.
+
+  Please see the [schedule for SIG room information](https://contsummiteu19.sched.com/overview/type/SIG+F2F), there will be signs outside the rooms as well, and please read through the guidelines here.
+
+- **New Contributor Meet and Greet**  
+  Starting at 16:00 after the workshops, we will host a Meet and Greet for all new and existing contributors. Come say hi, introduce yourself and get to know someone new!
+
+**TALK TO US**  
+Join the conversation in Kubernetes Slack in the [#contributor-summit](https://kubernetes.slack.com/messages/contributor-summit) channel (if you don’t have an account yet, join here: https://slack.k8s.io).
+Are you tweeting at the event? Include us in your Twitter posts throughout the event with the hashtag [#k8scontribsummit](https://twitter.com/search?q=%23k8scontribsummit).
+
+See you in Barcelona!
+
+- Kubernetes Contributor Summit Events Team
+
+---
+
+## [Kubernetes Contributor Summit EU] [Post Event - Current Contributors] Email
+_Sent out a week after the Contributor Summit to current contributors_
+
+Hi (Name),
+
+Thank you for attending [Kubernetes Contributor Summit EU](https://events.linuxfoundation.org/events/contributor-summit-europe-2019/). What a fantastic event! Your active participation and enthusiasm were critical to the success of the event -- we hope that you found it valuable.
+
+It is our goal to continually improve Kubernetes Contributor Summit events, so please share your feedback in this brief [survey](https://forms.gle/VD1NmkZeCsMCGKdT7)!
+
+We’d like to share a number of resources from the event:
+
+**Presentations**  
+All the slides from the workshops [can be found here](https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/).
+
+**Videos**  
+The New Contributor Workshops were recorded and are available via [our Summit playlist](https://www.youtube.com/watch?v=-GayuFobHBo&list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx).
+
+**Photo Gallery**  
+Thank you for all the great memories! See if you can spot yourself in the [gallery](https://bit.ly/2VrG8eB).
+
+Share Your Experience!
+Join the conversation in Kubernetes Slack on the [#contributor-summit](https://kubernetes.slack.com/messages/contributor-summit) channel (if you don’t have an account yet, join here: https://slack.k8s.io).
+Don’t forget to include us in your Twitter posts from the event #k8scontribsummit.
+
+Join Us in [Shanghai](https://www.lfasiallc.com/events/contributors-summit-china-2019/) and [San Diego](https://events.linuxfoundation.org/events/contributor-summit-north-america-2019/)!
+
+On behalf of the entire Kubernetes Contributor Summit team, thank you again for attending and we look forward to seeing you at a future event!
+
+Kind regards,
+
+- Kubernetes Contributor Summit Events Team
+
+---
+
+## [Kubernetes Contributor Summit EU] [Post Event - New Contributors] Email
+_Sent out a week after the Contributor Summit to new contributors_
+
+Hi (Name),
+
+Thank you for attending [Kubernetes Contributor Summit EU](https://events.linuxfoundation.org/events/contributor-summit-europe-2019/). What a fantastic event! Your active participation and enthusiasm were critical to the success of the event -- we hope that you found it valuable.
+
+It is our goal to continually improve Kubernetes Contributor Summit events, so please share your feedback in this brief [survey](https://docs.google.com/forms/d/e/1FAIpQLSffTryOAfIITqpNYzgJsnu9CziNXbUwZmwCxtuyqMXkc0vFKw/viewform)!
+
+We’d like to share a number of resources from the event:
+
+**Presentations**  
+All the slides from the workshops [can be found here](https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/).
+
+**Videos**  
+The New Contributor Workshops were recorded and are available via [our Summit playlist](https://www.youtube.com/watch?v=-GayuFobHBo&list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx).
+
+**Photo Gallery**  
+Thank you for all the great memories! See if you can spot yourself in the [gallery](https://bit.ly/2VrG8eB).
+
+Share Your Experience!
+Join the conversation in Kubernetes Slack on the [#contributor-summit](https://kubernetes.slack.com/messages/contributor-summit) channel (if you don’t have an account yet, join here: https://slack.k8s.io).
+Don’t forget to include us in your Twitter posts from the event #k8scontribsummit.
+
+Join Us in [Shanghai](https://www.lfasiallc.com/events/contributors-summit-china-2019/) and [San Diego](https://events.linuxfoundation.org/events/contributor-summit-north-america-2019/)!
+
+On behalf of the entire Kubernetes Contributor Summit team, thank you again for attending and we look forward to seeing you at a future event!
+
+Kind regards,
+
+- Kubernetes Contributor Summit Events Team


### PR DESCRIPTION
This PR adds all pre- and post-event email communications sent out to attendees of Contributor Summit Barcelona.

Signed-off-by: jonasrosland <jrosland@vmware.com>