### PR TITLE
Add #garden and #garden-dev Slack Channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -61,6 +61,8 @@ channels:
   - name: fi-users
   - name: fr-events
   - name: fr-users
+  - name: garden
+  - name: garden-dev
   - name: gardener
   - name: gimbal
   - name: github


### PR DESCRIPTION
Hi! I work at [Garden.io](https://garden.io/), we're responsible for the eponymous development tool, [Garden](https://github.com/garden-io/garden). 

We'd like to be more easily accessible to the Kubernetes community, and since Garden is completely OSS, we'd like to have our development channel on Kubernetes Slack as well.