### PR TITLE
Add cluster-api-vsphere slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -32,6 +32,7 @@ channels:
   - name: cluster-api-azure
   - name: cluster-api-baremetal
   - name: cluster-api-openstack
+  - name: cluster-api-vsphere
   - name: cn-dev
   - name: cn-events
   - name: cn-users


### PR DESCRIPTION
This is to add a cluster-api-vsphere channel, in preparation to the upcoming folding of SIG-VMware.

/cc: @akutz @andrewsykim