### PR TITLE
Adds two sig-cluster-lifecycle projects

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -77,12 +77,18 @@ The following subprojects are owned by sig-cluster-lifecycle:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
   - Contact
     - Slack: [#cluster-api](https://kubernetes.slack.com/messages/cluster-api)
+- **cluster-api-bootstrap-provider-kubeadm**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/master/OWNERS
 - **cluster-api-provider-aws**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
 - **cluster-api-provider-digitalocean**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS
+- **cluster-api-provider-docker**
+  - Owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-docker/master/OWNERS
 - **cluster-api-provider-gcp**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -947,12 +947,18 @@ sigs:
       slack: cluster-api
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
+  - name: cluster-api-bootstrap-provider-kubeadm
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/master/OWNERS
   - name: cluster-api-provider-aws
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
   - name: cluster-api-provider-digitalocean
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS
+  - name: cluster-api-provider-docker
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-docker/master/OWNERS
   - name: cluster-api-provider-gcp
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

Adding two new subprojects. I will need the repos created before I can link to the owner files, unless I'm going about this the wrong way?

cc @detiber 

edit: after this I can make an issue to make a repo that references this change