### PR TITLE
New Contributor Content Lead Role fleshed out

### DIFF
--- a/events/events-team/content-lead.md
+++ b/events/events-team/content-lead.md
@@ -27,23 +27,41 @@ TODO
 New Contributor Content Lead
 
 ## Overview
-
-TODO
+The New Contributor Content Lead is in charge of planning and executing the New Contributor Workshop at the Kubernetes Contributor Summit. They will coordinate with the overall Events Team and the organizers of related activities aimed at new contributors.
 
 ## Skills and Qualifications
 
-TODO
+The New Contributor Content Lead must be a current, active Kubernetes contributor who is knowledgeable of the community and organizational structure of the Kubernetes project, as well as familiar with building and developing Kubernetes.
+They should have experience and be comfortable with teaching in a workshop setting and presenting interactively in front of an audience.
+Additionally, they must be able to relate to and empathize with newcomers of many different experience levels. 
+As this role is part of a subproject of SIG-contributor-experience, the New Contributor Content Lead must be a member of SIG-contributor-experience.
 
 ## Activities  
 
-Make modifications and continuous improvements to the new contributor workshop template  
-Incorporate the new contributor playground  
-Teach the class or recruit teachers and teachers assistants  
-Work with Lead on determining the capacity and how many sessions will run  
-Determine if different levels need to be offered  
-Organize SIG Meet and Greet (may be a different role to be determined by core team)  
-
+*These tasks reflect a rough timeline leading from the end of the previous Contributor Summit to the currently planned one.*
+- Attend event planning meetings in preparation for the Contributor Summit, where applicable
+- Create a Workshop Content Proposal and link in an Issue to k/community:
+    - determine sessions and their overall topic (e.g. How We Communicate, Code Base Walkthrough, etc)
+    - determine what difficulty/experience levels will be offered, if any, and coordinate with Lead
+    - determine workshop capacity, and coordinate with Lead 
+    - determine room requirements (size, number, table/chair layout, A/V) and coordinate with the planning team
+- Coordinate with New Contributor Content Shadows to prepare them for leading this role.
+- Recruit and coordinate with workshop teachers for any sessions/topics you do not wish to teach yourself (e.g. invite someone to speak on "Communication in the Kubernetes Project").
+- Make modifications and continuous improvements to the new contributor workshop template. 
+Incorporate feedback from previous New Contributor Workshops.
+Shadows and co-presenters are expected to assist and review these updates.
+[Past presentations are linked here](https://github.com/cncf/presentations/tree/master/kubernetes) - please make a copy of the existing deck before updating/editing.
+- Work with Registration to:
+    - disseminate course materials (slides) in advance
+    - ensure participants sign the CLA
+    - ensure attendees meet technical and experience requirements for their course
+    - obtain a comprehensive list of names, emails, and github handles
+- Incorporate the new contributor playground into the workshop.
+Create a New Contributor Workshop folder specific to this event, with teachers' and participants' github handles in the OWNERS file - [here is an example](sigs.k8s.io/contributor-playground/seattle)
+- Coordinate with the SIG Meet and Greet organizer(may be a different role to be determined by core team)
+- Ensure to advertise the SIG-Intros
+- Solicit feedback from workshop participants
 
 ## Time Commitment
 
-TODO
+1-2 hours/week most of the time, 4-5 in the weeks leading up to KubeCon, depending on previous teaching/shadowing experience.


### PR DESCRIPTION
This PR adds a description for the New Contributor Content Lead role.

/sig-contributor-experience
/assign @parispittman 
