### PR TITLE
conventional test args to bypass UTs

### DIFF
--- a/contributors/devel/sig-scheduling/scheduler_benchmarking.md
+++ b/contributors/devel/sig-scheduling/scheduler_benchmarking.md
@@ -11,7 +11,7 @@ To run integration benchmarks use the following command from inside a Kubernetes
 directory. 
 
 ```sh
-make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=xxx -bench=."
+make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=^$$ -bench=."
 ```
 
 You can also provide a benchmark name in order to run a specific set of
@@ -19,8 +19,10 @@ benchmarks. Please refer to [Go documentation on benchmarks](https://golang.org/
 for more information.
 
 ```sh
-make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=xxx -bench=BenchmarkScheduling"
+make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=^$$ -bench=BenchmarkScheduling"
 ```
+
+> To display benchmark output only, you can append `-alsologtostderr=false -logtostderr=false` to `KUBE_TEST_ARGS`.
 
 These benchmarks are located in `./test/integration/scheduler_perf/scheduler_bench_test.go`. 
 The function names start with `BenchmarkScheduling`. At the beginning of each
@@ -51,7 +53,7 @@ it in the `-bench` argument. For example, the following will run only those
 benchmarks with 5000 nodes and 1000 existing pods.
 
 ```sh
-make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=xxx -bench=BenchmarkScheduling/5000Nodes/1000Pods"
+make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=^$$ -bench=BenchmarkScheduling/5000Nodes/1000Pods"
 ```
 
 ## Profiling the scheduler
@@ -60,7 +62,7 @@ You can get CPU profiling information from the benchmarks by adding a `-cpuprofi
 to the command above. Example:
 
 ```sh
-make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=xxx -bench=BenchmarkScheduling -cpuprofile cpu.out"
+make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=^$$ -bench=BenchmarkScheduling -cpuprofile cpu.out"
 ```
 
 After obtaining the CPU profile, you can use `pprof` to view the results. For


### PR DESCRIPTION
- when running benchmark tests, we used to use `-run=xxx` to exclude unit tests; however a more conventional way is to use `-run=^$`, `-run=^$$` here is to escape the $ symbol, otherwise it won't work.
- add info to display benchmark output only

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

/assign @bsalamat 
/sig scheduling