### PR TITLE
Revert "slack: Add Release Managers usergroup"

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -1,23 +1,6 @@
 # This file contains a list of all Slack usergroups that exist.
 
 usergroups:
-  - name: release-managers
-    long_name: Release Managers
-    description: Release Managers. Ping for questions on branch cuts and building/packaging Kubernetes.
-    channels:
-      - release-managers
-      - sig-release
-    members:
-      - aleksandra-malinowska
-      - bubblemelon
-      - calebamiles
-      - feiskyer
-      - hoegaarden
-      - idealhack
-      - justaugustus
-      - listx
-      - sumitranr
-      - tpepper
   - name: test-infra-oncall
     external: true
   - name: youtube-admins

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -2,22 +2,12 @@
 # usernames to Kubernetes Slack user IDs.
 users:
   alejandrox1: U6AS37R50
-  aleksandra-malinowska: U357LUPHS
-  bubblemelon: U7K9C643G
-  calebamiles: U1ZDD4CUR
   castrojo: U1W1Q6PRQ
-  feiskyer: U0ASA4398
-  hoegaarden: U7VA4RZS9
-  idealhack: U5NJ3DQM9
   idvoretskyi: U0CBHE6GM
   jbeda: U09QZ63DX
   jdumars: U0YJS6LHL
   jeefy: U5MCFK468
-  justaugustus: U0E0E78AK
   katharine: UBTBNJ6GL
-  listx: UFCU8S8P3
   mrbobbytables: U511ZSKHD
   paris: U5SB22BBQ
   sarahnovotny: U0AGW7007
-  sumitranr: UCQN13L9H
-  tpepper: U6UB5V4TX


### PR DESCRIPTION
Reverts kubernetes/community#3827

Apparently this causes a naming conflict when applied. I guess the channel names count??

/cc @justaugustus 