### PR TITLE
slack: Rename release-managers channel to release-management

### DIFF
--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -16,5 +16,5 @@ restrictions:
   - path: "sig-release/*.yaml"
     channels:
       - "^sig-release$"
-      - "^release-managers$"
+      - "^release-"
   - path: "**/*" # prevent any other file from containing anything

--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -1,3 +1,4 @@
 channels:
   - name: sig-release
-  - name: release-managers
+  - name: release-management
+    id: CJH2GBF7Y


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Supercedes: #3828 
Ref: #3827 

/sig release
/assign @Katharine @jdumars 