### PR TITLE
Request new channel for CAPD

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -31,6 +31,7 @@ channels:
   - name: cluster-api-aws
   - name: cluster-api-azure
   - name: cluster-api-baremetal
+  - name: cluster-api-docker
   - name: cluster-api-openstack
   - name: cluster-api-vsphere
   - name: cn-dev


### PR DESCRIPTION
cluster-api-provider-docker can be found here: https://github.com/kubernetes-sigs/cluster-api-provider-docker.

This is part of the Cluster-API sub project which is a sub project of SIG Cluster Lifecycle.

Happy to answer any more questions, I am @ cha on the k8s slack!

Signed-off-by: Chuck Ha <chuckh@vmware.com>