### PR TITLE
Revert "Create AKS channel"

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -3,7 +3,6 @@
 
 channels:
   - name: airflow-operator
-  - name: aks
   - name: announcements
   - name: api-reviews
   - name: apisnoop


### PR DESCRIPTION
Reverts kubernetes/community#3770. Apparently the name `aks` is irrevocably(?) taken by a user, so we fail every time we try to create the channel.

We may want to recreate this with a different name.