### PR TITLE
mentoring: add nikhita as approver

### DIFF
--- a/mentoring/OWNERS
+++ b/mentoring/OWNERS
@@ -5,6 +5,7 @@ reviewers:
   - nikhita
 approvers:
   - parispittman
+  - nikhita
   - sig-contributor-experience-leads
 labels:
   - sig/contributor-experience


### PR DESCRIPTION
This is essentially a no-op as `sig-contributor-experience-leads` already have approval access, but adding it explicitly for subproject ownership.

/assign @parispittman 