### PR TITLE
Added link to SIG contributor event doc

### DIFF
--- a/events/events-team/content-lead.md
+++ b/events/events-team/content-lead.md
@@ -58,7 +58,7 @@ Shadows and co-presenters are expected to assist and review these updates.
     - obtain a comprehensive list of names, emails, and github handles
 - Incorporate the new contributor playground into the workshop.
 Create a New Contributor Workshop folder specific to this event, with teachers' and participants' github handles in the OWNERS file - [here is an example](sigs.k8s.io/contributor-playground/seattle)
-- Coordinate with the SIG Meet and Greet organizer(may be a different role to be determined by core team)
+- Coordinate with the [SIG Meet and Greet organizer](sig-contrib-events.md) (may be a different role to be determined by core team)
 - Ensure to advertise the SIG-Intros
 - Solicit feedback from workshop participants
 


### PR DESCRIPTION
Added a link from the Content Handbook, which mentioned the SIG Meet and Greet, to the new page describing how it is organized.