### PR TITLE
Update contributor guide about assign feature

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -103,8 +103,8 @@ Another good strategy is to find a documentation improvement, such as a missing/
 
 #### Issue Assignment in Github
 
-Often, new contributors ask to be assigned an issue they are willing to take on. Unfortunately, due to GitHub limitations we can only assign issues to [org members](#community) or repo collaborators. 
-Instead, please state in a comment that you intend to work on this issue and it will be assumed to be yours.
+When you are willing to take on an issue, you can assign it to yourself. Just reply with `/assign` or `/assign @yourself` on an issue, 
+then the robot will assign the issue to you and your name will present at `Assignees` list.
 
 ### Learn about SIGs
 


### PR DESCRIPTION
New contributor can assign issue by themself now. 

The feature is provided by GitHub, more details please refer to [Change log](https://github.blog/changelog/2019-06-25-assign-issues-to-issue-commenters/).