### PR TITLE
Delete contributor-cheatsheet.md placeholder

### DIFF
--- a/contributors/guide/contributor-cheatsheet.md
+++ b/contributors/guide/contributor-cheatsheet.md
@@ -1,3 +1,0 @@
-This file has moved to https://git.k8s.io/community/contributors/guide/contributor-cheatsheet/README.md.
-
-This file is a placeholder to preserve links.  Please remove after 2019-08-01 or the release of kubernetes 1.15, whichever comes first.


### PR DESCRIPTION
> This file is a placeholder to preserve links. Please remove after 2019-08-01 or the release of kubernetes 1.15, whichever comes first.
