### PR TITLE
Add sig-usability Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -261,6 +261,7 @@ channels:
   - name: sig-storage
   - name: sig-testing
   - name: sig-ui
+  - name: sig-usability
   - name: sig-vmware
   - name: sig-windows
   - name: skaffold


### PR DESCRIPTION
Create #sig-usability Slack channel, as a followup to the SIG being approved.

https://github.com/kubernetes/community/pull/3801
