### PR TITLE
generator: add emeritus leads to WG and UG template

### DIFF
--- a/generator/ug_readme.tmpl
+++ b/generator/ug_readme.tmpl
@@ -26,6 +26,13 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 * {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
 {{- end }}
 {{- end }}
+{{- if .Leadership.EmeritusLeads }}
+
+## Emeritus Organizers
+{{ range .Leadership.EmeritusLeads }}
+* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+{{- end }}
+{{- end }}
 {{- end }}
 
 ## Contact

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -32,6 +32,13 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 * {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
 {{- end }}
 {{- end }}
+{{- if .Leadership.EmeritusLeads }}
+
+## Emeritus Organizers
+{{ range .Leadership.EmeritusLeads }}
+* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+{{- end }}
+{{- end }}
 {{- end }}
 
 ## Contact

--- a/wg-multitenancy/README.md
+++ b/wg-multitenancy/README.md
@@ -28,6 +28,10 @@ Define the models of multitenancy that Kubernetes will support. Discuss and exec
 * Sanjeev Rampal (**[@srampal](https://github.com/srampal)**), Cisco
 * Tasha Drew (**[@tashimi](https://github.com/tashimi)**), VMware
 
+## Emeritus Organizers
+
+* David Oppenheimer (**[@davidopp](https://github.com/davidopp)**), Google
+
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/wg-multitenancy)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy)


### PR DESCRIPTION
See https://github.com/kubernetes/community/pull/3923 where an emeritus lead was added to a WG, but the README was not updated.

/cc @cblecker @spiffxp 
/assign @cblecker 