### PR TITLE
Document private mailing list for GitHub Admin team

### DIFF
--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -90,6 +90,8 @@ better.
   Experience) about a community issue.
 - conduct@kubernetes.io - Contact the Code of Conduct committee, private mailing
   list.
+- github@kubernetes.io - Mail the [GitHub Administration Team] privately,
+  for sensitive items.
 - steering@kubernetes.io - Mail the steering committee. Public address with
   public archive.
 - steering-private@kubernetes.io - Mail the steering committee privately, for
@@ -396,3 +398,4 @@ the other contributors assigned to review and approve your PR.
 [git magic]: http://www-cs-students.stanford.edu/~blynn/gitmagic/
 [Security and Disclosure Information]: https://kubernetes.io/docs/reference/issues-security/security/
 [approve]: https://prow.k8s.io/command-help#approve
+[GitHub Administration Team]: /github-management#github-administration-team

--- a/github-management/opening-a-request.md
+++ b/github-management/opening-a-request.md
@@ -31,6 +31,9 @@ Please open an issue against the [kubernetes/test-infra] repository describing
 your issue. If your request is urgent, please escalate to the
 [test-infra on-call] or reach out to `#testing-ops` on Slack.
 
+## Sensitive issues
+
+To report any sensitive information, please email the private github@kubernetes.io list.
 
 [kubernetes/org]: https://github.com/kubernetes/org/issues
 [@kubernetes/owners]: https://github.com/orgs/kubernetes/teams/owners


### PR DESCRIPTION
The mailing list has been already setup.

/cc @kubernetes/owners 
/assign @cblecker @spiffxp 