### PR TITLE
CoCC: Fix the length of Carolyn's term

### DIFF
--- a/committee-code-of-conduct/README.md
+++ b/committee-code-of-conduct/README.md
@@ -39,13 +39,13 @@ Note that the links to display team membership will only work if you are a membe
 The members and their terms are as follows:
 
 ### Term ends on August 7, 2019
-- Carolyn Van Slyck (Microsoft) - 1 year
 - Eric Paris (Red Hat) - 1 year
 - Jennifer Rondeau (Heptio) - 1 year
 
 ### Term ends on August 7, 2020
 - Jaice Singer Dumars (Google) - 2 years
 - Paris Pittman (Google) - 2 years
+- Carolyn Van Slyck (Microsoft) - 2 year
 
 Please see the [bootstrapping document](./bootstrapping-process.md) for more information on how members are picked, their responsibilities, and how the committee will initially function.
 


### PR DESCRIPTION
The bootstrapping document stated that the top 3 voted would get 2-year
terms and the bottom 2 would get 1-year terms.

See the bootstrap document: https://github.com/kubernetes/community/blob/3db34d4f6aa092cbbf55c13eaf099cc34d6b1f15/committee-code-of-conduct/bootstrapping-process.md

However when announced 2 people were stated for 2 year terms and 3 were
stated for 1 year terms. This fixes the announced result to comply with
the rules as written.