### PR TITLE
Remove kubeadm-dind-cluster sig-cluster-lifecycle subproject.

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -135,9 +135,6 @@ The following subprojects are owned by sig-cluster-lifecycle:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
   - Contact
     - Slack: [#kubeadm](https://kubernetes.slack.com/messages/kubeadm)
-- **kubeadm-dind-cluster**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/OWNERS
 - **kubernetes-anywhere**
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -986,9 +986,6 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
-  - name: kubeadm-dind-cluster
-    owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kubeadm-dind-cluster/master/OWNERS
   - name: kubernetes-anywhere
     owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS


### PR DESCRIPTION
The project kubeadm-dind-cluster has been retired. For more information see issue https://github.com/kubernetes/org/issues/1016.

/cc @timothysc @ivan4th 