### PR TITLE
sig-cloud-provider: s/sig-<provider>-leads/provider-<provider> in OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -180,8 +180,6 @@ aliases:
   provider-gcp:
     - abgworrall
   provider-ibmcloud:
-    - khahmed
-    - rtheis
     - spzala
   provider-openstack:
     - adisky

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -168,5 +168,26 @@ aliases:
     - spiffxp
     - timothysc
 ## BEGIN CUSTOM CONTENT
-
+  provider-aws:
+    - d-nishi
+    - justinsb
+    - kris-nova
+  provider-azure:
+    - craiglpeters
+    - justaugustus
+    - feiskyer
+    - khenidak
+  provider-gcp:
+    - abgworrall
+  provider-ibmcloud:
+    - khahmed
+    - rtheis
+    - spzala
+  provider-openstack:
+    - adisky
+    - chrigl
+    - hogepodge
+  provider-vmware:
+    - cantbewong
+    - frapposelli
 ## END CUSTOM CONTENT

--- a/contributors/design-proposals/aws/OWNERS
+++ b/contributors/design-proposals/aws/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-aws-leads
+  - provider-aws
 approvers:
-  - sig-aws-leads
+  - provider-aws
 labels:
   - sig/aws

--- a/contributors/design-proposals/gcp/OWNERS
+++ b/contributors/design-proposals/gcp/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-gcp-leads
+  - provider-gcp
 approvers:
-  - sig-gcp-leads
+  - provider-gcp
 labels:
   - sig/gcp

--- a/sig-aws/OWNERS
+++ b/sig-aws/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-aws-leads
+  - provider-aws
 approvers:
-  - sig-aws-leads
+  - provider-aws
 labels:
   - sig/aws

--- a/sig-aws/README.md
+++ b/sig-aws/README.md
@@ -10,6 +10,8 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 The AWS Special Interest Group is now a subproject of [SIG Cloud Provider](https://github.com/kubernetes/community/tree/master/sig-cloud-provider).
 
+## This directory is a placeholder to preserve links.  Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.
+
 The [charter](charter.md) defines the scope and governance of the [DEPRECATED] AWS Special Interest Group.
 
 

--- a/sig-azure/OWNERS
+++ b/sig-azure/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-azure-leads
+  - provider-azure
 approvers:
-  - sig-azure-leads
+  - provider-azure
 labels:
   - sig/azure

--- a/sig-azure/README.md
+++ b/sig-azure/README.md
@@ -10,6 +10,8 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 The Azure Special Interest Group is now a subproject of [SIG Cloud Provider](https://github.com/kubernetes/community/tree/master/sig-cloud-provider).
 
+### (This directory is a placeholder to preserve links. Please remove after 6 months or the release of Kubernetes 1.17, whichever comes first.)
+
 The [charter](charter.md) defines the scope and governance of the [DEPRECATED] Azure Special Interest Group.
 
 ## Meetings

--- a/sig-gcp/OWNERS
+++ b/sig-gcp/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-gcp-leads
+  - provider-gcp
 approvers:
-  - sig-gcp-leads
+  - provider-gcp
 labels:
   - sig/gcp

--- a/sig-gcp/README.md
+++ b/sig-gcp/README.md
@@ -10,6 +10,8 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 The GCP Special Interest Group is now a subproject of [SIG Cloud Provider](https://github.com/kubernetes/community/tree/master/sig-cloud-provider).
 
+### (This directory is a placeholder to preserve links. Please remove after 6 months or the release of Kubernetes 1.17, whichever comes first.)
+
 The [charter](charter.md) defines the scope and governance of the [DEPRECATED] GCP Special Interest Group.
 
 

--- a/sig-ibmcloud/OWNERS
+++ b/sig-ibmcloud/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-ibmcloud-leads
+  - provider-ibmcloud
 approvers:
-  - sig-ibmcloud-leads
+  - provider-ibmcloud
 labels:
   - sig/ibmcloud

--- a/sig-ibmcloud/README.md
+++ b/sig-ibmcloud/README.md
@@ -10,6 +10,8 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 The IBMCloud Special Interest Group is now a subproject of [SIG Cloud Provider](https://github.com/kubernetes/community/tree/master/sig-cloud-provider).
 
+### (This directory is a placeholder to preserve links. Please remove after 6 months or the release of Kubernetes 1.17, whichever comes first.)
+
 The [charter](charter.md) defines the scope and governance of the [DEPRECATED] IBMCloud Special Interest Group.
 
 ## Meetings

--- a/sig-openstack/OWNERS
+++ b/sig-openstack/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-openstack-leads
+  - provider-openstack
 approvers:
-  - sig-openstack-leads
+  - provider-openstack
 labels:
   - sig/openstack

--- a/sig-openstack/README.md
+++ b/sig-openstack/README.md
@@ -10,6 +10,8 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 The OpenStack Special Interest Group is now a subproject of [SIG Cloud Provider](https://github.com/kubernetes/community/tree/master/sig-cloud-provider).
 
+### (This directory is a placeholder to preserve links. Please remove after 6 months or the release of Kubernetes 1.17, whichever comes first.)
+
 The [charter](charter.md) defines the scope and governance of the [DEPRECATED] OpenStack Special Interest Group.
 
 

--- a/sig-vmware/OWNERS
+++ b/sig-vmware/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-vmware-leads
+  - provider-vmware
 approvers:
-  - sig-vmware-leads
+  - provider-vmware
 labels:
   - sig/vmware

--- a/sig-vmware/README.md
+++ b/sig-vmware/README.md
@@ -10,6 +10,8 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 The VMware Special Interest Group is now a subproject of [SIG Cloud Provider](https://github.com/kubernetes/community/tree/master/sig-cloud-provider).
 
+### (This directory is a placeholder to preserve links. Please remove after 6 months or the release of Kubernetes 1.17, whichever comes first.)
+
 The [charter](charter.md) defines the scope and governance of the [DEPRECATED] VMware Special Interest Group.
 
 


### PR DESCRIPTION
Adds custom content OWNERS for former cloud provider SIG Chairs/TLs

There may have been a more elegant way to do this, but here's what I did:
```shell
for provider in "aws" "azure" "gcp" "ibmcloud" "openstack" "vmware"; do 
  for i in $(grep --exclude-dir=.git -lR sig-${provider}-leads .); do
    sed -i "s/sig-${provider}-leads/provider-${provider}/g" "$i";
  done
done
```

/assign @andrewsykim @nikhita 

Ref: #3895, https://github.com/kubernetes/org/pull/1050, https://github.com/kubernetes/org/issues/1051

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->