### PR TITLE
Document version string pattern

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -86,6 +86,12 @@ word names ("extensions", "apps"), and any group name ending in "*.k8s.io" for
 its sole use. When choosing a group name, we recommend selecting a subdomain
 your group or organization owns, such as "widget.mycompany.com".
 
+Version strings should match
+[DNS_LABEL](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md)
+format.
+
+
+
 Resource collections should be all lowercase and plural, whereas kinds are
 CamelCase and singular. Group names must be lower case and be valid DNS
 subdomains.


### PR DESCRIPTION
Document that the version portion of an apiVersion should be a DNS_LABEL.
This is required for CRDs, as encoded here:
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go#L176-L178
It seems like an eminently reasonable convention to have for built-in and aggregated APIs too.

