### PR TITLE
Add kube-oidc-proxy slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -136,6 +136,7 @@ channels:
   - name: kube-aws
   - name: kube-deploy
   - name: kube-monkey
+  - name: kube-oidc-proxy
   - name: kube-router
   - name: kube-score
   - name: kube-spawn


### PR DESCRIPTION
kube-oidc-proxy is a reverse proxy to authenticate to managed Kubernetes API servers via OIDC. The project can be found here https://github.com/jetstack/kube-oidc-proxy

I'm also @JoshVanL on k8s.slack, happy to answer any questions :)

Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>