### PR TITLE
Add okteto channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -211,6 +211,7 @@ channels:
   - name: node-problem-detector
   - name: norw-users
   - name: office-hours
+  - name: okteto
   - name: opencontainers
   - name: openshift-dev
   - name: openshift-users


### PR DESCRIPTION
`okteto` is a tool to develop directly in your dev Kubernetes cluster. No commit, build or push required. The channel will be used to share experiences between okteto users.

https://github.com/okteto/okteto

I'm @pablo on k8s.slack, happy to answer any questions :) 