### PR TITLE
sig-release: move publishing-bot to release-eng subproject

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -47,15 +47,12 @@ The following subprojects are owned by sig-release:
   - Description: The Licensing subproject is responsible for analyzing/reporting/remediating licensing concerns within the Kubernetes project orgs.
   - Owners:
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/licensing/OWNERS
-- **publishing-bot**
-  - Description: The publishing-bot publishes the contents of staging repos that live in k8s.io/kubernetes/staging to their own repositories in kubernetes
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
 - **release-engineering**
   - Description: The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
   - Owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/k8s-container-image-promoter/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/release-notes/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS
 - **release-team**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1591,17 +1591,13 @@ sigs:
       The Licensing subproject is responsible for analyzing/reporting/remediating licensing concerns within the Kubernetes project orgs.
     owners:
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/licensing/OWNERS
-  - name: publishing-bot
-    description: |
-      The publishing-bot publishes the contents of staging repos that live in k8s.io/kubernetes/staging to their own repositories in kubernetes
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
   - name: release-engineering
     description: |
       The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/k8s-container-image-promoter/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/release-notes/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS
   - name: release-team


### PR DESCRIPTION
As discussed in the Aug 5 Release Engineering meeting: https://docs.google.com/document/d/16GqCjnEh86w8yADcrUylNoE1y1sqjIMYNC_gdk5WPSQ/edit#heading=h.v4ysdzxj9fan

/assign @sttts @dims 
other publishing-bot owners

/assign @justaugustus @tpepper @calebamiles 
sig release leads

/hold
for lgtm by sig-release leads

