### PR TITLE
Add Slack channel for Octant

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -211,6 +211,7 @@ channels:
   - name: nl-users
   - name: node-problem-detector
   - name: norw-users
+  - name: octant
   - name: office-hours
   - name: okteto
   - name: opencontainers


### PR DESCRIPTION
Octant is a tool for developers to understand how applications run on a Kubernetes cluster. It aims to be part of the developer's toolkit for gaining insight and approaching complexity found in Kubernetes. Octant offers a combination of introspective tooling, cluster navigation, and object management along with a plugin system to further extend its capabilities.

We would like to have a channel dedicated to the project in the K8s Slack, to share experiences and grow the community.

The project can be found here: https://github.com/vmware/octant

Signed-off-by: jonasrosland <jrosland@vmware.com>