### PR TITLE
add new slack channel for kubeadm china

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -142,6 +142,7 @@ channels:
   - name: kube-spawn
   - name: kube-state-metrics
   - name: kubeadm
+  - name: kubeadm-cn
   - name: kubeapps
   - name: kubebuilder
   - name: kubecon


### PR DESCRIPTION
ref: https://github.com/kubernetes/kubeadm/issues/1622

We've started a kubeadm meeting in a Chinese friendly time. A new slack channel is preferred for communication.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->