### PR TITLE
Make subprojects linkable, move github teams under contacts

### DIFF
--- a/committee-code-of-conduct/README.md
+++ b/committee-code-of-conduct/README.md
@@ -21,18 +21,12 @@ The [charter](charter.md) defines the scope and governance of the Code of Conduc
 * Paris Pittman (**[@parispittman](https://github.com/parispittman)**), Google
 
 ## Contact
-* Private Mailing List: conduct@kubernetes.io
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fcode-of-conduct)
+- Private Mailing List: conduct@kubernetes.io
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/committee%2Fcode-of-conduct)
+- GitHub Teams:
+    - [@kubernetes/code-of-conduct-committee](https://github.com/orgs/kubernetes/teams/code-of-conduct-committee) - General Discussion
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/code-of-conduct-committee | [link](https://github.com/orgs/kubernetes/teams/code-of-conduct-committee) | General Discussion |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 ## Terms
 

--- a/committee-product-security/README.md
+++ b/committee-product-security/README.md
@@ -21,26 +21,20 @@ The Kubernetes Product Security Committee is the body that is responsible for re
 * Tim Allclair (**[@tallclair](https://github.com/tallclair)**), Google
 
 ## Contact
-* Private Mailing List: security@kubernetes.io
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fproduct-security)
+- Private Mailing List: security@kubernetes.io
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/committee%2Fproduct-security)
+- GitHub Teams:
+    - [@kubernetes/product-security-committee](https://github.com/orgs/kubernetes/teams/product-security-committee) - General Discussion
 
 ## Subprojects
 
-The following subprojects are owned by the Product Security Committee:
-- **security**
-  - Description: Policies and documentation for the Product Security Committee
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/security/master/OWNERS
+The following [subprojects][subproject-definition] are owned by the Product Security Committee:
+### security
+Policies and documentation for the Product Security Committee
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/security/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/product-security-committee | [link](https://github.com/orgs/kubernetes/teams/product-security-committee) | General Discussion |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 **Note**: Information on how members are selected can be found
 [here](https://git.k8s.io/security/security-release-process.md#product-security-committee-membership).

--- a/committee-steering/README.md
+++ b/committee-steering/README.md
@@ -32,39 +32,33 @@ The [charter](https://git.k8s.io/steering/charter.md) defines the scope and gove
 * Timothy St. Clair (**[@timothysc](https://github.com/timothysc)**), VMware
 
 ## Contact
-* [Mailing list](https://groups.google.com/a/kubernetes.io/forum/#!forum/steering)
-* Private Mailing List: steering-private@kubernetes.io
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fsteering)
+- [Mailing list](https://groups.google.com/a/kubernetes.io/forum/#!forum/steering)
+- Private Mailing List: steering-private@kubernetes.io
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/committee%2Fsteering)
+- GitHub Teams:
+    - [@kubernetes/steering-committee](https://github.com/orgs/kubernetes/teams/steering-committee) - General Discussion
 
 ## Subprojects
 
-The following subprojects are owned by the Steering Committee:
-- **funding**
-  - Description: Funding requests for project infrastructure, events, and consulting
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/funding/master/OWNERS
-- **kubernetes-template-project**
-  - Description: Template for starting new projects in the GitHub organizations owned by Kubernetes.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
-- **spartakus**
-  - Description: Collection of usage information about Kubernetes clusters.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
-- **steering**
-  - Description: Steering Committee policy and documentation
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS
+The following [subprojects][subproject-definition] are owned by the Steering Committee:
+### funding
+Funding requests for project infrastructure, events, and consulting
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/funding/master/OWNERS
+### kubernetes-template-project
+Template for starting new projects in the GitHub organizations owned by Kubernetes.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
+### spartakus
+Collection of usage information about Kubernetes clusters.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
+### steering
+Steering Committee policy and documentation
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/steering-committee | [link](https://github.com/orgs/kubernetes/teams/steering-committee) | General Discussion |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/generator/committee_readme.tmpl
+++ b/generator/committee_readme.tmpl
@@ -32,55 +32,67 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 ## Contact
 
 {{- if .Contact.Slack }}
-* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+- Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
 {{- end }}
 {{- if .Contact.MailingList }}
-* [Mailing list]({{.Contact.MailingList}})
+- [Mailing list]({{.Contact.MailingList}})
 {{- end }}
 {{- if .Contact.PrivateMailingList }}
-* Private Mailing List: {{.Contact.PrivateMailingList}}
+- Private Mailing List: {{.Contact.PrivateMailingList}}
 {{- end }}
 {{- if .Label }}
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2F{{.Label}})
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/committee%2F{{.Label}})
 {{- end }}
+{{- if .Contact.GithubTeams }}
+- GitHub Teams:
+{{- range .Contact.GithubTeams }}
+    - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }} - {{.Description}} {{- end}}
+{{- end }}
+{{- end }}
+
 {{- if .Subprojects }}
 
 ## Subprojects
 
-The following subprojects are owned by the {{.Name}} Committee:
+The following [subprojects][subproject-definition] are owned by the {{.Name}} Committee:
 
 {{- range .Subprojects }}
-- **{{.Name}}**
+### {{.Name}}
 {{- if .Description }}
-  - Description: {{ trimSpace .Description }}
+{{ trimSpace .Description }}
 {{- end }}
-  - Owners:
+- **Owners:**
 {{- range .Owners }}
-    - {{.}}
+  - {{.}}
+{{- end }}
+{{- if .Contact }}
+- **Contact:**
+{{- if .Contact.Slack }}
+  - Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+{{- end }}
+{{- if .Contact.MailingList }}
+  - [Mailing List]({{.Contact.MailingList}})
+{{- end }}
+{{- if .Contact.GithubTeams }}
+  - GitHub Teams: 
+{{- range .Contact.GithubTeams }}
+    - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }} - {{.Description}}{{- end}}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if .Meetings }}
-  - Meetings:
+- **Meetings:**
 {{- range .Meetings }}
-    - {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
+  - {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
 {{- if .ArchiveURL }}
-      - [Meeting notes and Agenda]({{.ArchiveURL}}).
+    - [Meeting notes and Agenda]({{.ArchiveURL}}).
 {{- end }}
 {{- if .RecordingsURL }}
-      - [Meeting recordings]({{.RecordingsURL}}).
+    - [Meeting recordings]({{.RecordingsURL}}).
 {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
-{{ if .Contact.GithubTeams }}
-## GitHub Teams
 
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-{{- range .Contact.GithubTeams }}
-| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
-{{- end }}
-{{  end }}
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -48,64 +48,61 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 {{- end }}
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
-* [Mailing list]({{.Contact.MailingList}})
+- Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+- [Mailing list]({{.Contact.MailingList}})
 {{- if .Label }}
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2F{{.Label}})
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2F{{.Label}})
 {{- end }}
+{{- if .Contact.GithubTeams }}
+- GitHub Teams:
+{{- range .Contact.GithubTeams }}
+    - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }} - {{.Description}} {{- end}}
+{{- end }}
+{{- end }}
+
 {{- if .Subprojects }}
 
 ## Subprojects
 
-The following subprojects are owned by sig-{{.Label}}:
+The following [subprojects][subproject-definition] are owned by sig-{{.Label}}:
 
 {{- range .Subprojects }}
-- **{{.Name}}**
+### {{.Name}}
 {{- if .Description }}
-  - Description: {{ trimSpace .Description }}
+{{ trimSpace .Description }}
 {{- end }}
-  - Owners:
+- **Owners:**
 {{- range .Owners }}
-    - {{.}}
+  - {{.}}
 {{- end }}
 {{- if .Contact }}
-  - Contact
+- **Contact:**
 {{- if .Contact.Slack }}
-    - Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+  - Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
 {{- end }}
 {{- if .Contact.MailingList }}
-    - [Mailing List]({{.Contact.MailingList}})
+  - [Mailing List]({{.Contact.MailingList}})
 {{- end }}
 {{- if .Contact.GithubTeams }}
-    - GitHub Teams: 
+  - GitHub Teams: 
 {{- range .Contact.GithubTeams }}
-      - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }}({{.Description}}){{- end}}
+    - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }} - {{.Description}}{{- end}}
 {{- end }}
 {{- end }}
 {{- end }}
 {{- if .Meetings }}
-  - Meetings:
+- **Meetings:**
 {{- range .Meetings }}
-    - {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
+  - {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
 {{- if .ArchiveURL }}
-      - [Meeting notes and Agenda]({{.ArchiveURL}}).
+    - [Meeting notes and Agenda]({{.ArchiveURL}}).
 {{- end }}
 {{- if .RecordingsURL }}
-      - [Meeting recordings]({{.RecordingsURL}}).
+    - [Meeting recordings]({{.RecordingsURL}}).
 {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
-{{ if .Contact.GithubTeams }}
-## GitHub Teams
 
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-{{- range .Contact.GithubTeams }}
-| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
-{{- end }}
-{{  end }}
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects

--- a/generator/ug_readme.tmpl
+++ b/generator/ug_readme.tmpl
@@ -36,21 +36,14 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{- end }}
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
-* [Mailing list]({{.Contact.MailingList}})
+- Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+- [Mailing list]({{.Contact.MailingList}})
 {{- if .Label }}
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2F{{.Label}})
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2F{{.Label}})
 {{- end }}
-
-{{ if .Contact.GithubTeams }}
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
+{{- if .Contact.GithubTeams }}
+- GitHub Teams:
 {{- range .Contact.GithubTeams }}
-| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
+    - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }} - {{.Description}} {{- end}}
 {{- end }}
-{{  end }}
+{{- end }}

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -42,49 +42,14 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{- end }}
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
-* [Mailing list]({{.Contact.MailingList}})
+- Slack: [#{{.Contact.Slack}}](https://kubernetes.slack.com/messages/{{.Contact.Slack}})
+- [Mailing list]({{.Contact.MailingList}})
 {{- if .Label }}
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2F{{.Label}})
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2F{{.Label}})
 {{- end }}
-{{- if .Subprojects }}
-
-## Subprojects
-
-The following subprojects are owned by wg-{{.Label}}:
-
-{{- range .Subprojects }}
-- **{{.Name}}**
-{{- if .Description }}
-  - Description: {{ .Description }}
-{{- end }}
-  - Owners:
-{{- range .Owners }}
-    - {{.}}
-{{- end }}
-{{- if .Meetings }}
-  - Meetings:
-{{- range .Meetings }}
-    - {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
-{{- if .ArchiveURL }}
-      - [Meeting notes and Agenda]({{.ArchiveURL}}).
-{{- end }}
-{{- if .RecordingsURL }}
-      - [Meeting recordings]({{.RecordingsURL}}).
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{ if .Contact.GithubTeams }}
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
+{{- if .Contact.GithubTeams }}
+- GitHub Teams:
 {{- range .Contact.GithubTeams }}
-| @kubernetes/{{.Name}} | [link](https://github.com/orgs/kubernetes/teams/{{.Name}}) | {{.Description}} |
+    - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }} - {{.Description}} {{- end}}
 {{- end }}
-{{  end }}
+{{- end }}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -28,102 +28,96 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Daniel Smith (**[@lavalamp](https://github.com/lavalamp)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-api-machinery)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapi-machinery)
+- Slack: [#sig-api-machinery](https://kubernetes.slack.com/messages/sig-api-machinery)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapi-machinery)
+- GitHub Teams:
+    - [@kubernetes/sig-api-machinery-api-reviews](https://github.com/orgs/kubernetes/teams/sig-api-machinery-api-reviews) - API Changes and Reviews (API Machinery APIs, NOT all APIs)
+    - [@kubernetes/sig-api-machinery-bugs](https://github.com/orgs/kubernetes/teams/sig-api-machinery-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-api-machinery-feature-requests](https://github.com/orgs/kubernetes/teams/sig-api-machinery-feature-requests) - Feature Requests
+    - [@kubernetes/sig-api-machinery-misc](https://github.com/orgs/kubernetes/teams/sig-api-machinery-misc) - General Discussion
+    - [@kubernetes/sig-api-machinery-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-api-machinery-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-api-machinery-proposals](https://github.com/orgs/kubernetes/teams/sig-api-machinery-proposals) - Design Proposals
+    - [@kubernetes/sig-api-machinery-test-failures](https://github.com/orgs/kubernetes/teams/sig-api-machinery-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-api-machinery:
-- **component-base**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/legacyflag/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/component-base/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/OWNERS
-- **control-plane-features**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/OWNERS
-- **idl-schema-client-pipeline**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/structured-merge-diff/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/code-generator/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/gengo/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kube-openapi/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/code-generator/OWNERS
-- **kubernetes-clients**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-client/csharp/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/go-base/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/go/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/haskell/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/java/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/javascript/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/perl/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/python-base/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-client/ruby/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-incubator/client-python/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/client-go/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/OWNERS
-- **server-api-aggregation**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kube-aggregator/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/kube-aggregator/OWNERS
-- **server-binaries**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/controller-manager/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-apiserver/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-controller-manager/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/master/OWNERS
-- **server-crd**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/apiextensions-apiserver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiextensions-apiserver/OWNERS
-- **server-frameworks**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/apiserver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/OWNERS
-- **server-sdk**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/apiserver-builder-alpha/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder-declarative-pattern/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-apiserver/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-controller/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/sample-apiserver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/sample-controller/master/OWNERS
-  - Contact
-    - [Mailing List](https://groups.google.com/forum/#!forum/kubebuilder)
-- **universal-machinery**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/apimachinery/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apimachinery/OWNERS
-- **yaml**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/yaml/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-api-machinery:
+### component-base
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/legacyflag/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/component-base/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/OWNERS
+### control-plane-features
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/OWNERS
+### idl-schema-client-pipeline
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/structured-merge-diff/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/code-generator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/gengo/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kube-openapi/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/code-generator/OWNERS
+### kubernetes-clients
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-client/csharp/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/go-base/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/go/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/haskell/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/java/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/javascript/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/perl/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/python-base/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-client/ruby/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-incubator/client-python/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/client-go/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/OWNERS
+### server-api-aggregation
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kube-aggregator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/kube-aggregator/OWNERS
+### server-binaries
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/controller-manager/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-apiserver/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-controller-manager/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/master/OWNERS
+### server-crd
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/apiextensions-apiserver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+### server-frameworks
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/apiserver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/OWNERS
+### server-sdk
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/apiserver-builder-alpha/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder-declarative-pattern/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-apiserver/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-controller/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/sample-apiserver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/sample-controller/master/OWNERS
+- **Contact:**
+  - [Mailing List](https://groups.google.com/forum/#!forum/kubebuilder)
+### universal-machinery
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/apimachinery/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apimachinery/OWNERS
+### yaml
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/yaml/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-api-machinery-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-api-reviews) | API Changes and Reviews (API Machinery APIs, NOT all APIs) |
-| @kubernetes/sig-api-machinery-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-api-machinery-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-feature-requests) | Feature Requests |
-| @kubernetes/sig-api-machinery-misc | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-misc) | General Discussion |
-| @kubernetes/sig-api-machinery-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-pr-reviews) | PR Reviews |
-| @kubernetes/sig-api-machinery-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-proposals) | Design Proposals |
-| @kubernetes/sig-api-machinery-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-api-machinery-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 ## Additional links
 

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -28,70 +28,64 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Adnan Abdulhussein (**[@prydonius](https://github.com/prydonius)**), VMware
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-apps)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapps)
+- Slack: [#sig-apps](https://kubernetes.slack.com/messages/sig-apps)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fapps)
+- GitHub Teams:
+    - [@kubernetes/sig-apps-api-reviews](https://github.com/orgs/kubernetes/teams/sig-apps-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-apps-bugs](https://github.com/orgs/kubernetes/teams/sig-apps-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-apps-feature-requests](https://github.com/orgs/kubernetes/teams/sig-apps-feature-requests) - Feature Requests
+    - [@kubernetes/sig-apps-misc](https://github.com/orgs/kubernetes/teams/sig-apps-misc) - General Discussion
+    - [@kubernetes/sig-apps-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-apps-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-apps-proposals](https://github.com/orgs/kubernetes/teams/sig-apps-proposals) - Design Proposals
+    - [@kubernetes/sig-apps-test-failures](https://github.com/orgs/kubernetes/teams/sig-apps-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-apps:
-- **application**
-  - Description: Application metadata descriptor CRD
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/application/master/OWNERS
-- **examples**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/examples/master/OWNERS
-- **execution-hook**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/execution-hook/master/OWNERS
-- **kompose**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kompose/master/OWNERS
-  - Contact
-    - Slack: [#kompose](https://kubernetes.slack.com/messages/kompose)
-- **workloads-api**
-  - Description: The core workloads API, which is composed of the CronJob, DaemonSet, Deployment, Job, ReplicaSet, ReplicationController, and StatefulSet kinds
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/apps/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/batch/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/core/v1/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/extensions/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cronjob/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/daemon/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/deployment/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/disruption/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/history/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/job/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replicaset/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/statefulset/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/apps/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/batch/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/extensions/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/apps/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/batch/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/core/v1/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/extensions/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/apps/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/daemonset/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/deployment/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-apps:
+### application
+Application metadata descriptor CRD
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/application/master/OWNERS
+### examples
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/examples/master/OWNERS
+### execution-hook
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/execution-hook/master/OWNERS
+### kompose
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kompose/master/OWNERS
+- **Contact:**
+  - Slack: [#kompose](https://kubernetes.slack.com/messages/kompose)
+### workloads-api
+The core workloads API, which is composed of the CronJob, DaemonSet, Deployment, Job, ReplicaSet, ReplicationController, and StatefulSet kinds
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/apps/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/batch/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/core/v1/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/extensions/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cronjob/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/daemon/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/deployment/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/disruption/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/history/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/job/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replicaset/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/statefulset/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/apps/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/batch/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/extensions/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/apps/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/batch/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/core/v1/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/extensions/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/apps/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/daemonset/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/deployment/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-apps-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-apps-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-apps-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-apps-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-apps-feature-requests) | Feature Requests |
-| @kubernetes/sig-apps-misc | [link](https://github.com/orgs/kubernetes/teams/sig-apps-misc) | General Discussion |
-| @kubernetes/sig-apps-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-apps-pr-reviews) | PR Reviews |
-| @kubernetes/sig-apps-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-apps-proposals) | Design Proposals |
-| @kubernetes/sig-apps-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-apps-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Goals

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -35,53 +35,47 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Matt Farina (**[@mattfarina](https://github.com/mattfarina)**), Samsung SDS
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-architecture)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Farchitecture)
+- Slack: [#sig-architecture](https://kubernetes.slack.com/messages/sig-architecture)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Farchitecture)
+- GitHub Teams:
+    - [@kubernetes/sig-architecture-api-reviews](https://github.com/orgs/kubernetes/teams/sig-architecture-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-architecture-bugs](https://github.com/orgs/kubernetes/teams/sig-architecture-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-architecture-feature-requests](https://github.com/orgs/kubernetes/teams/sig-architecture-feature-requests) - Feature Requests
+    - [@kubernetes/sig-architecture-misc-use-only-as-a-last-resort](https://github.com/orgs/kubernetes/teams/sig-architecture-misc-use-only-as-a-last-resort) - General Discussion
+    - [@kubernetes/sig-architecture-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-architecture-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-architecture-proposals](https://github.com/orgs/kubernetes/teams/sig-architecture-proposals) - Design Proposals
+    - [@kubernetes/sig-architecture-test-failures](https://github.com/orgs/kubernetes/teams/sig-architecture-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-architecture:
-- **architecture-and-api-governance**
-  - Description: [Described below](#architecture-and-api-governance)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/community/master/contributors/design-proposals/architecture/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
-- **code-organization**
-  - Description: [Described below](#code-organization)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/vendor/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
-  - Contact
-    - Slack: [#k8s-code-organization](https://kubernetes.slack.com/messages/k8s-code-organization)
-- **conformance-definition**
-  - Description: [Described below](#conformance-definition)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
-  - Contact
-    - Slack: [#k8s-conformance](https://kubernetes.slack.com/messages/k8s-conformance)
-    - GitHub Teams:
-      - [@kubernetes/cncf-conformance-wg](https://github.com/orgs/kubernetes/teams/cncf-conformance-wg)
+The following [subprojects][subproject-definition] are owned by sig-architecture:
+### architecture-and-api-governance
+[Described below](#architecture-and-api-governance)
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/community/master/contributors/design-proposals/architecture/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
+### code-organization
+[Described below](#code-organization)
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/vendor/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
+- **Contact:**
+  - Slack: [#k8s-code-organization](https://kubernetes.slack.com/messages/k8s-code-organization)
+### conformance-definition
+[Described below](#conformance-definition)
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
+- **Contact:**
+  - Slack: [#k8s-conformance](https://kubernetes.slack.com/messages/k8s-conformance)
+  - GitHub Teams:
+    - [@kubernetes/cncf-conformance-wg](https://github.com/orgs/kubernetes/teams/cncf-conformance-wg)
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-architecture-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-architecture-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-architecture-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-feature-requests) | Feature Requests |
-| @kubernetes/sig-architecture-misc-use-only-as-a-last-resort | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-misc-use-only-as-a-last-resort) | General Discussion |
-| @kubernetes/sig-architecture-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-pr-reviews) | PR Reviews |
-| @kubernetes/sig-architecture-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-proposals) | Design Proposals |
-| @kubernetes/sig-architecture-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-architecture-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 # Details about SIG-Architecture sub-projects

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -42,112 +42,106 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Eric Tune (**[@erictune](https://github.com/erictune)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-auth)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-auth)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fauth)
+- Slack: [#sig-auth](https://kubernetes.slack.com/messages/sig-auth)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-auth)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fauth)
+- GitHub Teams:
+    - [@kubernetes/sig-auth-api-reviews](https://github.com/orgs/kubernetes/teams/sig-auth-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-auth-bugs](https://github.com/orgs/kubernetes/teams/sig-auth-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-auth-feature-requests](https://github.com/orgs/kubernetes/teams/sig-auth-feature-requests) - Feature Requests
+    - [@kubernetes/sig-auth-misc](https://github.com/orgs/kubernetes/teams/sig-auth-misc) - General Discussion
+    - [@kubernetes/sig-auth-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-auth-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-auth-proposals](https://github.com/orgs/kubernetes/teams/sig-auth-proposals) - Design Proposals
+    - [@kubernetes/sig-auth-test-failures](https://github.com/orgs/kubernetes/teams/sig-auth-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-auth:
-- **audit-logging**
-  - Description: Kubernetes API support for audit logging.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/auditregistration/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/apis/audit/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/audit/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/audit/OWNERS
-- **authenticators**
-  - Description: Kubernetes API support for authentication.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authenticator/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authenticator/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/plugin/pkg/client/auth/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/tools/auth/OWNERS
-- **authorizers**
-  - Description: Kubernetes API support for authorization.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/rbac/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authorizer/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/cmd/auth/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/rbac/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/rbac/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/rbac/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authorization/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/rbac/OWNERS
-- **certificates**
-  - Description: Certificates APIs and client infrastructure to support PKI.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/certificates/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/certificates/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/cert/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/certificate/OWNERS
-- **encryption-at-rest**
-  - Description: API storage support for storing data encrypted at rest in etcd.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/OWNERS
-- **multi-tenancy**
-  - Description: Proposals and prototypes for introducing tenant model to enable multi-tenant cluster
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/OWNERS
-- **node-identity-and-isolation**
-  - Description: Node identity management (co-owned with sig-lifecycle), and authorization restrictions for isolating workloads on separate nodes (co-owned with sig-node).
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/approver/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/certificate/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/noderestriction/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/node/OWNERS
-- **policy-management**
-  - Description: API validation and policies enforced during admission, such as PodSecurityPolicy. Excludes run-time policies like NetworkPolicy and Seccomp.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/imagepolicy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/policy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/policy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/security/podsecuritypolicy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/imagepolicy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/security/podsecuritypolicy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/imagepolicy/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/policy/OWNERS
-- **service-accounts**
-  - Description: Infrastructure implementing Kubernetes service account based workload identity.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/serviceaccount/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/token/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/serviceaccount/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/serviceaccount/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-auth:
+### audit-logging
+Kubernetes API support for audit logging.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/auditregistration/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/apis/audit/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/audit/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/audit/OWNERS
+### authenticators
+Kubernetes API support for authentication.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authenticator/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authenticator/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/plugin/pkg/client/auth/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/tools/auth/OWNERS
+### authorizers
+Kubernetes API support for authorization.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/rbac/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authorizer/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/cmd/auth/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/rbac/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/rbac/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/rbac/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authorization/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/rbac/OWNERS
+### certificates
+Certificates APIs and client infrastructure to support PKI.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/certificates/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/certificates/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/cert/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/certificate/OWNERS
+### encryption-at-rest
+API storage support for storing data encrypted at rest in etcd.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/OWNERS
+### multi-tenancy
+Proposals and prototypes for introducing tenant model to enable multi-tenant cluster
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/OWNERS
+### node-identity-and-isolation
+Node identity management (co-owned with sig-lifecycle), and authorization restrictions for isolating workloads on separate nodes (co-owned with sig-node).
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/approver/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/certificate/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/noderestriction/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/node/OWNERS
+### policy-management
+API validation and policies enforced during admission, such as PodSecurityPolicy. Excludes run-time policies like NetworkPolicy and Seccomp.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/imagepolicy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/policy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/policy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/security/podsecuritypolicy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/imagepolicy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/security/podsecuritypolicy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/imagepolicy/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/policy/OWNERS
+### service-accounts
+Infrastructure implementing Kubernetes service account based workload identity.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/serviceaccount/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/token/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/serviceaccount/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/serviceaccount/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-auth-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-auth-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-auth-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-auth-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-auth-feature-requests) | Feature Requests |
-| @kubernetes/sig-auth-misc | [link](https://github.com/orgs/kubernetes/teams/sig-auth-misc) | General Discussion |
-| @kubernetes/sig-auth-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-auth-pr-reviews) | PR Reviews |
-| @kubernetes/sig-auth-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-auth-proposals) | Design Proposals |
-| @kubernetes/sig-auth-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-auth-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -24,51 +24,45 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Marcin Wielgus (**[@mwielgus](https://github.com/mwielgus)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-autoscaling)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fautoscaling)
+- Slack: [#sig-autoscaling](https://kubernetes.slack.com/messages/sig-autoscaling)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fautoscaling)
+- GitHub Teams:
+    - [@kubernetes/sig-autoscaling-api-reviews](https://github.com/orgs/kubernetes/teams/sig-autoscaling-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-autoscaling-bugs](https://github.com/orgs/kubernetes/teams/sig-autoscaling-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-autoscaling-feature-requests](https://github.com/orgs/kubernetes/teams/sig-autoscaling-feature-requests) - Feature Requests
+    - [@kubernetes/sig-autoscaling-misc](https://github.com/orgs/kubernetes/teams/sig-autoscaling-misc) - General Discussion
+    - [@kubernetes/sig-autoscaling-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-autoscaling-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-autoscaling-proposals](https://github.com/orgs/kubernetes/teams/sig-autoscaling-proposals) - Design Proposals
+    - [@kubernetes/sig-autoscaling-test-failures](https://github.com/orgs/kubernetes/teams/sig-autoscaling-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-autoscaling:
-- **addon-resizer**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
-- **cluster-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
-- **cluster-proportional-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
-- **cluster-proportional-vertical-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
-- **horizontal-pod-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
-- **scale-client**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/client-go/master/scale/OWNERS
-- **vertical-pod-autoscaler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-autoscaling:
+### addon-resizer
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
+### cluster-autoscaler
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+### cluster-proportional-autoscaler
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
+### cluster-proportional-vertical-autoscaler
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
+### horizontal-pod-autoscaler
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
+### scale-client
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/client-go/master/scale/OWNERS
+### vertical-pod-autoscaler
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-autoscaling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-autoscaling-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-autoscaling-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-feature-requests) | Feature Requests |
-| @kubernetes/sig-autoscaling-misc | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-misc) | General Discussion |
-| @kubernetes/sig-autoscaling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-pr-reviews) | PR Reviews |
-| @kubernetes/sig-autoscaling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-proposals) | Design Proposals |
-| @kubernetes/sig-autoscaling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-autoscaling-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 ## Concerns
 * autoscaling of clusters,

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -38,59 +38,53 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Fabiano Franz (**[@fabianofranz](https://github.com/fabianofranz)**), Red Hat
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-cli)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cli)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcli)
+- Slack: [#sig-cli](https://kubernetes.slack.com/messages/sig-cli)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cli)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcli)
+- GitHub Teams:
+    - [@kubernetes/sig-cli-api-reviews](https://github.com/orgs/kubernetes/teams/sig-cli-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-cli-bugs](https://github.com/orgs/kubernetes/teams/sig-cli-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-cli-feature-requests](https://github.com/orgs/kubernetes/teams/sig-cli-feature-requests) - Feature Requests
+    - [@kubernetes/sig-cli-maintainers](https://github.com/orgs/kubernetes/teams/sig-cli-maintainers) - CLI Maintainers
+    - [@kubernetes/sig-cli-misc](https://github.com/orgs/kubernetes/teams/sig-cli-misc) - General Discussion
+    - [@kubernetes/sig-cli-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-cli-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-cli-proposals](https://github.com/orgs/kubernetes/teams/sig-cli-proposals) - Design Proposals
+    - [@kubernetes/sig-cli-test-failures](https://github.com/orgs/kubernetes/teams/sig-cli-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-cli:
-- **cli-experimental**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cli-experimental/master/OWNERS
-- **cli-sdk**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cli-runtime/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cli-runtime/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-cli-plugin/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/sample-cli-plugin/master/OWNERS
-- **cli-utils**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cli-utils/master/OWNERS
-- **krew**
-  - Description: Plugin manager for kubectl.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/krew/master/OWNERS
-- **krew-index**
-  - Description: Centralized plugin index for krew.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/OWNERS
-- **kubectl**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubectl/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/OWNERS
-- **kustomize**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/OWNERS
-  - Contact
-    - Slack: [#kustomize](https://kubernetes.slack.com/messages/kustomize)
+The following [subprojects][subproject-definition] are owned by sig-cli:
+### cli-experimental
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cli-experimental/master/OWNERS
+### cli-sdk
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/cli-runtime/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cli-runtime/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-cli-plugin/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/sample-cli-plugin/master/OWNERS
+### cli-utils
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cli-utils/master/OWNERS
+### krew
+Plugin manager for kubectl.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/krew/master/OWNERS
+### krew-index
+Centralized plugin index for krew.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/OWNERS
+### kubectl
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubectl/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/OWNERS
+### kustomize
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/OWNERS
+- **Contact:**
+  - Slack: [#kustomize](https://kubernetes.slack.com/messages/kustomize)
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-cli-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-cli-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-cli-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-cli-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-cli-feature-requests) | Feature Requests |
-| @kubernetes/sig-cli-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-cli-maintainers) | CLI Maintainers |
-| @kubernetes/sig-cli-misc | [link](https://github.com/orgs/kubernetes/teams/sig-cli-misc) | General Discussion |
-| @kubernetes/sig-cli-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cli-pr-reviews) | PR Reviews |
-| @kubernetes/sig-cli-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cli-proposals) | Design Proposals |
-| @kubernetes/sig-cli-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cli-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -31,100 +31,94 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Jago Macleod (**[@jagosan](https://github.com/jagosan)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-cloud-provider)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cloud-provider)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcloud-provider)
+- Slack: [#sig-cloud-provider](https://kubernetes.slack.com/messages/sig-cloud-provider)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cloud-provider)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcloud-provider)
+- GitHub Teams:
+    - [@kubernetes/sig-cloud-provider-api-reviews](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-cloud-provider-bugs](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-cloud-provider-feature-requests](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-feature-requests) - Feature Requests
+    - [@kubernetes/sig-cloud-provider-maintainers](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-maintainers) - Cloud Providers Maintainers
+    - [@kubernetes/sig-cloud-provider-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-cloud-provider-proposals](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-proposals) - Design Proposals
+    - [@kubernetes/sig-cloud-provider-test-failures](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-test-failures) - Test Failures and Triage
+    - [@kubernetes/sig-cloud-providers-misc](https://github.com/orgs/kubernetes/teams/sig-cloud-providers-misc) - General Discussion
 
 ## Subprojects
 
-The following subprojects are owned by sig-cloud-provider:
-- **cloud-provider-extraction-migration**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/apiserver-network-proxy/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-cloud-provider/cloud-provider-extraction-migration/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/legacy-cloud-providers/master/OWNERS
-  - Meetings:
-    - Weekly Sync removing the in-tree cloud providers led by @cheftako and @mcrute: [Thursdays at 13:30 PT (Pacific Time)](https://docs.google.com/document/d/1KLsGGzNXQbsPeELCeF_q-f0h0CEGSe20xiwvcR2NlYM/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:30&tz=PT%20%28Pacific%20Time%29).
-- **kubernetes-cloud-provider**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-sample/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/cloudprovider/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cloud/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/OWNERS
-- **provider-alibaba-cloud**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-alibaba-cloud/master/OWNERS
-- **provider-aws**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-encryption-provider/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-fsx-csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-iam-authenticator/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS
-  - Meetings:
-    - Regular AWS Subproject Meeting: [Fridays at 9:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly 2019 start date: Jan. 11th). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit).
-      - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29DzPOBBaJi-SO3AQ_b4HC).
-- **provider-azure**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
-  - Meetings:
-    - Regular Azure Subproject Meeting: [Wednesdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/1SpxvmOgHDhnA72Z0lbhBffrfe9inQxZkU9xqlafOW9k/edit).
-      - [Meeting recordings](https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4).
-- **provider-gcp**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/gcp-filestore-csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
-  - Meetings:
-    - Regular GCP Subproject Meeting: [Thursdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/1mtmwZ4oVSSWhbEw8Lfzvc7ig84qxUpdK6uHyJp8rSGU/edit).
-- **provider-ibmcloud**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-ibmcloud/master/OWNERS
-  - Meetings:
-    - Regular IBM Subproject Meeting: [Wednesdays at 14:00 EST](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=EST).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/1qd_LTu5GFaxUhSWTHigowHt3XwjJVf1L57kupj8lnwg/edit).
-- **provider-openstack**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
-  - Meetings:
-    - Regular OpenStack Subproject Meeting: [Wednesdays at 08:00 PT (Pacific Time)](https://docs.google.com/document/d/1bW3j4hFN4D8rv2LFv-DybB3gcE5ISAaOO_OpvDCgrGg/edit) (biweekly starting Wednesday March 20, 2019). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=08:00&tz=PT%20%28Pacific%20Time%29).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/15UwgLbEyZyXXxVtsThcSuPiJru4CuqU9p3ttZSfTaY4/edit).
-      - [Meeting recordings](https://www.youtube.com/watch?v=iCfUx7ilh0E&list=PL69nYSiGNLP20iTSChQ_i2QQmTBl3M7ax).
-- **provider-vsphere**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/OWNERS
-  - Meetings:
-    - Cloud Provider vSphere monthly syncup: [Wednesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (monthly - first Wednesday every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/1B0NmmKVh8Ea5hnNsbUsJC7ZyNCsq_6NXl5hRdcHlJgY/edit?usp=sharing).
-      - [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIpOT4bOfuO3MEMHvU1tRqyR).
+The following [subprojects][subproject-definition] are owned by sig-cloud-provider:
+### cloud-provider-extraction-migration
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/apiserver-network-proxy/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-cloud-provider/cloud-provider-extraction-migration/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/legacy-cloud-providers/master/OWNERS
+- **Meetings:**
+  - Weekly Sync removing the in-tree cloud providers led by @cheftako and @mcrute: [Thursdays at 13:30 PT (Pacific Time)](https://docs.google.com/document/d/1KLsGGzNXQbsPeELCeF_q-f0h0CEGSe20xiwvcR2NlYM/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:30&tz=PT%20%28Pacific%20Time%29).
+### kubernetes-cloud-provider
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-sample/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/cloudprovider/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cloud/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/OWNERS
+### provider-alibaba-cloud
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-alibaba-cloud/master/OWNERS
+### provider-aws
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-encryption-provider/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-fsx-csi-driver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/aws-iam-authenticator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS
+- **Meetings:**
+  - Regular AWS Subproject Meeting: [Fridays at 9:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly 2019 start date: Jan. 11th). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit).
+    - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29DzPOBBaJi-SO3AQ_b4HC).
+### provider-azure
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
+- **Meetings:**
+  - Regular Azure Subproject Meeting: [Wednesdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1SpxvmOgHDhnA72Z0lbhBffrfe9inQxZkU9xqlafOW9k/edit).
+    - [Meeting recordings](https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4).
+### provider-gcp
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/gcp-filestore-csi-driver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
+- **Meetings:**
+  - Regular GCP Subproject Meeting: [Thursdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1mtmwZ4oVSSWhbEw8Lfzvc7ig84qxUpdK6uHyJp8rSGU/edit).
+### provider-ibmcloud
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-ibmcloud/master/OWNERS
+- **Meetings:**
+  - Regular IBM Subproject Meeting: [Wednesdays at 14:00 EST](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=EST).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1qd_LTu5GFaxUhSWTHigowHt3XwjJVf1L57kupj8lnwg/edit).
+### provider-openstack
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
+- **Meetings:**
+  - Regular OpenStack Subproject Meeting: [Wednesdays at 08:00 PT (Pacific Time)](https://docs.google.com/document/d/1bW3j4hFN4D8rv2LFv-DybB3gcE5ISAaOO_OpvDCgrGg/edit) (biweekly starting Wednesday March 20, 2019). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=08:00&tz=PT%20%28Pacific%20Time%29).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/15UwgLbEyZyXXxVtsThcSuPiJru4CuqU9p3ttZSfTaY4/edit).
+    - [Meeting recordings](https://www.youtube.com/watch?v=iCfUx7ilh0E&list=PL69nYSiGNLP20iTSChQ_i2QQmTBl3M7ax).
+### provider-vsphere
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/OWNERS
+- **Meetings:**
+  - Cloud Provider vSphere monthly syncup: [Wednesdays at 09:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (monthly - first Wednesday every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1B0NmmKVh8Ea5hnNsbUsJC7ZyNCsq_6NXl5hRdcHlJgY/edit?usp=sharing).
+    - [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIpOT4bOfuO3MEMHvU1tRqyR).
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-cloud-provider-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-cloud-provider-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-cloud-provider-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-feature-requests) | Feature Requests |
-| @kubernetes/sig-cloud-provider-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-maintainers) | Cloud Providers Maintainers |
-| @kubernetes/sig-cloud-provider-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-pr-reviews) | PR Reviews |
-| @kubernetes/sig-cloud-provider-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-proposals) | Design Proposals |
-| @kubernetes/sig-cloud-provider-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-test-failures) | Test Failures and Triage |
-| @kubernetes/sig-cloud-providers-misc | [link](https://github.com/orgs/kubernetes/teams/sig-cloud-providers-misc) | General Discussion |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -57,108 +57,102 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Robert Bailey (**[@roberthbailey](https://github.com/roberthbailey)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-cluster-lifecycle)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcluster-lifecycle)
+- Slack: [#sig-cluster-lifecycle](https://kubernetes.slack.com/messages/sig-cluster-lifecycle)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcluster-lifecycle)
+- GitHub Teams:
+    - [@kubernetes/sig-cluster-lifecycle](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle) - Notify group
+    - [@kubernetes/sig-cluster-lifecycle-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-pr-reviews) - PR Reviews
 
 ## Subprojects
 
-The following subprojects are owned by sig-cluster-lifecycle:
-- **bootkube**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/bootkube/master/OWNERS
-  - Contact
-    - Slack: [#bootkube](https://kubernetes.slack.com/messages/bootkube)
-- **cluster-addons**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/addon-operators/master/OWNERS
-  - Contact
-    - Slack: [#cluster-addons](https://kubernetes.slack.com/messages/cluster-addons)
-- **cluster-api**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
-  - Contact
-    - Slack: [#cluster-api](https://kubernetes.slack.com/messages/cluster-api)
-- **cluster-api-provider-aws**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
-- **cluster-api-provider-digitalocean**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS
-- **cluster-api-provider-docker**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-docker/master/OWNERS
-- **cluster-api-provider-gcp**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
-- **cluster-api-provider-openstack**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
-- **cluster-api-provider-vsphere**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-vsphere/master/OWNERS
-  - Contact
-    - Slack: [#cluster-api-vsphere](https://kubernetes.slack.com/messages/cluster-api-vsphere)
-  - Meetings:
-    - Cluster API vSphere syncup meeting: [Wednesdays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/1jQrQiOW75uWraPk4b_LWtCTHwT7EZwrWWwMdxeWOEvk/edit?usp=sharing).
-      - [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIovV-AONxMa2cyv-_5LAYiu).
-- **etcdadm**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/etcdadm/master/OWNERS
-  - Contact
-    - Slack: [#etcdadm](https://kubernetes.slack.com/messages/etcdadm)
-- **image-builder**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/image-builder/master/OWNERS
-- **kops**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS
-- **kube-aws**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/kube-aws/master/OWNERS
-  - Contact
-    - Slack: [#kube-aws](https://kubernetes.slack.com/messages/kube-aws)
-- **kube-deploy**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kube-deploy/master/OWNERS
-  - Contact
-    - Slack: [#kube-deploy](https://kubernetes.slack.com/messages/kube-deploy)
-- **kube-up**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS
-- **kubeadm**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
-  - Contact
-    - Slack: [#kubeadm](https://kubernetes.slack.com/messages/kubeadm)
-- **kubernetes-anywhere**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS
-- **kubespray**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS
-  - Contact
-    - Slack: [#kubespray](https://kubernetes.slack.com/messages/kubespray)
-- **minikube**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/minikube/master/OWNERS
-  - Contact
-    - Slack: [#minikube](https://kubernetes.slack.com/messages/minikube)
+The following [subprojects][subproject-definition] are owned by sig-cluster-lifecycle:
+### bootkube
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/bootkube/master/OWNERS
+- **Contact:**
+  - Slack: [#bootkube](https://kubernetes.slack.com/messages/bootkube)
+### cluster-addons
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/addon-operators/master/OWNERS
+- **Contact:**
+  - Slack: [#cluster-addons](https://kubernetes.slack.com/messages/cluster-addons)
+### cluster-api
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
+- **Contact:**
+  - Slack: [#cluster-api](https://kubernetes.slack.com/messages/cluster-api)
+### cluster-api-provider-aws
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
+### cluster-api-provider-digitalocean
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS
+### cluster-api-provider-docker
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-docker/master/OWNERS
+### cluster-api-provider-gcp
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
+### cluster-api-provider-openstack
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
+### cluster-api-provider-vsphere
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-vsphere/master/OWNERS
+- **Contact:**
+  - Slack: [#cluster-api-vsphere](https://kubernetes.slack.com/messages/cluster-api-vsphere)
+- **Meetings:**
+  - Cluster API vSphere syncup meeting: [Wednesdays at 13:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1jQrQiOW75uWraPk4b_LWtCTHwT7EZwrWWwMdxeWOEvk/edit?usp=sharing).
+    - [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIovV-AONxMa2cyv-_5LAYiu).
+### etcdadm
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/etcdadm/master/OWNERS
+- **Contact:**
+  - Slack: [#etcdadm](https://kubernetes.slack.com/messages/etcdadm)
+### image-builder
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/image-builder/master/OWNERS
+### kops
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS
+### kube-aws
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/kube-aws/master/OWNERS
+- **Contact:**
+  - Slack: [#kube-aws](https://kubernetes.slack.com/messages/kube-aws)
+### kube-deploy
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kube-deploy/master/OWNERS
+- **Contact:**
+  - Slack: [#kube-deploy](https://kubernetes.slack.com/messages/kube-deploy)
+### kube-up
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS
+### kubeadm
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
+- **Contact:**
+  - Slack: [#kubeadm](https://kubernetes.slack.com/messages/kubeadm)
+### kubernetes-anywhere
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS
+### kubespray
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS
+- **Contact:**
+  - Slack: [#kubespray](https://kubernetes.slack.com/messages/kubespray)
+### minikube
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/minikube/master/OWNERS
+- **Contact:**
+  - Slack: [#minikube](https://kubernetes.slack.com/messages/minikube)
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-cluster-lifecycle | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle) | Notify group |
-| @kubernetes/sig-cluster-lifecycle-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-pr-reviews) | PR Reviews |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -37,73 +37,67 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Garrett Rodrigues (**[@grodrigues3](https://github.com/grodrigues3)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-contribex)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-contribex)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience)
+- Slack: [#sig-contribex](https://kubernetes.slack.com/messages/sig-contribex)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-contribex)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcontributor-experience)
+- GitHub Teams:
+    - [@kubernetes/sig-contributor-experience-bugs](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-contributor-experience-feature-requests](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-feature-requests) - Feature Requests
+    - [@kubernetes/sig-contributor-experience-misc-use-only-as-a-last-resort](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-misc-use-only-as-a-last-resort) - General Discussion
+    - [@kubernetes/sig-contributor-experience-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-contributor-experience-proposals](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-proposals) - Design Proposals
+    - [@kubernetes/sig-contributor-experience-test-failures](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-contributor-experience:
-- **community**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/OWNERS
-- **community-management**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/communication/OWNERS
-  - Meetings:
-    - APAC Coordinator Meeting: [Thursdays at 5:00 UTC](https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=5:00&tz=UTC).
-- **contributors-documentation**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
-  - Meetings:
-    - Non-Code Contributors Meeting: [Wednesdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1gdFWfkrapQclZ4-z4Lx2JwqKsJjXXUOVoLhBzZiZgSk/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
-- **devstats**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
-  - Contact
-    - Slack: [#devstats](https://kubernetes.slack.com/messages/devstats)
-- **events**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/events/OWNERS
-  - Contact
-    - Slack: [#events](https://kubernetes.slack.com/messages/events)
-  - Meetings:
-    - Events Planning Subproject: [Mondays at 10:00 PT (Pacific Time)](https://docs.google.com/document/d/1oLXv5_rM4f645jlXym_Vd7AUq7x6DV-O87E6tcW1sjU/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
-- **github-management**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
-- **k8s.io**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/k8s.io/master/OWNERS
-- **mentoring**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
-- **repo-infra**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
-- **slack-infra**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/slack-infra/master/OWNERS
-  - Contact
-    - Slack: [#slack-infra](https://kubernetes.slack.com/messages/slack-infra)
+The following [subprojects][subproject-definition] are owned by sig-contributor-experience:
+### community
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/OWNERS
+### community-management
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/communication/OWNERS
+- **Meetings:**
+  - APAC Coordinator Meeting: [Thursdays at 5:00 UTC](https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=5:00&tz=UTC).
+### contributors-documentation
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
+- **Meetings:**
+  - Non-Code Contributors Meeting: [Wednesdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1gdFWfkrapQclZ4-z4Lx2JwqKsJjXXUOVoLhBzZiZgSk/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
+### devstats
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
+- **Contact:**
+  - Slack: [#devstats](https://kubernetes.slack.com/messages/devstats)
+### events
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/events/OWNERS
+- **Contact:**
+  - Slack: [#events](https://kubernetes.slack.com/messages/events)
+- **Meetings:**
+  - Events Planning Subproject: [Mondays at 10:00 PT (Pacific Time)](https://docs.google.com/document/d/1oLXv5_rM4f645jlXym_Vd7AUq7x6DV-O87E6tcW1sjU/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
+### github-management
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
+### k8s.io
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/k8s.io/master/OWNERS
+### mentoring
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
+### repo-infra
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
+### slack-infra
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/slack-infra/master/OWNERS
+- **Contact:**
+  - Slack: [#slack-infra](https://kubernetes.slack.com/messages/slack-infra)
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-contributor-experience-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-contributor-experience-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-feature-requests) | Feature Requests |
-| @kubernetes/sig-contributor-experience-misc-use-only-as-a-last-resort | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-misc-use-only-as-a-last-resort) | General Discussion |
-| @kubernetes/sig-contributor-experience-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-pr-reviews) | PR Reviews |
-| @kubernetes/sig-contributor-experience-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-proposals) | Design Proposals |
-| @kubernetes/sig-contributor-experience-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-contributor-experience-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -34,44 +34,38 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Andrew Chen (**[@chenopis](https://github.com/chenopis)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-docs)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fdocs)
+- Slack: [#sig-docs](https://kubernetes.slack.com/messages/sig-docs)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fdocs)
+- GitHub Teams:
+    - [@kubernetes/kubernetes-blog](https://github.com/orgs/kubernetes/teams/kubernetes-blog) - Kubernetes blog maintainers
+    - [@kubernetes/sig-docs-de-owners](https://github.com/orgs/kubernetes/teams/sig-docs-de-owners) - German language content
+    - [@kubernetes/sig-docs-en-owners](https://github.com/orgs/kubernetes/teams/sig-docs-en-owners) - English content (default)
+    - [@kubernetes/sig-docs-es-owners](https://github.com/orgs/kubernetes/teams/sig-docs-es-owners) - Spanish language content
+    - [@kubernetes/sig-docs-fr-owners](https://github.com/orgs/kubernetes/teams/sig-docs-fr-owners) - French language content
+    - [@kubernetes/sig-docs-id-owners](https://github.com/orgs/kubernetes/teams/sig-docs-id-owners) - Indonesian language content
+    - [@kubernetes/sig-docs-it-owners](https://github.com/orgs/kubernetes/teams/sig-docs-it-owners) - Italian language content
+    - [@kubernetes/sig-docs-ja-owners](https://github.com/orgs/kubernetes/teams/sig-docs-ja-owners) - Japanese language content
+    - [@kubernetes/sig-docs-ko-owners](https://github.com/orgs/kubernetes/teams/sig-docs-ko-owners) - Korean language content
+    - [@kubernetes/sig-docs-maintainers](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers) - Documentation maintainers
+    - [@kubernetes/sig-docs-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-docs-pr-reviews) - Documentation PR reviews
+    - [@kubernetes/sig-docs-pt-owners](https://github.com/orgs/kubernetes/teams/sig-docs-pt-owners) - Portuguese language content
+    - [@kubernetes/sig-docs-zh-owners](https://github.com/orgs/kubernetes/teams/sig-docs-zh-owners) - Chinese language content
 
 ## Subprojects
 
-The following subprojects are owned by sig-docs:
-- **kubernetes-blog**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/website/master/content/en/blog/OWNERS
-- **reference-docs**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/reference-docs/master/OWNERS
-- **website**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-docs:
+### kubernetes-blog
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/website/master/content/en/blog/OWNERS
+### reference-docs
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/reference-docs/master/OWNERS
+### website
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/kubernetes-blog | [link](https://github.com/orgs/kubernetes/teams/kubernetes-blog) | Kubernetes blog maintainers |
-| @kubernetes/sig-docs-de-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-de-owners) | German language content |
-| @kubernetes/sig-docs-en-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-en-owners) | English content (default) |
-| @kubernetes/sig-docs-es-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-es-owners) | Spanish language content |
-| @kubernetes/sig-docs-fr-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-fr-owners) | French language content |
-| @kubernetes/sig-docs-id-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-id-owners) | Indonesian language content |
-| @kubernetes/sig-docs-it-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-it-owners) | Italian language content |
-| @kubernetes/sig-docs-ja-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ja-owners) | Japanese language content |
-| @kubernetes/sig-docs-ko-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-ko-owners) | Korean language content |
-| @kubernetes/sig-docs-maintainers | [link](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers) | Documentation maintainers |
-| @kubernetes/sig-docs-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-docs-pr-reviews) | Documentation PR reviews |
-| @kubernetes/sig-docs-pt-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-pt-owners) | Portuguese language content |
-| @kubernetes/sig-docs-zh-owners | [link](https://github.com/orgs/kubernetes/teams/sig-docs-zh-owners) | Chinese language content |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 * Discuss documentation and docs issues for kubernetes.io

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -25,55 +25,49 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Piotr Szczesniak (**[@piosz](https://github.com/piosz)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-instrumentation)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Finstrumentation)
+- Slack: [#sig-instrumentation](https://kubernetes.slack.com/messages/sig-instrumentation)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Finstrumentation)
+- GitHub Teams:
+    - [@kubernetes/sig-instrumentation-api-reviews](https://github.com/orgs/kubernetes/teams/sig-instrumentation-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-instrumentation-bugs](https://github.com/orgs/kubernetes/teams/sig-instrumentation-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-instrumentation-feature-requests](https://github.com/orgs/kubernetes/teams/sig-instrumentation-feature-requests) - Feature Requests
+    - [@kubernetes/sig-instrumentation-misc](https://github.com/orgs/kubernetes/teams/sig-instrumentation-misc) - General Discussion
+    - [@kubernetes/sig-instrumentation-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-instrumentation-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-instrumentation-proposals](https://github.com/orgs/kubernetes/teams/sig-instrumentation-proposals) - Design Proposals
+    - [@kubernetes/sig-instrumentation-test-failures](https://github.com/orgs/kubernetes/teams/sig-instrumentation-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-instrumentation:
-- **custom-metrics-apiserver**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/custom-metrics-apiserver/master/OWNERS
-- **heapster**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/heapster/master/OWNERS
-- **klog**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
-  - Contact
-    - Slack: [#klog](https://kubernetes.slack.com/messages/klog)
-- **kube-state-metrics**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS
-  - Contact
-    - Slack: [#kube-state-metrics](https://kubernetes.slack.com/messages/kube-state-metrics)
-- **metrics**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/metrics/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
-- **metrics-server**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/metrics-server/master/OWNERS
-- **mutating-trace-admission-controller**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-instrumentation:
+### custom-metrics-apiserver
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/custom-metrics-apiserver/master/OWNERS
+### heapster
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/heapster/master/OWNERS
+### klog
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
+- **Contact:**
+  - Slack: [#klog](https://kubernetes.slack.com/messages/klog)
+### kube-state-metrics
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS
+- **Contact:**
+  - Slack: [#kube-state-metrics](https://kubernetes.slack.com/messages/kube-state-metrics)
+### metrics
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/metrics/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
+### metrics-server
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/metrics-server/master/OWNERS
+### mutating-trace-admission-controller
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-instrumentation-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-instrumentation-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-instrumentation-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-feature-requests) | Feature Requests |
-| @kubernetes/sig-instrumentation-misc | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-misc) | General Discussion |
-| @kubernetes/sig-instrumentation-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-pr-reviews) | PR Reviews |
-| @kubernetes/sig-instrumentation-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-proposals) | Design Proposals |
-| @kubernetes/sig-instrumentation-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-instrumentation-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -29,41 +29,35 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Quinton Hoole (**[@quinton-hoole](https://github.com/quinton-hoole)**), Huawei
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-multicluster)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fmulticluster)
+- Slack: [#sig-multicluster](https://kubernetes.slack.com/messages/sig-multicluster)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fmulticluster)
+- GitHub Teams:
+    - [@kubernetes/sig-multicluster-api-reviews](https://github.com/orgs/kubernetes/teams/sig-multicluster-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-multicluster-bugs](https://github.com/orgs/kubernetes/teams/sig-multicluster-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-multicluster-feature-requests](https://github.com/orgs/kubernetes/teams/sig-multicluster-feature-requests) - Feature Requests
+    - [@kubernetes/sig-multicluster-misc](https://github.com/orgs/kubernetes/teams/sig-multicluster-misc) - General Discussion
+    - [@kubernetes/sig-multicluster-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-multicluster-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-multicluster-test-failures](https://github.com/orgs/kubernetes/teams/sig-multicluster-test-failures) - Test Failures and Triage
+    - [@kubernetes/sig-mutlicluster-proposals](https://github.com/orgs/kubernetes/teams/sig-mutlicluster-proposals) - Design Proposals
 
 ## Subprojects
 
-The following subprojects are owned by sig-multicluster:
-- **Kubefed**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/OWNERS
-- **cluster-registry**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cluster-registry/master/OWNERS
-- **federation-v1**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/federation/master/OWNERS
-- **kubemci**
-  - Owners:
-    - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-multicluster:
+### Kubefed
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/OWNERS
+### cluster-registry
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/cluster-registry/master/OWNERS
+### federation-v1
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/federation/master/OWNERS
+### kubemci
+- **Owners:**
+  - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-multicluster-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-multicluster-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-multicluster-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-feature-requests) | Feature Requests |
-| @kubernetes/sig-multicluster-misc | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-misc) | General Discussion |
-| @kubernetes/sig-multicluster-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-pr-reviews) | PR Reviews |
-| @kubernetes/sig-multicluster-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-multicluster-test-failures) | Test Failures and Triage |
-| @kubernetes/sig-mutlicluster-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-mutlicluster-proposals) | Design Proposals |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 ## Subprojects
 

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -27,53 +27,47 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Tim Hockin (**[@thockin](https://github.com/thockin)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-network)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-network)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnetwork)
+- Slack: [#sig-network](https://kubernetes.slack.com/messages/sig-network)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-network)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnetwork)
+- GitHub Teams:
+    - [@kubernetes/sig-network-api-reviews](https://github.com/orgs/kubernetes/teams/sig-network-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-network-bugs](https://github.com/orgs/kubernetes/teams/sig-network-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-network-feature-requests](https://github.com/orgs/kubernetes/teams/sig-network-feature-requests) - Feature Requests
+    - [@kubernetes/sig-network-misc](https://github.com/orgs/kubernetes/teams/sig-network-misc) - General Discussion
+    - [@kubernetes/sig-network-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-network-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-network-proposals](https://github.com/orgs/kubernetes/teams/sig-network-proposals) - Design Proposals
+    - [@kubernetes/sig-network-test-failures](https://github.com/orgs/kubernetes/teams/sig-network-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-network:
-- **external-dns**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/external-dns/master/OWNERS
-  - Contact
-    - Slack: [#external-dns](https://kubernetes.slack.com/messages/external-dns)
-- **ingress**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/ingress-gce/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/OWNERS
-- **kube-dns**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
-- **network-policy**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
-- **pod-networking**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
-- **services**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-network:
+### external-dns
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/external-dns/master/OWNERS
+- **Contact:**
+  - Slack: [#external-dns](https://kubernetes.slack.com/messages/external-dns)
+### ingress
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/ingress-gce/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/OWNERS
+### kube-dns
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
+### network-policy
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
+### pod-networking
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
+### services
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-network-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-network-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-network-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-network-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-network-feature-requests) | Feature Requests |
-| @kubernetes/sig-network-misc | [link](https://github.com/orgs/kubernetes/teams/sig-network-misc) | General Discussion |
-| @kubernetes/sig-network-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-network-pr-reviews) | PR Reviews |
-| @kubernetes/sig-network-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-network-proposals) | Design Proposals |
-| @kubernetes/sig-network-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-network-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 ## Areas of Responsibility
 

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -26,57 +26,51 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**), Red Hat
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-node)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnode)
+- Slack: [#sig-node](https://kubernetes.slack.com/messages/sig-node)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnode)
+- GitHub Teams:
+    - [@kubernetes/sig-node-api-reviews](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-node-bugs](https://github.com/orgs/kubernetes/teams/sig-node-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-node-feature-requests](https://github.com/orgs/kubernetes/teams/sig-node-feature-requests) - Feature Requests
+    - [@kubernetes/sig-node-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-node-proposals](https://github.com/orgs/kubernetes/teams/sig-node-proposals) - Design Proposals
+    - [@kubernetes/sig-node-test-failures](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-node:
-- **cri-api**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/cri-api/master/OWNERS
-- **cri-tools**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/cri-tools/master/OWNERS
-- **frakti**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/frakti/master/OWNERS
-- **kubelet**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubelet/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/OWNERS
-- **node-api**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/node-api/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/node-api/master/OWNERS
-- **node-feature-discovery**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/OWNERS
-- **node-problem-detector**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
-  - Contact
-    - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
-- **rktlet**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/rktlet/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-node:
+### cri-api
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/cri-api/master/OWNERS
+### cri-tools
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cri-tools/master/OWNERS
+### frakti
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/frakti/master/OWNERS
+### kubelet
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubelet/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/OWNERS
+### node-api
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/node-api/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/node-api/master/OWNERS
+### node-feature-discovery
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery-operator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/OWNERS
+### node-problem-detector
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
+- **Contact:**
+  - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
+### rktlet
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/rktlet/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-node-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-node-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-node-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-node-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-node-feature-requests) | Feature Requests |
-| @kubernetes/sig-node-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) | PR Reviews |
-| @kubernetes/sig-node-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-node-proposals) | Design Proposals |
-| @kubernetes/sig-node-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 

--- a/sig-pm/README.md
+++ b/sig-pm/README.md
@@ -36,17 +36,18 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**), CNCF
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-pm)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-pm)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fpm)
+- Slack: [#sig-pm](https://kubernetes.slack.com/messages/sig-pm)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-pm)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fpm)
 
 ## Subprojects
 
-The following subprojects are owned by sig-pm:
-- **enhancements**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/enhancements/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-pm:
+### enhancements
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/enhancements/master/OWNERS
 
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 SIG-PM (Program, Product, Project Management)

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -31,57 +31,51 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-release)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Frelease)
+- Slack: [#sig-release](https://kubernetes.slack.com/messages/sig-release)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-release)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Frelease)
+- GitHub Teams:
+    - [@kubernetes/kubernetes-milestone-maintainers](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers) - Milestone Maintainers
+    - [@kubernetes/kubernetes-release-managers](https://github.com/orgs/kubernetes/teams/kubernetes-release-managers) - Release Managers
+    - [@kubernetes/sig-release](https://github.com/orgs/kubernetes/teams/sig-release) - SIG Release Members
+    - [@kubernetes/sig-release-admins](https://github.com/orgs/kubernetes/teams/sig-release-admins) - Admins for SIG Release repositories
 
 ## Subprojects
 
-The following subprojects are owned by sig-release:
-- **hyperkube**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/debian-hyperkube-base/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/hyperkube/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/hyperkube/OWNERS
-- **licensing**
-  - Description: The Licensing subproject is responsible for analyzing/reporting/remediating licensing concerns within the Kubernetes project orgs.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/sig-release/master/licensing/OWNERS
-- **release-engineering**
-  - Description: The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/k8s-container-image-promoter/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/release-notes/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS
-  - Contact
-    - Slack: [#release-management](https://kubernetes.slack.com/messages/release-management)
-  - Meetings:
-    - Regular SIG Meeting: [Mondays at 15:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC).
-      - [Meeting notes and Agenda](https://bit.ly/k8s-releng-meeting).
-      - [Meeting recordings](https://bit.ly/k8s-sig-release-videos).
-- **release-team**
-  - Description: The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
-- **sig-release**
-  - Description: Documents and processes related to SIG Release
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-release:
+### hyperkube
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/debian-hyperkube-base/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/hyperkube/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/hyperkube/OWNERS
+### licensing
+The Licensing subproject is responsible for analyzing/reporting/remediating licensing concerns within the Kubernetes project orgs.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/sig-release/master/licensing/OWNERS
+### release-engineering
+The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/k8s-container-image-promoter/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/release-notes/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS
+- **Contact:**
+  - Slack: [#release-management](https://kubernetes.slack.com/messages/release-management)
+- **Meetings:**
+  - Regular SIG Meeting: [Mondays at 15:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC).
+    - [Meeting notes and Agenda](https://bit.ly/k8s-releng-meeting).
+    - [Meeting recordings](https://bit.ly/k8s-sig-release-videos).
+### release-team
+The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
+### sig-release
+Documents and processes related to SIG Release
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/kubernetes-milestone-maintainers | [link](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers) | Milestone Maintainers |
-| @kubernetes/kubernetes-release-managers | [link](https://github.com/orgs/kubernetes/teams/kubernetes-release-managers) | Release Managers |
-| @kubernetes/sig-release | [link](https://github.com/orgs/kubernetes/teams/sig-release) | SIG Release Members |
-| @kubernetes/sig-release-admins | [link](https://github.com/orgs/kubernetes/teams/sig-release-admins) | Admins for SIG Release repositories |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 ---
 

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -26,56 +26,50 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Wojciech Tyczynski (**[@wojtek-t](https://github.com/wojtek-t)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-scalability)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scale)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscalability)
+- Slack: [#sig-scalability](https://kubernetes.slack.com/messages/sig-scalability)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scale)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscalability)
+- GitHub Teams:
+    - [@kubernetes/sig-scalability-api-reviews](https://github.com/orgs/kubernetes/teams/sig-scalability-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-scalability-bugs](https://github.com/orgs/kubernetes/teams/sig-scalability-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-scalability-feature-requests](https://github.com/orgs/kubernetes/teams/sig-scalability-feature-requests) - Feature Requests
+    - [@kubernetes/sig-scalability-misc](https://github.com/orgs/kubernetes/teams/sig-scalability-misc) - General Discussion
+    - [@kubernetes/sig-scalability-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-scalability-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-scalability-proprosals](https://github.com/orgs/kubernetes/teams/sig-scalability-proprosals) - Design Proposals
+    - [@kubernetes/sig-scalability-test-failures](https://github.com/orgs/kubernetes/teams/sig-scalability-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-scalability:
-- **kubernetes-scalability-and-performance-tests-and-validation**
-  - Description: [Described below](#kubernetes-scalability-and-performance-tests-and-validation)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/processes/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/scalability/OWNERS
-- **kubernetes-scalability-bottlenecks-detection**
-  - Description: [Described below](#kubernetes-scalability-bottlenecks-detection)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/blogs/OWNERS
-- **kubernetes-scalability-definition**
-  - Description: [Described below](#kubernetes-scalability-definition)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/configs-and-limits/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/slos/OWNERS
-- **kubernetes-scalability-governance**
-  - Description: [Described below](#kubernetes-scalability-governance)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/governance/OWNERS
-- **kubernetes-scalability-test-frameworks**
-  - Description: [Described below](#kubernetes-scalability-test-frameworks)
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/kubemark/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubemark/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubemark/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/kubemark/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/perf-tests/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/perf-tests/master/clusterloader2/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-scalability:
+### kubernetes-scalability-and-performance-tests-and-validation
+[Described below](#kubernetes-scalability-and-performance-tests-and-validation)
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/processes/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/scalability/OWNERS
+### kubernetes-scalability-bottlenecks-detection
+[Described below](#kubernetes-scalability-bottlenecks-detection)
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/blogs/OWNERS
+### kubernetes-scalability-definition
+[Described below](#kubernetes-scalability-definition)
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/configs-and-limits/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/slos/OWNERS
+### kubernetes-scalability-governance
+[Described below](#kubernetes-scalability-governance)
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/governance/OWNERS
+### kubernetes-scalability-test-frameworks
+[Described below](#kubernetes-scalability-test-frameworks)
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/kubemark/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubemark/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubemark/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/kubemark/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/perf-tests/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/perf-tests/master/clusterloader2/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-scalability-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-scalability-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-scalability-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-feature-requests) | Feature Requests |
-| @kubernetes/sig-scalability-misc | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-misc) | General Discussion |
-| @kubernetes/sig-scalability-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-pr-reviews) | PR Reviews |
-| @kubernetes/sig-scalability-proprosals | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-proprosals) | Design Proposals |
-| @kubernetes/sig-scalability-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scalability-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 # Scalability Regression - Contact Points
 

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -27,45 +27,39 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Klaus Ma (**[@k82cn](https://github.com/k82cn)**), Huawei
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-scheduling)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscheduling)
+- Slack: [#sig-scheduling](https://kubernetes.slack.com/messages/sig-scheduling)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscheduling)
+- GitHub Teams:
+    - [@kubernetes/sig-scheduling-api-reviews](https://github.com/orgs/kubernetes/teams/sig-scheduling-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-scheduling-bugs](https://github.com/orgs/kubernetes/teams/sig-scheduling-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-scheduling-feature-requests](https://github.com/orgs/kubernetes/teams/sig-scheduling-feature-requests) - Feature Requests
+    - [@kubernetes/sig-scheduling-misc](https://github.com/orgs/kubernetes/teams/sig-scheduling-misc) - General Discussion
+    - [@kubernetes/sig-scheduling-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-scheduling-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-scheduling-proposals](https://github.com/orgs/kubernetes/teams/sig-scheduling-proposals) - Design Proposals
+    - [@kubernetes/sig-scheduling-test-failures](https://github.com/orgs/kubernetes/teams/sig-scheduling-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-scheduling:
-- **cluster-capacity**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-capacity/master/OWNERS
-- **descheduler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/descheduler/master/OWNERS
-- **kube-batch**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS
-- **poseidon**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS
-- **scheduler**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-scheduler/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/scheduler/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-scheduling:
+### cluster-capacity
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-capacity/master/OWNERS
+### descheduler
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/descheduler/master/OWNERS
+### kube-batch
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS
+### poseidon
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS
+### scheduler
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-scheduler/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/scheduler/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-scheduling-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-scheduling-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-scheduling-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-feature-requests) | Feature Requests |
-| @kubernetes/sig-scheduling-misc | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-misc) | General Discussion |
-| @kubernetes/sig-scheduling-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-pr-reviews) | PR Reviews |
-| @kubernetes/sig-scheduling-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-proposals) | Design Proposals |
-| @kubernetes/sig-scheduling-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-scheduling-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -36,35 +36,29 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Ville Aikas (**[@vaikas-google](https://github.com/vaikas-google)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-service-catalog)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fservice-catalog)
+- Slack: [#sig-service-catalog](https://kubernetes.slack.com/messages/sig-service-catalog)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fservice-catalog)
+- GitHub Teams:
+    - [@kubernetes/sig-service-catalog-api-reviews](https://github.com/orgs/kubernetes/teams/sig-service-catalog-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-service-catalog-bugs](https://github.com/orgs/kubernetes/teams/sig-service-catalog-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-service-catalog-feature-requests](https://github.com/orgs/kubernetes/teams/sig-service-catalog-feature-requests) - Feature Requests
+    - [@kubernetes/sig-service-catalog-misc](https://github.com/orgs/kubernetes/teams/sig-service-catalog-misc) - General Discussion
+    - [@kubernetes/sig-service-catalog-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-service-catalog-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-service-catalog-proposals](https://github.com/orgs/kubernetes/teams/sig-service-catalog-proposals) - Design Proposals
+    - [@kubernetes/sig-service-catalog-test-failures](https://github.com/orgs/kubernetes/teams/sig-service-catalog-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-service-catalog:
-- **minibroker**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/minibroker/master/OWNERS
-- **service-catalog**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/service-catalog/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-service-catalog:
+### minibroker
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/minibroker/master/OWNERS
+### service-catalog
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/service-catalog/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-service-catalog-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-service-catalog-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-service-catalog-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-feature-requests) | Feature Requests |
-| @kubernetes/sig-service-catalog-misc | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-misc) | General Discussion |
-| @kubernetes/sig-service-catalog-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-pr-reviews) | PR Reviews |
-| @kubernetes/sig-service-catalog-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-proposals) | Design Proposals |
-| @kubernetes/sig-service-catalog-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-service-catalog-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -26,71 +26,65 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Saad Ali (**[@saad-ali](https://github.com/saad-ali)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-storage)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fstorage)
+- Slack: [#sig-storage](https://kubernetes.slack.com/messages/sig-storage)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fstorage)
+- GitHub Teams:
+    - [@kubernetes/sig-storage-api-reviews](https://github.com/orgs/kubernetes/teams/sig-storage-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-storage-bugs](https://github.com/orgs/kubernetes/teams/sig-storage-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-storage-feature-requests](https://github.com/orgs/kubernetes/teams/sig-storage-feature-requests) - Feature Requests
+    - [@kubernetes/sig-storage-misc](https://github.com/orgs/kubernetes/teams/sig-storage-misc) - General Discussion
+    - [@kubernetes/sig-storage-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-storage-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-storage-proposals](https://github.com/orgs/kubernetes/teams/sig-storage-proposals) - Design Proposals
+    - [@kubernetes/sig-storage-test-failures](https://github.com/orgs/kubernetes/teams/sig-storage-test-failures) - Test Failures and Triage
 
 ## Subprojects
 
-The following subprojects are owned by sig-storage:
-- **external-storage**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-lib-external-provisioner/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/OWNERS
-- **git-sync**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/git-sync/master/OWNERS
-- **kubernetes-csi**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-fc/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-iscsi/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-utils/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-proxy/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-test/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/docs/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/driver-registrar/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/drivers/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/kubernetes-csi.github.io/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/livenessprobe/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/node-driver-registrar/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/csi-translation-lib/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-translation-lib/OWNERS
-- **nfs-provisioner**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/nfs-provisioner/master/OWNERS
-- **volumes**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-storage:
+### external-storage
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-lib-external-provisioner/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/OWNERS
+### git-sync
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/git-sync/master/OWNERS
+### kubernetes-csi
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-fc/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-iscsi/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-utils/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-proxy/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/csi-test/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/docs/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/driver-registrar/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/drivers/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/kubernetes-csi.github.io/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/livenessprobe/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-csi/node-driver-registrar/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/csi-translation-lib/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-translation-lib/OWNERS
+### nfs-provisioner
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/nfs-provisioner/master/OWNERS
+### volumes
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-storage-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-storage-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-storage-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-storage-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-storage-feature-requests) | Feature Requests |
-| @kubernetes/sig-storage-misc | [link](https://github.com/orgs/kubernetes/teams/sig-storage-misc) | General Discussion |
-| @kubernetes/sig-storage-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-storage-pr-reviews) | PR Reviews |
-| @kubernetes/sig-storage-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-storage-proposals) | Design Proposals |
-| @kubernetes/sig-storage-test-failures | [link](https://github.com/orgs/kubernetes/teams/sig-storage-test-failures) | Test Failures and Triage |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Details

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -28,66 +28,60 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Timothy St. Clair (**[@timothysc](https://github.com/timothysc)**), VMware
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-testing)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-testing)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Ftesting)
+- Slack: [#sig-testing](https://kubernetes.slack.com/messages/sig-testing)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-testing)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Ftesting)
+- GitHub Teams:
+    - [@kubernetes/sig-testing](https://github.com/orgs/kubernetes/teams/sig-testing) - General Discussion
+    - [@kubernetes/sig-testing-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-testing-pr-reviews) - PR Reviews
 
 ## Subprojects
 
-The following subprojects are owned by sig-testing:
-- **boskos**
-  - Description: Boskos is a resource manager service that handles different kinds of resources and transitions between different states. We use it on the Kubernetes project to manage pools of GCP projects for CI/CD.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
-- **gopherage**
-  - Description: Gopherage is a tool for manipulating Go coverage files. We use it on the Kubernetes project to report on code coverage due to e2e tests
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/gopherage/OWNERS
-- **gubernator**
-  - Description: Gubernator is a frontend for displaying Kubernetes test results stored in GCS. See gubernator.k8s.io to see it in action for the Kubernetes project.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/gubernator/OWNERS
-- **kind**
-  - Description: Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
-  - Contact
-    - Slack: [#kind](https://kubernetes.slack.com/messages/kind)
-  - Meetings:
-    - sigs.k8s.io/kind bi-weekly meeting: [Mondays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/1b9Ppm7ZT_tMWRs5Ph1zGJJKb5nF9c3ZHzMwg1olJIrc/edit).
-      - [Meeting recordings](https://bit.ly/k8s-sig-testing-videos).
-- **prow**
-  - Description: Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
-  - Contact
-    - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
-- **test-infra**
-  - Description: Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/OWNERS
-- **testing-commons**
-  - Description: The Testing Commons is a subproject within the Kubernetes sig-testing community interested code structure, layout, and execution of common test code used throughout the kubernetes project
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/testing_frameworks/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/OWNERS
-  - Contact
-    - Slack: [#testing-commons](https://kubernetes.slack.com/messages/testing-commons)
-  - Meetings:
-    - Testing Commons: [Fridays at 07:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:30&tz=PT%20%28Pacific%20Time%29).
-      - [Meeting notes and Agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit#heading=h.tnoevy5f439o).
+The following [subprojects][subproject-definition] are owned by sig-testing:
+### boskos
+Boskos is a resource manager service that handles different kinds of resources and transitions between different states. We use it on the Kubernetes project to manage pools of GCP projects for CI/CD.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
+### gopherage
+Gopherage is a tool for manipulating Go coverage files. We use it on the Kubernetes project to report on code coverage due to e2e tests
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/gopherage/OWNERS
+### gubernator
+Gubernator is a frontend for displaying Kubernetes test results stored in GCS. See gubernator.k8s.io to see it in action for the Kubernetes project.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/gubernator/OWNERS
+### kind
+Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
+- **Contact:**
+  - Slack: [#kind](https://kubernetes.slack.com/messages/kind)
+- **Meetings:**
+  - sigs.k8s.io/kind bi-weekly meeting: [Mondays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1b9Ppm7ZT_tMWRs5Ph1zGJJKb5nF9c3ZHzMwg1olJIrc/edit).
+    - [Meeting recordings](https://bit.ly/k8s-sig-testing-videos).
+### prow
+Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
+- **Contact:**
+  - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
+### test-infra
+Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/test-infra/master/OWNERS
+### testing-commons
+The Testing Commons is a subproject within the Kubernetes sig-testing community interested code structure, layout, and execution of common test code used throughout the kubernetes project
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/testing_frameworks/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/OWNERS
+- **Contact:**
+  - Slack: [#testing-commons](https://kubernetes.slack.com/messages/testing-commons)
+- **Meetings:**
+  - Testing Commons: [Fridays at 07:30 PT (Pacific Time)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:30&tz=PT%20%28Pacific%20Time%29).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit#heading=h.tnoevy5f439o).
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-testing | [link](https://github.com/orgs/kubernetes/teams/sig-testing) | General Discussion |
-| @kubernetes/sig-testing-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-testing-pr-reviews) | PR Reviews |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Presentations

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -28,18 +28,19 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Marcin Maciaszczyk (**[@maciaszczykm](https://github.com/maciaszczykm)**), Loodse
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-ui)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fui)
+- Slack: [#sig-ui](https://kubernetes.slack.com/messages/sig-ui)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fui)
 
 ## Subprojects
 
-The following subprojects are owned by sig-ui:
-- **dashboard**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/dashboard-metrics-scraper/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/dashboard/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-ui:
+### dashboard
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/dashboard-metrics-scraper/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/dashboard/master/OWNERS
 
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-usability/README.md
+++ b/sig-usability/README.md
@@ -28,31 +28,25 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Vallery Lancey (**[@vllry](https://github.com/vllry)**), Lyft
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-usability)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-usability)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fusability)
+- Slack: [#sig-usability](https://kubernetes.slack.com/messages/sig-usability)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-usability)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fusability)
+- GitHub Teams:
+    - [@kubernetes/sig-usability-api-reviews](https://github.com/orgs/kubernetes/teams/sig-usability-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-usability-bugs](https://github.com/orgs/kubernetes/teams/sig-usability-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-usability-feature-requests](https://github.com/orgs/kubernetes/teams/sig-usability-feature-requests) - Feature Requests
+    - [@kubernetes/sig-usability-misc](https://github.com/orgs/kubernetes/teams/sig-usability-misc) - General Discussion
+    - [@kubernetes/sig-usability-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-usability-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-usability-proposals](https://github.com/orgs/kubernetes/teams/sig-usability-proposals) - Design Proposals
 
 ## Subprojects
 
-The following subprojects are owned by sig-usability:
-- **sig-usability**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/sig-usability/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-usability:
+### sig-usability
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/sig-usability/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-usability-api-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-usability-api-reviews) | API Changes and Reviews |
-| @kubernetes/sig-usability-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-usability-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-usability-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-usability-feature-requests) | Feature Requests |
-| @kubernetes/sig-usability-misc | [link](https://github.com/orgs/kubernetes/teams/sig-usability-misc) | General Discussion |
-| @kubernetes/sig-usability-pr-reviews | [link](https://github.com/orgs/kubernetes/teams/sig-usability-pr-reviews) | PR Reviews |
-| @kubernetes/sig-usability-proposals | [link](https://github.com/orgs/kubernetes/teams/sig-usability-proposals) | Design Proposals |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -26,34 +26,28 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Michael Michael (**[@michmike](https://github.com/michmike)**), VMware
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/sig-windows)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-windows)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fwindows)
+- Slack: [#sig-windows](https://kubernetes.slack.com/messages/sig-windows)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-windows)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fwindows)
+- GitHub Teams:
+    - [@kubernetes/sig-windows-bugs](https://github.com/orgs/kubernetes/teams/sig-windows-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-windows-feature-requests](https://github.com/orgs/kubernetes/teams/sig-windows-feature-requests) - Feature Requests
+    - [@kubernetes/sig-windows-misc](https://github.com/orgs/kubernetes/teams/sig-windows-misc) - General Discussion
 
 ## Subprojects
 
-The following subprojects are owned by sig-windows:
-- **windows-gmsa**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/windows-gmsa/master/OWNERS
-- **windows-testing**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/OWNERS
-- **windows-tools**
-  - Owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/OWNERS
+The following [subprojects][subproject-definition] are owned by sig-windows:
+### windows-gmsa
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/windows-gmsa/master/OWNERS
+### windows-testing
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/OWNERS
+### windows-tools
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/OWNERS
 
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/sig-windows-bugs | [link](https://github.com/orgs/kubernetes/teams/sig-windows-bugs) | Bug Triage and Troubleshooting |
-| @kubernetes/sig-windows-feature-requests | [link](https://github.com/orgs/kubernetes/teams/sig-windows-feature-requests) | Feature Requests |
-| @kubernetes/sig-windows-misc | [link](https://github.com/orgs/kubernetes/teams/sig-windows-misc) | General Discussion |
-
+[subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->
 ## Getting Started
 

--- a/ug-big-data/README.md
+++ b/ug-big-data/README.md
@@ -22,20 +22,11 @@ Serve as a community resource for advising big data and data science related sof
 * Yinan Li (**[@liyinan926](https://github.com/liyinan926)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/ug-big-data)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-ug-big-data)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fbig-data)
-
-
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/ug-big-data | [link](https://github.com/orgs/kubernetes/teams/ug-big-data) | General Discussion |
-
+- Slack: [#ug-big-data](https://kubernetes.slack.com/messages/ug-big-data)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-ug-big-data)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fbig-data)
+- GitHub Teams:
+    - [@kubernetes/ug-big-data](https://github.com/orgs/kubernetes/teams/ug-big-data) - General Discussion
 <!-- BEGIN CUSTOM CONTENT -->
 
 ### Goals

--- a/wg-apply/README.md
+++ b/wg-apply/README.md
@@ -23,10 +23,9 @@ Resources can be found in [this Google drive folder](https://drive.google.com/dr
 * Daniel Smith (**[@lavalamp](https://github.com/lavalamp)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-apply)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-apply)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fapply)
-
+- Slack: [#wg-apply](https://kubernetes.slack.com/messages/wg-apply)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-apply)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fapply)
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/wg-component-standard/README.md
+++ b/wg-component-standard/README.md
@@ -26,19 +26,11 @@ Develop a standard foundation (philosophy and libraries) for core Kubernetes com
 * Dr. Stefan Schimanski (**[@sttts](https://github.com/sttts)**), Red Hat
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-component-standard)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-component-standard)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fcomponent-standard)
-
-## GitHub Teams
-
-The below teams can be mentioned on issues and PRs in order to get attention from the right people.
-Note that the links to display team membership will only work if you are a member of the org.
-
-| Team Name | Details | Description |
-| --------- |:-------:| ----------- |
-| @kubernetes/wg-component-standard | [link](https://github.com/orgs/kubernetes/teams/wg-component-standard) | Component Standard Discussion |
-
+- Slack: [#wg-component-standard](https://kubernetes.slack.com/messages/wg-component-standard)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-component-standard)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fcomponent-standard)
+- GitHub Teams:
+    - [@kubernetes/wg-component-standard](https://github.com/orgs/kubernetes/teams/wg-component-standard) - Component Standard Discussion
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/wg-iot-edge/README.md
+++ b/wg-iot-edge/README.md
@@ -28,10 +28,9 @@ A Working Group dedicated to discussing, designing and documenting using Kuberne
 * Preston Holmes (**[@ptone](https://github.com/ptone)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-iot-edge)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fiot-edge)
-
+- Slack: [#wg-iot-edge](https://kubernetes.slack.com/messages/wg-iot-edge)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fiot-edge)
 <!-- BEGIN CUSTOM CONTENT -->
 This working group is a cross-SIG effort currently sponsored by _sig-networking_ and _sig-multicluster_ with
 a focus on improving Kubernetes IoT and Edge deployments. Community members are encouraged to share their ideas in this working group to reach broad consensus across the SIGs. Once consensus is reached, the enhancements

--- a/wg-k8s-infra/README.md
+++ b/wg-k8s-infra/README.md
@@ -29,10 +29,9 @@ The [charter](charter.md) defines the scope and governance of the K8s Infra Work
 * Aaron Crickenberger (**[@spiffxp](https://github.com/spiffxp)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-k8s-infra)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-k8s-infra)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fk8s-infra)
-
+- Slack: [#wg-k8s-infra](https://kubernetes.slack.com/messages/wg-k8s-infra)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-k8s-infra)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fk8s-infra)
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/wg-lts/README.md
+++ b/wg-lts/README.md
@@ -30,10 +30,9 @@ The [charter](charter.md) defines the scope and governance of the LTS Working Gr
 * Nick Young (**[@youngnick](https://github.com/youngnick)**), Atlassian
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-lts)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-lts)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Flts)
-
+- Slack: [#wg-lts](https://kubernetes.slack.com/messages/wg-lts)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-lts)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Flts)
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Goals

--- a/wg-machine-learning/README.md
+++ b/wg-machine-learning/README.md
@@ -26,10 +26,9 @@ Identify and fix gaps in Kubernetes to better support Machine Learning applicati
 * Vishnu Kannan (**[@vishh](https://github.com/vishh)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-machine-learning)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-machine-learning)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fmachine-learning)
-
+- Slack: [#wg-machine-learning](https://kubernetes.slack.com/messages/wg-machine-learning)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-machine-learning)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fmachine-learning)
 <!-- BEGIN CUSTOM CONTENT -->
 A working group dedicated towards making Kubernetes work best for Machine Learning workloads.
 

--- a/wg-multitenancy/README.md
+++ b/wg-multitenancy/README.md
@@ -33,10 +33,9 @@ Define the models of multitenancy that Kubernetes will support. Discuss and exec
 * David Oppenheimer (**[@davidopp](https://github.com/davidopp)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-multitenancy)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fmultitenancy)
-
+- Slack: [#wg-multitenancy](https://kubernetes.slack.com/messages/wg-multitenancy)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fmultitenancy)
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/wg-policy/README.md
+++ b/wg-policy/README.md
@@ -32,10 +32,9 @@ Provide an overall architecture that describes both the current policy related i
 * Torin Sandall (**[@tsandall](https://github.com/tsandall)**), Styra
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-policy)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-policy)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fpolicy)
-
+- Slack: [#wg-policy](https://kubernetes.slack.com/messages/wg-policy)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-policy)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fpolicy)
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/wg-resource-management/README.md
+++ b/wg-resource-management/README.md
@@ -29,10 +29,9 @@ Designing and shepherding cross-cutting features around compute resource isolati
 * Vishnu Kannan (**[@vishh](https://github.com/vishh)**), Google
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-resource-mgmt)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-resource-management)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fresource-management)
-
+- Slack: [#wg-resource-mgmt](https://kubernetes.slack.com/messages/wg-resource-mgmt)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-resource-management)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fresource-management)
 <!-- BEGIN CUSTOM CONTENT -->
 A working group that is a cross-SIG effort currently sponsored by sig-node and sig-scheduling with
 a focus on improving Kubernetes Compute Resource Management.

--- a/wg-security-audit/README.md
+++ b/wg-security-audit/README.md
@@ -24,10 +24,9 @@ Perform a security audit on k8s with a vendor and produce as artifacts a threat 
 * Joel Smith (**[@joelsmith](https://github.com/joelsmith)**), Red Hat
 
 ## Contact
-* [Slack](https://kubernetes.slack.com/messages/wg-security-audit)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-security-audit)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fsecurity-audit)
-
+- Slack: [#wg-security-audit](https://kubernetes.slack.com/messages/wg-security-audit)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-security-audit)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fsecurity-audit)
 <!-- BEGIN CUSTOM CONTENT -->
 ## Published Documents
 


### PR DESCRIPTION
The bulleted list of subprojects makes it impossible to link someone to
specific info for a given subproject. Now, instead of linking someone to
sig-testing#subprojects and asking them to scroll, I link them directly to
sig-testing#kind.

While I was at this, I made the main SIG/WG/UG/Committee contact info
format match what is used for subprojects, specifically:
- display the slack channel name
- list github teams as part of contact info instead of in a table
- use - instead of * for bullets

I also removed subproject rendering from WGs, since WGs cannot own code,
and added a link to the governance definition of what a subproject is.

This is obviously prone to rebase fun, so if necessary I'm happy to help
shepherd through whatever would conflict with this and rebase.