### PR TITLE
Update root OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - cblecker
   - idvoretskyi
   - jdumars
+  - mrbobbytables
   - nikhita
   - parispittman
   - committee-steering

--- a/OWNERS
+++ b/OWNERS
@@ -10,3 +10,5 @@ approvers:
   - nikhita
   - parispittman
   - committee-steering
+emeritus_approvers:
+  - grodrigues3


### PR DESCRIPTION
Specifically
- add @grodigues3 as an emeritus_approver
- add @mrbobbytables as an approver

out of 145 most recently updated merged PRs in 'kubernetes/community'
involving 'mrbobbytables'... 73 touched files matching regex '.*' and no
files matching '^communication|^github-management' of those, mrbobbytables
authored 19, and commented '/lgtm' on 32

though not formally listed as a reviewer for 3 months, mrbobbytables has
been playing the part for PRs that are outside of the subprojects they own,
which is good enough for me