### PR TITLE
Update devstats OWNERS

### DIFF
--- a/sig-contributor-experience/devstats/OWNERS
+++ b/sig-contributor-experience/devstats/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - Phillels
   - lukaszgryglicki
   - jberkus
+emeritus_approvers:
   - spiffxp
 labels:
   - sig/contributor-experience

--- a/sig-contributor-experience/devstats/OWNERS
+++ b/sig-contributor-experience/devstats/OWNERS
@@ -1,12 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - Phillels
   - dims
-  - jberkus
   - nikhita
   - parispittman
-  - spiffxp
 approvers:
   - Phillels
   - lukaszgryglicki

--- a/sig-contributor-experience/devstats/OWNERS
+++ b/sig-contributor-experience/devstats/OWNERS
@@ -3,7 +3,6 @@
 reviewers:
   - dims
   - nikhita
-  - parispittman
 approvers:
   - Phillels
   - lukaszgryglicki


### PR DESCRIPTION
Specifically
- remove redundant reviewers
- move @spiffxp to emeritus_approvers

I haven't really been involved with the day to day of devstats for some
time now. I am periodically interested in ensuring it has accurate and
useful data, but feel that I have taken it about as far as I care to
via https://github.com/kubernetes/community/issues/3305