### PR TITLE
move repo-infra subproject to sig-testing

### DIFF
--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -88,9 +88,6 @@ The following [subprojects][subproject-definition] are owned by sig-contributor-
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
-### repo-infra
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
 ### slack-infra
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/slack-infra/master/OWNERS

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -66,6 +66,9 @@ Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action 
   - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
 - **Contact:**
   - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
+### repo-infra
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
 ### test-infra
 Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1107,9 +1107,6 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
-  - name: repo-infra
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
   - name: slack-infra
     contact:
       slack: slack-infra
@@ -2012,6 +2009,9 @@ sigs:
       slack: prow
     owners:
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
+  - name: repo-infra
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
   - name: test-infra
     description: |
       Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project


### PR DESCRIPTION
repo-infra is mostly used for kazel, which relates to bazel, which
is under sig-testing's purview

/cc @fejta
subproject owner, sig-testing chair

/cc @cblecker @nikhita @parispittman @Phillels
sig-contribex chairs and TLs