### PR TITLE
Conformance Tests: Reduce soak time for new tests

### DIFF
--- a/contributors/devel/sig-architecture/conformance-tests.md
+++ b/contributors/devel/sig-architecture/conformance-tests.md
@@ -51,7 +51,7 @@ specifically, a test is eligible for promotion to conformance if:
 - it passes against the appropriate versions of kubernetes as spelled out in
   the [conformance test version skew policy]
 - it is stable and runs consistently (e.g., no flakes), and has been running
-  for at least one release cycle
+  for at least two weeks
 - new conformance tests or updates to conformance tests for additional scenarios
   are only allowed before code freeze dates set by the release team to allow
   enough soak time of the changes and gives folks a chance to kick the tires


### PR DESCRIPTION
New tests don't need to be run for a full release-cycle before getting
promoted to Conformance. Two weeks should be sufficient, and more practical.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->