### PR TITLE
slack-config: rename #gsoc-apps to #outreachy-apps

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -84,7 +84,6 @@ channels:
   - name: gitops
   - name: gke
   - name: gloo
-  - name: gsoc-apps
   - name: helm-chart-testing
   - name: helm-deprecated
     archived: true
@@ -224,6 +223,8 @@ channels:
   - name: ops-status
     archived: true
   - name: osbkit
+  - name: outreachy-apps
+    id: CDH610735
   - name: pharmer
   - name: pl-users
   - name: pr-reviews


### PR DESCRIPTION
For preparation for setting up Outreachy for Kubernetes.

We plan to toggle the channel name as and when we change programs.
Rationale behind using the same channel for both programs:
since both programs involve similar process/discussions/conversations,
the channel history is usually useful and has related context.

/hold
for lgtm by @parispittman 