### PR TITLE
Add literal string requirement

### DIFF
--- a/contributors/devel/sig-architecture/conformance-tests.md
+++ b/contributors/devel/sig-architecture/conformance-tests.md
@@ -57,6 +57,7 @@ specifically, a test is eligible for promotion to conformance if:
   enough soak time of the changes and gives folks a chance to kick the tires
   either in the community CI or their own infrastructure to make sure the tests
   are robust
+- it has a name that is a literal string
 
 Examples of features which are not currently eligible for conformance tests:
 


### PR DESCRIPTION
Add conformance requirement for test names in `framework.ConformanceIt` statements to be a literal string.

[`walk.go`](https://github.com/kubernetes/kubernetes/blob/39724859b524e345881eb8ef458f0d5a2f25bd9a/test/conformance/walk.go#L222) fails when a statement contains a non-literal string.