### PR TITLE
Fix the command with KUBE_TIMEOUT

### DIFF
--- a/contributors/devel/sig-testing/testing.md
+++ b/contributors/devel/sig-testing/testing.md
@@ -63,7 +63,7 @@ desire.
 If any unit test fails with a timeout panic (see [#1594](https://github.com/kubernetes/community/issues/1594)) on the testing package, you can increase the `KUBE_TIMEOUT` value as shown below.
 
 ```sh
-make test KUBE_TIMEOUT="-timeout 300s"
+make test KUBE_TIMEOUT="-timeout=300s"
 ```
 
 ### Set go flags during unit tests


### PR DESCRIPTION
When I ran the command,
```sh
make test KUBE_TIMEOUT="-timeout 300s"
```
I got the following error message:
```
can't load package: package k8s.io/kubernetes: no Go files in /home/noguchi/kubernetes/_output/local/go/src/k8s.io/kubernetes
make: *** [test] Error 1
Makefile:185: recipe for target 'test' failed
```

This patch fixes the command above.

ref.
https://github.com/kubernetes/kubernetes/blob/master/hack/make-rules/test.sh#L72
```sh
KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout=120s}
```