### PR TITLE
Updated link to meeting notes

### DIFF
--- a/sig-usability/README.md
+++ b/sig-usability/README.md
@@ -14,7 +14,7 @@ The [charter](charter.md) defines the scope and governance of the Usability Spec
 
 ## Meetings
 * Regular SIG Meeting: [Tuesdays at 14:00 PT (Pacific Time)](https://zoom.us/j/3832562240) (every third week). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1-dYznZR7Q5XCd2bVYoNfMPYs4uNn1aaePQF0q0JQ0uU/).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1gJHgt8RpH4TvqPuC8NtR31-CMqtTYkHy_loxubHq8lg).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0eY-U8DVJWHBwKvMDEtOxx).
 
 ## Leadership

--- a/sig-usability/README.md
+++ b/sig-usability/README.md
@@ -14,7 +14,7 @@ The [charter](charter.md) defines the scope and governance of the Usability Spec
 
 ## Meetings
 * Regular SIG Meeting: [Tuesdays at 14:00 PT (Pacific Time)](https://zoom.us/j/3832562240) (every third week). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1gJHgt8RpH4TvqPuC8NtR31-CMqtTYkHy_loxubHq8lg).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1gJHgt8RpH4TvqPuC8NtR31-CMqtTYkHy_loxubHq8lg/).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0eY-U8DVJWHBwKvMDEtOxx).
 
 ## Leadership

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2138,7 +2138,7 @@ sigs:
     tz: PT (Pacific Time)
     frequency: every third week
     url: https://zoom.us/j/3832562240
-    archive_url: https://docs.google.com/document/d/1-dYznZR7Q5XCd2bVYoNfMPYs4uNn1aaePQF0q0JQ0uU/
+    archive_url: https://docs.google.com/document/d/1gJHgt8RpH4TvqPuC8NtR31-CMqtTYkHy_loxubHq8lg/
     recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP0eY-U8DVJWHBwKvMDEtOxx
   contact:
     slack: sig-usability


### PR DESCRIPTION
SIG Usability README has a link to an empty meeting notes google doc. Updated the link with our first meeting notes document.