### PR TITLE
Add #release-ci-signal Slack channel

### DIFF
--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -1,4 +1,5 @@
 channels:
   - name: sig-release
+  - name: release-ci-signal
   - name: release-management
     id: CJH2GBF7Y


### PR DESCRIPTION
This channel is for CI signal specific conversations.Hoping to help make information easier to find and to provide and to help contributors jump in.

/cc @alenkacz @Verolop @jimangel @soggiest @justaugustus @jberkus

/area release-team
/sig release