### PR TITLE
slack: add aus-nz-dev channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -10,6 +10,7 @@ channels:
     archived: true
   - name: argentina
   - name: arm64
+  - name: aus-nz-dev
   - name: aus-nz-users
   - name: awesome-kubernetes
   - name: aws-authenticator


### PR DESCRIPTION
There is an `aus-nz-users` channel already, this would be nice for contributors in those regions as well.

We discussed this at last APAC coordinator meeting, this PR is to raise it to border audiences.

/sig contributor-experience

/cc @alisondy @DylanGraham 