### PR TITLE
Add slack channel for sig-contribex issue triage team

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -260,6 +260,7 @@ channels:
   - name: sig-configuration
     archived: true
   - name: sig-contribex
+  - name: sig-contribex-triage
   - name: sig-docs
   - name: sig-docs-blog
   - name: sig-docs-maintainers


### PR DESCRIPTION
Purpose of this channel is to set a place where leads and shadows for the new sig-conttribex issue triage team can connect and talk but also for folks who want to be involved.

/assign @parispittman