### PR TITLE
Add channel for release notes team discussion, transparency and continuity

### DIFF
--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -3,3 +3,4 @@ channels:
   - name: release-ci-signal
   - name: release-management
     id: CJH2GBF7Y
+  - name: release-notes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
To follow up from the discussion in [Slack:](
https://kubernetes.slack.com/archives/C1TU9EB9S/p1567608031060200)
I am proposing a new channel for release notes team discussion. 
