### PR TITLE
Delegate storage related slack channels to sig-storage.

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -278,7 +278,6 @@ channels:
   - name: sig-scalability
   - name: sig-scheduling
   - name: sig-service-catalog
-  - name: sig-storage
   - name: sig-testing
   - name: sig-ui
   - name: sig-usability
@@ -316,8 +315,6 @@ channels:
     archived: true
   - name: wg-apply
   - name: wg-component-standard
-  - name: wg-csi
-  - name: wg-csi-migration
   - name: wg-iot-edge
   - name: wg-k8s-infra
   - name: wg-lts

--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -17,4 +17,9 @@ restrictions:
     channels:
       - "^sig-release$"
       - "^release-"
+  - path: "sig-storage/*.yaml"
+    channels:
+      - "^sig-storage$"
+      - "^csi$"
+      - "^csi-"
   - path: "**/*" # prevent any other file from containing anything

--- a/communication/slack-config/sig-storage/OWNERS
+++ b/communication/slack-config/sig-storage/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-storage-leads
+approvers:
+  - sig-storage-leads
+labels:
+  - sig/storage

--- a/communication/slack-config/sig-storage/config.yaml
+++ b/communication/slack-config/sig-storage/config.yaml
@@ -1,0 +1,7 @@
+channels:
+  - name: csi
+    id: C8EJ01Z46
+  - name: csi-migration
+    id: CG04EL876
+  - name: sig-storage
+  


### PR DESCRIPTION
This delegates the `sig-storage` channel and those prefixed with `csi` to the sig-storage-leads.

Channels `wg-csi` and `wg-csi-migration` are renamed to `csi` and `csi-migration` to better conform with slack channel name schema.

/cc @saad-ali @childsb

/hold 