### PR TITLE
Fix broken link in SIG Storage README

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -97,7 +97,7 @@ We hold a public meeting every two weeks, on Thursdays at 9 AM (PT).
 * Recordings of past meetings: https://www.youtube.com/playlist?list=PLb1_clREIGYVaqvKaUsVyXxjfcSQDBnmB
 
 ### Contributing
-Interested in contributing to storage features in Kubernetes? [Please read our guide for new contributors](/sig-storage/contributing.md)
+Interested in contributing to storage features in Kubernetes? [Please read our guide for new contributors](/sig-storage/CONTRIBUTING.md)
 
 ### Links
 * Public Slack Channel: https://kubernetes.slack.com/messages/sig-storage/details/


### PR DESCRIPTION
fixing broken link,
due to the capitalization of the contributing.md file form "contributing.md" to CONTRIBUTING.md" the link doesn't work anymore

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->