### PR TITLE
Add channel for fiaas project

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -73,6 +73,7 @@ channels:
   - name: events
   - name: external-dns
   - name: falco
+  - name: fiaas
   - name: fi-users
   - name: fr-events
   - name: fr-users


### PR DESCRIPTION
[FIAAS](https://fiaas.github.io) is a system that adds PaaS like functionality on top of Kubernetes. It is developed and used by several companies in [Schibsted Media Group](https://www.schibsted.com) and [Adevinta](https://www.adevinta.com). We have recently finalized the process of open sourcing the project, and are looking for ways to engage with what we hope will become a growing community outside the Schibsted and Adevinta companies.

As part of that process, we would like a project channel on the Kubernetes Slack, so that our users can reach out to us and discuss our project.