### PR TITLE
Update descheduler repo location.

### DIFF
--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -51,7 +51,7 @@ The following [subprojects][subproject-definition] are owned by sig-scheduling:
   - https://raw.githubusercontent.com/kubernetes-incubator/cluster-capacity/master/OWNERS
 ### descheduler
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/descheduler/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/OWNERS
 ### kube-batch
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1801,7 +1801,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-incubator/cluster-capacity/master/OWNERS
   - name: descheduler
     owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/descheduler/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/OWNERS
   - name: kube-batch
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS


### PR DESCRIPTION
Descheduler has now been relocated to kubernetes-sigs.
ref: https://github.com/kubernetes/org/issues/1176

/cc @k82cn @ravisantoshgudimetla @aveshagarwal
/hold

