### PR TITLE
Add a Slack channel for KubeOne

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -153,6 +153,7 @@ channels:
   - name: kubekhan
     archived: true
   - name: kubeless
+  - name: kubeone
   - name: kubepack
   - name: kubestack
   - name: kuberhealthy


### PR DESCRIPTION
KubeOne is an open-source project for creating and managing Kubernetes highly-available clusters. It is supposed to work with on any cloud provider, on on-premises (with VMware vSphere and OpenStack), as well as on bare-metal.

The project and more information about it can be found here: https://github.com/kubermatic/kubeone

We would like to have a channel for the project, so we can grow the community, improve the user experience, and communicate with contributors.

I'm not sure do we need a channel moderator, but I'd be happy to take care of that if needed. This channel is supposed to become the main one and replace the one we have on our Kubermatic Slack. If there are any concerns regarding that, please let me know. As far as I know, we don't have any Slack channel on Kubernetes Slack now.