### PR TITLE
adding nais as slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -212,6 +212,7 @@ channels:
     archived: true
   - name: multi-platform
   - name: mysql-operator
+  - name: nais
   - name: navigator
   - name: nl-users
   - name: node-problem-detector


### PR DESCRIPTION
[NAIS](nais.io) is a platform that adds PaaS like functionality on top of Kubernetes. It is developed and used by the Norwegian Labour and Welfare Administration(NAV). This platform has been open source from day one, and are used heavenly inside NAV, and has influenced several other platforms in the public sector in Norway. We think this can be used more broadly.

As part of that process, we would like a project channel on the Kubernetes Slack, so that our users can reach out to us and discuss our project.