### PR TITLE
Add Pod Mentoring Information

### DIFF
--- a/mentoring/mentor-guide.md
+++ b/mentoring/mentor-guide.md
@@ -96,8 +96,8 @@ A former GSoC intern for Kubernetes is now leading this for us - mentoring works
 
 *[Pod Mentoring](mentoring-events.md)*
 * Short group sessions with other mentors during KubeCon/CloudNativeCon events answering mentee questions
-  * Setup to eleminate awkwardness of 1:1s and ensure a wider breadth of knowledge to reduce pressure of having to provide an answer
-  * Requires one of the mentors to be an "anchor", someone who facilitates the conversation
+  * Designed to eliminate the awkwardness of 1:1s and ensure a wider breadth of knowledge to reduce pressure of having to provide an answer
+  * Requires one of the mentors to be an "anchor" who is responsible for facilitating the conversation
   * Great way to learn about struggles of new contributors
 * Mentees will be advised to ask well-formed questions to maximize time for mentor feedback
 

--- a/mentoring/mentor-guide.md
+++ b/mentoring/mentor-guide.md
@@ -94,6 +94,12 @@ A former GSoC intern for Kubernetes is now leading this for us - mentoring works
 * Typically a one hour a quarter time commitment is expected; this is an opt-in sign up.
 * You will need to be on the call 5 minutes early to test audio quality and make sure we are good to go for streaming.
 
+*[Pod Mentoring](mentoring-events.md)*
+* Short group sessions with other mentors during KubeCon/CloudNativeCon events answering mentee questions
+  * Setup to eleminate awkwardness of 1:1s and ensure a wider breadth of knowledge to reduce pressure of having to provide an answer
+  * Requires one of the mentors to be an "anchor", someone who facilitates the conversation
+  * Great way to learn about struggles of new contributors
+* Mentees will be advised to ask well-formed questions to maximize time for mentor feedback
 
 ### Other resources
 TODO - add external resources/links on being a good mentor, etc.

--- a/mentoring/mentoring-events.md
+++ b/mentoring/mentoring-events.md
@@ -1,16 +1,11 @@
 # Mentoring Activities at Events
 
-During events like KubeCon and other related events that arise, there will be the opportunity for mentoring activities. This doc will list those and their respective details. The KubeCon events are run by CNCF/LF and not Contributor Experience although we may advise and members could help out. 
+During events like KubeCon and other related events that arise, there will be the opportunity for mentoring activities. This doc will list those. The KubeCon events are run by CNCF/LF and not Contributor Experience although we may advise and members could help out.
 
----
+## Pod Mentoring
 
-CNCF is hosting another speed networking and mentoring session during [KubeCon + CloudNativeCon Europe 2018](https://events.linuxfoundation.org/kubecon-eu-2018/).  
-Speed Networking & Mentoring Event Details:  
-Date:  Wednesday, May 2  
-Time: 15:40 - 17:00  
-Location: Meeting Rooms 18 & 19  
-Registration: Complimentary - pre-registration required
+Pod mentoring gathers a group of mentors to help you get your Kubernetes-related questions answered quickly and efficiently. More mentors means more breadth of knowledge and experience, resulting in a better chance of at least one person being able to answer your question. It can also mean multiple perspectives since there isn't always one right answer!
 
-Please help spread the word by encouraging KubeCon attendees to sign up for the free session.  Pre-registration for this session is required - so fill out the [MENTOR](https://docs.google.com/forms/d/e/1FAIpQLSe6eClecYb4ZXWPpWDrk7FIqh6qPQPLLnXk9hSqC0b46sXO9Q/viewform) or [MENTEE](https://docs.google.com/forms/d/e/1FAIpQLSdxjqDS59NE1mi42JHDvHngSxBS4lGDDZzmXOLDO7nBawFhJw/viewform) forms today.
+To be respectul of each mentors time, please have succinct questions ready and a brief summary of what you've tried and what you'd like or expect to happen. For instance, an example of a poor question would be, "How do I write a controller?" An example of a good question would be, "I'd like to create a custom controller that checks for nodes that are in the 'Not Ready' state and print our their IP address. I'm not familiar with Golang so instead of using client-go I've looked at MetaController as a way to get started using Javascript. I'm having trouble with this portion of the webhook, can you please take a look?"
 
-The session is for those who are new or not so new to the community. Mentees are  paired with mentors from across the community and CNCF projects and have the opportunity to explore growing a cloud native career, getting more involved in the ecosystem or working with new, emerging projects in areas like networking or service meshes.  
+Pod mentoring will be avaialble during KubeCon + CloudNativeCon events. You will need to register to attend to be eligible for mentoring. For those who wish to be a mentor please take a look at the [mentor-guide](mentor-guide.md).

--- a/mentoring/mentoring-events.md
+++ b/mentoring/mentoring-events.md
@@ -8,4 +8,4 @@ Pod mentoring gathers a group of mentors to help you get your Kubernetes-related
 
 To be respectul of each mentors time, please have succinct questions ready and a brief summary of what you've tried and what you'd like or expect to happen. For instance, an example of a poor question would be, "How do I write a controller?" An example of a good question would be, "I'd like to create a custom controller that checks for nodes that are in the 'Not Ready' state and print our their IP address. I'm not familiar with Golang so instead of using client-go I've looked at MetaController as a way to get started using Javascript. I'm having trouble with this portion of the webhook, can you please take a look?"
 
-Pod mentoring will be avaialble during KubeCon + CloudNativeCon events. You will need to register to attend to be eligible for mentoring. For those who wish to be a mentor please take a look at the [mentor-guide](mentor-guide.md).
+Pod mentoring will be available during KubeCon + CloudNativeCon events. You will need to register to attend to be eligible for mentoring. For those who wish to be a mentor please take a look at the [mentor-guide](mentor-guide.md).


### PR DESCRIPTION
I changed the focus from "speed mentoring" to "pod mentoring". It seems like the speed portion is more of a feature rather than the main idea, which is getting a group of mentors together to answer questions.

* Added Pod Mentoring information for potential mentors
* Added Pod Mentoring information for potential mentees

Fixes https://github.com/kubernetes/community/issues/3744