### PR TITLE
fix typo in documentation

### DIFF
--- a/contributors/guide/owners.md
+++ b/contributors/guide/owners.md
@@ -260,7 +260,7 @@ pieces of prow are used to implement the code review process above.
 - [plugin: approve](https://git.k8s.io/test-infra/prow/plugins/approve)
   - per-repo configuration:
     - `issue_required`: defaults to `false`; when `true`, require that the PR description link to
-      an issue, or that at least one **approver** issues a `/approve no-isse`
+      an issue, or that at least one **approver** issues a `/approve no-issue`
     - `implicit_self_approve`: defaults to `false`; when `true`, if the PR author is in relevant
       OWNERS files, act as if they have implicitly `/approve`'d
   - adds the  `approved` label once an **approver** for each of the required


### PR DESCRIPTION
I think that there is a typo in the documentation when using the issue_required option I assume the value of the comment should be:

/approve no-issue instead of /approve no-isse

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->