### PR TITLE
Request for a new slack channel to collaborate chaos engineering on K8S

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -177,6 +177,7 @@ channels:
   - name: leadership-summit
     archived: true
   - name: linode
+  - name: litmus
   - name: malaysia-users
   - name: malta-users
   - name: meet-our-contributors


### PR DESCRIPTION
The open source chaos engineering project "Litmus" is a tool set for orchestrating chaos on Kubernetes. The project is at https://github.com/litmuschaos . As the users of this project will be in the Kubernetes community, we are requesting a separate channel to collaborate the communication.

Signed-off-by: Uma Mukkara <uma@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->