### PR TITLE
generator: don't specify company for emeritus_leads

### DIFF
--- a/generator/app.go
+++ b/generator/app.go
@@ -68,7 +68,7 @@ func (x FoldedString) MarshalYAML() (interface{}, error) {
 type Person struct {
 	GitHub  string
 	Name    string
-	Company string
+	Company string `yaml:"company,omitempty"`
 }
 
 // Meeting represents a regular meeting for a group.
@@ -233,11 +233,15 @@ func (c *Context) Validate() []error {
 			for prefix, persons := range group.Leadership.PrefixToPersonMap() {
 				for _, person := range persons {
 					if val, ok := people[person.GitHub]; ok {
-						if val.Name != person.Name || val.Company != person.Company {
+						if val.Name != person.Name || (prefix != "emeritus_lead" && val.Company != person.Company) {
 							errors = append(errors, fmt.Errorf("%s: %ss: expected person: %v, got: %v", group.Dir, prefix, val, person))
 						}
-					} else {
+					} else if prefix != "emeritus_lead" {
 						people[person.GitHub] = person
+					}
+
+					if prefix == "emeritus_lead" && person.Company != "" {
+						errors = append(errors, fmt.Errorf("%s: emeritus leads should not have company specified; company specified for: %s", group.Dir, person.Name))
 					}
 				}
 			}

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -42,7 +42,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 
 ## Emeritus Leads
 {{ range .Leadership.EmeritusLeads }}
-* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**)
 {{- end }}
 {{- end }}
 {{- end }}

--- a/generator/ug_readme.tmpl
+++ b/generator/ug_readme.tmpl
@@ -30,7 +30,7 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 
 ## Emeritus Organizers
 {{ range .Leadership.EmeritusLeads }}
-* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**)
 {{- end }}
 {{- end }}
 {{- end }}

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -36,7 +36,7 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 
 ## Emeritus Organizers
 {{ range .Leadership.EmeritusLeads }}
-* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**)
 {{- end }}
 {{- end }}
 {{- end }}

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -38,8 +38,8 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 
 ## Emeritus Leads
 
-* Eric Chiang (**[@ericchiang](https://github.com/ericchiang)**), Red Hat
-* Eric Tune (**[@erictune](https://github.com/erictune)**), Google
+* Eric Chiang (**[@ericchiang](https://github.com/ericchiang)**)
+* Eric Tune (**[@erictune](https://github.com/erictune)**)
 
 ## Contact
 - Slack: [#sig-auth](https://kubernetes.slack.com/messages/sig-auth)

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -34,8 +34,8 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 
 ## Emeritus Leads
 
-* Tony Ado (**[@AdoHe](https://github.com/AdoHe)**), Alibaba
-* Fabiano Franz (**[@fabianofranz](https://github.com/fabianofranz)**), Red Hat
+* Tony Ado (**[@AdoHe](https://github.com/AdoHe)**)
+* Fabiano Franz (**[@fabianofranz](https://github.com/fabianofranz)**)
 
 ## Contact
 - Slack: [#sig-cli](https://kubernetes.slack.com/messages/sig-cli)

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -27,8 +27,8 @@ The Chairs of the SIG run operations and processes governing the SIG.
 
 ## Emeritus Leads
 
-* Chris Hoge (**[@hogepodge](https://github.com/hogepodge)**), OpenStack Foundation
-* Jago Macleod (**[@jagosan](https://github.com/jagosan)**), Google
+* Chris Hoge (**[@hogepodge](https://github.com/hogepodge)**)
+* Jago Macleod (**[@jagosan](https://github.com/jagosan)**)
 
 ## Contact
 - Slack: [#sig-cloud-provider](https://kubernetes.slack.com/messages/sig-cloud-provider)

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -55,8 +55,8 @@ The Chairs of the SIG run operations and processes governing the SIG.
 
 ## Emeritus Leads
 
-* Lucas Käldström (**[@luxas](https://github.com/luxas)**), Luxas Labs (occasionally contracting for Weaveworks)
-* Robert Bailey (**[@roberthbailey](https://github.com/roberthbailey)**), Google
+* Lucas Käldström (**[@luxas](https://github.com/luxas)**)
+* Robert Bailey (**[@roberthbailey](https://github.com/roberthbailey)**)
 
 ## Contact
 - Slack: [#sig-cluster-lifecycle](https://kubernetes.slack.com/messages/sig-cluster-lifecycle)

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -34,7 +34,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 
 ## Emeritus Leads
 
-* Garrett Rodrigues (**[@grodrigues3](https://github.com/grodrigues3)**), Google
+* Garrett Rodrigues (**[@grodrigues3](https://github.com/grodrigues3)**)
 
 ## Contact
 - Slack: [#sig-contribex](https://kubernetes.slack.com/messages/sig-contribex)

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -34,8 +34,8 @@ The Chairs of the SIG run operations and processes governing the SIG.
 
 ## Emeritus Leads
 
-* Andrew Chen (**[@chenopis](https://github.com/chenopis)**), Google
-* Jared Bhatti (**[@jaredbhatti](https://github.com/jaredbhatti)**), Google
+* Andrew Chen (**[@chenopis](https://github.com/chenopis)**)
+* Jared Bhatti (**[@jaredbhatti](https://github.com/jaredbhatti)**)
 
 ## Contact
 - Slack: [#sig-docs](https://kubernetes.slack.com/messages/sig-docs)

--- a/sig-pm/README.md
+++ b/sig-pm/README.md
@@ -32,8 +32,8 @@ The Chairs of the SIG run operations and processes governing the SIG.
 
 ## Emeritus Leads
 
-* Aparna Sinha (**[@apsinha](https://github.com/apsinha)**), Google
-* Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**), CNCF
+* Aparna Sinha (**[@apsinha](https://github.com/apsinha)**)
+* Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**)
 
 ## Contact
 - Slack: [#sig-pm](https://kubernetes.slack.com/messages/sig-pm)

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -28,7 +28,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 
 ## Emeritus Leads
 
-* Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**), Google
+* Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**)
 
 ## Contact
 - Slack: [#sig-release](https://kubernetes.slack.com/messages/sig-release)

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -28,7 +28,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 
 ## Emeritus Leads
 
-* Bobby (Babak) Salamat (**[@bsalamat](https://github.com/bsalamat)**), Google
+* Bobby (Babak) Salamat (**[@bsalamat](https://github.com/bsalamat)**)
 
 ## Contact
 - Slack: [#sig-scheduling](https://kubernetes.slack.com/messages/sig-scheduling)

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -27,13 +27,13 @@ The Chairs of the SIG run operations and processes governing the SIG.
 
 ## Emeritus Leads
 
-* Aaron Schlesinger (**[@arschles](https://github.com/arschles)**), Microsoft
-* Carolyn Van Slyck (**[@carolynvs](https://github.com/carolynvs)**), Microsoft
-* Doug Davis (**[@duglin](https://github.com/duglin)**), IBM
-* Jay Boyd (**[@jboyd01](https://github.com/jboyd01)**), Red Hat
-* Michael Kibbe (**[@kibbles-n-bytes](https://github.com/kibbles-n-bytes)**), Google
-* Paul Morie (**[@pmorie](https://github.com/pmorie)**), Red Hat
-* Ville Aikas (**[@vaikas-google](https://github.com/vaikas-google)**), Google
+* Aaron Schlesinger (**[@arschles](https://github.com/arschles)**)
+* Carolyn Van Slyck (**[@carolynvs](https://github.com/carolynvs)**)
+* Doug Davis (**[@duglin](https://github.com/duglin)**)
+* Jay Boyd (**[@jboyd01](https://github.com/jboyd01)**)
+* Michael Kibbe (**[@kibbles-n-bytes](https://github.com/kibbles-n-bytes)**)
+* Paul Morie (**[@pmorie](https://github.com/pmorie)**)
+* Ville Aikas (**[@vaikas-google](https://github.com/vaikas-google)**)
 
 ## Contact
 - Slack: [#sig-service-catalog](https://kubernetes.slack.com/messages/sig-service-catalog)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -342,10 +342,8 @@ sigs:
     emeritus_leads:
     - github: ericchiang
       name: Eric Chiang
-      company: Red Hat
     - github: erictune
       name: Eric Tune
-      company: Google
   meetings:
   - description: Regular SIG Meeting
     day: Wednesday
@@ -558,10 +556,8 @@ sigs:
     emeritus_leads:
     - github: AdoHe
       name: Tony Ado
-      company: Alibaba
     - github: fabianofranz
       name: Fabiano Franz
-      company: Red Hat
   meetings:
   - description: Regular SIG Meeting
     day: Wednesday
@@ -642,10 +638,8 @@ sigs:
     emeritus_leads:
     - github: hogepodge
       name: Chris Hoge
-      company: OpenStack Foundation
     - github: jagosan
       name: Jago Macleod
-      company: Google
   meetings:
   - description: Regular SIG Meeting
     day: Wednesday
@@ -809,10 +803,8 @@ sigs:
     emeritus_leads:
     - github: luxas
       name: Lucas Käldström
-      company: Luxas Labs (occasionally contracting for Weaveworks)
     - github: roberthbailey
       name: Robert Bailey
-      company: Google
   meetings:
   - description: Cluster API (AWS implementation) office hours
     day: Monday
@@ -1041,7 +1033,6 @@ sigs:
     emeritus_leads:
     - github: grodrigues3
       name: Garrett Rodrigues
-      company: Google
   meetings:
   - description: Regular SIG Meeting
     day: Wednesday
@@ -1170,10 +1161,8 @@ sigs:
     emeritus_leads:
     - github: chenopis
       name: Andrew Chen
-      company: Google
     - github: jaredbhatti
       name: Jared Bhatti
-      company: Google
   meetings:
   - description: APAC SIG Meeting
     day: Wednesday
@@ -1564,10 +1553,8 @@ sigs:
     emeritus_leads:
     - github: apsinha
       name: Aparna Sinha
-      company: Google
     - github: idvoretskyi
       name: Ihor Dvoretskyi
-      company: CNCF
   meetings:
   - description: Regular SIG Meeting
     day: Tuesday
@@ -1605,7 +1592,6 @@ sigs:
     emeritus_leads:
     - github: jdumars
       name: Jaice Singer DuMars
-      company: Google
   meetings:
   - description: Regular SIG Meeting
     day: Monday
@@ -1767,7 +1753,6 @@ sigs:
     emeritus_leads:
     - github: bsalamat
       name: Bobby (Babak) Salamat
-      company: Google
   meetings:
   - description: 10AM PT Meeting
     day: Thursday
@@ -1839,25 +1824,18 @@ sigs:
     emeritus_leads:
     - github: arschles
       name: Aaron Schlesinger
-      company: Microsoft
     - github: carolynvs
       name: Carolyn Van Slyck
-      company: Microsoft
     - github: duglin
       name: Doug Davis
-      company: IBM
     - github: jboyd01
       name: Jay Boyd
-      company: Red Hat
     - github: kibbles-n-bytes
       name: Michael Kibbe
-      company: Google
     - github: pmorie
       name: Paul Morie
-      company: Red Hat
     - github: vaikas-google
       name: Ville Aikas
-      company: Google
   meetings:
   - description: Regular SIG Meeting
     day: Monday
@@ -2484,7 +2462,6 @@ workinggroups:
     emeritus_leads:
     - github: davidopp
       name: David Oppenheimer
-      company: Google
   meetings:
   - description: Regular WG Meeting
     day: Tuesday

--- a/wg-multitenancy/README.md
+++ b/wg-multitenancy/README.md
@@ -30,7 +30,7 @@ Define the models of multitenancy that Kubernetes will support. Discuss and exec
 
 ## Emeritus Organizers
 
-* David Oppenheimer (**[@davidopp](https://github.com/davidopp)**), Google
+* David Oppenheimer (**[@davidopp](https://github.com/davidopp)**)
 
 ## Contact
 - Slack: [#wg-multitenancy](https://kubernetes.slack.com/messages/wg-multitenancy)


### PR DESCRIPTION
If we end up specifying the company for emeritus leads, we could end up with stale information. Moreover, we don't gain any specific value from company info of emeritus leads either.

They shouldn't be required to update sigs.yaml in case they switch companies, especially if they've decided to step away from the project.

/hold
for discussion

/assign @cblecker 