### PR TITLE
Add channel for Kubernetes Edinburgh Meetup Group

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -186,6 +186,7 @@ channels:
   - name: meetup-bordeaux
   - name: meetup-boston
   - name: meetup-dfw
+  - name: meetup-edinburgh
   - name: meetup-guatemala
   - name: meetup-hannover
   - name: meetup-hongkong


### PR DESCRIPTION
Add a dedicated Slack channel for use by members of the [Kubernetes Edinburgh Meetup Group](https://www.meetup.com/Kubernetes-Edinburgh/), to be able to discuss and coordinate things such as topics for future events.