### PR TITLE
Update reference-docs repo location.

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -64,7 +64,7 @@ The following [subprojects][subproject-definition] are owned by sig-docs:
   - https://raw.githubusercontent.com/kubernetes/website/master/content/en/blog/OWNERS
 ### reference-docs
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/reference-docs/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/reference-docs/master/OWNERS
 ### website
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1231,7 +1231,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/website/master/content/en/blog/OWNERS
   - name: reference-docs
     owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/reference-docs/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/reference-docs/master/OWNERS
   - name: website
     owners:
     - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS


### PR DESCRIPTION
The reference-docs repo has now been migrated to kubernetes-sigs.

Ref: https://github.com/kubernetes/org/issues/1158

/cc @jimangel 
 /hold