### PR TITLE
FIxed invalid owners file in sigs.yaml

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -53,7 +53,8 @@ The following [subprojects][subproject-definition] are owned by sig-api-machiner
   - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/resourcequota/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/v1/OWNERS
 ### idl-schema-client-pipeline
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -61,7 +61,8 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/resourcequota/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/v1/OWNERS
   - name: idl-schema-client-pipeline
     owners:
     - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS


### PR DESCRIPTION
The file https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/OWNERS does not exist. 

Assuming the one in the V1 directory is the correct file, so updated sigs.yaml with a valid owners file: https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/v1/OWNERS