### PR TITLE
Add KubeCon lightning talk to release-notes docs

### DIFF
--- a/contributors/guide/release-notes.md
+++ b/contributors/guide/release-notes.md
@@ -35,3 +35,7 @@ For pull requests that don't need to be mentioned at release time, use the `/rel
 To see how to format your release notes, view the kubernetes/kubernetes [pull request template](https://git.k8s.io/kubernetes/.github/PULL_REQUEST_TEMPLATE.md) for a brief example. Pull Request titles and body comments can be modified at any time prior to the release to make them friendly for release notes.
 
 Release notes apply to pull requests on the master branch. For patch release branches the automated cherry-pick pull requests process (see the [cherry-pick instructions](/contributors/devel/sig-release/cherry-picks.md)) should be followed.  That automation will pull release notes from the master branch PR from which the cherry-pick originated. On a rare occasion a pull request on a patch release branch is not a cherry-pick, but rather is targeted directly to the non-master branch and in this case, a `release-note-*` label is required for that non-master pull request.
+
+## Related
+
+* [Behind The Scenes: Kubernetes Release Notes Tips & Tricks - Mike Arpaia, Kolide (KubeCon 2018 Lightning Talk)](https://www.youtube.com/watch?v=n62oPohOyYs)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

This PR adds a link to @marpaia's talk at KubeCon to the release notes documentation.

I just recently had the need to add a release note to my PR for the first time and was a bit lost because I couldn't quickly find more information about why and how. I found this talk incredibly helpful and a good addition to the written documentation.

Ref [release/#883](https://github.com/kubernetes/release/pull/883)