### PR TITLE
Document component-standard issues /w custom content

### DIFF
--- a/wg-component-standard/README.md
+++ b/wg-component-standard/README.md
@@ -35,4 +35,17 @@ Develop a standard foundation (philosophy and libraries) for core Kubernetes com
     - [@kubernetes/wg-component-standard](https://github.com/orgs/kubernetes/teams/wg-component-standard) - Component Standard Discussion
 <!-- BEGIN CUSTOM CONTENT -->
 
+## Issues
+* [Project Board](https://github.com/orgs/kubernetes/projects/26)
+* [kubernetes/kubernetes Issues / PR's needing Review](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=label%3Awg%2Fcomponent-standard+)
+
+Issues are opened in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) or the appropriate project/component repo with the `wg/component-standard` label.  
+To apply this label to an issue using Prow, leave a comment containing `/wg component-standard` on its own line.  
+
+[kubernetes/component-base](https://github.com/kubernetes/component-base) is an automated staging repository managed from the ./staging directory in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes). Issues are not currently looked at on this repo.  
+
+Adding issues to the project board is helpful.  
+The `wg/component-standard` label is used in other org's repos such as [kubernetes-sigs/kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) meaning you can't link them easily in the Project Board.  
+For repos outside of the kubernetes org, You can add(`+`) a note with links to the issues on the Project Board.  
+
 <!-- END CUSTOM CONTENT -->


### PR DESCRIPTION
Fixes #4117
/kind documentation
/wg component-standard
/sig cluster-lifecycle

This patch uses custom content.
The trade-off is that the information is at the bottom. Not everyone reads until the end.
Alternative to #4137

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->