### PR TITLE
Add Sslack channel for wg-component-standard mentorship program

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -323,6 +323,7 @@ channels:
     archived: true
   - name: wg-apply
   - name: wg-component-standard
+  - name: wg-component-standard-mentorship
   - name: wg-iot-edge
   - name: wg-k8s-infra
   - name: wg-lts


### PR DESCRIPTION
We recently signed up ~15 new contributors for mentorship in our working
group, and @parispittman suggested we provision a special Slack channel
for our mentorship program.