### PR TITLE
cluster-lifecycle: Move capz from SIG Cloud Provider to SIG CL

### DIFF
--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -83,7 +83,6 @@ The following [subprojects][subproject-definition] are owned by sig-cloud-provid
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
 - **Meetings:**
   - Azure Subproject Meeting (First Monday): [Mondays at 14:30 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (monthly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:30&tz=UTC).

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -88,6 +88,9 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
 ### cluster-api-provider-aws
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
+### cluster-api-provider-azure
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
 ### cluster-api-provider-digitalocean
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -729,7 +729,6 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/OWNERS
     meetings:
     - description: Azure Subproject Meeting (First Monday)
@@ -945,6 +944,9 @@ sigs:
   - name: cluster-api-provider-aws
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
+  - name: cluster-api-provider-azure
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
   - name: cluster-api-provider-digitalocean
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS


### PR DESCRIPTION
Now that the cloud provider SIG consolidation is complete and we've [buffed the OWNERS files](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/285) for capz, I'd like to official move capz in as a subproject of SIG Cluster Lifecycle (where it belongs).

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/284

/assign @timothysc @andrewsykim 
cc: @vincepri @CecileRobertMichon @soggiest @awesomenix @juan-lee @serbrech 