### PR TITLE
add new Slack channel for VMware User Group

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -313,6 +313,7 @@ channels:
   - name: tw-users
   - name: ug-big-data
     id: C0ELB338T
+  - name: ug-vmware
   - name: velero
   - name: virtlet
   - name: virtual-kubelet


### PR DESCRIPTION
The purpose of this Slack channel is to support activity associated with the new [VMware User Group](https://github.com/kubernetes/community/tree/master/ug-vmware-users) add with this [PR](https://github.com/kubernetes/community/pull/4083)

This channel will have some discussions closely aligned with the VMware cloud provider, but discourse will be about Kubernetes user focused topics and not proprietary information related to the provider.

