### PR TITLE
Update old glog references to klog

### DIFF
--- a/contributors/devel/README.md
+++ b/contributors/devel/README.md
@@ -32,7 +32,7 @@ Guide](http://kubernetes.io/docs/admin/).
 * **Hunting flaky tests** ([flaky-tests.md](sig-testing/flaky-tests.md)): We have a goal of 99.9% flake free tests.
   Here's how to run your tests many times.
 
-* **Logging Conventions** ([logging.md](sig-instrumentation/logging.md)): Glog levels.
+* **Logging Conventions** ([logging.md](sig-instrumentation/logging.md)): klog levels.
 
 * **Profiling Kubernetes** ([profiling.md](sig-scalability/profiling.md)): How to plug in go pprof profiler to Kubernetes.
 

--- a/contributors/devel/sig-api-machinery/controllers.md
+++ b/contributors/devel/sig-api-machinery/controllers.md
@@ -123,7 +123,7 @@ func (c *Controller) Run(threadiness int, stopCh chan struct{}) {
 	// make sure the work queue is shutdown which will trigger workers to end
 	defer c.queue.ShutDown()
 
-	glog.Infof("Starting <NAME> controller")
+	klog.Infof("Starting <NAME> controller")
 
 	// wait for your secondary caches to fill before starting your work
 	if !cache.WaitForCacheSync(stopCh, c.podsSynced) {
@@ -140,7 +140,7 @@ func (c *Controller) Run(threadiness int, stopCh chan struct{}) {
 
 	// wait until we're told to stop
 	<-stopCh
-	glog.Infof("Shutting down <NAME> controller")
+	klog.Infof("Shutting down <NAME> controller")
 }
 
 func (c *Controller) runWorker() {


### PR DESCRIPTION
Caught a few old references of `glog` and update them to `klog`.

There are still 2 remaining but wasn't sure if they should be updated since they are older design proposal. Happy to include them here if so.

- [contributors/design-proposals/storage/volumes.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/volumes.md)
- [contributors/design-proposals/storage/attacher-detacher-refactor-for-local-storage.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/attacher-detacher-refactor-for-local-storage.md)