### PR TITLE
contributor-guide: add note about #pr-reviews channel

### DIFF
--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -218,6 +218,8 @@ other forms of work that would be stored within a git repository.
   till the `[WIP]` or hold is lifted.
 - If you have not had your PR reviewed, do not close and open a new PR with the
   same changes. Ping your reviewers in a comment with `@<github username>`.
+- If your PR isn't getting enough attention, post a link to the PR in the
+  `#pr-reviews` channel on Slack to find additional reviewers.
 
 
 #### Example PR Description

--- a/contributors/guide/pull-requests.md
+++ b/contributors/guide/pull-requests.md
@@ -172,6 +172,8 @@ things you can do to move the process along:
 
    * If you have fixed all the issues from a review, and you haven't heard back, you should ping the assignee on the comment stream with a "please take another look" (`PTAL`) or similar comment indicating that you are ready for another review.
 
+   * If you still don't hear back, post a link to the pull request in the `#pr-reviews` channel on Slack to find additional reviewers.
+
 Read on to learn more about how to get faster reviews by following best practices.
 
 # Best Practices for Faster Reviews


### PR DESCRIPTION
Especially because we link to https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#why-is-my-pull-request-not-getting-reviewed as `recommended escalation practices` in the bot comment for new contributors' PRs (https://github.com/kubernetes/org/pull/1313#issuecomment-542466991).

/cc @castrojo @guineveresaenger @mrbobbytables 