### PR TITLE
Add public steering-committee slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -297,6 +297,7 @@ channels:
   - name: spark-operator
   - name: spinnaker
   - name: sre
+  - name: steering-committee
   - name: summit-staff
   - name: suse-caasp
   - name: talk-proposals


### PR DESCRIPTION
The private steering slack channel is also called `steering-committee`, we should probably rename that to `steering-private` first.

/hold
/cc @kubernetes/steering-committee 