### PR TITLE
Add meetup-egypt channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -188,6 +188,7 @@ channels:
   - name: meetup-boston
   - name: meetup-dfw
   - name: meetup-edinburgh
+  - name: meetup-egypt
   - name: meetup-guatemala
   - name: meetup-hannover
   - name: meetup-hongkong


### PR DESCRIPTION
Add a dedicated Slack channel for use by members of the [Kubernetes Cairo Meetup Group](https://www.meetup.com/Cairo-Kubernetes-Meetup/), to be able to discuss and coordinate things such as topics for future events, speakers, feedback, etc.