### PR TITLE
sig-network: move external-dns from k-incubator k-sigs

### DIFF
--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -44,7 +44,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-network:
 ### external-dns
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/external-dns/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/external-dns/master/OWNERS
 - **Contact:**
   - Slack: [#external-dns](https://kubernetes.slack.com/messages/external-dns)
 ### ingress

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1433,7 +1433,7 @@ sigs:
     contact:
       slack: external-dns
     owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/external-dns/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/external-dns/master/OWNERS
   - name: ingress
     owners:
     - https://raw.githubusercontent.com/kubernetes/ingress-gce/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1286

/assign @thockin @dcbw @caseydavenport 

/hold
for lgtm by sig network leads