### PR TITLE
steering: remove spartakus from sigs.yaml

### DIFF
--- a/committee-steering/README.md
+++ b/committee-steering/README.md
@@ -45,10 +45,6 @@ Funding requests for project infrastructure, events, and consulting
 Template for starting new projects in the GitHub organizations owned by Kubernetes.
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
-### spartakus
-Collection of usage information about Kubernetes clusters.
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
 ### steering
 Steering Committee policy and documentation
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2795,10 +2795,6 @@ committees:
       by Kubernetes.
     owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
-  - name: spartakus
-    description: Collection of usage information about Kubernetes clusters.
-    owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/spartakus/master/OWNERS
   - name: steering
     description: Steering Committee policy and documentation
     owners:


### PR DESCRIPTION
Ref https://github.com/kubernetes/org/issues/1354

The repo has been retired: https://github.com/kubernetes-retired/spartakus
