### PR TITLE
Add channel for production readiness review team

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -224,6 +224,7 @@ channels:
   - name: pharmer
   - name: pl-users
   - name: pr-reviews
+  - name: prod-readiness
   - name: prometheus
   - name: prometheus-operator
   - name: prow


### PR DESCRIPTION
This channel will be used to coordinate development of the production [readiness review process](https://github.com/kubernetes/enhancements/blob/37c1f0266a6371ca0ccc53965cfb376a53821000/keps/sig-architecture/20190731-production-readiness-review-process.md).