### PR TITLE
Adding channel for discussion of the distroless containers

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -47,6 +47,7 @@ channels:
   - name: de-users
   - name: devstats
   - name: digitalocean-k8s
+  - name: distroless
   - name: diversity
   - name: draft-dev
   - name: draft-users


### PR DESCRIPTION
This channel would be used to discuss issues with and roadmap for the distroless containers developed here:
https://github.com/GoogleContainerTools/distroless