### PR TITLE
sig-instrumentation: move metrics-server from k-incubator to k-sigs

### DIFF
--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -62,7 +62,7 @@ The following [subprojects][subproject-definition] are owned by sig-instrumentat
   - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
 ### metrics-server
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/metrics-server/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/OWNERS
 ### mutating-trace-admission-controller
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1308,7 +1308,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
   - name: metrics-server
     owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/metrics-server/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/OWNERS
   - name: mutating-trace-admission-controller
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/1382

/cc @serathius 
/assign @brancz @piosz

/hold
for sign off from leads