### PR TITLE
Add crash-diagnostics channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -41,6 +41,7 @@ channels:
   - name: compliance-hipaa
   - name: contour
   - name: contributor-summit
+  - name: crash-diagnostics
   - name: crd-installation
   - name: crio
   - name: de-events


### PR DESCRIPTION
Crash Recovery and Diagnostics for Kubernetes (Crash Diagnostics for short) is designed to help human operators who are investigating and troubleshooting unhealthy or unresponsive Kubernetes clusters. It is a project designed to automate the diagnosis of problem clusters that may be in an unstable state including completely inoperable.

We would like to have a channel dedicated to the project in the K8s Slack, to share experiences and grow the community.

The project can be found here: https://github.com/vmware-tanzu/crash-diagnostics

Signed-off-by: jonasrosland <jrosland@vmware.com>
