### PR TITLE
[WIP] Document patch strategy markers in api-conventions

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -596,11 +596,12 @@ In the context of strategic merge patch, a set of go markers can be used by API 
 
 | Marker | Definition |
 |--------|------------|
-| `// +patchStrategy=merge/replace` |  Defines that the merge strategy will be to merge elements of the two lists into one (merge), use the list provided in the patch literally rather than merging (replace) |
-| `// +patchMergeKey=<key-name>` |  This is applicable in the context of lists being used as maps/dictionaries, i.e. with each entry in the list seen as a key-value pair, with a specific field considered the key. `patchMergeKey` defines what field should be seen as the key. Combined with `patchStrategy`, this describes what changes should take place on specific elements of a list as part of a patch operation. |
-| `// +listType=atomic/set/associative` |            |
-| `// +mapType=separate/atomic` |            |
-| `// +structType=separate/atomic` |            |
+| `//+patchStrategy=merge/replace` |  Defines that the merge strategy will be to: merge elements of the two lists into one (if set to merge), or use the list provided in the patch literally rather than merging (if set to replace) |
+| `// +patchMergeKey=<key-name>` |  Applicable in the context of lists being used as maps/dictionaries, i.e. with each entry in the list seen as a key-value pair, with a specific field considered the key. `patchMergeKey` defines what field should be seen as the key. Combined with `patchStrategy`, this describes what changes should take place on specific elements of a list as part of a patch operation. |
+| `//+listType=atomic/set/map` |  Applicable to objects that are of type list. If set to `atomic`, it defines that a single actor can replace the entire list, but cannot change individual elements of it. If not set to `atomic`, different actors can update individual elements in the list. In that case, the listType can either be `set` (contains scalar elements) or `map` (contains map-like elements). |
+| `//+listMapKeys=<list of keys>` |  Applicable in the context of lists being used as maps/dictionaries. A list of strings, that defines which combination of keys should be used as the identifier of each element.          |
+| `//+mapType=atomic/granular` |  If set to `atomic`, a single actor can replace the map entirely. If set to `granular`, multiple actors can update individual map entries seprately. |
+| `//+structType=atomic/granular` |  If set to `atomic`, a single actor can replace the struct entirely. If set to `granular`, multiple actors can update individual struct fields seprately. |
 
 
 

--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -591,6 +591,19 @@ saved. For more details on how to use Merge Patch, see the RFC.
 detailed explanation of how it works and why it needed to be introduced, see
 [here](/contributors/devel/sig-api-machinery/strategic-merge-patch.md).
 
+#### Defining Patch Strategy
+In the context of strategic merge patch, a set of go markers can be used by API authors to define the merge strategy of collections of fields (lists, maps and structs).
+
+| Marker | Definition |
+|--------|------------|
+| `// +patchStrategy=merge/replace` |  Defines that the merge strategy will be to merge elements of the two lists into one (merge), use the list provided in the patch literally rather than merging (replace) |
+| `// +patchMergeKey=<key-name>` |  This is applicable in the context of lists being used as maps/dictionaries, i.e. with each entry in the list seen as a key-value pair, with a specific field considered the key. `patchMergeKey` defines what field should be seen as the key. Combined with `patchStrategy`, this describes what changes should take place on specific elements of a list as part of a patch operation. |
+| `// +listType=atomic/set/associative` |            |
+| `// +mapType=separate/atomic` |            |
+| `// +structType=separate/atomic` |            |
+
+
+
 ## Idempotency
 
 All compatible Kubernetes APIs MUST support "name idempotency" and respond with

--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -599,10 +599,10 @@ In the context of [strategic merge patch](/contributors/devel/sig-api-machinery/
 | `//+patchStrategy=merge` |  Defines that the merge strategy will be to merge elements of the two lists into one. |
 | `//+patchStrategy=replace` (default)|  Defines that the merge strategy will be touse the list provided in the patch literally rather than merging. |
 | `// +patchMergeKey=<key-name>` |  Applicable in the context where lists are used as maps/dictionaries, i.e. where each list entry is a key-value pair. `patchMergeKey` defines which field should be seen as the key. Combined with `patchStrategy`, this describes what changes should take place on specific elements of a list as part of a patch operation. |
-| `//+listType=atomic/set/map` |  Applicable to objects that are of type list. A single actor can replace the entire list, but cannot change individual elements of it. Unless set to `atomic`, different actors can update individual elements in the list. In that case, the listType can either be `set` (contains scalar elements only) or `map` (contains map-like elements). |
-| `//+listType=set` |  Applicable to objects that are of type list, and the elements are scalar. Different actors can update individual elements in the list.  |
+| `//+listType=atomic` |  Applicable to objects that are of type list. A single actor owns and can replace the entire list, but cannot change individual elements of it. |
+| `//+listType=set` |  Applicable to objects that are of type list, and the elements are unique and scalar. Different actors can update individual elements in the list. |
 | `//+listType=map` |  Applicable to objects that are of type list, and elements are map-like, i.e. lists that are used as dictionaries. Different actors can update individual elements in the list. |
-| `//+listMapKeys=<list of keys>` |  Applicable in the context where `listType=map`. `listMapKeys` a list of strings, that defines which combination of keys should be used as the identifier of each element. |
+| `//+listMapKeys=<list of keys>` |  Applicable in the context where `listType=map`. `listMapKeys` is a list of strings, that defines which combination of keys should be used as the identifier of each element. Combinations of `listMapKeys` must be unique. Values of keys may be of any scalar type. |
 | `//+mapType=atomic` |  A single actor can only replace the map entirely. |
 | `//+mapType=granular` (default) | Multiple actors can update individual map entries separately. |
 | `//+structType=atomic` |  A single actor can only replace the struct entirely. |

--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -591,17 +591,17 @@ saved. For more details on how to use Merge Patch, see the RFC.
 detailed explanation of how it works and why it needed to be introduced, see
 [here](/contributors/devel/sig-api-machinery/strategic-merge-patch.md).
 
-#### Defining Patch Strategy
-In the context of strategic merge patch, a set of go markers can be used by API authors to define the merge strategy of collections of fields (lists, maps and structs).
+#### Declaring Patch Strategy
+In the context of [strategic merge patch](/contributors/devel/sig-api-machinery/strategic-merge-patch.md), a set of go markers can be used by API authors to declare the merge strategy of collections of fields (lists, maps and structs).
 
 | Marker | Definition |
 |--------|------------|
-| `//+patchStrategy=merge/replace` |  Defines that the merge strategy will be to: merge elements of the two lists into one (if set to merge), or use the list provided in the patch literally rather than merging (if set to replace) |
-| `// +patchMergeKey=<key-name>` |  Applicable in the context of lists being used as maps/dictionaries, i.e. with each entry in the list seen as a key-value pair, with a specific field considered the key. `patchMergeKey` defines what field should be seen as the key. Combined with `patchStrategy`, this describes what changes should take place on specific elements of a list as part of a patch operation. |
-| `//+listType=atomic/set/map` |  Applicable to objects that are of type list. If set to `atomic`, it defines that a single actor can replace the entire list, but cannot change individual elements of it. If not set to `atomic`, different actors can update individual elements in the list. In that case, the listType can either be `set` (contains scalar elements) or `map` (contains map-like elements). |
-| `//+listMapKeys=<list of keys>` |  Applicable in the context of lists being used as maps/dictionaries. A list of strings, that defines which combination of keys should be used as the identifier of each element.          |
-| `//+mapType=atomic/granular` |  If set to `atomic`, a single actor can replace the map entirely. If set to `granular`, multiple actors can update individual map entries seprately. |
-| `//+structType=atomic/granular` |  If set to `atomic`, a single actor can replace the struct entirely. If set to `granular`, multiple actors can update individual struct fields seprately. |
+| `//+patchStrategy=merge/replace` |  Defines that the merge strategy will be to: merge elements of the two lists into one (if set to merge), or use the list provided in the patch literally rather than merging (if set to replace). Default is `replace`. |
+| `// +patchMergeKey=<key-name>` |  Applicable in the context where lists are used as maps/dictionaries, i.e. where each list entry is a key-value pair. `patchMergeKey` defines which field should be seen as the key. Combined with `patchStrategy`, this describes what changes should take place on specific elements of a list as part of a patch operation. |
+| `//+listType=atomic/set/map` |  Applicable to objects that are of type list. If set to `atomic`, it defines that a single actor can replace the entire list, but cannot change individual elements of it. Unless set to `atomic`, different actors can update individual elements in the list. In that case, the listType can either be `set` (contains scalar elements only) or `map` (contains map-like elements). |
+| `//+listMapKeys=<list of keys>` |  Applicable in the context of lists being used as maps/dictionaries. It's a list of strings, that defines which combination of keys should be used as the identifier of each element.          |
+| `//+mapType=atomic/granular` |  If set to `atomic`, a single actor can replace the map entirely. If set to `granular`, multiple actors can update individual map entries separately. |
+| `//+structType=atomic/granular` |  If set to `atomic`, a single actor can replace the struct entirely. If set to `granular`, multiple actors can update individual struct fields separately. |
 
 
 

--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -592,7 +592,7 @@ detailed explanation of how it works and why it needed to be introduced, see
 [here](/contributors/devel/sig-api-machinery/strategic-merge-patch.md).
 
 #### Declaring Patch Strategy
-In the context of [strategic merge patch](/contributors/devel/sig-api-machinery/strategic-merge-patch.md), a set of go markers can be used by API authors to declare the merge strategy of collections of fields (lists, maps and structs).
+In the context of [strategic merge patch](/contributors/devel/sig-api-machinery/strategic-merge-patch.md), a set of go markers can be used by API authors to declare the patch strategy of collections of fields (lists, maps and structs).
 
 | Marker | Definition |
 |--------|------------|
@@ -600,10 +600,23 @@ In the context of [strategic merge patch](/contributors/devel/sig-api-machinery/
 | `// +patchMergeKey=<key-name>` |  Applicable in the context where lists are used as maps/dictionaries, i.e. where each list entry is a key-value pair. `patchMergeKey` defines which field should be seen as the key. Combined with `patchStrategy`, this describes what changes should take place on specific elements of a list as part of a patch operation. |
 | `//+listType=atomic/set/map` |  Applicable to objects that are of type list. If set to `atomic`, it defines that a single actor can replace the entire list, but cannot change individual elements of it. Unless set to `atomic`, different actors can update individual elements in the list. In that case, the listType can either be `set` (contains scalar elements only) or `map` (contains map-like elements). |
 | `//+listMapKeys=<list of keys>` |  Applicable in the context of lists being used as maps/dictionaries. It's a list of strings, that defines which combination of keys should be used as the identifier of each element.          |
-| `//+mapType=atomic/granular` |  If set to `atomic`, a single actor can replace the map entirely. If set to `granular`, multiple actors can update individual map entries separately. |
-| `//+structType=atomic/granular` |  If set to `atomic`, a single actor can replace the struct entirely. If set to `granular`, multiple actors can update individual struct fields separately. |
+| `//+mapType=atomic/granular` |  If set to `atomic`, a single actor can only replace the map entirely. If set to `granular`, multiple actors can update individual map entries separately. |
+| `//+structType=atomic/granular` |  If set to `atomic`, a single actor can only replace the struct entirely. If set to `granular`, multiple actors can update individual struct fields separately. |
 
+##### Considerations on updates to patch strategies/topologies, and server-side apply
 
+A newer version of an API may decide to redefine the patch strategy or topology for a list, map, or struct. This section lists some scenarios and expected behaviours.
+
+* A `listType` can only be updated from `atomic` to `set` if the list elements are scalars. Similarly, `listType` updates from `atomic` to `map` will only succeed if the list items are key-value pairs, and a `listMapKeys` marker is added to define the list of keys that uniquely identify a list entry.
+* When updating `listType` from `set` to `atomic`, the next actor (e.g. `kubectl`) to apply the list will entirely replace it. The operation will not give out conflicts, even if the actor has't previously issued requests against this field.
+* When using a Kubernetes API version that does not support setting list, map and struct topologies (1.15 and before): lists, maps and structs are considered atomic. When upgrading to an API version that supports declaring topology for these fields (starting at 1.16):
+  * if `listType` is set to `set` or `map`
+  * if `listType` is set to `atomic`, `apply` operations using server-side apply will result in conflicts, unless they leave the field values unchanged.
+* Updates from specifying topologies to _not_ specifying them, will be equivalent to the topologies being set to `atomic`.
+* Updates between scalar and nested types are allowed, but are risky. If such a path must be followed, it's best to test outside a production system, and configure to `atomic` as a middle step.
+  * From `set` to `map`: while new objects can be created without problems following the updated topology, existing objects can no longer be changed.
+  * From `map` to `set`: there's high risk of losing or corrupting data of existing objects. Just reconfiguring `listType` without reapplying objects will empty the contents of existing objects.
+* Updating `listMapKeys` for a `listType=map` will succeed as long as the spec of the existing objects is valid by both key validations; the original and the update. For example, with an original configuration of `listMapKeys=port,protocol` and an updated configuration of `listMapKeys=name,version`, list entries of an existing object must have unique, not omitted combinations of both `port,protocol` and `name,version`; otherwise the object can't be updated.
 
 ## Idempotency
 

--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -597,7 +597,7 @@ In the context of [strategic merge patch](/contributors/devel/sig-api-machinery/
 | Marker | Definition |
 |--------|------------|
 | `//+patchStrategy=merge` |  Defines that the merge strategy will be to merge elements of the two lists into one. |
-| `//+patchStrategy=replace` (default)|  Defines that the merge strategy will be touse the list provided in the patch literally rather than merging. |
+| `//+patchStrategy=replace` (default)|  Defines that the merge strategy will be to use the list provided in the patch literally rather than merging. |
 | `// +patchMergeKey=<key-name>` |  Applicable in the context where lists are used as maps/dictionaries, i.e. where each list entry is a key-value pair. `patchMergeKey` defines which field should be seen as the key. Combined with `patchStrategy`, this describes what changes should take place on specific elements of a list as part of a patch operation. |
 | `//+listType=atomic` |  Applicable to objects that are of type list. A single actor owns and can replace the entire list, but cannot change individual elements of it. |
 | `//+listType=set` |  Applicable to objects that are of type list, and the elements are unique and scalar. Different actors can update individual elements in the list. |


### PR DESCRIPTION
Should eventually address https://github.com/kubernetes/community/issues/3752.
Also related: https://github.com/kubernetes-sigs/structured-merge-diff/issues/115

This PR adds a section in `contributors/devel/sig-architecture/api-conventions.md` that references available go markers that can be used to define merge strategies during PATCH operations.

Would love feedback on:
* Above all, any false information and/or unclear language:)
* Does the format of collecting everything in this doc work (as opposed to pointing to other docs as applicable, e.g. [the strategic merge patch documentation](https://github.com/kubernetes/community/blob/f4ecced46d49727ca5ae971eab691ffe0ce08535/contributors/devel/sig-api-machinery/strategic-merge-patch.md))
* Does it make sense to add a couple of syntax examples in this doc, or are these better placed elsewhere?

Remaining tasks in this PR:
* (once the general direction seems fine) Add information for `listType`, `mapType`, `structType`.

/cc @apelisse 
/kind documentation
/sig api-machinery
/sig architecture
(^^as owners of the doc)