### PR TITLE
Add test-failures channel to slack configuration

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -293,6 +293,7 @@ channels:
   - name: suse-caasp
   - name: talk-proposals
   - name: terraform-providers
+  - name: test-failures
   - name: testing-commons
   - name: testing-ops
   - name: tilt


### PR DESCRIPTION
This PR is part of the issue kubernetes/test-infra#14740
and required to the correct work of kubernetes/test-infra#15167.'

The slack reporter will push information about the test failures to the newly added channel #test-failures