### PR TITLE
Archive channel: cluster-api-docker

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -32,6 +32,7 @@ channels:
   - name: cluster-api-azure
   - name: cluster-api-baremetal
   - name: cluster-api-docker
+    archived: true
   - name: cluster-api-openstack
   - name: cluster-api-vsphere
   - name: cn-dev


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

/cc @jeefy 
/assign @mrbobbytables 

for context, the community/channel has had weeks of notification and we've merged into the cluster-api slack channel.

(copying folks who reviewed and approved from https://github.com/kubernetes/community/pull/3836)