### PR TITLE
Add a #prow-alerts channel to Slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -232,6 +232,7 @@ channels:
   - name: prometheus
   - name: prometheus-operator
   - name: prow
+  - name: prow-alerts
   - name: pt_br-users
   - name: rancher
   - name: random


### PR DESCRIPTION
This channel will field non-critical alerts for the prow.k8s.io
deployment to facilitate bug discovery and remediation while not
alerting the on-call.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>