### PR TITLE
Remove last-updated date line from api-conventions.md

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -1,8 +1,6 @@
 API Conventions
 ===============
 
-Updated: 3/7/2017
-
 *This document is oriented at users who want a deeper understanding of the
 Kubernetes API structure, and developers wanting to extend the Kubernetes API.
 An introduction to using resources with kubectl can be found in [the object management overview](https://kubernetes.io/docs/concepts/overview/working-with-objects/object-management/).*


### PR DESCRIPTION
Rationale: The line hasn't been updated since 2017, even though changes were still being made to the doc. We can already see the last-updated date from the git history, and if we just update it now folks will probably continue forgetting to do so in the future.