### PR TITLE
Add Slack channel for Project Antrea

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -4,6 +4,7 @@
 channels:
   - name: airflow-operator
   - name: announcements
+  - name: antrea
   - name: api-reviews
   - name: apisnoop
   - name: archived-sig-release


### PR DESCRIPTION
Antrea (https://github.com/vmware-tanzu/antrea) is an open-source CNI
plugin based on Open vSwitch. It was built specifically to be a
networking solution for Kubernetes clusters and supports Network
Policies.

We are adding a single channel at the moment (antrea) but may want to
have a dev channel in the future.

We would like to be part of the Kubernetes Slack so that our users have one
less workspace to "manage".

Signed-off-by: Antonin Bas <abas@vmware.com>