### PR TITLE
Added new slack channel for solr-operator

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -289,6 +289,7 @@ channels:
   - name: skaffold
   - name: slack-admins
   - name: slack-infra
+  - name: solr-operator
   - name: sonobuoy
   - name: spark-operator
   - name: spinnaker


### PR DESCRIPTION
solr-operator (https://github.com/bloomberg/solr-operator) is an open-source kubernetes operator to run solrclouds infrastructure on kubernetes. It is built using kubebuilder v2.

There is a lot of interest from the community ever since the project was open sourced. Due to lack of a common communication platform, contributors are having a hard time to run technical conversations related to the design and future of the operator. It will immensely help the project, if we can have slack channel in the kubernetes workspace.

Signed-off-by: swarupdonepudi <swarup.donepudi@gmail.com>