### PR TITLE
Add release notes guideline to contributors guide

### DIFF
--- a/contributors/guide/release-notes.md
+++ b/contributors/guide/release-notes.md
@@ -4,7 +4,47 @@ weight: 1
 slug: "release-notes"
 ---
 
-On the kubernetes/kubernetes repository, release notes are required for any pull request with user-visible changes, such as bug-fixes, feature additions, and output format changes.
+On the kubernetes/kubernetes repository, release notes are required for any pull
+request with user-visible changes, such as bug fixes, feature additions, and
+output format changes. Release notes are one of the most important reference
+points for users about to install or upgrade to a particular release of
+Kubernetes.
+
+## Does my pull request need a release note?
+
+Any user-visible or operator-visible change qualifies for a release note. This
+could be a:
+
+- CLI change
+- API change
+- UI change
+- configuration schema change
+- behavioral change
+- change in non-functional attributes such as efficiency or availability,
+  availability of a new platform
+- a warning about a deprecation
+- fix of a previous _Known Issue_
+- fix of a vulnerability (CVE)
+
+No release notes are required for changes to:
+
+- tests
+- build infrastructure
+- fixes of bugs which have not been released
+
+## Contents of a Release Note
+
+A release note needs a clear, concise description of the change. This includes:
+
+1. an indicator if the pull request _Added_, _Changed_, _Fixed_, _Removed_,
+   _Deprecated_ functionality or changed enhancement/feature maturity (alpha,
+   beta, stable/GA)
+2. an indicator if there is user _Action required_
+3. the name of the affected API or configuration fields, CLI commands/flags or
+   enhancement/feature
+4. a link to relevant user documentation about the enhancement/feature
+
+## Applying a Release Note
 
 To meet this requirement, do one of the following:
 - Add notes in the release notes block, or


### PR DESCRIPTION
Hey :wave:, I'd like to push forward #484 and think a good first step would be to put the information into the contributors guide. After this we should discuss how we apply the guide to be more visible to all users.

Refers to: #484