### PR TITLE
Adding details for 2020 events in Amsterdam, China, and Boston

### DIFF
--- a/events/2020/03-contributor-summit/README.md
+++ b/events/2020/03-contributor-summit/README.md
@@ -1,1 +1,55 @@
-# 2020 Kubernetes Contributor Summit Europe
+# 2020 Kubernetes Contributor Summit EU
+
+**This event is still in the planning stages. Please check back here for updates!**
+
+## What
+
+This event brings together new and current Kubernetes contributors to connect and learn from one another. 
+It is an opportunity for existing contributors to help shape the future of the project and offers a welcoming 
+space for new community members to learn, explore, and put the contributor workflow to practice. The summit 
+is held in the two days before KubeCon + CloudNativeCon with an optional social event in the evening of 
+Sunday, March 29th along with the main full-day event on Monday, March 30th.
+
+## Registration
+
+Registration is not yet open. We will announce the opening of registration on the 
+[kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) mailing list or check this page for updates.
+
+## When and Where
+
+The Contributor Summit takes place in the days leading up to 
+[KubeCon + CloudNativeCon EU](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2020), 
+so make sure you plan travel accordingly.
+
+- Sunday, March 29th, 2020 ~5PM - 9PM  
+  Social event (optional)
+- Monday, March 30th, 2020 ~8AM - 6PM   
+  Full day event
+- Amsterdam, The Netherlands
+- Event website with more information:   
+  https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2020
+
+### Transparency
+
+- Recording: Sessions will be video recorded and uploaded to YouTube.
+- Transcription: Transcriptions will be uploaded with the video.
+- Content Sharing: All presentations will be uploaded.
+
+## Team
+
+| Role | Lead | Shadow | Notes |
+|---|---|---|---|
+| Event Lead | Jeff [@jeefy](https://github.com/jeefy) | TBD | |
+| Other Roles| TBD | | |
+
+## Code of Conduct
+
+This event, like all Kubernetes events, has a [Code of Conduct](/code-of-conduct.md). We will have an onsite rep with contact information to be provided here and posted during the event.
+
+## Misc
+
+We want to remove as many barriers as possible for you to attend this event. Please contact community@kubernetes.io to see if we can accommodate a request.
+
+For general info and questions, please join and direct questions to the [#contributor-summit](https://kubernetes.slack.com/messages/C7J893413/) slack channel. To speak directly to the staff, please join the [#summit-staff](https://kubernetes.slack.com/messages/CEMM39SKG/) slack channel.
+
+As stated above, this doc will be updated with further details. Please check back for additional information.

--- a/events/2020/07-contributor-summit/README.md
+++ b/events/2020/07-contributor-summit/README.md
@@ -1,1 +1,51 @@
-# 2020 Kubernetes Contributor Summit China
+# 2020 Kubernetes Contributor Summit CN
+
+**This event is still in the planning stages. Please check back here for updates!**
+
+## What
+
+This event brings together new and current Kubernetes contributors to connect and learn from one another. 
+It is an opportunity for existing contributors to help shape the future of the project and offers a welcoming 
+space for new community members to learn, explore, and put the contributor workflow to practice. The summit 
+is held the day before KubeCon + CloudNativeCon + Open Source Summit on Tuesday, July 28th.
+
+## Registration
+
+Registration is not yet open. We will announce the opening of registration on the 
+[kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) mailing list or check this page for updates.
+
+## When and Where
+
+The Contributor Summit takes place the day before
+[KubeCon + CloudNativeCon + Open Source Summit China](https://events.linuxfoundation.cn/kubecon-cloudnativecon-open-source-summit-china/),
+so make sure you plan travel accordingly.
+
+- Tuesday, July 28th, 2020 ~8AM - 6PM   
+  Full day event
+- Shanghai, China 
+- Event website with more information:   
+  https://events.linuxfoundation.cn/kubecon-cloudnativecon-open-source-summit-china/
+
+### Transparency
+
+- Recording: Sessions will be video recorded and uploaded to YouTube.
+- Transcription: Transcriptions will be uploaded with the video.
+- Content Sharing: All presentations will be uploaded.
+
+## Team
+
+| Role | Lead | Shadow | Notes |
+|---|---|---|---|
+| Roles| TBD | | |
+
+## Code of Conduct
+
+This event, like all Kubernetes events, has a [Code of Conduct](/code-of-conduct.md). We will have an onsite rep with contact information to be provided here and posted during the event.
+
+## Misc
+
+We want to remove as many barriers as possible for you to attend this event. Please contact community@kubernetes.io to see if we can accommodate a request.
+
+For general info and questions, please join and direct questions to the [#contributor-summit](https://kubernetes.slack.com/messages/C7J893413/) slack channel. To speak directly to the staff, please join the [#summit-staff](https://kubernetes.slack.com/messages/CEMM39SKG/) slack channel.
+
+As stated above, this doc will be updated with further details. Please check back for additional information.

--- a/events/2020/11-contributor-summit/README.md
+++ b/events/2020/11-contributor-summit/README.md
@@ -1,1 +1,54 @@
 # 2020 Kubernetes Contributor Summit NA
+
+**This event is still in the planning stages. Please check back here for updates!**
+
+## What
+
+This event brings together new and current Kubernetes contributors to connect and learn from one another. 
+It is an opportunity for existing contributors to help shape the future of the project and offers a welcoming 
+space for new community members to learn, explore, and put the contributor workflow to practice. The summit 
+is held in the two days before KubeCon + CloudNativeCon with an optional social event in the evening of 
+Monday, November 16th along with the main full-day event on Tuesday, November 17th.
+
+## Registration
+
+Registration is not yet open. We will announce the opening of registration on the 
+[kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) mailing list or check this page for updates.
+
+## When and Where
+
+The Contributor Summit takes place in the days leading up to 
+[KubeCon + CloudNativeCon NA](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/)
+so make sure you plan travel accordingly.
+
+- Monday, November 16th, 2020 ~5PM - 9PM  
+  Social event (optional)
+- Tuesday, November 17th, 2020 ~8AM - 6PM   
+  Full day event
+- Boston, MA
+- Event website with more information:   
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america
+
+### Transparency
+
+- Recording: Sessions will be video recorded and uploaded to YouTube.
+- Transcription: Transcriptions will be uploaded with the video.
+- Content Sharing: All presentations will be uploaded.
+
+## Team
+
+| Role | Lead | Shadow | Notes |
+|---|---|---|---|
+| Roles| TBD | | |
+
+## Code of Conduct
+
+This event, like all Kubernetes events, has a [Code of Conduct](/code-of-conduct.md). We will have an onsite rep with contact information to be provided here and posted during the event.
+
+## Misc
+
+We want to remove as many barriers as possible for you to attend this event. Please contact community@kubernetes.io to see if we can accommodate a request.
+
+For general info and questions, please join and direct questions to the [#contributor-summit](https://kubernetes.slack.com/messages/C7J893413/) slack channel. To speak directly to the staff, please join the [#summit-staff](https://kubernetes.slack.com/messages/CEMM39SKG/) slack channel.
+
+As stated above, this doc will be updated with further details. Please check back for additional information.


### PR DESCRIPTION
Adding details for 2020 events in Amsterdam, China, and Boston to the placeholder pages. Some of the details are still TBD, but I thought it would be good to add the dates and get all of them into a common template based on what we had for San Diego.

/sig contributor-experience
/area contributor-summit

/assign @jeefy @parispittman 