### PR TITLE
Add release notes review section

### DIFF
--- a/contributors/guide/release-notes.md
+++ b/contributors/guide/release-notes.md
@@ -76,6 +76,22 @@ To see how to format your release notes, view the kubernetes/kubernetes [pull re
 
 Release notes apply to pull requests on the master branch. For patch release branches the automated cherry-pick pull requests process (see the [cherry-pick instructions](/contributors/devel/sig-release/cherry-picks.md)) should be followed.  That automation will pull release notes from the master branch PR from which the cherry-pick originated. On a rare occasion a pull request on a patch release branch is not a cherry-pick, but rather is targeted directly to the non-master branch and in this case, a `release-note-*` label is required for that non-master pull request.
 
+## Reviewing Release Notes
+
+Reviewing the release notes of a pull request should be a dedicated step in the
+overall review process. It is necessary to rely on the same metrics as other
+reviewers to be able to distinguish release notes which might need to be
+rephrased.
+
+As a guideline, a release notes entry needs to be rephrased if one of the
+following cases apply:
+
+- The release note does not communicate the full purpose of the change.
+- The release note has no impact on any user.
+- The release note is grammatically incorrect.
+
+In any other case the release note should be fine.
+
 ## Related
 
 * [Behind The Scenes: Kubernetes Release Notes Tips & Tricks - Mike Arpaia, Kolide (KubeCon 2018 Lightning Talk)](https://www.youtube.com/watch?v=n62oPohOyYs)


### PR DESCRIPTION
This adds a dedicated section about the review of release notes.

**Background information:** I have a highly experimental idea of classifying past release notes regarding the three cases described in the change (actually four cases when we assume that the note is correct). I would like to use this data to train a machine learning model which means that the number of classes needs to be as low as possible whereas the accuracy needs to be high. For example, If I classify something as _"Has no impact on the user"_ then someone else should classify it as the same. After the model exists with a fair amount of data, we could use it to classify new release notes and provide some sort of automatism around. To me this seems more useful than providing a dedicated checklist. WDYT?

Refers to #484
/cc @jeefy 