### PR TITLE
releng: Update release-managers Slack user group

### DIFF
--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -17,6 +17,8 @@ restrictions:
     channels:
       - "^sig-release$"
       - "^release-"
+    usergroups:
+      - "^release-"
   - path: "sig-storage/*.yaml"
     channels:
       - "^sig-storage$"

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -8,13 +8,13 @@ usergroups:
       - release-management
       - sig-release
     members:
-      - aleksandra-malinowska
-      - bubblemelon
-      - calebamiles
-      - feiskyer
-      - hoegaarden
-      - idealhack
-      - justaugustus
-      - listx
-      - sumitranr
-      - tpepper
+      - aleksandra-malinowska # Patch Release Team
+      - calebamiles # subproject owner
+      - cpanato # Branch Manager
+      - dougm # Patch Release Team
+      - feiskyer # Patch Release Team
+      - hoegaarden # Patch Release Team
+      - idealhack # Patch Release Team
+      - justaugustus # subproject owner / Patch Release Team
+      - saschagrunert # Branch Manager
+      - tpepper # subproject owner / Patch Release Team

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -1,0 +1,20 @@
+# This file contains a list of all Slack User Groups that are managed by SIG Release.
+
+usergroups:
+  - name: release-managers
+    long_name: Release Managers
+    description: Release Managers. Ping for questions on branch cuts and building/packaging Kubernetes.
+    channels:
+      - release-management
+      - sig-release
+    members:
+      - aleksandra-malinowska
+      - bubblemelon
+      - calebamiles
+      - feiskyer
+      - hoegaarden
+      - idealhack
+      - justaugustus
+      - listx
+      - sumitranr
+      - tpepper

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -1,23 +1,9 @@
-# This file contains a list of all Slack usergroups that exist.
+# This file contains a top-level list of Slack User Groups.
+# SIG-specific User Groups may be defined within a SIG's subdirectory
+#
+# e.g., @release-managers is defined in sig-release/usergroups.yaml
 
 usergroups:
-  - name: release-managers
-    long_name: Release Managers
-    description: Release Managers. Ping for questions on branch cuts and building/packaging Kubernetes.
-    channels:
-      - release-management
-      - sig-release
-    members:
-      - aleksandra-malinowska
-      - bubblemelon
-      - calebamiles
-      - feiskyer
-      - hoegaarden
-      - idealhack
-      - justaugustus
-      - listx
-      - sumitranr
-      - tpepper
   - name: test-infra-oncall
     external: true
   - name: youtube-admins

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -6,6 +6,8 @@ users:
   bubblemelon: U7K9C643G
   calebamiles: U1ZDD4CUR
   castrojo: U1W1Q6PRQ
+  cpanato: U8DFY4TTK
+  dougm: U8GG20UE9
   feiskyer: U0ASA4398
   hoegaarden: U7VA4RZS9
   idealhack: U5NJ3DQM9
@@ -19,5 +21,6 @@ users:
   mrbobbytables: U511ZSKHD
   paris: U5SB22BBQ
   sarahnovotny: U0AGW7007
+  saschagrunert: U53SUDBD4
   sumitranr: UCQN13L9H
   tpepper: U6UB5V4TX


### PR DESCRIPTION
Syncing up the Slack user group with the current set of Release Managers.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**On hold until https://github.com/kubernetes/sig-release/pull/868 merges**
/hold

/assign @tpepper @calebamiles 
@kubernetes/sig-release-admins @kubernetes/release-engineering @kubernetes/release-managers 
/milestone v1.18
/priority important-longterm
/kind feature cleanup