### PR TITLE
Fixed some typos in NCW event handbooks

### DIFF
--- a/events/events-team/content/new-contributor-workshops/README.md
+++ b/events/events-team/content/new-contributor-workshops/README.md
@@ -21,11 +21,11 @@ This workshop is meant for folks who have never contributed to opensource before
 1. [Local Build&Test](./build-and-test.md)
 1. [Pull Request Exercise](./playground-exercise.md)
 1. [Find Your First Issue](./first-issue-help.md)
-1. [SIG Meet-and-Greet](../sig-contrib-events.md#sig-meet-and-greet)x
+1. [SIG Meet-and-Greet](/events/events-team/content/sig-contrib-events.md#sig-meet-and-greet)
 
 ## Sample Track for Intermediate Workshop
 
-This workshop differs from the Beginner workshop in that participants are expected to have a working Docker/Kubernetes/Go setup. They have a baisc understanding of how opensource contributions work, and may have opened a PR against Kubernetes before.
+This workshop differs from the Beginner workshop in that participants are expected to have a working Docker/Kubernetes/Go setup. They have a basic understanding of how opensource contributions work, and may have opened a PR against Kubernetes before.
 
 1. Welcome
 1. [Live PR Demo](./live-pr-demo.md)
@@ -37,4 +37,4 @@ This workshop differs from the Beginner workshop in that participants are expect
 1. [Local Build&Test](./build-and-test.md)
 1. Labels, Bots and Git Workflow
 1. [Find Your First Issue](./first-issue-help.md)
-1. [SIG Meet-and-Greet](../sig-contrib-events.md#sig-meet-and-greet)
+1. [SIG Meet-and-Greet](/events/events-team/content/sig-contrib-events.md#sig-meet-and-greet)

--- a/events/events-team/content/new-contributor-workshops/build-and-test.md
+++ b/events/events-team/content/new-contributor-workshops/build-and-test.md
@@ -6,7 +6,7 @@
 
 ### Task Overview
 
-Build Kuberentes binaries locally, and do some fun things with them.
+Build Kubernetes binaries locally, and do some fun things with them.
 
 **Important** Have facilitators to help with technical issues (2-3 is enough for Intermediate, you want 5 for Beginner)
 

--- a/events/events-team/content/new-contributor-workshops/contributor-paths.md
+++ b/events/events-team/content/new-contributor-workshops/contributor-paths.md
@@ -17,10 +17,10 @@ Refer to previous workshops for inspirations
 - Who can contribute?
 - What skills are needed?
 - How to Fit Contributions Into Your Job
-- Balance knowlede with learning and the needs of the project
+- Balance knowledge with learning and the needs of the project
 
 ### Ideas
 
 - Share some contributor origin stories
-- Ask the room why they are at the workshop.
+- Ask the room why they are at the workshop
 - Have a few people share their thoughts

--- a/events/events-team/content/new-contributor-workshops/first-issue-help.md
+++ b/events/events-team/content/new-contributor-workshops/first-issue-help.md
@@ -16,12 +16,12 @@ Refer to previous workshops for inspirations
 ### Details To Cover 
 
 - help-wanted and good-first-issue labels
-- up and coming sandbox projects
+- Up and coming sandbox projects
 - Working with your SIG
 - Refer participants to specific SIGs
 - How to "claim" an issue (since non-members cannot self-assign)
-- Encourage the [SIG Meet-and-Greet](../sig-contrib-events.md#sig-meet-and-greet)
-- Path to [membership](git.k8s.io/community-membership.md)
+- Encourage attendance at the [SIG Meet-and-Greet](/events/events-team/content/sig-contrib-events.md#sig-meet-and-greet)
+- Path to [membership](/community-membership.md)
 
 ### Ideas
 

--- a/events/events-team/content/new-contributor-workshops/labels-and-bots.md
+++ b/events/events-team/content/new-contributor-workshops/labels-and-bots.md
@@ -22,4 +22,4 @@ The [PR workflow diagram](git.k8s.io/community/contributors/guide/git_workflow.p
 
 ### Ideas
 
-- Play with bots in the [contributor playground]
+- Play with bots in the [contributor playground](https://github.com/kubernetes-sigs/contributor-playground)

--- a/events/events-team/content/new-contributor-workshops/new-contributor-workshop-lead.md
+++ b/events/events-team/content/new-contributor-workshops/new-contributor-workshop-lead.md
@@ -29,8 +29,8 @@ Shadows and co-presenters are expected to assist and review these updates.
     - disseminate course materials (slides) in advance
     - ensure participants sign the CLA
     - ensure attendees meet technical and experience requirements for their course
-    - obtain a comprehensive list of names, emails, and github handles
-- Coordinate with the [SIG Meet and Greet organizer](sig-contrib-events.md) (may be a different role to be determined by core team)
+    - obtain a comprehensive list of names, emails, and GitHub handles
+- Coordinate with the [SIG Meet and Greet organizer](/events/events-team/content/sig-contrib-events.md#sig-meet-and-greet) (may be a different role to be determined by core team)
 - Ensure to advertise the SIG-Intros
 - Solicit feedback from workshop participants
 

--- a/events/events-team/content/new-contributor-workshops/playground-exercise.md
+++ b/events/events-team/content/new-contributor-workshops/playground-exercise.md
@@ -9,7 +9,7 @@
 Give new contributors the experience of the Kubernetes GitHub workflow!
 This task requires some setup and planning.
 
-Create a New Contributor Workshop folder specific to this event, with teachers' and participants' github handles in the OWNERS file. 
+Create a New Contributor Workshop folder specific to this event, with teachers' and participants' GitHub handles in the OWNERS file. 
 [Here is an example](sigs.k8s.io/contributor-playground/seattle). Make sure to obtain participants' GitHub handles from the event registrar in advance.
 Issue and PR exercise ideas can be found in sigs.k8s.io/contributor-playground/exercises.
 


### PR DESCRIPTION
Fixed the typos that several of us found during reviews of PR #4278 since we decided to merge it and fix the typos later to get the content live.

/sig contributor-experience
/area contributor-summit
/assign @mrbobbytables 
/assign @castrojo 
/assign @guineveresaenger 
