### PR TITLE
slack: rename provider-alibaba-cloud channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -3,7 +3,6 @@
 
 channels:
   - name: airflow-operator
-  - name: alibaba-cloud
   - name: announcements
   - name: antrea
   - name: api-reviews

--- a/communication/slack-config/sig-cloud-provider/config.yaml
+++ b/communication/slack-config/sig-cloud-provider/config.yaml
@@ -1,6 +1,8 @@
 channels:
   - name: apiserver-network-proxy
   - name: cloud-provider-extraction
+  - name: provider-alibaba-cloud
+    id: CRX9UN2DN
   - name: provider-aws
     id: C0LRMHZ1T
   - name: provider-azure


### PR DESCRIPTION
and moved to the sig-cloud-provider folder

addresses https://github.com/kubernetes/community/pull/4339#discussion_r360207711

/cc @zhangxiaoyu-zidif @cheftako @idvoretskyi 