### PR TITLE
Add slack #jp-users-novice channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -105,6 +105,7 @@ channels:
   - name: jp-dev
   - name: jp-events
   - name: jp-users
+  - name: jp-users-novice
   - name: jsonnet
   - name: k14s
   - name: kaniko


### PR DESCRIPTION
I want to append a channel for study and q&a by novice users of Kubernetes in Japan(for Japanese speakers).
ref: https://kubernetes.slack.com/archives/C0QKVN230/p1577342193032500
