### PR TITLE
adding kubemove slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -150,6 +150,7 @@ channels:
   - name: kubekhan
     archived: true
   - name: kubeless
+  - name: kubemove
   - name: kubeone
   - name: kubepack
   - name: kubestack


### PR DESCRIPTION
[KubeMove](http://www.github.com/kubemove/kubemove) is a opensource project providing framework for applications running on Kubernetes to migrate across clusters in different cloud providers, on-prem along with data. This is under active development and licensed under Apache 2.0. This project, being providing framework, is having contributions from more than one company and expected to be interested by multiple applications.

To help multiple companies coordinate on this opensource project, we would like to have a slack channel for open discussions and to reach out to interested parties.

Signed-off-by: Vitta <vitta@mayadata.io>