### PR TITLE
add kurl channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -171,6 +171,7 @@ channels:
   - name: kubespray-dev
   - name: kubicorn
   - name: kudo
+  - name: kurl
   - name: kustomize
   - name: kyverno
   - name: leadership-summit


### PR DESCRIPTION
Requesting a channel for discussion and support of the [kURL Open Source Kubernetes Installer](https://kurl.sh/) project.  kURL creates unique URLs to download customizable Kubernetes cluster install scripts, with a variety of selectable add-on components.  Public github repo for the project is [here](https://github.com/replicatedhq/kurl/).
