### PR TITLE
add schemahero channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -249,6 +249,7 @@ channels:
   - name: ro-users
   - name: ru-users
   - name: scaleway-k8s
+  - name: schemahero
   - name: se-users
   - name: sealed-secrets
   - name: shippable


### PR DESCRIPTION
Requesting a channel for discussion and support of the SchemaHero Open Source project. SchemaHero is a Kubernetes Operator that manages database schema migrations as code.

SchemaHero docs: https://schemahero.io/docs/
SchemaHero public repo: https://github.com/schemahero/schemahero
