### PR TITLE
add app-troubleshoot channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -7,6 +7,7 @@ channels:
   - name: antrea
   - name: api-reviews
   - name: apisnoop
+  - name: app-troubleshoot
   - name: archived-sig-release
     archived: true
   - name: argentina


### PR DESCRIPTION
Requesting a channel for discussion and support of the Troubleshoot Open Source project. Troubleshoot is a tool for running PreFlight checks on a cluster (to determine if the cluster meets necessary preconditions for installing an application or service) and for collecting support bundles for remote diagnosis of cluster issues.

Troubleshoot docs: https://troubleshoot.sh/
Troubleshoot public repo: https://github.com/replicatedhq/troubleshoot