### PR TITLE
Delete instructions describing the `kubetest -ctl` command

### DIFF
--- a/contributors/devel/sig-testing/e2e-tests.md
+++ b/contributors/devel/sig-testing/e2e-tests.md
@@ -120,12 +120,6 @@ GINKGO_PARALLEL=y kubetest --test --test_args="--ginkgo.skip=\[Serial\] --delete
 #
 # e.g.:
 kubetest --provider=aws --build --up --test --down
-
-# -ctl can be used to quickly call kubectl against your e2e cluster. Useful for
-# cleaning up after a failed test or viewing logs.
-# kubectl output is default on, you can use --verbose-commands=false to suppress output.
-kubetest -ctl='get events'
-kubetest -ctl='delete pod foobar'
 ```
 
 The tests are built into a single binary which can be used to deploy a


### PR DESCRIPTION
As far as I can tell, `kubetest` no longer has a `-ctl` flag.
Remove it from the examples of commands that can be run using `kubetest`.

**Which issue(s) this PR fixes**:
Fixes #
