### PR TITLE
sig-scheduling: move cluster-capacity from k-incubator to k-sigs

### DIFF
--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -48,7 +48,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-scheduling:
 ### cluster-capacity
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-capacity/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-capacity/master/OWNERS
 ### descheduler
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1844,7 +1844,7 @@ sigs:
   subprojects:
   - name: cluster-capacity
     owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-capacity/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-capacity/master/OWNERS
   - name: descheduler
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/OWNERS


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/1529
/assign @ahg-g @k82cn 
/cc @ingvagabund
/hold
for confirm from leads