### PR TITLE
New slack channel for Inspektor Gadget

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -97,6 +97,7 @@ channels:
   - name: in-events
   - name: in-users
   - name: ingress-nginx
+  - name: inspektor-gadget
   - name: it-events
   - name: it-users
   - name: java


### PR DESCRIPTION
Inspektor Gadget (https://github.com/kinvolk/inspektor-gadget) contains
a collection of gadgets for developers of Kubernetes applications. Its
main gadget, traceloop, uses BPF to record system calls performed by
each pod like a flight recorder. It can be used to see the last system
calls performed by a pod after it crashed.

It is available under the Apache license.

It is built on top of BCC (https://github.com/iovisor/bcc) and traceloop
(https://github.com/kinvolk/traceloop).

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

