### PR TITLE
slack-config: archive #navigator channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -218,6 +218,7 @@ channels:
   - name: mysql-operator
   - name: nais
   - name: navigator
+    archived: true
   - name: ncw-staff
   - name: nl-users
   - name: node-problem-detector


### PR DESCRIPTION
This channel hasn't been used since May '18 and was originally requested by myself - this does not need to continue existing 😄 if anything changes in future, we can un-archive it.
