### PR TITLE
add code for alphanumeric sorting and formatting of OWNERS_ALIASES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ reset-docs:
 
 generate:
 	go run ./generator/app.go
+	./hack/update-owners-aliases.sh
 
 generate-dockerized:
 	docker run --rm -e WHAT -e GO111MODULE -e GOPROXY -v $(shell pwd):/go/src/app:Z $(IMAGE_NAME) make -C /go/src/app generate

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,8 +1,29 @@
 aliases:
+  committee-code-of-conduct:
+    - AevaOnline
+    - Bradamant3
+    - carolynvs
+    - jdumars
+    - tashimi
+  committee-product-security:
+    - cjcullen
+    - joelsmith
+    - jonpulsifer
+    - liggitt
+    - lukehinds
+    - philips
+    - tallclair
+  committee-steering:
+    - cblecker
+    - derekwaynecarr
+    - dims
+    - nikhita
+    - parispittman
+    - spiffxp
+    - timothysc
   sig-api-machinery-leads:
     - deads2k
     - fedebongio
-    - deads2k
     - lavalamp
   sig-apps-leads:
     - janetkuo
@@ -14,31 +35,29 @@ aliases:
     - dims
     - johnbelamaric
   sig-auth-leads:
-    - enj
-    - mikedanese
-    - tallclair
     - deads2k
+    - enj
     - liggitt
     - mikedanese
+    - tallclair
   sig-autoscaling-leads:
     - mwielgus
   sig-cli-leads:
-    - seans3
-    - soltysh
     - pwittrock
+    - seans3
     - soltysh
   sig-cloud-provider-leads:
     - andrewsykim
     - cheftako
   sig-cluster-lifecycle-leads:
+    - fabriziopandini
     - justinsb
     - neolit123
     - timothysc
-    - fabriziopandini
   sig-contributor-experience-leads:
     - Phillels
-    - mrbobbytables
     - cblecker
+    - mrbobbytables
     - nikhita
   sig-docs-leads:
     - Bradamant3
@@ -94,9 +113,16 @@ aliases:
     - vllry
   sig-windows-leads:
     - PatrickLang
-    - michmike
     - benmoss
     - ddebroy
+    - michmike
+  ug-big-data-leads:
+    - erikerlandson
+    - foxish
+    - liyinan926
+  ug-vmware-users-leads:
+    - cantbewong
+    - mylesagray
   wg-apply-leads:
     - lavalamp
   wg-component-standard-leads:
@@ -142,35 +168,6 @@ aliases:
     - cji
     - jaybeale
     - joelsmith
-  ug-big-data-leads:
-    - erikerlandson
-    - foxish
-    - liyinan926
-  ug-vmware-users-leads:
-    - cantbewong
-    - mylesagray
-  committee-code-of-conduct:
-    - AevaOnline
-    - Bradamant3
-    - carolynvs
-    - jdumars
-    - tashimi
-  committee-product-security:
-    - cjcullen
-    - joelsmith
-    - jonpulsifer
-    - liggitt
-    - lukehinds
-    - philips
-    - tallclair
-  committee-steering:
-    - cblecker
-    - derekwaynecarr
-    - dims
-    - nikhita
-    - parispittman
-    - spiffxp
-    - timothysc
 ## BEGIN CUSTOM CONTENT
   provider-aws:
     - d-nishi
@@ -178,8 +175,8 @@ aliases:
     - kris-nova
   provider-azure:
     - craiglpeters
-    - justaugustus
     - feiskyer
+    - justaugustus
     - khenidak
   provider-gcp:
     - abgworrall

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,7 @@ go 1.12
 
 require (
 	github.com/client9/misspell v0.3.4
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
 	gopkg.in/yaml.v3 v3.0.0-20190409140830-cdc409dda467
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20190409140830-cdc409dda467 h1:w3VhdSYz2sIVz54Ta/eDCCfCQ4fQkDgRxMACggArIUw=

--- a/hack/format-owners-aliases.go
+++ b/hack/format-owners-aliases.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/pmezard/go-difflib/difflib"
+	yaml "gopkg.in/yaml.v3"
+)
+
+const (
+	aliasesPrefix = "aliases:\n"
+	customStart   = "## BEGIN CUSTOM CONTENT"
+	customEnd     = "## END CUSTOM CONTENT"
+)
+
+type flags struct {
+	diff   bool
+	write  bool
+	custom bool
+}
+
+type nodes []yaml.Node
+
+func (n nodes) Len() int {
+	return len(n)
+}
+
+func (n nodes) Swap(i, j int) {
+	n[i], n[j] = n[j], n[i]
+}
+
+func (n nodes) Less(i, j int) bool {
+	return n[i].Value < n[j].Value
+}
+
+type aliases struct {
+	Aliases map[string]nodes
+}
+
+func (a *aliases) marshalYAML() []byte {
+	// add the keys to a string slice
+	keys := make([]string, len(a.Aliases))
+	i := 0
+	for k := range a.Aliases {
+		keys[i] = k
+		// remove dupes and sort the list of OWNERS
+		a.Aliases[k] = mergeDupes(a.Aliases[k])
+		sort.Sort(a.Aliases[k])
+		i++
+	}
+	sort.Strings(keys)
+
+	// write YAML
+	const indent = "  "
+	b := bytes.Buffer{}
+	b.WriteString(aliasesPrefix)
+
+	for _, k := range keys {
+		b.WriteString(indent + k + ":\n")
+		for _, v := range a.Aliases[k] {
+			line := indent + indent + "- " + v.Value
+			// there seems to be a bug in yaml.v3 where a LineComment
+			// from a parent Node ends up on a child Node,
+			// thus comments on group lines (e.g. "some-sig: # comment")
+			// is not supported.
+			if len(v.LineComment) > 0 {
+				line += " " + v.LineComment
+			}
+			line += "\n"
+			b.WriteString(line)
+		}
+	}
+	return b.Bytes()
+}
+
+func mergeDupes(s nodes) nodes {
+	seen := make(map[string]struct{}, len(s))
+	i := 0
+	for _, v := range s {
+		val := v.Value
+		if _, ok := seen[val]; ok {
+			continue
+		}
+		seen[val] = struct{}{}
+		s[i] = v
+		i++
+	}
+	return s[:i]
+}
+
+func printErrorAndExit(err error) {
+	fmt.Println(err)
+	os.Exit(1)
+}
+
+func newDecoderFromBytes(b []byte) *yaml.Decoder {
+	d := yaml.NewDecoder(bytes.NewReader(b))
+	d.KnownFields(true)
+	return d
+}
+
+func processData(original []byte, f *flags) ([]byte, error) {
+	var custom []byte
+	regular := original[:]
+
+	// look for custom content if requested
+	if f.custom {
+		customErr := errors.Errorf("custom content must be located at the end of the file "+
+			"enclosed between \"%s\" and \"%s\\n\"", customStart, customEnd)
+		str := string(original)
+		idxStart := strings.Index(str, customStart)
+		idxEnd := strings.Index(str, customEnd)
+		if idxStart == -1 {
+			return nil, customErr
+		}
+		if idxEnd != len(str)-len(customEnd)-1 {
+			return nil, customErr
+		}
+		regular = regular[:idxStart]
+		custom = original[idxStart : idxEnd+len(customEnd)+1]
+		// prepend 'aliases:\n' to the custom content
+		custom = append([]byte(aliasesPrefix), custom...)
+	}
+
+	// unmarshal the YAMLs
+	aRegular := aliases{}
+	d := newDecoderFromBytes(regular)
+	if err := d.Decode(&aRegular); err != nil {
+		return nil, err
+	}
+	sorted := aRegular.marshalYAML()
+
+	if len(custom) > 0 {
+		aCustom := aliases{}
+		d := newDecoderFromBytes(custom)
+		if err := d.Decode(&aCustom); err != nil {
+			return nil, err
+		}
+		sortedCustom := aCustom.marshalYAML()
+
+		// trim the aliases prefix from the custom YAML
+		sortedCustom = bytes.TrimPrefix(sortedCustom, []byte(aliasesPrefix))
+
+		// concatenate the regular and custom content
+		sorted = append(sorted, []byte(customStart)...)
+		sorted = append(sorted, []byte("\n")...)
+		sorted = append(sorted, sortedCustom...)
+		sorted = append(sorted, []byte(customEnd)...)
+		sorted = append(sorted, []byte("\n")...)
+	}
+
+	return sorted, nil
+}
+
+func processFile(filePath string, f *flags) error {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+
+	original, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	sorted, err := processData(original, f)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Compare(original, sorted) != 0 {
+		// if writing in place was requested, write and return
+		if f.write {
+			if err := ioutil.WriteFile(filePath, sorted, info.Mode()); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// check if a diff is requested
+		if f.diff {
+			diff := difflib.UnifiedDiff{
+				A:        difflib.SplitLines(string(original)),
+				B:        difflib.SplitLines(string(sorted)),
+				FromFile: "Original",
+				ToFile:   "Formatted",
+				Context:  3,
+			}
+			text, err := difflib.GetUnifiedDiffString(diff)
+			if err != nil {
+				return errors.Wrapf(err, "could not obtain a unified diff for file %q", filePath)
+			}
+			fmt.Println(text)
+		} else {
+			fmt.Println(string(sorted))
+		}
+		return errors.Errorf("the file %q is not formatted", filePath)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		printErrorAndExit(errors.New("Usage: format-owners-aliases <flags> <OWNERS_ALIASES_FILE>"))
+	}
+
+	f := flags{}
+	flag.BoolVar(&f.custom, "c", false, "look for custom content in the file")
+	flag.BoolVar(&f.diff, "d", false, "write a diff instead of the whole formatted output")
+	flag.BoolVar(&f.write, "w", false, "write result to (source) file instead of stdout")
+	flag.Parse()
+
+	// treat the first non-flag as the file path to process
+	var filePath string
+	for _, f := range os.Args[1:] {
+		if !strings.HasPrefix(f, "-") {
+			filePath = f
+			break
+		}
+	}
+
+	if err := processFile(filePath, &f); err != nil {
+		printErrorAndExit(err)
+	}
+}

--- a/hack/format-owners-aliases_test.go
+++ b/hack/format-owners-aliases_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+const (
+	testInputWithCustom = `aliases:
+  B:
+    - C
+    - B
+    - A
+  A:
+    - C
+    - B
+    - A
+## BEGIN CUSTOM CONTENT
+  C:
+    - B
+    - A
+## END CUSTOM CONTENT
+`
+	testInputWithCustomFormatted = `aliases:
+  A:
+    - A
+    - B
+    - C
+  B:
+    - A
+    - B
+    - C
+## BEGIN CUSTOM CONTENT
+  C:
+    - A
+    - B
+## END CUSTOM CONTENT
+`
+
+	testInputWithCustomWrongPosition = `aliases:
+## BEGIN CUSTOM CONTENT
+  C:
+    - A
+    - B
+## END CUSTOM CONTENT
+  A:
+    - A
+    - B
+    - C
+`
+	testInputWithComments = `aliases:
+# heading comments are ignored
+  B:
+    - T # commentT
+    - S
+    - R # commentR
+  A:
+    - C
+    - B
+    - A
+`
+	testInputWithCommentsFormatted = `aliases:
+  A:
+    - A
+    - B
+    - C
+  B:
+    - R # commentR
+    - S
+    - T # commentT
+`
+	testInputWithDuplicateOwners = `aliases:
+  A:
+    - A
+    - A
+    - B
+`
+	testInputWithDuplicateOwnersFormatted = `aliases:
+  A:
+    - A
+    - B
+`
+	testInputWithDuplicateGroup = `aliases:
+  A:
+    - A
+    - B
+  A:
+    - A
+    - B
+    - C
+`
+)
+
+func TestProcessData(t *testing.T) {
+	var tests = []struct {
+		name           string
+		input          string
+		f              *flags
+		expectedOutput string
+		expectedError  bool
+	}{
+		{
+			name:           "valid: with custom content and formating",
+			input:          testInputWithCustom,
+			expectedOutput: testInputWithCustomFormatted,
+			f:              &flags{custom: true},
+		},
+		{
+			name:           "valid: format without custom content",
+			input:          testInputWithComments,
+			expectedOutput: testInputWithCommentsFormatted,
+		},
+		{
+			name:           "valid: format without custom content",
+			input:          testInputWithComments,
+			expectedOutput: testInputWithCommentsFormatted,
+		},
+		{
+			name:           "valid: should remove duplicates from owners",
+			input:          testInputWithDuplicateOwners,
+			expectedOutput: testInputWithDuplicateOwnersFormatted,
+		},
+		{
+			name:          "invalid: custom content requested but not present",
+			input:         testInputWithComments,
+			f:             &flags{custom: true},
+			expectedError: true,
+		},
+		{
+			name:          "invalid: custom content present at wrong position",
+			input:         testInputWithCustomWrongPosition,
+			f:             &flags{custom: true},
+			expectedError: true,
+		},
+		{
+			name:          "invalid: duplicate groups should fail unmarshaling",
+			input:         testInputWithDuplicateGroup,
+			expectedError: true,
+		},
+		{
+			name:          "invalid: input does not have aliases",
+			input:         "",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.f == nil {
+				tt.f = &flags{}
+			}
+			output, err := processData([]byte(tt.input), tt.f)
+			if (err != nil) != tt.expectedError {
+				t.Fatalf("expected error: %v, got: %v, error: %v", tt.expectedError, err != nil, err)
+			}
+			if bytes.Compare(output, []byte(tt.expectedOutput)) != 0 {
+				t.Fatalf("expected output does not match\n"+
+					"output:\n%s\n"+
+					"expectedOutput:\n%s\n",
+					output, tt.expectedOutput)
+			}
+		})
+	}
+}

--- a/hack/update-owners-aliases.sh
+++ b/hack/update-owners-aliases.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+root=$(dirname "${BASH_SOURCE[@]}")/..
+export KUBE_ROOT=$root
+export GO111MODULE=on
+export GOPROXY="${GOPROXY:-https://proxy.golang.org}"
+
+go run "$KUBE_ROOT"/hack/format-owners-aliases.go -w -c "$KUBE_ROOT"/OWNERS_ALIASES

--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -41,6 +41,9 @@ for file in $(ls ${CRT_DIR}/sigs.yaml ${CRT_DIR}/sig-*/README.md ${CRT_DIR}/wg-*
   real=${file#$CRT_DIR/}
   if ! diff -q ${file} ${WORKING_DIR}/${real} &>/dev/null; then
     echo "${file} does not match ${WORKING_DIR}/${real}";
+    if [[ ${file} == *"OWNERS_ALIASES"* ]]; then
+      echo "make sure you run ./hack/update-owners-aliases.sh"
+    fi
     mismatches=$((mismatches+1))
   fi;
 done

--- a/hack/verify-owners-aliases-test.sh
+++ b/hack/verify-owners-aliases-test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+root=$(dirname "${BASH_SOURCE[@]}")/..
+export KUBE_ROOT=$root
+export GO111MODULE=on
+export GOPROXY="${GOPROXY:-https://proxy.golang.org}"
+
+a="${KUBE_ROOT}/hack/format-owners-aliases.go"
+b="${KUBE_ROOT}/hack/format-owners-aliases_test.go"
+go vet "$a" "$b"
+go test "$a" "$b" -count=1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

- add hack/format-owners-aliases.go and unit tests in _test.go
- call the unit tests in hack/verify-owners-aliases-test.sh
- add hack/update-owners-aliases.sh that will update the OWNERS_ALIASES
file in place
- modify verify-generated-docs.sh and Makefile to include
the new verification
- include a couple of new dependencies in go.* files
- update the actual OWNERS_ALIASES file to remove duplicate owners
and sort the groups and owners

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

/kind feature
/area test
/priority important-longterm
/assign @justaugustus 
