### PR TITLE
generator/app: add means for sorted and de-duped OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,6 @@ aliases:
   sig-api-machinery-leads:
     - deads2k
     - fedebongio
-    - deads2k
     - lavalamp
   sig-apps-leads:
     - janetkuo
@@ -14,31 +13,29 @@ aliases:
     - dims
     - johnbelamaric
   sig-auth-leads:
-    - enj
-    - mikedanese
-    - tallclair
     - deads2k
+    - enj
     - liggitt
     - mikedanese
+    - tallclair
   sig-autoscaling-leads:
     - mwielgus
   sig-cli-leads:
-    - seans3
-    - soltysh
     - pwittrock
+    - seans3
     - soltysh
   sig-cloud-provider-leads:
     - andrewsykim
     - cheftako
   sig-cluster-lifecycle-leads:
+    - fabriziopandini
     - justinsb
     - neolit123
     - timothysc
-    - fabriziopandini
   sig-contributor-experience-leads:
     - Phillels
-    - mrbobbytables
     - cblecker
+    - mrbobbytables
     - nikhita
   sig-docs-leads:
     - Bradamant3
@@ -94,9 +91,9 @@ aliases:
     - vllry
   sig-windows-leads:
     - PatrickLang
-    - michmike
     - benmoss
     - ddebroy
+    - michmike
   wg-apply-leads:
     - lavalamp
   wg-component-standard-leads:
@@ -146,8 +143,10 @@ aliases:
     - foxish
     - liyinan926
   ug-vmware-users-leads:
+    - brysonshepherd
     - cantbewong
     - mylesagray
+    - phenixblue
   committee-code-of-conduct:
     - AevaOnline
     - Bradamant3

--- a/generator/aliases.tmpl
+++ b/generator/aliases.tmpl
@@ -1,28 +1,25 @@
 aliases:
   {{- range .Sigs}}
   {{.Dir}}-leads:
-    {{- range .Leadership.Chairs}}
-    - {{.GitHub}}
-    {{- end}}
-    {{- range .Leadership.TechnicalLeads}}
+    {{- range .Leadership.Owners}}
     - {{.GitHub}}
     {{- end}}
   {{- end}}
   {{- range .WorkingGroups}}
   {{.Dir}}-leads:
-    {{- range .Leadership.Chairs}}
+    {{- range .Leadership.Owners}}
     - {{.GitHub}}
     {{- end}}
   {{- end}}
   {{- range .UserGroups}}
   {{.Dir}}-leads:
-    {{- range .Leadership.Chairs}}
+    {{- range .Leadership.Owners}}
     - {{.GitHub}}
     {{- end}}
   {{- end}}
   {{- range .Committees}}
   {{.Dir}}:
-    {{- range .Leadership.Chairs}}
+    {{- range .Leadership.Owners}}
     - {{.GitHub}}
     {{- end}}
   {{- end}}

--- a/generator/app.go
+++ b/generator/app.go
@@ -122,6 +122,29 @@ func (g *LeadershipGroup) PrefixToPersonMap() map[string][]Person {
 	}
 }
 
+// Owners returns a sorted and de-duped list of owners for a LeadershipGroup
+func (g *LeadershipGroup) Owners() []Person {
+	o := append(g.Chairs, g.TechnicalLeads...)
+
+	// Sort
+	sort.Slice(o, func(i, j int) bool {
+		return o[i].GitHub < o[j].GitHub
+	})
+
+	// De-dupe
+	seen := make(map[string]struct{}, len(o))
+	i := 0
+	for _, p := range o {
+		if _, ok := seen[p.GitHub]; ok {
+			continue
+		}
+		seen[p.GitHub] = struct{}{}
+		o[i] = p
+		i++
+	}
+	return o[:i]
+}
+
 // Group represents either a Special Interest Group (SIG) or a Working Group (WG)
 type Group struct {
 	Dir              string


### PR DESCRIPTION
- Add LeadershipGroup#Owners() which returns a sorted and de-duped
list of owners ([]Person) for this LeadershipGroup by combining
Chairs and TechnicalLeads
- The function is used in generator/aliases.tmpl
- Update OWNERS_ALIASES with the new results

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

/assign @nikhita 
/kind feature
/priority important-longterm

