### PR TITLE
Update style guide with a few minor additions

### DIFF
--- a/contributors/guide/style-guide.md
+++ b/contributors/guide/style-guide.md
@@ -103,6 +103,8 @@ These are **guidelines**, not rules. Use your best judgement.
 - If using acronyms, ensure they are clearly defined in the same document.
 - If using an abbreviation, spell it out the first time it is used in the
   document unless it is commonly known. (example: TCP/IP)
+- When referring to a Kubernetes Group (SIG, WG, or UG) do not use the hyphenated
+  form unless it is for a specific purpose such as a file-name or URI.
 
 **[Moving a Document:](#moving-a-document)**
 
@@ -389,6 +391,10 @@ external appearance.
   - **Good example:** A _CustomResourceDefinition_ (CRD) extends the Kubernetes
     API.
   - **Bad example:** A CRD extends the Kubernetes API.
+- When referring to a Kubernetes Group (SIG, WG, or UG) do not use the hyphenated
+  form unless it is for a specific purpose such as a file-name or URI.
+  - **Good example:** SIG Docs oversees the Kubernetes website.
+  - **Bad example:** SIG-Docs oversees the Kubernetes website.
 
 
 ### Moving a Document

--- a/contributors/guide/style-guide.md
+++ b/contributors/guide/style-guide.md
@@ -200,6 +200,7 @@ These are **guidelines**, not rules. Use your best judgement.
 - If the document is intended to be surfaced on the Contributor Site; include a
   yaml metadata header at the beginning of the document.
 - Metadata must include the `title` attribute.
+- If including the `slug` attribute. It **must** match the filename.
 
 **[Tables:](#tables)**
 
@@ -673,6 +674,8 @@ relative links. However, how and what they're being linked to can vary widely.
 - Metadata must include the `title` attribute.
   - `title` will be used as the title of the document when rendered with
     [Hugo].
+- If including the `slug` attribute. It **must** match the filename for
+  intra-site links to be resolved correctly.
 
 
 ### Tables


### PR DESCRIPTION
- Adds a note on how to refer to Kubernetes Groups (SIG, WG, UG).
- Adds a note on usage of the `slug` attribute if used.