### PR TITLE
adding chair and tl folder

### DIFF
--- a/contributors/chairs-and-techleads/README.md
+++ b/contributors/chairs-and-techleads/README.md
@@ -1,0 +1,37 @@
+future home for chairs and tech leads resources and materials for onboarding,
+offboarding, operations, and more.
+files like zoom guidelines will still remain in their current home but included
+in documentation here in the form of canonical links.   
+
+## Resources for community group leads:    
+
+operations  
+TODO
+//add meeting agenda templates    
+
+governance  
+TODO  
+//add sig-gov.md, wg-gov,md, gov.md, steering folder in community, etc.
+
+[mentoring, succession planning, and staffing]    
+
+[code of conduct]  
+- conduct@kubernetes.io if you need anything from them or to report  
+- may have training or guidance - ask!    
+
+Communication and feedback loops:  
+[Need to Know email archive]  
+[Monthly meeting]  
+Slack: #chairs-and-techleads, #sig-contribex  
+Mailing list: kubernetes-sig-leads@googlegroups.com  
+Github: File issues against kubernetes/community  
+
+[values]  
+[principles]
+
+[Need to Know email archive]: https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit
+[Monthly meeting]: https://docs.google.com/document/d/1Jio9rEtYxlBbntF8mRGmj6Q1JAdzZ9fTDo3ru1HK_LI/edit
+[values]: https://github.com/kubernetes/community/blob/master/values.md
+[principles]: https://github.com/kubernetes/community/blob/master/governance.md#principles
+[code of conduct]: https://github.com/kubernetes/community/tree/master/committee-code-of-conduct
+[mentoring, succession planning, and staffing]: https://github.com/kubernetes/community/tree/master/mentoring

--- a/contributors/chairs-and-techleads/meeting-host.md
+++ b/contributors/chairs-and-techleads/meeting-host.md
@@ -1,0 +1,18 @@
+this is the future home for hosting instructions: monthly sig chair/tl meeting  
+
+1. make sure both timezones are booked on the calendar. contact contribex chairs
+if there is a problem.
+2. add the date and host name to the meeting [agenda]  
+3. start curating the agenda based on previous templates  
+  -  welcome and intros to those new to the call first   
+  -  relevant community news  
+  -  previous meeting recap, questions, and discussion. this is helpful to sync the
+discussion points from other timezone friendly meetings and review actions/ongoing
+work to keep everyone on the same page.  
+- recruit someone to do a how to topic and make the discussion in a similar
+category. parking lot of ideas is at the top of the agenda. solicit agenda items
+from the chairs/tls
+4. send agenda to chairs/tls on the mailing list and slack channel
+
+
+[agenda]: https://docs.google.com/document/d/1Jio9rEtYxlBbntF8mRGmj6Q1JAdzZ9fTDo3ru1HK_LI/edit

--- a/contributors/chairs-and-techleads/meeting-host.md
+++ b/contributors/chairs-and-techleads/meeting-host.md
@@ -4,14 +4,14 @@ this is the future home for hosting instructions: monthly sig chair/tl meeting
 if there is a problem.
 2. add the date and host name to the meeting [agenda]  
 3. start curating the agenda based on previous templates  
-  -  welcome and intros to those new to the call first   
-  -  relevant community news  
-  -  previous meeting recap, questions, and discussion. this is helpful to sync the
-discussion points from other timezone friendly meetings and review actions/ongoing
-work to keep everyone on the same page.  
-- recruit someone to do a how to topic and make the discussion in a similar
-category. parking lot of ideas is at the top of the agenda. solicit agenda items
-from the chairs/tls
+    - welcome and intros to those new to the call first   
+    - relevant community news  
+    - previous meeting recap, questions, and discussion. this is helpful to
+      sync the discussion points from other timezone friendly meetings and
+      review actions/ongoing work to keep everyone on the same page  
+    - recruit someone to do a how to topic and make the discussion in a similar
+      category. parking lot of ideas is at the top of the agenda. solicit
+      agenda items from the chairs/tls
 4. send agenda to chairs/tls on the mailing list and slack channel
 
 


### PR DESCRIPTION
/hold
for comments. i think this is the best place to put this. documentation geared towards a certain type of contributor. i don't think the folder will be that extensive so not sure it warrants its own in the root. 

this would also house the archive for the chair/tl need to know email