### PR TITLE
Update docs for granting approval privileges to NMCs

### DIFF
--- a/github-management/README.md
+++ b/github-management/README.md
@@ -53,6 +53,8 @@ community members, guiding them through the
 [process](new-membership-procedure.md) to request membership to a Kubernetes
 GitHub organization.
 
+They also have approval privileges for adding new members to the GitHub config.
+
 Our current coordinators are:
 * Naeil Ezzoueidi (**[@nzoueidi](https://github.com/nzoueidi)**, Central European)
 * Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**, US Eastern)

--- a/github-management/new-membership-procedure.md
+++ b/github-management/new-membership-procedure.md
@@ -92,9 +92,19 @@ resolving. One PR can be used to resolve multiple membership requests.
 1. Add a note to the original membership request stating that a membership
 invite will be sent out once the PR has merged.
 
-1. Wait for a member of the GitHub administration team to approve the PR for
-merge.
+1. Wait for another New Membership Coordinator or a member of the
+GitHub administration team to lgtm the PR for merge.
 
+## Approving New Membership Requests
+
+New Membership Coordinators and members of the GitHub administration team
+have approval privileges for the GitHub config in the
+[kubernetes/org] repo.
+
+New Membership Coordinators should ensure that they approve PRs that
+_only_ update members. Approval for any other config changes (like
+GitHub teams) should be delegated to the respective SIG/WG/UG leads
+or the GitHub administration team.
 
 
 


### PR DESCRIPTION
We get multiple  membership requests per day and New Membership Coordinators (NMCs) do the bulk of the work for adding members to the GitHub config. Currently, they need to wait for approval from a member of the GitHub admin team on such PRs.

To make the process smoother and faster, this PR updates docs to grant approval privileges to NMCs for PRs updating members in the GitHub config.

Discussed this with the GitHub admin team already.

/hold
for written sign off from github admin team