### PR TITLE
slack-config: add #krew

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -134,6 +134,7 @@ channels:
   - name: kr-users
   - name: kraken
   - name: krane
+  - name: krew
   - name: krex
   - name: kube-aws
   - name: kube-deploy


### PR DESCRIPTION
https://sigs.k8s.io/krew is a vibrant SIG CLI project with user and developer
communities.

Proposing `#krew` channel to Kubernetes Slack for colalboration.