### PR TITLE
Update TZ converter for meet-our-contributors mtg

### DIFF
--- a/mentoring/meet-our-contributors.md
+++ b/mentoring/meet-our-contributors.md
@@ -80,7 +80,7 @@ better!
 
 [kubernetes.io/community]: https://kubernetes.io/community/
 [#meet-our-contributors]: https://kubernetes.slack.com/messages/meet-our-contributors
-[Convert to your timezone]: https://www.thetimezoneconverter.com/?t=02%3A30%20pm&tz=UTC&
+[Convert to your timezone]: https://www.thetimezoneconverter.com/?t=03%3A30%20pm&tz=UTC&
 [Kubernetes YouTube Channel]: (https://www.youtube.com/c/KubernetesCommunity/live
 [previous Meet-Our-Contributors monthly meetings]: https://www.youtube.com/playlist?list=PL69nYSiGNLP3QpQrhZq_sLYo77BVKv09F
 [#office-hours]: https://kubernetes.slack.com/messages/office-hours


### PR DESCRIPTION
In 4d540852a the time of the meet-our-contributors meeting was updated
to 3:30pm UTC, but the link to the timezone converter still pointed to
2:30pm. This change fixes the link to point to the updated meeting time.
