### PR TITLE
Add Meeting Notes Link to VMware UG

### DIFF
--- a/sig-list.md
+++ b/sig-list.md
@@ -68,7 +68,7 @@ When the need arises, a [new SIG can be created](sig-wg-lifecycle.md)
 | Name | Label |Organizers | Contact | Meetings |
 |------|-------|------------|--------|----------|
 |[Big Data](ug-big-data/README.md)|big-data|* [Erik Erlandson](https://github.com/erikerlandson), Red Hat<br>* [Anirudh Ramanathan](https://github.com/foxish), Rockset<br>* [Yinan Li](https://github.com/liyinan926), Google<br>|* [Slack](https://kubernetes.slack.com/messages/ug-big-data)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-ug-big-data)|* Regular User Group Meeting: [Wednesdays at 18:00 UTC (biweekly)](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit)<br>
-|[VMware Users](ug-vmware-users/README.md)|vmware-users|* [Steve Wong](https://github.com/cantbewong), VMware<br>* [Myles Gray](https://github.com/mylesagray), VMware<br>|* [Slack](https://kubernetes.slack.com/messages/ug-vmware)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-ug-vmware)|* Regular User Group Meeting: [Thursdays at 11:00 PT (Pacific Time) (monthly)]()<br>
+|[VMware Users](ug-vmware-users/README.md)|vmware-users|* [Steve Wong](https://github.com/cantbewong), VMware<br>* [Myles Gray](https://github.com/mylesagray), VMware<br>|* [Slack](https://kubernetes.slack.com/messages/ug-vmware)<br>* [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-ug-vmware)|* Regular User Group Meeting: [Thursdays at 11:00 PT (Pacific Time) (monthly)](https://docs.google.com/document/d/1ujpqj4hhcIBrSCK2qn6J1r--3QyD96rfDjXTZQ7n7Mw/edit)<br>
 
 ### Master Committee List
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2759,6 +2759,7 @@ usergroups:
     time: "11:00"
     tz: PT (Pacific Time)
     frequency: monthly
+    url: https://docs.google.com/document/d/1ujpqj4hhcIBrSCK2qn6J1r--3QyD96rfDjXTZQ7n7Mw/edit
   contact:
     slack: ug-vmware
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-ug-vmware

--- a/ug-vmware-users/README.md
+++ b/ug-vmware-users/README.md
@@ -11,7 +11,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 The VMware User Group facilitates communication among Kubernetes users and contributors on topics pertaining to running all conformant forms of Kubernetes on VMware infrastructure.
 
 ## Meetings
-* Regular User Group Meeting: [Thursdays at 11:00 PT (Pacific Time)]() (monthly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
+* Regular User Group Meeting: [Thursdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1ujpqj4hhcIBrSCK2qn6J1r--3QyD96rfDjXTZQ7n7Mw/edit) (monthly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
 
 ## Organizers
 


### PR DESCRIPTION
Added a link to the VMware User Group Meeting Notes doc

Signed-off-by: Kendrick Coleman <kendrickc@vmware.com>

/assign @cantbewong @mylesagray 