### PR TITLE
slack channel: create cluster-api-digitalocean channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -33,6 +33,7 @@ channels:
   - name: cluster-api-aws
   - name: cluster-api-azure
   - name: cluster-api-baremetal
+  - name: cluster-api-digitalocean
   - name: cluster-api-docker
     archived: true
   - name: cluster-api-openstack


### PR DESCRIPTION
Request the slack channel for the `cluster-api-digitalocean` similar that aws and azure have, to discuss subjects related to the CAPDO

/cc @xmudrii @detiber 
