### PR TITLE
slack-config: add #metallb-dev.

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -213,6 +213,7 @@ channels:
   - name: meetup-tunisia
   - name: metacontroller
   - name: metallb
+  - name: metallb-dev
   - name: microk8s
   - name: minikube
   - name: minikube-dev


### PR DESCRIPTION
Signed-Off-By: David Anderson <dave@natulte.net>

Rationale (copied from #slack-admins): we already have #metallb for user traffic, but we'd like a place for myself (current maintainer) and new maintainers to talk project logistics and stuff that would get drowned out in the support cries for help on #metallb. Right now as a workaround, we have a private channel on Rancher's slack, but that's becoming an issue as non-Rancher people want to get involved. It seems natural to move things into the open on the k8s slack.