### PR TITLE
add openebs slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -233,6 +233,7 @@ channels:
   - name: office-hours
   - name: okteto
   - name: opencontainers
+  - name: openebs
   - name: openshift-dev
   - name: openshift-users
   - name: openstack-helm


### PR DESCRIPTION
It would be great to have a channel for OpenEBS: https://openebs.io/ in slack.
OpenEBS is developed under Apache License 2.0 license at the project level. Some components of the projects are derived from the other Open Source projects and are distributed under their respective licenses.
OpenEBS is a sandbox CNCF project and provides storage-integration for Kubernetes.

Signed-off-by: David Karlsen <david@davidkarlsen.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/community/4528)
<!-- Reviewable:end -->
