### PR TITLE
Add channel for dc kubernetes meetup

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -204,6 +204,7 @@ channels:
   - name: meetup-manchester
   - name: meetup-minneapolis
   - name: meetup-nyc
+  - name: meetup-dc
   - name: meetup-paris
   - name: meetup-pittsburgh
   - name: meetup-sacramento


### PR DESCRIPTION
The DC meetup wants to use the kubernetes slack to communicate and post relevant information.

