### PR TITLE
Fix invalid command: replace absent package

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -250,7 +250,7 @@ make update
 make test
 
 # Run package tests verbosely
-make test WHAT=./pkg/api/helper GOFLAGS=-v
+make test WHAT=./pkg/apis/core/helper GOFLAGS=-v
 
 # Run integration tests, requires etcd
 # For more info, visit https://git.k8s.io/community/contributors/devel/sig-testing/testing.md#integration-tests


### PR DESCRIPTION
`./pkg/api/helper` doesn't exist in the kubernetes repo. Replace it with [./pkg/apis/core/helper](https://github.com/kubernetes/kubernetes/tree/master/pkg/apis/core/helper).