### PR TITLE
Add kcli channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -126,6 +126,7 @@ channels:
   - name: keel
   - name: kiam
   - name: kind
+  - name: kcli
   - name: klog
   - name: knative
   - name: kompose


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This requests a new channel for kcli, which is a tool designed to handle vms, containers and other objects on libvirt, ovirt, vsphere and cloud platforms.
The tool also allows to easily create kubernetes clusters either using kubeadm or openshift/okd, with the idea to extend it to other kubernetes deployment tooling, hence the request to host it here.

