### PR TITLE
Update release managers group in documentation

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -36,7 +36,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Frelease)
 - GitHub Teams:
     - [@kubernetes/kubernetes-milestone-maintainers](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers) - Milestone Maintainers
-    - [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers) - Release Managers
+    - [@kubernetes/kubernetes-release-managers](https://github.com/orgs/kubernetes/teams/kubernetes-release-managers) - Release Managers
     - [@kubernetes/sig-release](https://github.com/orgs/kubernetes/teams/sig-release) - SIG Release Members
     - [@kubernetes/sig-release-admins](https://github.com/orgs/kubernetes/teams/sig-release-admins) - Admins for SIG Release repositories
 

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -36,7 +36,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Frelease)
 - GitHub Teams:
     - [@kubernetes/kubernetes-milestone-maintainers](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers) - Milestone Maintainers
-    - [@kubernetes/kubernetes-release-managers](https://github.com/orgs/kubernetes/teams/kubernetes-release-managers) - Release Managers
+    - [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers) - Release Managers
     - [@kubernetes/sig-release](https://github.com/orgs/kubernetes/teams/sig-release) - SIG Release Members
     - [@kubernetes/sig-release-admins](https://github.com/orgs/kubernetes/teams/sig-release-admins) - Admins for SIG Release repositories
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1715,7 +1715,7 @@ sigs:
     teams:
     - name: kubernetes-milestone-maintainers
       description: Milestone Maintainers
-    - name: kubernetes-release-managers
+    - name: release-managers
       description: Release Managers
     - name: sig-release
       description: SIG Release Members


### PR DESCRIPTION
The existing group was not valid.  This may have been updated at some point.  This ensures the documentation is pointed to the correct group.
