### PR TITLE
Add NOTE to know how to download kubetest command

### DIFF
--- a/contributors/devel/sig-testing/e2e-tests.md
+++ b/contributors/devel/sig-testing/e2e-tests.md
@@ -67,7 +67,7 @@ should also read [Writing Good e2e Tests](writing-good-e2e-tests.md)
 There are a variety of ways to run e2e tests, but we aim to decrease the number
 of ways to run e2e tests to a canonical way: `kubetest`.
 
-You can install `kubetest` as follows:
+You can install `kubetest` as follows (If you face a download issue, please see issue [#14712](https://github.com/kubernetes/test-infra/issues/14712#issuecomment-541560441)):
 ```sh
 go get -u k8s.io/test-infra/kubetest
 ```


### PR DESCRIPTION
According to the test-infra issue, some people seem to face the issue
when downloading kubetest command. So this adds NOTE to know how to
avoid the issue at this time.

Ref: https://github.com/kubernetes/test-infra/issues/14712
