### PR TITLE
fixes contrib doc bug #4486 - kubetest replaces hack/e2e.go

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -257,7 +257,6 @@ make test WHAT=./pkg/apis/core/helper GOFLAGS=-v
 make test-integration
 
 # Run e2e tests by building test binaries, turn up a test cluster, run all tests, and tear the cluster down
-# Equivalent to: go run hack/e2e.go -- -v --build --up --test --down
 # Note: running all e2e tests takes a LONG time! To run specific e2e tests, visit:
 # ./e2e-tests.md#building-kubernetes-and-running-the-tests
 make test-e2e

--- a/contributors/devel/sig-architecture/conformance-tests.md
+++ b/contributors/devel/sig-architecture/conformance-tests.md
@@ -178,7 +178,7 @@ following branches:
 
 Conformance tests are designed to be run even when there is no cloud provider
 configured. Conformance tests must be able to be run against clusters that have
-not been created with `hack/e2e.go`, just provide a kubeconfig with the
+not been created with `test-infra/kubetest`, just provide a kubeconfig with the
 appropriate endpoint and credentials.
 
 These commands are intended to be run within a kubernetes directory, either

--- a/contributors/devel/sig-node/node-performance-testing.md
+++ b/contributors/devel/sig-node/node-performance-testing.md
@@ -58,12 +58,9 @@ sampling.
 
 There is an end-to-end test for collecting overall resource usage of node
 components: [kubelet_perf.go](https://git.k8s.io/kubernetes/test/e2e/node/kubelet_perf.go). To
-run the test, simply make sure you have an e2e cluster running (`go run
-hack/e2e.go -- -up`) and [set up](#cluster-set-up) correctly.
+run the test, simply make sure you have an e2e cluster running (`kubetest --up`) and [set up](#cluster-set-up) correctly.
 
-Run the test with `go run hack/e2e.go -- -v -test
---test_args="--ginkgo.focus=resource\susage\stracking"`. You may also wish to
-customise the number of pods or other parameters of the test (remember to rerun
+Run the test with `kubetest --test --test_args="--ginkgo.focus=resource\susage\stracking"`. You may also wish to customise the number of pods or other parameters of the test (remember to rerun
 `make WHAT=test/e2e/e2e.test` after you do).
 
 ## Profiling

--- a/contributors/devel/sig-testing/e2e-tests.md
+++ b/contributors/devel/sig-testing/e2e-tests.md
@@ -124,8 +124,7 @@ kubetest --provider=aws --build --up --test --down
 
 The tests are built into a single binary which can be used to deploy a
 Kubernetes system or run tests against an already-deployed Kubernetes system.
-See `kubetest --help` (or the flag definitions in `hack/e2e.go`) for
-more options, such as reusing an existing cluster.
+See `kubetest --help` for more options, such as reusing an existing cluster.
 
 ### Cleaning up
 
@@ -249,20 +248,21 @@ set. The flags asks ginkgo to run the test repeatedly until it fails.
 
 ### Federation e2e tests
 
-By default, `e2e.go` provisions a single Kubernetes cluster, and any `Feature:Federation` ginkgo tests will be skipped.
+-By default, `kubetest` provisions a single Kubernetes cluster, and any `Feature:Federation` ginkgo tests will be skipped.-
 
-Federation e2e testing involve bringing up multiple "underlying" Kubernetes clusters,
+Federation e2e testing involves bringing up multiple "underlying" Kubernetes clusters,
 and deploying the federation control plane as a Kubernetes application on the underlying clusters.
 
-The federation e2e tests are still managed via `e2e.go`, but require some extra configuration items.
+-The federation e2e tests are still managed via `kubetest`, but require some extra configuration items.-
 
 #### Configuring federation e2e tests
 
 The following environment variables will enable federation e2e building, provisioning and testing.
 
 ```sh
-$ export FEDERATION=true
-$ export E2E_ZONES="us-central1-a us-central1-b us-central1-f"
+export FEDERATION=true
+export E2E_ZONES="us-central1-a us-central1-b us-central1-f"
+
 ```
 
 A Kubernetes cluster will be provisioned in each zone listed in `E2E_ZONES`. A zone can only appear once in the `E2E_ZONES` list.
@@ -297,7 +297,7 @@ Next, specify the docker repository where your ci images will be pushed.
 	Given this example, the `federation-apiserver` container image will be pushed to the repository
 	`quay.io/colin_hom/federation-apiserver`.
 
-	The docker client on the machine running `e2e.go` must have push access for the following pre-existing repositories:
+	The docker client on the machine running `kubetest` must have push access for the following pre-existing repositories:
 
 	* `${FEDERATION_PUSH_REPO_BASE}/federation-apiserver`
 	* `${FEDERATION_PUSH_REPO_BASE}/federation-controller-manager`

--- a/contributors/devel/sig-testing/e2e-tests.md
+++ b/contributors/devel/sig-testing/e2e-tests.md
@@ -248,7 +248,7 @@ set. The flags asks ginkgo to run the test repeatedly until it fails.
 
 ### Federation e2e tests
 
--By default, `kubetest` provisions a single Kubernetes cluster, and any `Feature:Federation` ginkgo tests will be skipped.-
+- By default, `kubetest` provisions a single Kubernetes cluster, and any `Feature:Federation` ginkgo tests will be skipped.
 
 Federation e2e testing involves bringing up multiple "underlying" Kubernetes clusters,
 and deploying the federation control plane as a Kubernetes application on the underlying clusters.

--- a/contributors/devel/sig-testing/e2e-tests.md
+++ b/contributors/devel/sig-testing/e2e-tests.md
@@ -248,7 +248,7 @@ set. The flags asks ginkgo to run the test repeatedly until it fails.
 
 ### Federation e2e tests
 
-- By default, `kubetest` provisions a single Kubernetes cluster, and any `Feature:Federation` ginkgo tests will be skipped.
+By default, `kubetest` provisions a single Kubernetes cluster, and any `Feature:Federation` ginkgo tests will be skipped.
 
 Federation e2e testing involves bringing up multiple "underlying" Kubernetes clusters,
 and deploying the federation control plane as a Kubernetes application on the underlying clusters.


### PR DESCRIPTION
**Which issue(s) this PR fixes**
Fixes #4486 
I changed contributor docs that referenced hack/e2e.go, to refer to kubetest instead

Thanks to @mrbobbytables for providing signposting.