### PR TITLE
Update channels.yaml to include a sig-windows-leads channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -305,6 +305,7 @@ channels:
   - name: sig-ui
   - name: sig-usability
   - name: sig-windows
+  - name: sig-windows-leads
   - name: skaffold
   - name: slack-admins
   - name: slack-infra


### PR DESCRIPTION
we would like a new slack channel called "sig-windows-leads"
We sometimes have lead specific work (like talking about presentations, deadlines, PRs, reviews, operations, etc) that makes sense to keep outside of the sig-windows channel. today, the only way we achieve this is by having many 2 and 3 and 4 people private chats. this is an unmanageable and we would like a dedicated channel.