### PR TITLE
Add k8spin channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -121,6 +121,7 @@ channels:
   - name: k8s-infra-alerts
   - name: k8s-release
     archived: true
+  - name: k8spin
   - name: kapitan
   - name: keda
   - name: keel


### PR DESCRIPTION
From k8spin.cloud we want to include a new channel in the kubernete slack group.

The channel will be used to share experiences between k8spin users.

K8Spin is a Kubernetes namespace as a service platform online.

In addition to the SaaS service, we are building some OSS tools related to kubernetes multi-tenant stuff: 

https://github.com/k8spin

Thanks!