### PR TITLE
Add submariner to slack channels.yaml file

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -318,6 +318,7 @@ channels:
   - name: spinnaker
   - name: sre
   - name: steering-committee
+  - name: submariner
   - name: summit-staff
   - name: suse-caasp
   - name: talk-proposals


### PR DESCRIPTION
From the submariner[1][2] community we are looking for a neutral discussion place. We participate on the sig-multicluster and sig-networking SIG discussions to align API design with upstream.
We have lots of internal design threads which would pollute #sig-multicluster or #sig-networking channels.

Submariner is a project for connecting the IP address spaces of separate k8s clusters via IPSEC (and eventually WireGuard) plus routing. Today it mainly works with kube-proxy / iptables based implementations, but we plan to make proposals to the CNI interface for routing enhancements.


[1] https://submariner-io.github.io
[2] https://submariner.io