### PR TITLE
Correct scheduler-plugins as a standalone subproject

### DIFF
--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -61,9 +61,11 @@ The following [subprojects][subproject-definition] are owned by sig-scheduling:
   - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS
 ### scheduler
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-scheduler/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/scheduler/OWNERS
+### scheduler-plugins
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/master/OWNERS
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1936,9 +1936,11 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS
   - name: scheduler
     owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-scheduler/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/scheduler/OWNERS
+  - name: scheduler-plugins
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/master/OWNERS
 - dir: sig-service-catalog
   name: Service Catalog
   mission_statement: >


### PR DESCRIPTION
This PR updates `scheduler-plugins` as a standalone sig-scheduling subproject, instead of hosting under `scheduler`.

/sig scheduling