### PR TITLE
Retire jbeda and sarahnovotny from youtube admin slack notifications

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -31,7 +31,6 @@ usergroups:
       - castrojo
       - idealhack
       - idvoretskyi
-      - jbeda
       - jdumars
       - jeefy
       - markyjackson-taulia
@@ -39,7 +38,6 @@ usergroups:
       - nzoueidi
       - onlydole
       - paris
-      - sarahnovotny
 
   - name: zoom-admins
     long_name: Zoom Admins

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -13,7 +13,6 @@ users:
   hoegaarden: U7VA4RZS9
   idealhack: U5NJ3DQM9
   idvoretskyi: U0CBHE6GM
-  jbeda: U09QZ63DX
   jdumars: U0YJS6LHL
   jeefy: U5MCFK468
   jonasrosland: U0A4G34S2
@@ -27,7 +26,6 @@ users:
   onlydole: U1DD4AZND
   paris: U5SB22BBQ
   Rin Oliver: USF4LMDCN
-  sarahnovotny: U0AGW7007
   saschagrunert: U53SUDBD4
   simplytunde: UAY1NBYHE
   sumitranr: UCQN13L9H


### PR DESCRIPTION
This removes them from the slack notifications when someone pings `@youtube-admins` on slack. 