### PR TITLE
[slack channel] add kubernetes-arm channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -165,6 +165,7 @@ channels:
   - name: kubepack
   - name: kubestack
   - name: kuberhealthy
+  - name: kubernetes-arm
   - name: kubernetes-batch-jobs
   - name: kubernetes-careers
   - name: kubernetes-client


### PR DESCRIPTION
Some of my colleagues and I are forming a group for enablement of Kubernetes on ARM platform.

This is just getting started, and currently includes a [Github Organization](https://github.com/kubernetes-arm), some [Projects](https://github.com/orgs/kubernetes-arm/projects) we want to work on to better enable Kubernetes on ARM and [Blog](https://kubernetes-arm.com/) where we're going to post about the relevant projects and issues we work on, as well as experiments and guides.

The basic idea is just to invite engineers with similar interest and focus on improving ARM compatibility across upstream repos and it would be helpful if we could please have a Slack channel to organize ourselves in.

Thank you!
