### PR TITLE
Add Taylor Dolezal to SIG Docs Tech Leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,6 +41,7 @@ aliases:
     - jimangel
     - kbarnard10
     - kbhawkey
+    - onlydole
     - sftim
     - zacharysarah
   sig-instrumentation-leads:

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -37,6 +37,7 @@ The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
 * Karen Bradshaw (**[@kbhawkey](https://github.com/kbhawkey)**), Independent
+* Taylor Dolezal (**[@onlydole](https://github.com/onlydole)**), Independent
 * Tim Bannister (**[@sftim](https://github.com/sftim)**), The Scale Factory
 
 ## Emeritus Leads

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1253,6 +1253,9 @@ sigs:
     - github: kbhawkey
       name: Karen Bradshaw
       company: Independent
+    - github: onlydole
+      name: Taylor Dolezal
+      company: Independent
     - github: sftim
       name: Tim Bannister
       company: The Scale Factory


### PR DESCRIPTION
Update `sigs.yaml` with my information around becoming a new tech lead for SIG Docs.
