### PR TITLE
Add meetup-lasvegas channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -204,6 +204,7 @@ channels:
   - name: meetup-guatemala
   - name: meetup-hannover
   - name: meetup-hongkong
+  - name: meetup-lasvegas
   - name: meetup-losangeles
   - name: meetup-manchester
   - name: meetup-minneapolis


### PR DESCRIPTION
The Las Vegas meetup community would like to use slack for communication.