### PR TITLE
Improve squashing documentation

### DIFF
--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -350,13 +350,13 @@ git checkout -b myfeature
 
 #### Squashing Commits
 
-The main purpose of [squashing commits](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md#squash-commits) is to create a clean readable git
+The main purpose of [squashing commits] is to create a clean readable git
 history or log of the changes that were made. Usually this is done in last
 phase of a PR revision. If you are unsure if you should squash your commits, it
 is better to err on the side of having more and leave it up to the judgement of
 the other contributors assigned to review and approve your PR.
 
-Perform an interactive rebase to choose which commits you want to keep and which you want to squash, then force push your new timeline:
+Perform an interactive rebase to choose which commits you want to keep and which you want to squash, then force push your branch:
 
 ```
 git rebase -i HEAD~3

--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -350,11 +350,19 @@ git checkout -b myfeature
 
 #### Squashing Commits
 
-The main purpose of [squashing commits] is to create a clean readable git
+The main purpose of [squashing commits](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md#squash-commits) is to create a clean readable git
 history or log of the changes that were made. Usually this is done in last
 phase of a PR revision. If you are unsure if you should squash your commits, it
 is better to err on the side of having more and leave it up to the judgement of
 the other contributors assigned to review and approve your PR.
+
+Perform an interactive rebase to choose which commits you want to keep and which you want to squash, then force push your new timeline:
+
+```
+git rebase -i HEAD~3
+...
+git push --force
+```
 
 
 

--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -137,33 +137,100 @@ fork.
 
 Very small PRs are easy to review.  Very large PRs are very difficult to review.
 
-#### Squash and Merge
+#### Squash commits
 
-Upon merge (by either you or your reviewer), all commits left on the review
-branch should represent meaningful milestones or units of work.  Use commits to
-add clarity to the development and review process.
+After a review, prepare your PR for merging by squashing your commits.
 
-Before merging a PR, squash any _fix review feedback_, _typo_, _merged_, and
-_rebased_ sorts of commits.
+All commits left on the timeline after a review should represent meaningful milestones or units of work. Use commits to add clarity to the development and review process.
 
-It is not imperative that every commit in a PR compile and pass tests
-independently, but it is worth striving for.
+Before merging a PR, squash the following kinds of commits:
 
-In particular, if you happened to have used `git merge` and have merge
-commits, please squash those away: they do not meet the above test.
+- Fixes/review feedback
+- Typos
+- Merges and rebases
+- Work in progress
 
-A nifty way to manage the commits in your PR is to do an [interactive
-rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History),
-which will let you tell git what to do with every commit:
+Aim to have every commit in a PR compile and pass tests independently if you can, but it's not a requirement. In particular, squash `git merge` commits won't pass tests and should be squashed.
 
-```sh
-git fetch upstream
-git rebase -i upstream/master
-```
+To squash your commits, perform an [interactive
+rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History):
+
+1. Check your git branch:
+  
+  ```
+  git status
+  ```
+  
+  Output is similar to:
+  
+  ```
+  On branch your-contribution
+  Your branch is up to date with 'origin/your-contribution'.
+  ```
+  
+2. Start an interactive rebase using a specific commit hash, or count backwards from your last commit using `HEAD~<n>`, where `<n>` represents the number of commits to include in the rebase. 
+
+  ```
+  git rebase -i HEAD~3
+  ```
+  
+  Output is similar to: 
+  
+  ```
+  pick 2ebe926 Original commit
+  pick 31f33e9 Address feedback
+  pick b0315fe Second unit of work
+
+  # Rebase 7c34fc9..b0315ff onto 7c34fc9 (3 commands)
+  #
+  # Commands:
+  # p, pick <commit> = use commit
+  # r, reword <commit> = use commit, but edit the commit message
+  # e, edit <commit> = use commit, but stop for amending
+  # s, squash <commit> = use commit, but meld into previous commit
+  # f, fixup <commit> = like "squash", but discard this commit's log message
+  
+  ...
+  
+  ```
+
+3. Use a command line text editor to change the word `pick` to `fixup` for the commits you want to squash, then save your changes and continue the rebase: 
+
+  ```
+  pick 2ebe926 Original commit
+  squash 31f33e9 Address feedback
+  pick b0315fe Second unit of work
+  
+  ...
+  
+  ```
+  
+  Output (after saving changes) is similar to: 
+  
+  ```
+  [detached HEAD 61fdded] Second unit of work
+   Date: Thu Mar 5 19:01:32 2020 +0100
+   2 files changed, 15 insertions(+), 1 deletion(-)
+   
+   ...
+   
+  Successfully rebased and updated refs/heads/master.
+  ```
+4. Force push your changes to your remote branch:
+
+  ```
+  git push --force
+  ```
 
 For mass automated fixups (e.g. automated doc formatting), use one or more
 commits for the changes to tooling and a final commit to apply the fixup en
 masse. This makes reviews easier.
+
+### Merging a commit
+
+Once you've received review and approval, your commits are squashed, your PR is ready for merging. 
+
+Merging happens automatically when a Reviewer or Approver approves the PR. If you haven't squashed your commits, they may ask you to do so before approving a PR. .
 
 ### Reverting a commit
 

--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -141,7 +141,7 @@ Very small PRs are easy to review.  Very large PRs are very difficult to review.
 
 After a review, prepare your PR for merging by squashing your commits.
 
-All commits left on the timeline after a review should represent meaningful milestones or units of work. Use commits to add clarity to the development and review process.
+All commits left on your branch after a review should represent meaningful milestones or units of work. Use commits to add clarity to the development and review process.
 
 Before merging a PR, squash the following kinds of commits:
 
@@ -150,7 +150,7 @@ Before merging a PR, squash the following kinds of commits:
 - Merges and rebases
 - Work in progress
 
-Aim to have every commit in a PR compile and pass tests independently if you can, but it's not a requirement. In particular, squash `git merge` commits won't pass tests and should be squashed.
+Aim to have every commit in a PR compile and pass tests independently if you can, but it's not a requirement. In particular, remove `merge` commits should be removed. They won't pass tests and should be removed.
 
 To squash your commits, perform an [interactive
 rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History):
@@ -230,7 +230,7 @@ masse. This makes reviews easier.
 
 Once you've received review and approval, your commits are squashed, your PR is ready for merging. 
 
-Merging happens automatically when a Reviewer or Approver approves the PR. If you haven't squashed your commits, they may ask you to do so before approving a PR. .
+Merging happens automatically after both a  Reviewer and Approver have approved the PR. If you haven't squashed your commits, they may ask you to do so before approving a PR.
 
 ### Reverting a commit
 

--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -150,7 +150,7 @@ Before merging a PR, squash the following kinds of commits:
 - Merges and rebases
 - Work in progress
 
-Aim to have every commit in a PR compile and pass tests independently if you can, but it's not a requirement. In particular, remove `merge` commits should be removed. They won't pass tests and should be removed.
+Aim to have every commit in a PR compile and pass tests independently if you can, but it's not a requirement. In particular, `merge` commits must be removed, as they will not pass tests.
 
 To squash your commits, perform an [interactive
 rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History):

--- a/contributors/guide/pull-requests.md
+++ b/contributors/guide/pull-requests.md
@@ -290,7 +290,7 @@ We might still ask you to clean up your commits at the very end for the sake of 
 
 Each commit should have a good title line (<70 characters) and include an additional description paragraph describing in more detail the change intended.
 
-For more information, see [squash commits](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md#squash-commits).
+For more information, see [squash commits](./github-workflow.md#squash-commits).
 
 **General squashing guidelines:**
 

--- a/contributors/guide/pull-requests.md
+++ b/contributors/guide/pull-requests.md
@@ -290,6 +290,8 @@ We might still ask you to clean up your commits at the very end for the sake of 
 
 Each commit should have a good title line (<70 characters) and include an additional description paragraph describing in more detail the change intended.
 
+For more information, see [squash commits](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md#squash-commits).
+
 **General squashing guidelines:**
 
 * Sausage => squash


### PR DESCRIPTION
Related to `kubernetes/release` [#1204](https://github.com/kubernetes/release/issues/1204). 

This PR improves documentation and instruction around squashing commits – when you should do it (before a merge), who should do it (the PR author), and what to squash (anything that isn't a meaningful unit of work.)

SIG Docs wants this improvement because we often get contributors who aren't as familiar with Git as some of the other repositories/SIG's. It's difficult to tell a (very) new contributor that they're responsible for squashing their own commits if we don't provide a bit of guidance as to how to do that. Third party resources are good and perhaps preferred, but we often get requests for help with "the end to end process of making my first contribution" regardless of whether we link to third party resources or not. This is a step in that direction.

Similar content will probably land on the `kubernetes/website`'s Contribute section shortly.
