### PR TITLE
Adding dex slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -54,6 +54,7 @@ channels:
   - name: de-events
   - name: de-users
   - name: devstats
+  - name: dex
   - name: digitalocean-k8s
   - name: distroless
   - name: diversity


### PR DESCRIPTION
This PR adds a slack channel for https://github.com/dexidp/dex, an OAuth2 identity provider used significantly throughout the Kubernetes community. A conversation on both the [Dex Repo](https://github.com/dexidp/dex/issues/1682#issuecomment-609991257) and the #slack-admins channel motivated this change.

