### PR TITLE
releng: Update release-managers Slack User Group

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -5,14 +5,15 @@ usergroups:
     long_name: Release Managers
     description: Release Managers. Ping for questions on branch cuts and building/packaging Kubernetes.
     channels:
+      - release-ci-signal
       - release-management
       - sig-release
     members:
-      - aleksandra-malinowska # Patch Release Team
       - calebamiles # subproject owner
       - cpanato # Branch Manager
       - dougm # Patch Release Team
       - feiskyer # Patch Release Team
+      - hasheddan # Branch Manager
       - hoegaarden # Patch Release Team
       - idealhack # Patch Release Team
       - justaugustus # subproject owner / Patch Release Team

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -10,6 +10,7 @@ users:
   cpanato: U8DFY4TTK
   dougm: U8GG20UE9
   feiskyer: U0ASA4398
+  hasheddan: ULLQEF30C
   hoegaarden: U7VA4RZS9
   idealhack: U5NJ3DQM9
   idvoretskyi: U0CBHE6GM


### PR DESCRIPTION
- Remove @aleksandra-malinowska from Patch Release Team (ref: https://github.com/kubernetes/sig-release/issues/987)
- Promote @hasheddan to Branch Manager (ref: https://github.com/kubernetes/sig-release/issues/1041)
- Automatically add Release Managers to `release-ci-signal` channel

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper 
cc: @kubernetes/release-engineering 