### PR TITLE
Creating channel for Dex (#dexidp)

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -54,7 +54,7 @@ channels:
   - name: de-events
   - name: de-users
   - name: devstats
-  - name: dex
+  - name: dexidp
   - name: digitalocean-k8s
   - name: distroless
   - name: diversity


### PR DESCRIPTION
In #4690 we created a channel for Dex (#dex) but it turns out there is a uniqueness constraint that prevents duplicates: 

From @jeefy: 
> Slack in its infinite wisdom requires a unique name within the workspace -- meaning if someone is named "dex" we cannot create a channel named "dex". We ran into this before but it's infrequent so we forgot.

This PR moves from #dex to #dexidp

