### PR TITLE
Add windows-containerd slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -366,4 +366,5 @@ channels:
   - name: wg-security-audit
   - name: wg-virtual-kubelet
     archived: true
+  - name: windows-containerd
   - name: workshop-chat


### PR DESCRIPTION
SIG-Windows is working towards supporting the ContainerD container runtime on Windows nodes (instead of Docker) and would like a dedicated slack channel to better organize and collaborate.

ContainerD support for Windows went Alpha in 1.18 and we are currently focused on the following

- Identifying stability issues
- Identifying/closing feature parity gaps with Docker EE on Windows
- Identifying  potential feature parity gaps in Windows containers with respect to Linux containers which can be addressed with ContainerD

Having a dedicated slack channel would help us keep track of issues/test pass results/PRs/etc without adding noise to the sig-windows channel which is primarily used by cluster operators today.

KEP for ContainerD support on Windows: https://github.com/kubernetes/enhancements/blob/master/keps/sig-windows/20190424-windows-cri-containerd.md