### PR TITLE
Move cluster-proportional subprojects to sig-network

### DIFF
--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -46,12 +46,6 @@ The following [subprojects][subproject-definition] are owned by sig-autoscaling:
 ### cluster-autoscaler
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
-### cluster-proportional-autoscaler
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
-### cluster-proportional-vertical-autoscaler
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
 ### horizontal-pod-autoscaler
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -48,6 +48,12 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-network:
+### cluster-proportional-autoscaler
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
+### cluster-proportional-vertical-autoscaler
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
 ### external-dns
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/external-dns/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -546,12 +546,6 @@ sigs:
   - name: cluster-autoscaler
     owners:
     - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
-  - name: cluster-proportional-autoscaler
-    owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
-  - name: cluster-proportional-vertical-autoscaler
-    owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
   - name: horizontal-pod-autoscaler
     owners:
     - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
@@ -1557,6 +1551,12 @@ sigs:
     - name: sig-network-test-failures
       description: Test Failures and Triage
   subprojects:
+  - name: cluster-proportional-autoscaler
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-autoscaler/master/OWNERS
+  - name: cluster-proportional-vertical-autoscaler
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/master/OWNERS
   - name: external-dns
     contact:
       slack: external-dns


### PR DESCRIPTION
The OWNERS at the root of these repos are sig-network people, and
the recent activity I've seen around these repos is coming from
sig-network people. My understanding is sig-autoscaling doesn't
want these projects anymore.

This is the first step, the next step is to suggest that these be
moved to kubernetes-sigs or kubernetes-retired depending on your
willingness to support or own them.

/hold
/assign @MrHohn @thockin
looking for an /lgtm from sig-network
/assign @gjtempleton @mwielgus
looking for an /lgtm from sig-autoscaling