### PR TITLE
sig-storage: add gluster provisioner repos

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -60,6 +60,10 @@ The following [subprojects][subproject-definition] are owned by sig-storage:
 ### git-sync
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/git-sync/master/OWNERS
+### gluster-provisioner
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/gluster-block-external-provisioner/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/gluster-file-external-provisioner/master/OWNERS
 ### kubernetes-csi
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2039,6 +2039,10 @@ sigs:
   - name: git-sync
     owners:
     - https://raw.githubusercontent.com/kubernetes/git-sync/master/OWNERS
+  - name: gluster-provisioner
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/gluster-block-external-provisioner/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/gluster-file-external-provisioner/master/OWNERS
   - name: kubernetes-csi
     owners:
     - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1800, https://github.com/kubernetes/org/issues/1801 

/assign @saad-ali @xing-yang @msau42 @jsafrane 

/hold
for sign off from sig-storage leads