### PR TITLE
Update mailing list permissions guidelines

### DIFF
--- a/communication/mailing-list-guidelines.md
+++ b/communication/mailing-list-guidelines.md
@@ -93,7 +93,7 @@ following the below procedure:
     - Group visibility: Anyone on the web
     - View topics: Anyone on the web
     - Post: Owners of the group, Managers of the group, All members of the group. Ensure that "Anyone on the web" is NOT selected here. 
-    - Join the group: Anyone can ask
+    - Join the group: Anyone on the web
   - `kubernetes-sig-<foo>-leads` (list for the leads, to be used with Zoom and
     Calendars)
     - Group type: Email list


### PR DESCRIPTION
The previous setting does not reflect the current state of most of our lists. We use the new member moderation as the general protection mechanism instead.

/cc @justaugustus 