### PR TITLE
adding steering kep guidelines for twitter

### DIFF
--- a/communication/marketing-team/social-guidelines.md
+++ b/communication/marketing-team/social-guidelines.md
@@ -10,9 +10,9 @@ Original messages should come out of this teams' accounts at least twice a week 
 
 Attempt to keep abbreviations to a minimum. Things like `k/k`, for example, might be known in the community, but for new contributors, this is something that is learned with time. Minimizing abbreviations and using plain language is strongly encouraged.
 
-Responses should include helpful links, validation, and/or additional information. Responses should occur within 48 hours. At the very least, like things as an acknowledgment. Sources of information should include Kubernetes contributor related web properties and documentation. TODO: CLEARLY DEFINE THOSE WEB PROPERTIES
+Responses should include helpful links, validation, and/or additional information. Responses should occur within 48 hours. At the very least, like things as an acknowledgment. Sources of information should include Kubernetes contributor related web properties and documentation: kubernetes/community and kubernetes/website. You can't go wrong linking to an official Kubernetes repo.  
 
-Ideally, no individuals outside of the contributor community with the possible exception that they are talking about contributors should be an considered a topic of messaging. Example: Bill Gates isn't part of the Kubernetes community, so tweets with @BillGates will not be published.
+Ideally, no individuals outside of the contributor community, with the possible exception that they are talking about contributors, should be an considered a topic of messaging. Example: Bill Gates isn't part of the Kubernetes community, so tweets with @BillGates will not be published.
 
 Other CNCF projects, unless there is a common contributor cause, are out of scope for coverage by this team's social media accounts.
 
@@ -24,19 +24,34 @@ Kubernetes Organization Members with access to account are:
 ## Themes/Topics
 
 - Contributor/SIG blog posts
-- Events
-- KEPs
+- Contributor events
 - Process changes
 - Release info, code freeze, et al
 - Accomplishments (reaching 100,000 GitHub stars for example)
 - Significant historical events as related to the project (Kubernetes birthday, previous events, etc.)
+- Steering Committee Announcements
+
+## KEPs
+([Kubernetes Enhancement Proposals])
+
+### Ground Rules  
+- The social media team cannot tweet KEPs at this time.
+- This may change if we can get a few owner(s)/group who can approve them
+- This guideline can only change with Steering, SIG-Arch, and SIG-Release approval  
+
 
 ### Frequently Asked Questions (FAQ)
 
-Q: Will the account follow other accounts?
+Q: Will the account follow other accounts?  
+
 A: TODO (Y/N). The account is designed for information dissemination, so we will focus on that by (following no one and focusing on sharing || following everyone to extend our reach).
 
-Q: Do we engage with hostile messages? 
+Q: Do we engage with hostile messages?  
+
 A: No. Don't feed the trolls. Mute them is the correct response. Block them as a last resort and only after discussing with team members. Reasons to block include verbal abuse, violating the platform's terms, or violating the [Code of Conduct](https://github.com/kubernetes/community/blob/master/code-of-conduct.md). The community is focused on openness and our accounts should be too, but there are times when we should reduce harmful people's visibility through blocking.
 
 Credit: [Fedora Community](https://fedoraproject.org/wiki/Marketing)
+
+
+[#KEPs]: (#KEPs)
+[Kubernetes Enhancement Proposals]: https://github.com/kubernetes/enhancements/tree/master/keps


### PR DESCRIPTION
per last [steering meeting](http://bit.ly/k8s-steering-wd) on April 6th, folks wanted clarity around KEPs being promoted on social channels. 

//also added: source of truth for the TODO

steering review timebox: sunday, april 26th @ 6am UTC. no comments = no issues. 