### PR TITLE
sig-cluster-lifecycle: remove kubernetes-anywhere

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -157,9 +157,6 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
   - https://raw.githubusercontent.com/kubernetes/system-validators/master/OWNERS
 - **Contact:**
   - Slack: [#kubeadm](https://kubernetes.slack.com/messages/kubeadm)
-### kubernetes-anywhere
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS
 ### kubespray
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1059,9 +1059,6 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
     - https://raw.githubusercontent.com/kubernetes/system-validators/master/OWNERS
-  - name: kubernetes-anywhere
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/OWNERS
   - name: kubespray
     contact:
       slack: kubespray


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1812
The repo is archived.

/assign @neolit123 
for lgtm