### PR TITLE
adding handbook templates for marketing team 

### DIFF
--- a/communication/marketing-team/README.md
+++ b/communication/marketing-team/README.md
@@ -6,13 +6,13 @@ The Contributor Marketing Team is part of the community-management subproject in
 to better inform the Kubernetes contributor community and highlight their work to
 the broader ecosystem
 
-| Area | Handbook | Lead | Team | Notes |
-| --- | --- | --- | --- | --- |
-| Editorial | TODO | editor: @parispittman (to bootstrap)| assoc editor: @mbbroberg |  |
-| Internal Communications | TODO | @jonasrosland | @simplytunde |  |
-| Social Media | TODO | @chris-short | [Could be you!] (paris to help bootstrap) | |
-| Storytellers | TODO | liaison to sig-docs-blog team @onlydole |  @celanthe, @vonguard, @boluisa, [Could be you!] |  |
-| Designer | TODO | [Could be you!] |  | help us with digital assets, infographics, contributor site |  
+| Area & Handbook Link | Lead | Team | Notes |
+| --- | --- | --- | --- |
+| [Editorial] | editor: @parispittman (to bootstrap)| assoc editor: @mbbroberg |  |
+| [Internal Communications] | @jonasrosland | @simplytunde |  |
+| [Social Media] | @chris-short | @kaslin (paris to help bootstrap) | |
+| [Storytellers] | liaison to sig-docs-blog team @onlydole |  @celanthe, @vonguard, @boluisa, @kaslin, and [Could be you!] |  |
+| [Designer] | [Could be you!] |  | help us with digital assets, infographics, contributor site |  
 
 
 ## Contact Us!
@@ -39,3 +39,8 @@ Let us know you are interested and if you have any questions.
 [charter]: ./CHARTER.md
 [Could be you!]: (#Could-be-you!)
 [Contributor Experience]: /sig-contributor-experience
+[Editorial]: /role-handbooks/editor.md
+[Internal Communications]: /role-handbooks/internal-marketing.md
+[Social Media]: /role-handbooks/social-media.md
+[Storytellers]: /role-handbooks/storytellers.md
+[Designer]: /role-handboos/wip-roles.md

--- a/communication/marketing-team/role-handbooks/editor.md
+++ b/communication/marketing-team/role-handbooks/editor.md
@@ -1,0 +1,81 @@
+# Editor Handbook
+
+## Overview
+
+The Editor takes on a beacon role for the group to bring multiple functions together ensuring Kubernetes contributors have a wealth of robust content and communications.
+
+### Responsibilities
+
+- Develop high level marketing strategies and themes to address problem areas, challenges, and innovation/moving the project forward; expected to collaborate with Leads on their strategies for functional areas
+- Ensure the team has a unified voice, focus, and work within the charter scope
+- Research and identify new and innovative ways of delivering content that
+appeals to our mission
+- Facilitates meetings or can delegate to Associate Editor
+- Manage the [editorial calendar] and [marketing project] boards.
+- Proofreading and editing articles with our [blogging] and [ethos] in mind
+- Act as or facilitate conversations and workflows between all types of stakeholders:
+  - SIG Contributor Experience
+  - Community Group Chairs and Tech Leads  
+  - CNCF
+  - Steering Committee
+  - Contributors
+- Working with the liaison team members to manage communications and workflows
+between the groups
+- Helping to recruit other members of the team, ensuring onboarding but delegating to proper lead; fall back when no lead present is the Editor
+- Has the ability to modify the team charter and seeks consensus with Contributor Experience communication [OWNERS] when considering any major changes.
+- If time allows, market the team; blog about the team and it's progress, encourage team to blog about their work   
+
+### Minimum Skills and Requirements
+
+Skills:
+- Be comfortable with general GitHub workflows. We can teach you ours but a foundation for this role is necessary. You'll be working inside of multiple repositories with different experiences and helping others on the team with troubleshooting.
+- Strong written and verbal skills
+- Be ok with saying no, but with a reason to back it up; be empathetic.
+- Have existing relationships with the contributor community either through other work or as an Associate Editor
+- Patience
+
+Requirements:  
+- Member of the [Kubernetes GitHub Org]
+- [Reviewer] in the marketing team folder
+- Shadowed under a lead in any role on the team for 6 months total (could be a combination of roles during that time period
+
+
+#### Expected Time Investment
+
+- Four hours a week as a minimal target.
+
+### Platforms, Tools, Access
+
+Here is a checklist of items we will work to get access when you accept the role.
+
+- Access to send and respond to email from community@kubernetes.io
+- Access to community and website repositories, all relevant calendars, and project boards
+- Other items listed in [team-resources.md]
+
+### Duration  
+
+6months to 12months??
+//discussion point
+
+## Associates Overview (Shadow)
+
+The Associate Editor should be able to achieve the above list of skills by the time they will be eligible to become the lead.
+
+### Expectations
+
+Collaborate closely with the lead Editor toward the responsibilities outlined above. Be ready to backfill for them when they are unable to attend a meeting or represent the working group.
+
+
+
+TODO  
+
+
+
+[editorial calendar]: https://github.com/orgs/kubernetes/projects/41
+[marketing project]: https://github.com/orgs/kubernetes/projects/39
+[team resources]: /team-resources.md
+[Kubernetes GitHub Org]: https://git.k8s.io/community/community-membership.md
+[Reviewer]: ./OWNERS
+[OWNERS]: /communication/OWNERS
+[blogging]: /blog-guidelines.md
+[ethos]: /CHARTER.md#ethos/vision

--- a/communication/marketing-team/role-handbooks/internal-marketing.md
+++ b/communication/marketing-team/role-handbooks/internal-marketing.md
@@ -1,0 +1,42 @@
+# Internal Communications and Marketing Handbook
+
+## Overview
+
+TODO
+
+## Responsibilities
+- Working towards a more streamlined communication process within the project for different use cases
+- Create and maintain a one stop shop intake form/issue template/etc for contributors to get comms and marketing support
+- identifying communication milestones and deadlines
+- map out communication pipelines
+- promoting contributor events
+Events
+- in the events folder or one off contributor events like SIG onboarding sessions
+KEPs
+- to follow the same process as [social guidelines]
+- no promotion unless there is an explicit documented request
+
+
+## Minimum Skills and Requirements  
+- Are a member of the [Kubernetes GitHub Org]
+- Shadowed in this role or another role on the marketing team for at least 3 months
+
+
+### Expected Time Investment
+
+TODO  
+3-5 hours a week?
+
+### Platforms, Tools, and Access
+
+- Needs access to send and respond to mail on community@kubernetes.io
+- contributor calendar
+- and everything listed in [team-resources.md]
+
+## Associates Overview (Shadow)
+
+
+## Out of scope
+- release; there is a communications coordinator (can help where needed, be an advisor, or help with reach)
+- contributor summit; there is a role that will assume a communications function (can help where needed, be an advisor, or help with reach)
+- TODO

--- a/communication/marketing-team/role-handbooks/social-media.md
+++ b/communication/marketing-team/role-handbooks/social-media.md
@@ -1,0 +1,26 @@
+# Social Media Handbook
+
+## Overview
+
+TODO
+
+## Minimum Skills and Requirements
+
+- Are a member of the [Kubernetes GitHub Org]
+- Familiar with twitter by either having a personal account or managing another account (brand, oss project, employer, local nonprofit, etc)
+- TODO
+
+### Expected Time Investment
+
+TODO
+3-5 hours a week
+
+## General Expectations
+
+- Most of this information can be found in our [social guidelines]
+- Be welcoming, be yourself
+
+
+## Associates Overview (Shadow)
+
+TODO  

--- a/communication/marketing-team/role-handbooks/storytellers.md
+++ b/communication/marketing-team/role-handbooks/storytellers.md
@@ -1,0 +1,36 @@
+# Storytellers 📖 Handbook
+
+## Overview
+
+It's no secret that governance and technical documentation can be kind of on the boring side. And that's ok - it's not there to put on a circus but provide valuable information and get you were you need to go.
+
+In this role, Storytellers are here for both! Storytellers will take us on journeys through words and visuals to help us craft...
+TODO add more here
+
+## Workflow ⚡️
+
+TODO  
+document a short workflow here
+1 should be for those who are comfortable going back and forth on a PR
+another option should include agreeing on a *final* version in a separate
+collaborative doc tool and the sig-docs-liaison or Editor will start the PR
+process
+
+## Minimum Skills and Experience
+- Have a passion for telling stories, technical writing, journalism, and painting pictures with words
+- Desire to be a Kubernetes Org Member and if not already, work your way towards membership
+- Comfortable with working with GitHub workflows or working in a collaborative doc tool with the Editor  
+
+## Expectations
+Anyone is welcome to contribute when they have time. The core expectation of storytelling is taking responsibility for getting the story from inception to published.
+
+If you would like to be listed as a member of the team, here are the expectations:
+
+1. Be prepared to write one blog a quarter and participate in edits to other articles. The time commitment is typically 5-10 hours per quarter depending on the number of blog posts in the review queue.
+2. Storytellers are expected to attend at least one upstream marketing team meeting a month or check-in to remain active.
+3. Remain non-partial: if you receive a request to write about a project, an individual, or a group of people from your employer, you should ask an impartial blogger to write it.
+4. As with all contribution to Kubernetes, adhere to the [code of conduct](/code-of-conduct.md), values, and principles of the project.
+
+There is no shadow roles for Storytellers. If Storytellers are interested in
+becoming the teams sig-docs-liaison they should follow the process for the
+community role on the sig-docs-blog team. TODO add link here

--- a/communication/marketing-team/role-handbooks/wip-roles.md
+++ b/communication/marketing-team/role-handbooks/wip-roles.md
@@ -1,0 +1,12 @@
+# Work In Progress Roles
+
+## Purpose  
+Capture roles that we would like to have but don't have them filled for Reasons.
+
+
+## Roles
+1. Designer
+someone to help with youtube thumbnails, logos, social clips/gifs  
+help us manage digital assets  
+
+2. TODO / Add one here


### PR DESCRIPTION
adding handbook templates for the upstream marketing team. 

Ideally, quick reviews/edits and then to merge and iterate. (and passing tests of course :p ) The leads and shadows for each functional area will complete the rest in later PRs. 
