### PR TITLE
sig-network: document service-apis slack channel

### DIFF
--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -83,6 +83,8 @@ The following [subprojects][subproject-definition] are owned by sig-network:
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
+- **Contact:**
+  - Slack: [#sig-network-service-apis](https://kubernetes.slack.com/messages/sig-network-service-apis)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1601,6 +1601,8 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/ip-masq-agent/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
   - name: service-apis
+    contact:
+      slack: sig-network-service-apis
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/service-apis/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS


### PR DESCRIPTION
Ref:

https://github.com/kubernetes/community/blob/d8817f1a8d466fabb215410302a2bc705c27f356/communication/slack-config/sig-network/config.yaml#L1-L2

/assign @thockin 
for lgtm