### PR TITLE
Create a slack channel to discuss Topology Aware Scheduling

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -328,6 +328,7 @@ channels:
   - name: testing-ops
   - name: tilt
   - name: tn-users
+  - name: topology-aware-scheduling
   - name: tor-controller
   - name: tr-events
   - name: tr-users


### PR DESCRIPTION
Create a new channel where folks can discuss all aspects of
adding NUMA Topology Awareness to the scheduling phase
for pods.

Signed-off-by: vpickard <vpickard@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
