### PR TITLE
Add user kaslin to Upstream Marketing

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -34,6 +34,7 @@ usergroups:
       - "Rin Oliver"
       - simplytunde
       - Tunde
+      - kaslin
 
   - name: test-infra-oncall
     external: true

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -22,6 +22,7 @@ users:
   johnbelamaric: U246A1A0N
   jonasrosland: U0A4G34S2
   justaugustus: U0E0E78AK
+  kaslin: U5ENKU0AE
   katharine: UBTBNJ6GL
   listx: UFCU8S8P3
   markyjackson-taulia: U19TKJ64E


### PR DESCRIPTION
Adding user kaslin to the slack config for the Upstream Marketing usergroup. Added kaslin to users.yaml and usergroups.yaml.

Related to issue [k8s blog] series: SIG profiles/storytelling #3654 - Kaslin is joining and taking on one of the tasks in this issue. (As a starter task.)

/assign @parispittman
/assign @mrbobbytables 