### PR TITLE
adding GSoC Jenkins X Channel, to avoid noise from the other Jenkins …

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -109,6 +109,7 @@ channels:
   - name: java
   - name: jenkins-ci
   - name: jenkins-x-dev
+  - name: jenkins-x-gsoc
   - name: jenkins-x-user
   - name: jp-dev
   - name: jp-events


### PR DESCRIPTION
Requesting a dedicated GSoC Jenkins X channel for this year and future events.  

This does not fix an issue.  The Jenkins X Community is requesting a new channel for [GSoC](https://summerofcode.withgoogle.com/dashboard/organization/4945163270488064/proposal/6564184512266240/) program Jenkins X is part of, to help mentor students.  This channel will be dedicated and will help reduce the noise from the other channels.

