### PR TITLE
sig-contribex: archive 2018 and 2019 meeting notes

### DIFF
--- a/sig-contributor-experience/meeting-notes-archive/2018-meeting-notes.md
+++ b/sig-contributor-experience/meeting-notes-archive/2018-meeting-notes.md
@@ -1,0 +1,2854 @@
+
+# 2018
+
+
+### December 27 (no meeting - happy holidays!)
+
+
+### December 19 (recording)
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Bob Killen
+*   John Harris
+*   Matt Jarvis
+*   Nikhita Raghunath
+*   Tim Pepper
+*   Eduar Tua
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   No Thursday community meeting until January
+        *   Need more volunteers for Jan 2nd MoC @ 730aPT if you are free! - contact paris on slack
+        *   Always looking for office hours - contact jorge on slack
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+        *   Contributor Summit Follow up
+            *   NCW survey out
+            *   Current Contributor survey and follow up to be sent out soon
+            *   Blog post pushed back to January 7th, 2019
+        *   Style Guide
+            *   Near Completion
+            *   [“Working doc” on hackmd](https://hackmd.io/Fe8YTu5XSUyt4dP3P2MGkg?view)
+        *   Project Management
+            *   Define done, milestones (kubecon vs releases)
+            *   Tools
+    *   Open Mic/Open Discussion - add yours here
+        *   Project Management! \o/
+        *   Revamp Dev Guide update - Eduar
+        *   [your topic here]
+
+
+### December 12 (no meeting - KubeCon/CloudNativeCon)
+
+
+### December 5 ([recording](https://youtu.be/M6UAuK4jz3U))
+
+
+### Attendees:
+
+
+
+*   Guinevere Saenger
+*   Bob Killen
+*   Jeffrey Sica 
+*   Zach Shepherd, VMware
+*   Łukasz Gryglicki, CNCF
+*   Nikhita Raghunath
+*   Dawn Foster
+*   Noah Abrahams
+*   Martin Murphy
+*   Abubakr-Sadik Nii Nai Davis
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Thurs Community Call - host? SIGs? Contribex tip?
+            *   Make sure we have a tip of the week
+            *   Release follow-up for 1.13
+            *   Paris will moderate
+        *   [Office Hours](https://github.com/kubernetes/community/blob/master/events/office-hours.md) - need more volunteers? 
+            *   Always - sign up at the link
+        *   [Meet Our Contributors](https://github.com/kubernetes/community/blob/master/mentoring/meet-our-contributors.md) - need more volunteers? 
+            *   Always - sign up through [parispittman@google.com](mailto:parispittman@google.com)
+            *   Need 1 more for Dec 5th at 9pm UTC
+            *   Looking for more for January
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+        *   Style guide is being worked on, should be available post KubeCon
+        *   SIG/TL training will occur at KubeCon as a MVP
+        *   Speed Mentoring is looking for more Mentors
+        *   Content Strategy for Contributor Site 
+            *   Will kick off more after KubeCon
+            *   KEP is being reworked
+            *   MVP will be a good ‘view’ of KEPs
+        *   Contributor Survey Results
+            *   graphics about 90% done
+            *   most tasks are stalled currently
+        *   Communication Sprawl
+            *   close to being done
+            *   Need to explain and expand on communication channels
+            *   Need to document remaining google groups
+        *   Zoom Automation
+            *   Audit complete
+            *   Half of SIGs are not using proper zoom settings
+            *   New roll-out of how zoom is managed
+        *   Github service account audit
+            *   still in progress
+            *   need to chase down remaining accounts
+        *   Contributor Experience Charter
+            *   Last changes need to be approved
+        *   Sunset procedures
+            *   Done, needs to be closed out.
+*   Open Mic/Open Discussion - add yours here
+    *   Diversity Lunch 
+        *   Sold Out! 
+    *   Contributor Summit 
+        *   Sched link: kcs2018.sched.com
+        *   Unconferences
+            *   [unconference procedure](https://github.com/kubernetes/community/tree/master/events/2018/12-contributor-summit#proposing-a-bof-session)
+            *   4 slots available
+            *   Sign up will be available both days
+            *   sessions will be recorded
+        *   Find/assign note takers for BoFs and unconferences
+        *   Looking for 1 contribex member for SIG Meet and Greet at NCW
+            *   Bob volunteered
+        *   Looking for more facilitators 
+
+
+###  \
+November 28
+
+Attendees:
+
+
+
+*   Bob Killen
+*   Paris Pittman
+*   Guinevere Saenger
+*   Pandiyaraja
+*   Christoph Blecker
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Thurs Community Call - host? SIGs? Contribex tip?
+            *   Make sure we have a tip of the week
+        *   [Office Hours](https://github.com/kubernetes/community/blob/master/events/office-hours.md) - need more volunteers? 
+            *   Always - sign up at the link
+        *   [Meet Our Contributors](https://github.com/kubernetes/community/blob/master/mentoring/meet-our-contributors.md) - need more volunteers? 
+            *   Always - sign up through [parispittman@google.com](mailto:parispittman@google.com)
+            *   Need 1 more for Dec 5th at 9pm UTC
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+        *   Working on a contribex topic - File an issue and put on the project board
+        *   Content strategy is new - call for help
+            *   Keps are moving at the end of the month to their own area and away from k/community
+*   Open Mic/Open Discussion - add yours here
+    *   Example: [discussion topic] [your name]
+    *   Project Manager search is complete. 4 folks are interested and setting up a separate meeting to kick things off. 
+    *   KubeCon
+        *   Contributor summit 
+            *   Closing down registration as of early next week TBD on date
+            *   Closing down agenda changes as of this Friday
+        *   Two speed mentoring session weds dec 12th AM and PM
+            *   Tim Pepper and myself with CNCF
+            *   [Mentors - sign up here!!](https://docs.google.com/forms/d/e/1FAIpQLSfgoF2EybJiM8YtquP_dtYkp1DfwqIEgQNLUzMuMGkdS8DZ7w/viewform)
+        *   Diversity lunch weds dec 12th at lunch
+            *   Sign up going out 11/29
+        *   Intro session on tuesday
+            *   TODO: send out slide deck by next Weds for community review
+        *   Delivering a sig training at contributor summit
+        *   Delivering a talk on automation and ci related stuffs from christoph and aaron at contributor summit
+        *   Delivering a new contributor workshop
+        *   Send a contribex represented to the sig meet and greet
+            *   Who is this? Is that you?
+            *   Nikhita might be good for this
+            *   **Where: Room 605**
+            *   **When: **Please plan to arrive early, at **3:20 pm; **the planned start time is 3:30
+
+
+### November 21 ([recording](https://youtu.be/IwS_UQy9Ess))
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Aaron Crickenberger
+*   Bob Killen
+*   Jeffrey Sica
+*   Łukasz Gryglicki, CNCF
+*   Dawn Foster
+*   Jaice Singer DuMars
+*   Tim Pepper
+*   Matt Farina
+*   Noah Abrahams
+*   Ihor Dvoretskyi
+*   Christoph Blecker
+*   Guinevere Saenger
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Thurs Community Call - host? SIGs? Contribex tip?
+            *   Ihor hosting for Thanksgiving holiday
+        *   [Office Hours](https://github.com/kubernetes/community/blob/master/events/office-hours.md) - need more volunteers? 
+        *   [Meet Our Contributors](https://github.com/kubernetes/community/blob/master/mentoring/meet-our-contributors.md) - need more volunteers? 
+            *   Yes - reach out to paris on slack
+            *   Need dec 5th @ 1pm PT and jan 2 @ 730am PT
+            *   Prefer folks who have not joined before
+            *   Yes - new folks can mentor
+            *   Code base tours would be much appreciated
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+        *   Due to smaller group - only ask for blockers, work through it, and look at backlog for any issues that can be labeled H-W/G-F-I/anyone that can be assigned
+        *   Contributor Summit NA
+            *   Locking down schedule and content
+        *   [DevStats README is complete](https://github.com/cncf/devstats/blob/master/README_K8s.md)
+    *   Open Mic / Open Discussion
+        *   Your topic [your name]
+        *   PM role went live on mailing list and discuss board. Ihor and others may tackle - will give us an update at next meeting. [paris]
+            *   Looking for more than one person to help with this.
+        *   Outreachy intern is official - say hello to [Eduar](https://github.com/eduartua) after December 5th. We will give him an intro on the mailing list and on this call. Eduar will be working on dev guide. We will start his onboarding plan next week and welcome suggestions. Most of you will be on his meetings list. [paris]
+        *   Aaron and Christoph are working on automation talk, looking for more suggestions.
+        *   Call has been out for shadows for 1.14
+        *   [Trivial PRs](https://github.com/kubernetes/community/issues/2953)
+            *   ‘First issue’ is fine, encourage new contributors to fix these.
+            *   Need metrics on the volume of trivial PRs and how much of an impact/problem it is for the community. [AI]
+                *   [nikhita] Added a [comment](https://github.com/kubernetes/community/issues/2953#issuecomment-440954739) on the issue.
+            *   Problem is ‘gaming’ devstats / stack-analytics.
+            *   There is no policy regarding Trivial PRs in CoC.
+            *   Suggestion: Add acceptable behaviour to contributor guide.
+
+
+### November 14th ([recording](https://www.youtube.com/edit?o=U&video_id=IDAU1hIukOE))
+
+Attendees:
+
+
+
+*   Jeffrey Sica, University of Michigan
+*   Nikhita Raghunath
+*   Elsie Phillips
+*   Jorge Castro
+*   Paris Pittman
+*   Guinevere Saenger
+*   Christoph Blecker
+*   Matt Farina
+*   Arnaud Meukam
+*   Dhawal Yogesh Bhanushali
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Thurs Community Call - host? SIGs? Contribex tip?
+            *   Unsure about who will host on release retro - shouldn’t be an issue since it’s just handing it over to the release team.
+        *   [Office Hours](https://github.com/kubernetes/community/blob/master/events/office-hours.md) - need more volunteers? @castrojo [jorge on slack]
+            *   All set 
+        *   [Meet Our Contributors](https://github.com/kubernetes/community/blob/master/mentoring/meet-our-contributors.md) - need more volunteers?
+*   Subproject Stand up:
+
+    -Name of your subproject
+
+
+    -Name your top 3 priorities right now
+
+
+    -What is something in your subproject that you're proud of completing in the last year?
+
+
+    -What is one thing in your immediate roadmap to be accomplished after Kubecon? 
+
+    *   Mentoring
+        *   Proud of: continued with GSOC-amazing talent and projects and meet our contributors, code based tours particularly
+        *   Want to focus on getting more mentors and GSOC students (10 interns across 10 SIGS) 
+        *   Focus: process improvements to 1:1 hour
+        *   Top 3:
+            *   Onboard outreachy intern who will do dev guide (starting dec 5th)
+            *   Standup 1:1 hour and group mentoring program officially
+    *   Devstats
+        *   Moving away from dashboards as check ins
+        *   Fleshing out the readme into a full users guide; add workflows to make it more useful; provide more documentations
+        *   Make site mobile friendly
+        *   Repo groups 
+        *   Post kubecon will do mobile site focus
+    *   Contributor Docs
+        *   Contributor guide section: in maintenance 
+        *   Contributor site: 
+            *   rework KEP- bumping back to draft
+                *   Content strategy to be added
+                    *   Put unofficial working group together to do this
+                *   Dedicated meeting 
+                *   File an issue and set up contrib docs sprint 
+            *   Metadata for keps isn’t standardized
+            *   CLI to manage KEP lifecycle, generation of templates, due before Kubecon - calebmiles and jaice are working on it. Hope to have it rolled out pre kubecon SEA
+            *   Next steps: get a small group together to refocus on content strategy, adjust scope, do a style guide, after do a contributor doc sprint
+    *   Workflow and Automation
+        *   Disorganized right now. spiffxp@ and cblecker@ haven’t had the cycles to reset their priorities 
+        *   Most proud of label sync
+        *   Know we need to implement:
+            *   Cherry picking process, docs updated -thx guin and nikhita
+            *   Removing direct write access to repos, GH permissions set is not sufficiently granular
+            *   Surface areas where we need help
+    *   GitHub Management
+        *   ORG MANAGEMENT \O/! Automated through k/orgs now
+        *   Thx to bob and stephen for being the glue that we need here
+        *   Tackle next: github team management, repo perms, sig recs
+        *   Proud of: being able to delegate
+        *   Extending the tool for teams is the next priority post kubecon. Need to roll that out asap.  
+    *   Community management
+        *   Proud of: 
+            *   Moderation process
+            *   Office Hours  & Meet our contributors are thriving
+        *   Working on:
+            *   Relieving chairs of admin duties
+            *   Continuing to work on Zoom to keep the community safe
+            *   Gsuite proposal- goes to the steering committee before next Thursday
+        *   Up next after Kubecon: [https://github.com/kubernetes/community/issues/2466](https://github.com/kubernetes/community/issues/2466) - NEED HELP
+        *   AI: jorge to provide charts on discuss usage and a comparison chart with the k-users group
+        *   
+    *   Events
+        *   Most proud of: China Kubecon contrib summit came together with just a few people, doing a European edition of the contributor summit and working with SIG leads to curate Kubecon NA content
+        *   3 priorities:
+            *   Seattle Contrib Summit
+            *   Strategy for next year- e.g. we’d like to move to an invite only format
+            *   Defining roles w/ CNCF for contributor events
+        *   Coming up after Kubecon: meet w/ CNCF about responsibilities & budget
+
+
+### November 7th ([recording](https://www.youtube.com/watch?v=IDAU1hIukOE))
+
+Attendees:
+
+
+
+*   Elsie Phillips 
+*   Bob Killen, University of Michigan
+*   Ihor Dvoretskyi, CNCF
+*   Jorge Castro, Heptio
+*   Lukasz Gryglicki, CNCF
+*   Christoph Blecker
+*   Matt Farina, Samsung SDS
+*   Tim Pepper, VMware
+*   Arnaud Meukam, AWCC
+*   Sahdev Zala, IBM
+*   Aaron Crickenberger, Google (@spiffxp)
+*   Silvia T. Sandy-Martinez
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Thurs Community Call - host? SIGs? Contribex tip?
+            *   Host info: [https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895) 
+            *   Two KubeCons and some major holidays make for 6 of 7 next meetings conflicted:
+                *   Nov. 15 - KubeCon China, will have meeting
+                *   Nov. 22 - if demand outside US, try to have meeting
+                *   Nov. 29 - normal meeting
+                *   Dec. 6 - 1.13 release retrospective
+                *   Dec. 13 - KubeCon North American, cancel meeting
+                *   Dec. 20 - cancel
+                *   Dec. 27 - cancel
+        *   [Office Hours](https://github.com/kubernetes/community/blob/master/events/office-hours.md) - need more volunteers? @castrojo [jorge on slack]
+            *   Traffic is growing for both office hours and meet our contributors and getting good volunteer response
+            *   Please...contrib ex member do your k8s civic duty and volunteer at least once a year in these
+        *   [Meet Our Contributors](https://github.com/kubernetes/community/blob/master/mentoring/meet-our-contributors.md) - need more volunteers?
+            *   Ditto re: office hours above ^^^^
+    *   First 30 mins - [project board stand ups](https://github.com/orgs/kubernetes/projects/1)
+        *   KubeCon North America speed networking / mentoring: announcements about to go out.  In coming weeks if we see any mismatch in mentee desired info versus volunteer mentors, we’ll try to voluntell a few community folks who have that info that they should mentor
+        *   1:1 mentoring: calendaring is hard, especially between busy people who don’t know each other yet.  Trying to figure out how to keep this basic administrivia low overhead.
+*   Open Discussion / Open Mic (put your agenda items here):
+    *   Subproject leads reporting next call
+    *   Deep dive at KubeCon
+    *   Survey bits [paris will be on ~:50)
+        *   There’s a huge spreadsheet of data
+            *   Mentoring viewed as priority: need help on creating process around the idea of mentoring so that it sticks for people (and is not high adminstrivia overhead)
+            *   GitHub management: productivity and workflow friction
+            *   Communication platform: notifications, multiple platforms, complexity
+        *   What are we missing:
+            *   Need to communicate better:  things highlighted in data as needed do actually exist whether in PoC or MVP level, just not known to all yet.
+            *   Contributor documentation: people still looking for specific information that’s missing
+            *   Deep dives and code tours: have an issue for this now, it’s happening, but people don’t know
+        *   Important projects - how do we translate this into our current work?
+            *   Roadmap: now and over the next year.  Point people to backlog and ask them to work on it.
+        *   Help with this issue? 
+        *   Conveying information to developers/community members is still a challenge (both technical and non-technical)
+            *   need to distill information down to be more easily consumed
+            *   possible weekly newsletter?
+                *   [LWKD](http://lwkd.info/)
+            *   Information sprawl is still a challenge with information spread across github, slack etc
+            *   notification overload is still a problem
+            *   Slide template made it easy for sigs to provide their updates, is it worth pursuing providing more templates etc
+            *   Do we have things/are there things we have that make specific groups lives easier with regard to information updates?
+            *   Possible AI for kubecon contrib summit: get SIG leads etc together to figure out how we can communicate better. 
+                *   Encountering scaling issues with general communication as community has grown
+            *   Paris looking for help with [communication docs](https://github.com/kubernetes/community/tree/master/communication)
+            *   AI: reach out to survey people who asked for follow-up contact
+            *   Videos etc to cover little bits of the codebase and other tips etc
+
+
+### October 24 ([Recording](https://youtu.be/wTSjXRvNaR0))
+
+Attendees:
+
+Hi New Time Attendees!! :)
+
+
+
+*   Paris Pittman (@parispittman)
+*   Jintao Zhang (@tao12345666333)
+*   Lukasz Gryglicki
+*   Noah Abrahams (@nabrahams on slack)
+*   Christoph Blecker (@cblecker)
+*   Nikhita Raghunath (@nikhita)
+*   Jeffrey Sica (@jeefy)
+*   Bob Killen (@mrbobbytbles)
+*   Arnaud Meukam (@ameukam)
+*   Deep Sukhwani (@proprogrammer)
+*   Yang Li (@idealhack)
+*   [your name here]
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Thurs Community Call - host? SIGs? Contribex tip?
+        *   [Office Hours](https://github.com/kubernetes/community/blob/master/events/office-hours.md) - need more volunteers? @castrojo [jorge on slack]
+        *   [Meet Our Contributors](https://github.com/kubernetes/community/blob/master/mentoring/meet-our-contributors.md) - need more volunteers?
+    *   First 30 mins - [project board stand ups](https://github.com/orgs/kubernetes/projects/1)
+        *   File an issue if you are working on something for our group!
+            *   AI: follow up with CNCF re: regional CoC’s for discuss and file issue against k/community to mirror the CNCF issue
+                *   [https://github.com/cncf/foundation/issues/15](https://github.com/cncf/foundation/issues/15)
+            *   AI: noah is going to file an issue for facilitators for SEA contributor summit 
+    *   Open Discussion / Open Mic (put your agenda items here):
+        *   Nikhita to OWNERs for k/community/mentoring folder [paris]
+            *   Start a mailing list thread for nomination 
+            *   File an issue for outreachy kick off
+                *   AI: paris & nikhita; close issue when we’ve selected candidates
+                    *   [nikhita] Created [https://github.com/kubernetes/community/issues/2880](https://github.com/kubernetes/community/issues/2880) 
+        *   What should we focus our deep dive on for KubeCon Seattle? [paris]
+            *   Come back to this next week
+                *   AI: note out to the mailing list that we are officially thinking about this.
+        *   Declining attendance at community meeting (Jberkus):
+            *   CM attendees are averaging 45 for the last several weeks compared with 110 a year ago.
+            *   Particularly, SIG leads are not attending, which makes the SIG reports not useful (and often not delivered)
+            *   Should we look at changes?
+                *   AI: Potential poll for new/global times? Explore the marketing thing first 
+                *   AI: weekly k-dev with agenda 
+                *   AI: new marketing campaign? twitter, blogging
+        *   Keeping contributors informed of API and policy changes (Jberkus)
+            *   May have a solution for API changes - ML 
+            *   AI: look into arch ‘how they communicate’ changes; go to sig arch/jaice and see how we can help surface this better into a k-dev type of ‘newsletter’/weekly changes type 
+        *   [https://github.com/kubernetes/community/pull/2852](https://github.com/kubernetes/community/pull/2852) (Aaron but I may not be here for this)
+            *   Make devstats a subproject with an owners file
+            *   Add myself, Elsie, Jberkus as approvers (other contributors as reviewers, see PR)
+                *   Add lukasz, too.
+        *   Retro:
+            *   Paris pushed to master on Sunday night by accident and couldn’t revert changes because of protected branch
+                *   Christoph: branch protector was good; manually removed branch protector to revert. Will get with GH mgmt folks to see if they can make a recommendation.
+                *   Aaron: nothing was lost, no leaks
+                    *   An anti-commit would have been fine
+                    *   Paris is an admin for the community admin
+                        *   Do we want to split this up to folks who only contribute to project board, etc.?
+                *   AI: Create guidance on how to properly revert in protected branch situations
+
+
+### October 17 (Recording //todo:paris-desktop)
+
+Attendees:
+
+
+
+*   Aaron Crickenberger (@spiffxp)
+*   Paris Pittman
+*   Noah Abrahams
+*   Guinevere Saenger
+*   Elsie Phillips
+*   Hannes Hoerl
+*   Nikhita Raghunath
+*   Sahdev Zala
+*   Yang Li
+*   Arnaud Meukam
+*   Łukasz Gryglicki
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Thurs Community Call
+            *   Demo confirmed, SIG Updates confirmed
+            *   KEP of the Week?
+            *   Graph of the Week?
+            *   Bot command/demo of the week to be added
+            *   AI done, @spiffxp opened: [https://github.com/kubernetes/community/issues/2818](https://github.com/kubernetes/community/issues/2818) 
+*   First 30 mins: 
+    *   [Project board](https://github.com/orgs/kubernetes/projects/1), talk about blockers, ask about progress, standup
+        *   Spiffxp: subprojects in sigs.yaml is blocked now. Needs to be improvement but the concept needs to be hashed out by SIG Arch. Info may fall more out of date than it already is.
+            *   Matt to aaron: is it really SIG Arch or is it steering? Aaron: thinks sig arch has a fundamental stake
+        *   
+*   Open Mic / Open Discussion / Remaining time of call:
+    *   Devstats repo groups
+        *   [https://github.com/cncf/devstats/pull/145](https://github.com/cncf/devstats/pull/145)
+        *   Up on test server [https://k8s.teststats.cncf.io/d/12/dashboards?refresh=15m&orgId=1](https://k8s.teststats.cncf.io/d/12/dashboards?refresh=15m&orgId=1)
+    *   Contributor Summit Seattle - almost sold out! 
+    *   SIG speed dating issue: https://github.com/kubernetes/community/issues/2745
+
+
+### October 10th ([Recording](https://youtu.be/BhqZkYdJFQs))
+
+Attendees:
+
+
+
+*   Aaron Crickenberger
+*   Nikhita Raghunath
+*   Dhawal Yogesh bhansuhali
+*   Jonas Rosland
+*   Paris Pittman
+*   Josh Berkus
+*   Lindsey Tulloch
+*   Christoph Blecker
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: Thurs Community Call - Office Hours - Meet Our Contributors?
+        *   Jorge needs more volunteers for office hours - reach out.
+
+First 30 mins: 
+
+
+
+*   [Project board](https://github.com/orgs/kubernetes/projects/1), talk about blockers, ask about progress, standup
+    *   Non code comms went out last week. Gather more info from SIGs.
+    *   Ihor: start with GH and then do google groups re: github service accounts.
+    *   Jorge: updating the moderation guidelines to include mailing list stuff
+    *   Paris: sign up for seattle contributor summit ASAP
+    *   Josh: shanghai is sold out! :D
+
+Open Mic / Open Discussion / Remaining time of call:
+
+
+
+*   CoC Translation / Non-english subboards on discuss.kubernetes.io
+    *   Cncf is translating code of conducts.
+    *   Bob is leading the 
+*   Anyone know when the new community page is going to land?
+    *   Mid october
+*   Discussion around charter 
+    *   Christoph to look at tech lead items
+    *   Paris to finish the rest and Aaron to give some basic feedback now
+
+
+### October 3rd (Recording)
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Jeffrey Sica
+*   Łukasz Gryglicki
+*   Elsie Phillips
+*   Guinevere Saenger
+*   Arnaud Meukam
+*   Bob Killen
+*   Nikhita Raghunath
+*   Sahdev Zala 
+*   Noah Abrahams
+*   Aaron Crickenberger
+*   Tim Pepper
+*   Christoph Blecker
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: Thurs Community Call - Office Hours - Meet Our Contributors?
+
+First 30 mins: 
+
+
+
+*   [Project board](https://github.com/orgs/kubernetes/projects/1), talk about blockers, ask about progress, standup
+    *   File more issues y’all - assign it to the project board
+    *   Looking into an airtable integration
+    *   Does anyone have blockers?
+        *   Aaron has a few - move write access repo issue to backlog
+    *   New devstats presentation: [https://github.com/cncf/devstats#presentations](https://github.com/cncf/devstats#presentations)
+        *   Devstats example deployment (simplest possible) for Homebrew (just an example org): [https://github.com/cncf/devstats-example](https://github.com/cncf/devstats-example)
+        *   Instructions how to use devstats-example to deploy DevStats for your own project: [https://github.com/cncf/devstats-example/blob/master/SETUP_OTHER_PROJECT.md](https://github.com/cncf/devstats-example/blob/master/SETUP_OTHER_PROJECT.md)
+        *   Every CNCF project (projname) has its own devstats page:<span style="text-decoration:underline;"> projname.devstats.cncf.io</span>
+    *   
+
+Open Mic / Open Discussion / Remaining time of call:
+
+
+
+*   Looking for SIGs to get new contributors started at kubecon - is this a mentoring sub-issue? or its own? Tracking contacts in an issue would be great.
+
+
+### September 26th (Recording- paris has this and will upload 10/3)
+
+Attendees:
+
+
+
+*   Paris (she’s backkkk)
+*   Ihor Dvoretskyi
+*   Łukasz Gryglicki, CNCF
+*   Bob Killen
+*   Jeffrey Sica
+*   Hannes Hoerl
+*   Jonas Rosland
+*   Elsie
+*   Noah Abrahams
+*   Tim Pepper
+*   Sahdev Zala
+*   Christoph Blecker
+*   Aaron Crickenberger
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: Thurs Community Call - Office Hours - Meet Our Contributors?
+
+First 30 mins: 
+
+
+
+*   Project board, talk about blockers, ask about progress, standup
+    *   Board is open to the public now \o/
+    *   File more issues y’all - assign it to the project board
+    *   Looking into an airtable integration
+
+Open Mic / Open Discussion / Remaining time of call:
+
+
+
+*   Non-code letter and blog post [Jonas]
+    *   Letter - **Final yes/no**: [https://docs.google.com/document/d/12nQ_BbJT1E4Sz6pjwH3E6emvPy4rPgmDgVz0FXqeCPc/edit](https://docs.google.com/document/d/12nQ_BbJT1E4Sz6pjwH3E6emvPy4rPgmDgVz0FXqeCPc/edit)
+        *   Will be sent out to the distros by Ihor
+    *   Blog is being worked on by Noah, Ihor and Jonas - **To be published week of Oct 1**: [https://docs.google.com/document/d/11sL40FKtyd5W7S-gWaP5i-6QutHLbg46xV29RG-SAc4/edit](https://docs.google.com/document/d/11sL40FKtyd5W7S-gWaP5i-6QutHLbg46xV29RG-SAc4/edit)
+*   Regional Board added to Discuss
+    *   Find moderators that are ok with taking on responsibility of regional areas
+    *   Bob poked folks who are helping with Shanghai 
+*   [https://go.k8s.io/triage](https://go.k8s.io/triage) is back up and running
+    *   [https://k8s-testgrid.appspot.com/sig-testing-misc#triage](https://k8s-testgrid.appspot.com/sig-testing-misc#triage) - logs now available
+    *   Aaron to do a walk through that will be recorded and uploaded to YouTube
+*   [SURVEY! ](https://www.surveymonkey.com/r/k8s-contributor-2018)We have 140 responses. Ihor fixed some of the questions that were required so may have a lower barrier to entry/completion now. Would like to turn off on Friday. PLEASE FORWARD AROUND TO OTHER SIGS. A full campaign (ie - reddit, twitter, etc.) could skew results so trying to keep it within the targeted contributor community. 
+*   decouple lgtm and approve commands on k/k [Christoph]
+    *   [https://groups.google.com/d/msgid/kubernetes-sig-contribex/CAN4RaVT%3DhhN0S7-_B5rm8z5ao9NmyJNLXgPGi0or0hVxg8E6Bg%40mail.gmail.com](https://groups.google.com/d/msgid/kubernetes-sig-contribex/CAN4RaVT%3DhhN0S7-_B5rm8z5ao9NmyJNLXgPGi0or0hVxg8E6Bg%40mail.gmail.com?utm_medium=email&utm_source=footer).
+*   peribolos rollout [Christoph]
+    *   [https://k8s-testgrid.appspot.com/sig-testing-org#post-peribolos](https://k8s-testgrid.appspot.com/sig-testing-org#post-peribolos) - running in response to PR merges
+    *   [https://k8s-testgrid.appspot.com/sig-testing-org#ci-peribolos](https://k8s-testgrid.appspot.com/sig-testing-org#ci-peribolos) - running periodically to ensure the state of github doesn’t drift from the state of the kubernetes/org repo
+
+
+### September 19th (Recording)
+
+Attendees:
+
+
+
+*   Elsie 
+*   Jonas Rosland
+*   Noah Abrahams
+*   Hannes Hoerl
+*   Christoph Blecker
+*   Ofer Bartal
+*   Jorge Castro
+*   Josh Berkus
+*   Matt Farina
+*   Aaron Crickenberger (@spiffxp)
+*   Tim Fogarty
+*   Naomi
+*   Arnaud Meukam
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: Thurs Community Call - Office Hours - Meet Our Contributors?
+
+First 30 mins: 
+
+
+
+*   Project board, talk about blockers, ask about progress, standup
+    *   The only one being blocked “Remove write access direct to this repo” will be blocked for the foreseeable future
+
+Remaining time of call:
+
+
+
+*   Open Mic / Open Discussion
+    *   Hacktoberfest [tfogo]
+        *   [https://hacktoberfest.digitalocean.com/](https://hacktoberfest.digitalocean.com/)
+        *   Organized by DigitalOcean - month long event spanning October
+        *   Goal is to increase engagement with open source projects
+        *   “Attendees” are asked to make 5 contributions to open source projects, after that they get a nice t-shirt
+        *   “Hacktoberfest” labels on issues are listed as good ones to start with
+        *   Tim Fogarty will send a small writeup to Jonas to share with the larger group (ping Jorge once the snippet is done)
+        *   Jorge to generate a 404 report for this so students have a set of tasks that they can fix that aren’t trivial. 
+    *   Multi-repo Code Review [Ofer B]
+        *   Multi-repo
+        *   “Hosting agnostic”
+        *   Privacy preserving - cannot see other people’s private code
+        *   Source code never leaves the users’ machine
+        *   Can view local changes in tool - no need to push
+        *   Comes with a CLI
+        *   Supports multiple auth providers - GitHub, Google and others
+        *   [https://github.com/google/startup-os/tree/master/tools/reviewer](https://github.com/google/startup-os/tree/master/tools/reviewer)
+        *   [spiffxp]: multi repo review is very likely going to be in our future, and unfortunately there is nothing GitHub-native that really handles that well - there is lots of exploring to do
+    *   Removing some org-wide GitHub labels [spiffxp]
+        *   [https://groups.google.com/forum/#!topic/kubernetes-dev/UKxYbCIplPQ](https://groups.google.com/forum/#!topic/kubernetes-dev/UKxYbCIplPQ) 
+        *   No discussion needed, just a reminder this is happening today
+    *   Standardizing automation on kubernetes-incubator [spiffxp]
+        *   [https://github.com/kubernetes/test-infra/pull/9467](https://github.com/kubernetes/test-infra/pull/9467)
+        *   I’m not able to speak today, so this is also FYI, no discussion needed
+        *   I haven’t asked k-dev for lazy consensus yet
+        *   Two repos are requiring github approvals, and one repo is using a feature that we don’t support (require signed commits)... going to see if they are ok dropping use of that in favor of OWNERS-based merge automation
+    *   Elections start today (ballots/announcements after this call)
+    *   Spread the word in your networks about the survey!! (Paris) ends on the 25th.
+    *   kubernetes-users is now read only
+        *   mrbobbytables ftw.
+
+
+### September 12 ([Recording](https://youtu.be/7m4P0dkVLuc))
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Bob Killen
+*   Jeff Sica
+*   Jorge Castro (sends regrets, at an offsite, miss ya’ll tho!)
+*   Łukasz Gryglicki, CNCF
+*   Sahdev Zala 
+*   Christoph Blecker
+*   Elsie Phillips
+*   Noah Abrahams
+*   Jonas Rosland
+*   Guinevere Saenger
+*   Hannes Hörl
+*   Ihor Dvoretskyi
+
+Agenda:
+
+
+
+*   Project Board
+    *   [https://github.com/orgs/kubernetes/projects/1](https://github.com/orgs/kubernetes/projects/1)
+    *   Direct new contributors to issues on the board w/ help wanted labels
+    *   Blocked:
+        *   Communication & Collaboration Platform Sprawl - Paris
+        *   Remove direct write access to K/K
+        *   Rename release note labels
+            *   Need release note process to be overhauled  - help wanted
+                *   Maybe make it a WG 
+                    *   Formal invite to previous relnotes persons
+    *   Steering committee election
+        *   3 seats up for grab
+        *   This Friday is the deadline for candidate nomination/
+        *   50 contributions qualifies you for voting rights
+        *   Fill out the exception form if you contributed outside GH events 
+*   GitHub Issue Template [Christoph]
+    *   [https://github.com/kubernetes/kubernetes/issues/68527](https://github.com/kubernetes/kubernetes/issues/68527)
+    *   In the org repo, tried out feature to test multiple issue templates for different issue types
+    *   [https://github.com/kubernetes/org/issues/new/choose](https://github.com/kubernetes/org/issues/new/choose)
+    *   Roll out to K/K & Test-Infra - help wanted 
+        *   Jonas and Paris interested & have partial cycles available
+    *   Down the road send out to SIG leads 
+    *   The templates _do_ support emojis! Example here: [https://github.com/vmware/dispatch/issues/new/choose](https://github.com/vmware/dispatch/issues/new/choose)
+*   Tidying up automation in the Kubernetes orgs
+    *   Tide is now running on K/K
+    *   Simplifying and standardizing automation org wide 
+        *   In the next 2 weeks
+        *   Shout out: Test-Infra and SIG Testing 
+*   Cherry picking process has changed
+    *   Milestones no longer necessary because of how Tide works
+    *   Need to improve cherry picking process- help wanted
+*   GitHub administration
+    *   Creating or changing a repo setting- enforcing issue creation as a requirement
+        *   Follow up w/ policy and documentation 
+*   Working Groups
+    *   Requirement to have a SIG sponsor, no update yet
+    *   Criteria for WG also in progress
+    *   
+
+
+### September 5 (Recording)
+
+
+### Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Hannes Hoerl
+*   Jeffrey Sica
+*   Bob Killen
+*   Jorge Castro (can’t attend, will leave notes) 
+*   Paris
+*   Guinevere Saenger
+*   Aaron Crickenberger (@spiffxp)
+*   Nikhita Raghunath
+*   Paris Pittman
+*   Sahdev Zala 
+*   Noah Abrahams
+*   Josh Berkus
+*   Jonas Rosland (15 min late)
+*   Ihor Dvoretskyi
+
+
+### Agenda:
+
+
+
+*   …
+*   [k8s-contrib-tools](https://github.com/pivotal-k8s/kubernetes-contrib-tools) vs. [repo-infra](https://github.com/kubernetes/repo-infra) [Hannes & Maria … _if possible let’s discuss that at the second part of the meeting as Maria will join late_ ]
+    *   We changed the verify-boilerplate.sh to also allow adding boilerplates
+        *   and added some other changes (config file, ….)
+    *   We pushed that into [k8s-contrib-tools](https://github.com/pivotal-k8s/kubernetes-contrib-tools)
+    *   Only later we found [repo-infra](https://github.com/kubernetes/repo-infra)
+    *   Should we merge?
+*   discuss.k8s.io [Jorge] - doing well, about 1000 new people since we invited k-users, 777 of them from direct invites
+    *   Not planning on sending more emails, we’ll just close k-users list on the 14th.
+    *   4 complaints on email invites out of ~7,000 mails sent.
+    *   Hoping to connect official CNCF Events into the events subforum tomorrow with Kaitlyn. 
+    *   [Contributor Role Board](https://discuss.kubernetes.io/c/contributors/role-board) needs postings! Please mention this exists to SIGs.
+*   contributor.k8s.io [Jorge]
+    *   Just waiting on design from Alex
+        *   vote and discussion designs in [discuss thread](https://discuss.kubernetes.io/t/call-for-feedback-contributor-site-designs/1509)
+    *   Filed a ticket with CNCF for a contractor for implementing whatever the design ends up being
+    *   KEP metadata busting hugo? (Bob?)
+        *   improperly formatted yaml in frontmatter prevented hugo from building site
+    *   [KEP relocation](https://github.com/kubernetes/community/issues/2565) will impact site
+    *   Developer Guide
+        *   [https://github.com/kubernetes/community/issues/1919](https://github.com/kubernetes/community/issues/1919) 
+        *   Jberkus looking to take a stab at structure after mid-late Sept
+*   Contributor playground: need for students to practice reviewing and approving, in the case of large workshops, but without _actually_ being k8s org members
+    *   Does anyone have a clever workaround? Suggestions?
+        *   [jonas] suggestion: Create a small codebase that spits out something incorrect, such as changing the output from Kiubernetes to Blubernetes. Give the attendees sample code that _actually doesn’t pass tests_, and then give them correct sample code that does past tests and corrects the error.
+    *   [spiffxp] suggestion: file a kubernetes/org issue (or maybe PR at this time) with list of usernames prior to summit, revert after summit
+    *   Anticipate this will be easy to do w/ kubernetes/org automation w/ peribolos by Nov
+*   Graph of the week: meeting runner hit on me, I’ll do devstats changes (jberkus)
+*   Submit Queue -> Tide [spiffxp]
+    *   [https://groups.google.com/forum/#!topic/kubernetes-dev/pL3M8Qt0SxU](https://groups.google.com/forum/#!topic/kubernetes-dev/pL3M8Qt0SxU) 
+    *   “we hope to shift to the new and shiny tide implementation in the next week”
+    *   and then I rambled a bunch about whether we should or not switch
+    *   then tim pepper showed up as the release lead and said his piece
+    *   I then walked through a demo that roughly compared the tide UI to the submit queue UI
+    *   I then agreed to do this again tomorrow, and Tim will put together a proposed cutover timeline, thinking Monday/Tuesday of next week
+*   [https://github.com/kubernetes/community/issues/1919](https://github.com/kubernetes/community/issues/1919) -> dev guide. Needs an owner. Will do an umbrella issue to kick off the structure. (paris)
+*   [https://github.com/orgs/kubernetes/projects/1](https://github.com/orgs/kubernetes/projects/1) -> we have a project board! (paris)
+*   Survey update (paris/ihor)
+*   Quick question regarding the Community meeting (jonas)
+
+
+### August 30 (Recording)
+
+
+### Attendees:
+
+
+
+*   Jeffrey Sica (Leading this call!)
+*   Elsie Philips
+*   Jorge Castro
+*   Jonas Rosland
+*   Paris Pittman (on the road, listening in) 
+*   Christoph Blecker
+*   Vlad Shlosberg
+*   Sahdev Zala 
+*   Bob Killen
+*   Dhawal Yogesh Bhanushali
+
+
+### Agenda:
+
+
+
+*   Recurring Agenda [TBD]
+    *   Welcome new folks!
+    *   Hosts for next few community meetings
+        *   [Planning sheet](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895)
+    *   SIGs for the next few community meetings
+        *   (Same sheet as above) 
+*   Regular Agenda
+    *   Foqal
+    *   K-Users Archive / Discuss Updates [jorge]
+        *   Lots of users added after the two blasts to the mailing lists, close to 2k total users
+        *   Discussions are now pretty much self-running, even during the weekends
+    *   Election Updates [jorge?]
+    *   Survey Updates?
+        *   Test drive the SurveyMonkey survey and verify it against the docs version - needed ASAP
+        *   LINKS?
+    *   Non-Code docs discussion [Jonas]
+        *   Letter to SIGs
+            *   [https://docs.google.com/document/d/12nQ_BbJT1E4Sz6pjwH3E6emvPy4rPgmDgVz0FXqeCPc/edit?usp=sharing](https://docs.google.com/document/d/12nQ_BbJT1E4Sz6pjwH3E6emvPy4rPgmDgVz0FXqeCPc/edit?usp=sharing)
+            *   Send out to [Kubernetes-sig-leads@googlegroups.com](mailto:Kubernetes-sig-leads@googlegroups.com)
+            *   
+        *   GitHub issue, where to put the MD file?
+            *   [https://github.com/kubernetes/community/issues/2325#issuecomment-415269278](https://github.com/kubernetes/community/issues/2325#issuecomment-415269278)
+            *   Continue with this?
+                *   [https://github.com/kubernetes/community/blob/master/contributors/guide/non-code-contributions.md](https://github.com/kubernetes/community/blob/master/contributors/guide/non-code-contributions.md)
+        *   Christoph - need to add more defined trust models and guidelines to make sure people know how they can get more established and trusted to take on more admin roles
+        *   Sahdev - we should consolidate some of this with guideline we already have here, [https://github.com/kubernetes/community/tree/master/contributors/guide#contributing](https://github.com/kubernetes/community/tree/master/contributors/guide#contributing) And provide a link to this new docs from here. 
+    *   Global Time [Paris]
+        *   8pm PT / UTC won.
+        *   Need to carve out what week this will replace/cadence
+    *   Draft charter [Paris]
+        *   Need to revise our current charter and use the new SC template
+        *   Will try to have a next version draft by next meeting
+        *   [[Link?]](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/charter.md) -> old charter that needs to be revised
+
+
+### August 22 (Recording - to be uploaded)
+
+Attendees: 
+
+
+
+*   Paris Pittman
+*   Tim Pepper
+*   Łukasz Gryglicki, CNCF
+*   Guinevere Saenger
+*   Jonas Rosland
+*   Bob Killen
+*   Sahdev Zala
+*   Noah Abrahams
+*   Jorge Castro
+*   Josh Berkus
+*   Lindsey Tulloch
+
+Agenda:
+
+
+
+*   [Survey](https://docs.google.com/document/d/1s8op9D-qjNczDiFHIS01-2kDxyiLJHPB3qzW889f-W0/edit?usp=sharing) [paris]
+    *   Going out on Monday. Thanks Ihor for implementing in tool! 
+    *   Steering committee announcement went out last night and better to postpone so we can get more eyeballs on our survey
+*   Update on[ automating all the things](https://github.com/kubernetes/test-infra/issues/6227) [spiffxp]
+    *   [Labels have been synced](https://github.com/kubernetes/test-infra/pull/9054)
+    *   [All repos are in sigs.yaml](https://github.com/kubernetes/community/issues/2464)
+    *   [All but one to-be-deleted repo has OWNERS files](https://github.com/kubernetes/community/issues/1721)
+    *   [Branch protection for all orgs](https://github.com/kubernetes/test-infra/pull/9114): lazy consensus deadline Friday 10am PT
+    *   [Setup automation for kubernetes-client](https://github.com/kubernetes/test-infra/pull/9122): no lazy consensus yet
+    *   Next steps: tide+approve for kubernetes/*, kubernetes-incubator/*
+*   Update on github labels [spiffxp]
+    *   [kind/technical-debt, kind/friction into kind/cleanup](https://github.com/kubernetes/test-infra/pull/9089): lazy consensus deadline today 3pm PT
+    *   [Remove org-wide labels that are only relevant to k/k](https://github.com/kubernetes/test-infra/pull/9091) (wip and low in my heap right now)
+*   kubernetes-users read-only announcement sent
+    *   About 507 people have clicked on the invite (3139 left outstanding)
+    *   About 300ish bounced right away, so bad emails or people who moved on from k-users long ago.
+    *   Plan is to reinvite all outstanding invites one more time right before the Sept 15th deadline. 
+    *   Traffic spike: 
+    *   ["newsletter" for sig chairs/leads/etc](https://github.com/kubernetes/community/issues/2518)
+
+
+### August 15 ([Recording](https://youtu.be/NjKv5qSjt3k))
+
+
+#### Attendees: 
+
+
+
+*   Aaron Crickenberger (@spiffxp, Google)
+*   Paris Pitttman
+*   Bob Killen
+*   Jonas Rosland (first 30 mins)
+*   Jorge Castro
+*   Jeffrey Sica
+*   Ihor Dvoretskyi
+*   Elsie Phillips (30 mins)
+*   Christoph Blecker (@cblecker)
+*   Noah Abrahams
+*   Chris Love (@chrislovecnm, CNM Consulting)
+*   Guinevere Saenger
+*   Tim Pepper
+*   Sahdev Zala (joined late - dropping early)
+*   Lindsey Tulloch
+*   Nicole Huesman
+
+
+#### Agenda:
+
+
+
+*   Recurring Agenda [TBD]
+    *   Welcome new folks!
+        *   Chris Love re-introduction :) 
+    *   Hosts for next few community meetings
+        *   [Planning sheet](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895)
+    *   Meet our Contributors (Spicy edition)
+        *   7 Steering Committee members attending
+    *   SIGs for the next few community meetings
+        *   (Same sheet as above) 
+*   Regular Agenda
+    *   Turning on automation for all repos under actively managed github orgs [spiffxp]
+        *   It’s too noisy for me to talk today, but basically I want to push on the following and am looking for guidance on appropriate amount of notification and lazy consensus seeking for these changes
+        *   [label_sync for all actively managed github orgs](https://github.com/kubernetes/test-infra/pull/9054)
+        *   Tracking issue: [merge automation for all actively managed repos](https://github.com/kubernetes/test-infra/issues/6227)
+        *   TBD: branch_protection for all actively managed github orgs
+        *   TBD: “fejta bot” aka commenter jobs for /retest and /lifecycle
+        *   Related to this effort, I’m pushing on subproject ownership. No lazy consensus here, I’m just bugging people until it’s done.
+            *   Tracking issue: [all repos should be in sigs.yaml](https://github.com/kubernetes/community/issues/2464)
+            *   Tracking issue: [all repos must have OWNERS files at their root](https://github.com/kubernetes/community/issues/1721)
+        *   _Long running thing, wanting to become more consistent for contributors. _
+        *   _Many moving parts, might do certain things at certain times first._
+        *   _Extra labels won’t be affected. Existing labels get unified w/ happy descriptions_
+        *   _Time to start getting the bot(s) out to the other project orgs_
+        *   _Big hurdle: Getting the fringe repos with human-merge management converted over._
+        *   _Smaller hurdles: One week consensus_
+        *   _Larger hurdles: Ehhhh…. Let’s feel that out. Definitely longer._
+        *   _Keep ears to the ground, we need feedback to ensure happy adoption_
+        *   _Also alerting SIG-Leads. _
+    *   @kubernetes/sig-contributor-experience-misc-use-only-as-a-last-resort [spiffxp]
+        *   How do we feel about dropping our (contribex’s) other github teams and renaming this? Would we rather wait on a broad all-team-for-all-sigs proposal?
+        *   I’d like to do this for sig-testing, and want to understand if I need this SIG’s buy in…
+        *   [https://github.com/kubernetes/community/issues/2323](https://github.com/kubernetes/community/issues/2323)
+        *   _Feedback and comments are welcome, some direction would be great to help._
+        *   _Everyone has their own method to handle Github notifications (example [thread](https://groups.google.com/d/msg/kubernetes-dev/5qU8irU7_tE/aZov0LpCBwAJ) on k-dev). Sustainable? Ehh._
+        *   _[https://k8s-gubernator.appspot.com/pr](https://k8s-gubernator.appspot.com/pr)_
+            *   _Shorter URL: [http://k8s.reviews](http://k8s.reviews)_
+        *   _Volunteer to notify k-dev + sig leads, define the process change + time box, drive the communication. After the time box it’s super easy to implement._
+    *   Community Membership procedure [Christoph]
+        *   [https://github.com/kubernetes/community/pull/2521](https://github.com/kubernetes/community/pull/2521)
+        *   _Changing from emailing a list, to creating a GitHub issue_
+        *   _Problematic management of threads, moving to Issues makes it easier._
+        *   _Better tracking of +1s and invites_
+    *   [SC Elections](https://github.com/kubernetes/community/issues/2517) [paris/jorge/ihor]
+        *   Paris/Jorge/Ihor are the Election Officials
+        *   Eligibility list info was just pulled. Exception form if you feel you’re eligible but not on the list.
+        *   Communication will be primarily on k-dev list
+        *   3 seats are up for grabs. Call for nominations soon.
+        *   Rules refresher on certain company-affiliation restrictions (amongst others)
+        *   What happens if multiple people from company X are up for election? 
+        *   During call for nominees, read company affiliation SC guidelines
+        *   [https://github.com/kubernetes/steering/blob/master/elections.md#maximal-representation](https://github.com/kubernetes/steering/blob/master/elections.md#maximal-representation) 
+        *   TODO: “If the results of an election result in greater than 1/3 representation, the lowest vote getters from any particular company will be removed until representation on the committee is less than one-third.” -- Buried in steering, should also be as part of the announcement and voter’s guide?
+        *   TODO: Link to all the things~
+        *   Magic number is 4 (12 person steering committee) 
+    *   Doodle for global time [paris/elsie]
+        *   Went out this week on the ML (Aug 9?) -- Responses seem favorable (16-20)
+        *   Send out another reminder, close and announce next week
+        *   This is re: scheduling a “global” meeting -- change ¼ meetings/mo go to the decided-upon timeline
+        *   Anyone that can attend would be welcome
+    *   [Survey [paris/josh]](https://docs.google.com/document/d/1s8op9D-qjNczDiFHIS01-2kDxyiLJHPB3qzW889f-W0/edit?usp=sharing)
+        *   How do people like contributor experience, communications pathways, mentorships
+        *   Any additional questions get in ASAP (and have a decent reason or face the wrath of Paris) 
+        *   Will send out the final version before a Monday sendout. 
+        *   After a soft-sendout, engage CNCF and market it
+        *   2-week duration?
+        *   Data collected hopefully no later than September
+        *   Attempt to call out certain projects to get a pulse on priority in the eyes of the greater community. 
+            *   Any other projects to add, talk to Paris. (Question 15)
+    *   [Inventory sheet for communication](https://github.com/kubernetes/community/issues/2466) [paris]
+        *   Discovery and research to kick things off / decide on platforms (data driven) -- communication toil is draining
+        *   This should be a priority.
+        *   Survey is one part. List of communication channels is second part.
+        *   Who-what-when-where-why of communication~
+    *   Community Slidedeck
+        *   Announce tomorrow @ Community meeting + k-dev
+        *   [https://docs.google.com/presentation/d/1Vra2kT647AJvnC7eodFj9gAgknmnMQtQ9olzqMsZUiA/edit#slide=id.g3e784ddd32_0_0](https://docs.google.com/presentation/d/1Vra2kT647AJvnC7eodFj9gAgknmnMQtQ9olzqMsZUiA/edit#slide=id.g3e784ddd32_0_0) 
+    *   Bump thread re: Deleting github service accounts
+
+
+### August 8 ([Recording)](https://youtu.be/J-h2CPkFHmk)
+
+
+#### Attendees: 
+
+
+
+*   Łukasz Gryglicki (CNCF)
+*   Aaron Crickenberger (@spiffxp, Google)
+*   Vlad Shlosberg
+*   Jeffrey Sica
+*   Noah Abrahams
+*   Bob Killen
+*   Elsie Phillips
+*   Jorge Castro 
+*   Sahdev Zala 
+*   Ihor Dvoretskyi
+*   Josh Berkus
+*   Christoph Blecker (@cblecker)
+*   Jonas Rosland
+*   Chris Love (@chrislovecnm CNM Consulting)
+*   Tim Pepper
+*   Paris Pittman
+
+
+#### Agenda:
+
+
+
+*   Recurring Agenda [Jorge]
+    *   Welcome new folks! 
+    *   Hosts for next few community meetings
+        *   [Planning sheet](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895)
+    *   SIGs for the next few community meetings
+        *   (Same sheet as above) 
+*   Regular Agenda
+    *   Add your topic here
+    *   Contributor Board Bikeshed Extravaganza [Jorge]
+        *   We have the setup, but haven’t decided on a name
+        *   People don’t like Jobs Board, but they don’t have something else
+        *   We’ll be doing a poll for the name next.  Send your suggestions to Jorge.
+    *   Sunsetting SIG service accounts [Ihor]
+        *   Announcement proposal [[LINK](https://docs.google.com/document/d/1pmZkhdIYcycKZ-V9SI7Sqxdc9Sv2PchA9qTnDyxGjTw/edit?usp=sharing)]
+        *   To be announced tomorrow, Aug 9th (via email and at the community meeting) - on discuss.k8s.io as well?
+        *   We need sigs to remove most of these.  Please review the announcement above.
+            *   Time deadline of a week is kind of short
+            *   Some of the accounts/groups have special purposes like “how to recover your userid” so need to handle those cases
+            *   Aaron contanced Scalability, got no response after 3 weeks.
+        *   Many of these are generally dummy accounts used to anchor GH accounts.
+        *   Most SIGs have never used these.
+    *   Foqal Update - Vlad
+        *   Scraped all Kubernetes docs from website, added them as sections so that answers can target specific paragraphs.
+        *   Now bot can answer with docs citations
+        *   Set up yesterday
+        *   Now working on a new ML model for better answers
+        *   Not much user feedback so far
+        *   Now providing more answers based on SO questions.
+        *   Have looked at discuss.k.io but right now not much Q&A traffic
+        *   Discussion about what successful Foqual bot looks like.
+    *   New Kubernetes Slides template [Ihor]
+        *   Thanks to Alex Contini from CNCF
+        *   [Official Kubernetes Slide deck draft](https://docs.google.com/presentation/d/1Vra2kT647AJvnC7eodFj9gAgknmnMQtQ9olzqMsZUiA/edit#slide=id.g3e784ddd32_0_0) (open for comments)
+        *   Realized that one didn’t exist, wanted to provide one.  Please review!
+            *   Send feedback direct to Ihor
+    *   Automation Accounts [bob and jeff]
+        *   zapier, twitter, etc. 
+        *   Want to automate the social media accounts to post to discuss, twitter, etc.  
+        *   Tried to use IFTTT, issues, now using Zapier.  Better tool, really.
+        *   Been running for the last week, but it’s posing as Jeff, so need a service account.
+        *   If there’s a new realease on GH, will automatically post on dicuss
+        *   Give Jeff feedback on Slack
+    *   GitHub Administration Team Update [Christoph]
+        *   There is now a team, they are owners on all the orgs
+        *   Have removed all org owners who are not on team
+        *   Next step is issue templates & processes for if people need changes they can request them. There will be a new repo for GH admin requests.
+        *   Asked about official contact address other than issues, will be in PR.
+            *   Should mention at community meeting
+        *   [https://github.com/kubernetes/org/pull/3](https://github.com/kubernetes/org/pull/3)
+        *   [https://github.com/kubernetes/community/pull/2493](https://github.com/kubernetes/community/pull/2493)
+        *   
+    *   Contributor Site [Bob and Jorge]
+        *   The repo is up ([https://github.com/kubernetes-sigs/contributor-site](https://github.com/kubernetes-sigs/contributor-site)) 
+        *   Waiting for DNS name to point to [netlify address](https://kubernetes-contributor.netlify.com/).
+        *   Please [file issues](https://github.com/kubernetes-sigs/contributor-site/issues) with your ideas. 
+        *   In netlify you can put in scheduled updates for the site
+    *   Global meetings poll [Paris]
+        *   Have heard from contributors on various continents about having a more suitable time for sig-contibex meeting.  Could be very early AM, or very late
+        *   Alternate time will replace one of the weekly meetings but not both
+        *   Or maybe 2 9:30 meetings, and 2 early AM meetings
+    *   Communication and Collaboration Platform Discovery [paris]
+        *   Archiving k-users for discuss issue
+        *   In progress with review and refactoring
+        *   Other OSS communities are doing this to reduce sprawl like the Rust community
+        *   Please add channels to the discovery document 
+        *   Includes calendar invite ownership, please include those because we want to automate calendar
+    *   Mentoring [paris]
+        *   Need process help; overcommitted right now
+        *   Need help with group mentoring & 1-on-1 hour help
+            *   Need code base tours as well as pair programming
+            *   Need guide for pair programming with limited options, so that mentors don’t need to figure this out.
+            *   Need to do research on pair programming tools.
+        *   Chris Love has some time … @paris let me know
+    *   Community liaisons [paris]
+        *   How can we get contribex news to SIGs?
+        *   Maybe permanent “liaisons” to each SIG, if you attend those SIG meetings anyway.
+        *   Aaron expressed doubt about the concept, feels that going to SIG meetings isn’t very scalable.
+        *   Jorge mentioned messaging at contributor meeting, but a lot of SIG members don’t attend.
+        *   Jorge thinks people are getting the announcements, they’re just ignoring some of them.
+        *   This is a temporary/band-aid solution, because people don’t ready emails.
+    *   Still collecting survey question ideas [paris]
+        *   Will get this group to review before we send out
+        *   Is pretty much ready, but have not heard from most of Contribex about questions.
+        *   Deadline Monday for comments, then goes to CNCF
+        *   
+
+August 8 
+
+Attendees
+
+Agenda
+
+
+## August 1 ([Recording](https://youtu.be/A4dkue3hYBU))
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Chris Short (Red Hat)
+*   Bob Killen
+*   Jeffrey Sica
+*   Jonas Rosland (VMware) (first 30 mins)
+*   Noah Abrahams
+*   Kaitlyn Barnard
+*   Sahdev Zala 
+*   Vlad Shlosberg
+*   Christoph Blecker
+*   Garrett Rodrigues
+*   Aaron Crickenberger (@spiffxp)
+*   Stanton Xu
+*   Jorge Castro (last 30 minutes)
+
+Agenda:
+
+
+
+*   Proposal to archive k-users@ ml and move to discuss.k8s.io [Paris]
+    *   [https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/6XrvYg5UITM](https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/6XrvYg5UITM)
+    *   Long-term strategy: consolidation of information and resources for contributors
+    *   Archive ML; not deleting
+    *   Easier to manage spam/mal* via discuss
+    *   Thanks to Bob, Jorge, et. al. for helping to allay fears
+    *   TODO: Create GH Issue Link
+    *   Please add any and all contributions to conversation once Issue created
+*   Foqal Update [Vlad]
+    *   Paris apologizes for being awesome
+    *   Bot that looks for answers and responds to common questions
+    *   Addition of Workspaces is WIP
+    *   Relevance for answers is low but improvements are being iterated on
+    *   Opinion: This is really cool and will help lots of people
+    *   Q: What do you feel is a good measure of success?
+        *   Will always be a work in progress
+        *   As long as it provides value it's a success
+    *   Q: What's an experiment for real world usage
+        *   In progress
+        *   Once ready, we'll need to announce it's "in use"
+    *   Next meeting: Vote to implement
+*   Form GitHub Administration Team [Christoph]
+    *   [https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/ZShZJoUywFA](https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/ZShZJoUywFA)
+    *   [https://github.com/kubernetes/community/pull/2436](https://github.com/kubernetes/community/pull/2436)
+    *   We can FINALLY establish a team to formally handle GitHub administration tasks
+    *   Process to set up repos, add admin team members, manage/create bots, etc. from this newly formed GH Admin Team
+    *   Currently five on the list to seed group
+    *   Q: Contact info?
+        *   GitHub group
+    *   Q: Membership Process
+        *   Bot to manage adding new members from PRs
+    *   Q: Next Steps
+        *   Tomorrow at noon; merge PR
+        *   Manage ownership accordingly
+        *   Audit to purge access as necessary
+*   Website Design Update [Alex Contini]
+    *   kubernetes.io/community
+    *   A gorgeous website is in the works
+    *   Feedback positive
+    *   Suggestions:
+        *   Add text for what various resources are for
+        *   Add full calendar view
+        *   Submit your event button/Slackbot?
+            *   Concerns from Ihor about automatically adding events without vetting
+    *   Dynamic events are doable but some additional work/learning is needed
+*   Notification Fanout [ Jorge / Jeff ]
+    *   Additional event notification automation
+    *   Single source of truth
+    *   IFTTT integration
+    *   Concerns about IFTTT reliability
+    *   Garrett (sp?) has some custom automation that might help
+    *   Jorge would like some additional feed data/sources if anyone has anything
+*   Kubernetes Contributor Site [Jorge / Bob]
+    *   [https://discuss.kubernetes.io/t/contributor-site/1184](https://discuss.kubernetes.io/t/contributor-site/1184)
+    *   [https://github.com/kubernetes/community/blob/master/keps/sig-contributor-experience/0005-contributor-site.md](https://github.com/kubernetes/community/blob/master/keps/sig-contributor-experience/0005-contributor-site.md)
+    *   GitHub to Hugo flavored markdown conversion is an issue
+
+
+## July 25 ([Recording](https://youtu.be/XuSts0bUCLM))
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki
+*   Aaron Crickenberger (@spiffxp)
+*   Jeffrey Sica (@jeefy)
+*   Bob Killen
+*   Vlad Shlosberg
+*   Noah Abrahams
+*   Tim Pepper
+*   Paris Pittman
+*   Christoph Blecker
+*   Josh Berkus
+*   Matt Farina
+*   Sahdev Zala
+*   Guinevere Saenger
+*   
+
+Agenda:
+
+
+
+*   Foqal Update [Vlad]
+    *   People aren't always clicking the store; tweaked the design of the store functionality
+    *   WIP - dividing the content since channels have different context/content. Grouping info.
+*   Cherry pick experience of a casual contributor and ways to improve it [guinevere]
+    *   [https://github.com/kubernetes/test-infra/issues/1795](https://github.com/kubernetes/test-infra/issues/1795) umbrella issue @spiffxp was using to track potential improvements
+    *   Could cherry pick related automation between bot and OWNERS understand the current patch release manager and indicate in the cherry pick PR that the patch release manager be pinged?
+    *   We have a single person bottleneck because the release team disbands post-release, with a single volunteer shepherding patches into semi-regular patch releases.
+    *   There’s a lot of reasons and history...how can we get a summary of this into the PR so a submitter of a PR/cherry-pick better understands what the process looks like.  The info that hits the PR today is from the munger.
+    *   HELP WANTED: Need a volunteer to move it over to Prow and add more informative text
+    *   Cblecker to spiffxp- is there a Target date for mungers to go away? Spiffxp: not sure. Focus on submit queue and cherry pick right now. Just slowly crossing things[ off the list](https://github.com/kubernetes/test-infra/issues/3331).
+*   Adding a lifecycle/active label [spiffxp]
+    *   Suggesting we replace kubeadm’s “active” label and release team’s “status/in-progress” label with a “lifecycle/active” label
+    *   Would like to discuss and get sig-release perspective (since I know some release team members show up here)
+    *   Having this part of Prow and /lifecycle can allow non-members to claim an issue.  Today if a non-active issue was left unassigned, it can imply non-active, but only members can be assigned, which is limiting.
+    *   [https://github.com/kubernetes/test-infra/issues/8811](https://github.com/kubernetes/test-infra/issues/8811)
+*   Migrating from priority/failing-test to kind/failing-test [spiffxp]
+    *   Mainly just an fyi this will happen later today
+    *   [https://github.com/kubernetes/community/issues/1579](https://github.com/kubernetes/community/issues/1579) 
+*   Mentoring - Paris
+    *   Need small crew and bi weekly meeting
+    *   mentoring has been on pause due to other issues that have come up recently
+    *   Paris would like to form a small crew to help with mentoring initiative
+    *   in a blocked state currently, need help with process improvements
+        *   1-on-1 hour is greatly desired
+        *   need to decide on tools for pair programming, and sort out actual logistics 
+    *    setup a weekly or bi-weekly meeting to tackle some of the mentoring issues
+*   Survey - Paris 
+    *   [https://docs.google.com/document/d/1s8op9D-qjNczDiFHIS01-2kDxyiLJHPB3qzW889f-W0/edit?hl=en](https://docs.google.com/document/d/1s8op9D-qjNczDiFHIS01-2kDxyiLJHPB3qzW889f-W0/edit?hl=en) 
+    *   need to send out as soon as possible
+    *   last survey had 140 participants, aiming for 200+
+    *   goal to improve communication pipelines e.g. slack, mailing lists etc get quantitative data before taking things away or making changes
+    *   Will go out via blog post, tweets etc -- want to get as many responses as possible
+*   Github Management Subproject - Christoph
+    *   established, now focusing on organizing priorities to establish a framework for it going forward
+    *   should have more direction next week after initial feedback
+    *   need to enumerate the people who have ‘super powers’ within the kubernetes org
+
+
+## July 18 ([Recording](https://youtu.be/YGim06pnu8Q))
+
+Attendees:
+
+
+
+*   Christoph Blecker
+*   Bob Killen
+*   Noah Abrahams
+*   Aaron Crickenberger (@spiffxp) 
+*   Sahdev Zala
+*   Vlad Shlosberg
+*   Elsie Phillips
+*   Guinevere Saenger (9:50)
+*   Garrett Rodrigues
+*   Jonas Rosland
+
+Agenda:
+
+
+
+*   Foqal update
+    *   working on improving the algorithm to give people a ‘better’ or more relevant answer
+    *   new UI improvements added to dashboard
+    *   interactions section added to UI that displays responses given to users
+    *   will do a demo for graph of the week next week
+*   GitHub Management Subproject
+    *   [https://github.com/kubernetes/community/issues/2367](https://github.com/kubernetes/community/issues/2367)
+    *   Next steps?
+        *   Issue will become a PR once the review period is up (Friday)
+    *   policy needed to for idle purge, must be active in X way for Y timeframe etc
+*   New Contributor Playground [Christoph]
+    *   [https://github.com/kubernetes/community/issues/2321](https://github.com/kubernetes/community/issues/2321)
+    *   repo for people to learn how to interact with bots and learn how to interact with a kubernetes repo
+    *   look to set it up in the next month or so
+*   Github Team Structure [Christoph]
+    *   [https://github.com/kubernetes/community/issues/2323](https://github.com/kubernetes/community/issues/2323)
+    *   task to be picked up by github management subproject
+*   kubernetes/sig-foo-suffix -> @k8s-mirror-foo-suffix -> sig-foo-suffix googlegroup [spiffxp]
+    *   Removal of googlegroups from create-a-sig instructions [https://github.com/kubernetes/community/pull/2302](https://github.com/kubernetes/community/pull/2302)
+    *   k8s-mirror-* accounts getting kicked out of kubernetes org [https://github.com/kubernetes/community/issues/2324](https://github.com/kubernetes/community/issues/2324)
+    *   Is there an umbrella issue or proposal for what the plan is going forward? There is lots of detritus at the moment
+        *   Existing google groups?
+        *   Existing teams? Bots apply labels based on some
+        *   Links on SIG readmes?
+        *   Deletion of mirror accounts
+    *   google groups were never intended to contain important information
+        *   purpose was for github bots
+        *   proposed deadline for 1 month to shut down github users and groups
+        *   ihor will work on doc to discuss and send out
+*   Contributor Site Repo [Christoph]
+    *   [https://groups.google.com/d/msg/kubernetes-sig-contribex/vrzdIKpOTAY/c0gef0F-AwAJ](https://groups.google.com/d/msg/kubernetes-sig-contribex/vrzdIKpOTAY/c0gef0F-AwAJ)
+*   Issue with membership in kubernetes-sigs, actual policy will be delegated to github management subproject
+    *   current: email kubernetes-membership to be added
+    *   future: automation should resolve this issue long term and will be synced across orgs
+        *   current blocker is handling purging before syncing will be enabled
+
+
+## July 11 ([Recording](https://youtu.be/KqyAAuG0X1g))
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki
+*   Paris Pittman
+*   Bob Killen
+*   Ihor Dvoretskyi
+*   Vlad Shlosberg
+*   Kaitlyn Barnard
+*   Sahdev Zala
+*   Jorge Castro
+*   Hippie Hacker
+*   Noah Abrahams
+*   Christoph Blecker
+*   Tim Pepper
+*   Josh Berkus
+
+Agenda:
+
+
+
+*   Any interest in a k8s microconf track at [Linux Plumbers Conference](https://www.linuxplumbersconf.org/event/2/abstracts/), which will be held in Vancouver BC, Canada on November 13-15?  CFP closes September 2, 2018. (timpepper)
+    *   Includes convos from broader ecosystem
+    *   Does it make sense to have a k8s/cloud track here? Would not be a formal kubernetes dev event.
+    *   Lands in the middle of kubecon china
+    *   Contact @tpepper in slack if you’re interested in participating...next steps would be submitting a MicroConf proposal with a list of what’s to be discussed and who should attend.  Can get 3-6 free registration passes for organizer/leader/etc.
+*   Add Jeff Sica to YouTube management (Jorge)
+    *   Approved, yay!
+*   foqal update (Vlad)
+    *   stackoverflow answers added - ~8000 questions
+    *   Showing most useful information is the most challenging
+*   Meetings within the CNCF - @hh
+    *   Time choices (Asia Pacific Pains)
+    *   Cancelled meetings (notification channels)
+    *   
+*   Gathering user stories in a meaningful way @hh
+    *   [KEP](https://github.com/ii/k8s-community/blob/bd91582b8b9d19a2491e8e0ff7bd954eb9b16f3a/keps/sig-architecture/0016-20180601-identifying-api-usage-patterns.md)
+    *   [https://github.com/kubernetes/community/pull/2363](https://github.com/kubernetes/community/pull/2363) 
+*   ContribEx meeting update for tomorrow - paris
+    *   Contributor site and Community redesign
+    *   Zoom and our communication platforms 
+    *   Non-Code project will be accosting all other SIGs to see how we can help.  Expect us.
+    *   GH Management stuff
+*   Mock for community site - kb
+    *   https://github.com/kubernetes/website/issues/7795#issuecomment-404013653
+*   Question about devstats company representation (Jorge)
+*   OSSNA?
+    *   Cblecker, jonas, others are attending and we have some space but need to get an abstract up ASAP
+*   Devstats 
+    *   New events that are missing - about 16 days ago; GH API issues - can’t get past events
+    *   Getting better every day; just need to keep getting better
+*   GitHub Management Subproject Proposal [Christoph]
+    *   [https://docs.google.com/document/d/129HccP70nNlOf9MNgNnLUscglp4d97xQV_D-Vyl3Qr4/edit](https://docs.google.com/document/d/129HccP70nNlOf9MNgNnLUscglp4d97xQV_D-Vyl3Qr4/edit)
+    *   Perms, membership, repo creation, would fall under this
+    *   NOT tooling and automation - testing and contribex already has this
+        *   Also not: moderation/coc
+*   Objections to the discuss KEP? [will add link] (paris)
+*   GitHub Team Structure [Christoph]
+    *   [https://github.com/kubernetes/community/issues/2323](https://github.com/kubernetes/community/issues/2323)
+
+
+## June 27 (Recording)
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Bob Killen
+*   Jonas Rosland
+*   Vlad Shlosberg
+*   Yang Li
+*   Tim Pepper
+*   Jaice Singer DuMars
+*   Noah Abrahams
+*   Christoph Blecker
+*   Ihor Dvoretskyi
+*   Lindsey Tulloch
+*   Stephen Augustus
+*   Elsie Phillips
+
+Agenda:
+
+
+
+*   Foqal Update (reserving time for Vlad)
+    *   In a good place with less mutes
+    *   New features:
+        *   In admin site
+        *   Focusing on graphs that show how often we display feedback + how often people think that is useful
+        *   Need to get more people to add things, as well as other sources of information
+        *   Working on StackOverflow question integration (8000+ questions there to tap)
+        *   Scraping Kubernetes docs, which is difficult because they are long form
+            *   Need to break these down, so you get blurbs not the whole doc
+        *   Working on making the info shown valuable and concise 
+    *   Jorge and Bob can populate foqal with office hours questions and links
+    *   
+*   Intent to deprecate kubernetes-pm and kubernetes-build-cops github teams [Christoph]
+    *   Mail out to k-dev: [https://groups.google.com/forum/#!topic/kubernetes-dev/yp1HEJKM3e0](https://groups.google.com/forum/#!topic/kubernetes-dev/yp1HEJKM3e0)
+    *   [https://github.com/kubernetes/community/issues/2315](https://github.com/kubernetes/community/issues/2315) (kubernetes-pm)
+    *   [https://github.com/kubernetes/community/issues/2316](https://github.com/kubernetes/community/issues/2316) (kubernetes-build-cops)
+        *   Hasn’t heard any objections so far
+        *   We don’t have a build cops rotation
+        *   Next Tuesday is the deadline for objections; removing then
+*   GitHub teams for sigs [Christoph & Jorge]
+    *   Removal of service accounts/mirrors for new sigs: [https://github.com/kubernetes/community/pull/2302](https://github.com/kubernetes/community/pull/2302)
+    *   What should team structure look like going forward?
+    *   Found out that some of these are powering automation (PR reviews, misc)
+    *   **EDIT:** [https://github.com/kubernetes/community/issues/2323](https://github.com/kubernetes/community/issues/2323) 
+*   Proposal for sunsetting [k-users](https://groups.google.com/forum/#!forum/kubernetes-users)@ in favor of discuss.kubernetes.io [paris]
+    *   Needs to be ASAP, need proposal to mailing list + charter communication principles
+    *   Going away will include keeping the list in read-only form for archival purposes
+    *   Give users a month to transition over to discuss (end of July)
+    *   Provide links and information on how to interact with discuss in ‘mailing list style’
+*   Non-Code recurring meeting time is now set for Wednesdays at 11AM PST/2PM EST/6PM UTC, bi-weekly, starting June 27th - [Noah Abrahams]
+*   Zoom [paris]
+    *   [Best practices/moderation](https://docs.google.com/document/d/1fudC_diqhN2TdclGKnQ4Omu4mwom83kYbZ5uzVRI07w/edit#heading=h.j6izsh1tkobb)
+*   kubernetes.io/community [jorge]
+*   Discuss stats [jorge]
+*   Community page [jorge]
+*   Meet Our Contributors [paris]
+*   Steering Backlog [Jaice]
+
+
+## June 20 (Recording)
+
+Attendees:
+
+
+
+*   Elsie Phillips- Red Hat
+*   Jorge Castro - Heptio
+*   Bob Killen - U of Michigan
+*   Chris Short - unaffiliated
+*   Vlad Shlosberg - Foqal
+*   Erik Fejta - Google
+*   Jonas Rosland - VMware
+*   Christoph Blecker
+*   Jaice Singer DuMars - Google
+*   Noah Abrahams
+*   Guinevere Saenger -Samsung SDS (must leave at 10:00)
+*   Tim Pepper - VMware (must leave at 10:00 also)
+
+Agenda:
+
+
+
+*   foqal
+    *   admin site now has metrics and graphs
+    *   algorithm improvements have made it less ‘chatty’
+*   ACTION NEEDED: Release post mortem community call
+    *   2 parts
+    *   Release team and gen
+    *   eral Either July 12th (Tim Pepper to host) or June 28th (Jaice to host) 
+    *   June 28th w/ Jaice to host, containerd demo still going forward 
+*   Hosts needed 7/19 and 7/26
+    *   Tim Pepper to do 7/19
+    *   Chris Short to do 7/26
+*   Spread the love on “help-wanted” and “good-first-issue” labels to other SIGs/subrepos - often, they’re aware there’s a problem; we want them to know about and use our solution
+    *   Need to clarify and publicize the def of labels 
+    *   Add to next road show script
+    *   Add to community meeting as an announcement 
+*   Contributor guide help needed: 
+    *   FAQ on interpreting/dealing with test results, including when to recognize flakes
+    *   Improve “where to ask q’s” section - it links to the website which I remember being a bit more helpful in the past, it underwent some changes…
+    *   Go to SIG testing and ask if we can collaborate on this [Guin to take this]
+*   Meta Org Repo [Christoph]
+    *   Last call for comments: [https://groups.google.com/d/msg/kubernetes-sig-contribex/C4RaGEpgRLo/3GJmsLfFBgAJ](https://groups.google.com/d/msg/kubernetes-sig-contribex/C4RaGEpgRLo/3GJmsLfFBgAJ)
+*   Sigs.yaml [Jaice]
+    *   Lots of changes in that file-merge conflicts arising 
+    *   Proposal 1: break files down per SIG or WG, then create MD file on the backend 
+    *   Proposal 2: generate files on the backend
+        *   Christoph to work with Jaice on this
+        *   Jaice to open issue against community repo
+*   Non-Code recurring meeting time [Noah]
+    *   Poll for time slot will close on Friday
+    *   [https://doodle.com/poll/uuuf2hi9f8vnk324](https://doodle.com/poll/uuuf2hi9f8vnk324)
+    *   **Meeting: next or week after**
+*   Community page demo: [https://whs-dot-hk.github.io/k8sC-sigs-demo/sigs/](https://whs-dot-hk.github.io/k8sC-sigs-demo/sigs/) [jorge]
+    *   Meeting w/ designers next week
+    *   Start thread on public forum to get feedback
+*   discuss.k.i stats [jorge]
+    *   Traffic leveling off around 512 active users/week
+    *   Help out by posting things 
+*   
+
+
+## June 13 (Recording)
+
+Attendees:
+
+
+
+*   Jorge Castro (will miss first half of meeting) 
+*   Paris Pittman
+*   Bob Killen
+*   Tim Pepper
+*   Łukasz Gryglicki
+*   Jonas Rosland
+*   Sahdev Zala
+*   Vlad Shlosberg
+*   Christoph Blecker
+*   Guinevere Saenger (missed first half of meeting)
+*   Elsie Phillips- Red Hat
+
+Agenda: 
+
+
+
+*   OSSNA? Anyone interested in putting on a contributor event (live meet our contributors, AMA, test out a concept?)?
+    *   Paris, Jonas, Ihor, and perhaps others will be there, will sort out something for a k8s contributor topic
+*   Reminder for Paris - update the charter with prototyping time box window (ie - 30 days for first evaluation; 90 days for decision)
+*   Anymore centralized communication platform ideas?
+    *   moderation:
+        *   CNCF to own moderation of mailing lists?
+            *   Find out more details here; Taylor from CNCF 
+        *   Community management OWNERs to moderate mailing lists?  Dedicated community project-involved moderators seems preferred, with CNCF as an ownership fallback if something needs urgently removed and moderators hadn’t quite gotten it yet.
+        *   If k-users is deprecated to discuss.kubernetes.io, that leaves mostly k-dev needing mostly anti-spam.
+    *   Owners of any of tools (whether mailing list, GSuite, or other) need to find a way to not loose control of things when users change companies or email addresses.
+        *   GSuite documents owned by “team” alias could be better managed?  Paris had looked into it, but bumped into some limitations.  Jonas & Paris to look again.  For most sigs there’s maybe 20-50 active people, but the Thursday community call is where we hit limits as it has a huge list of revolving collaborators.
+    *   Open to even wild and crazy ideas: move off mailing lists, off GDocs, etc.
+        *   Etherpad?
+        *   https://hackmd.io/ 
+    *   Calendars are still a pain point
+*   Foqal Status
+    *   Initial usage seems to be showing value
+    *   Vlad’s tracking stats and looking at data quality improvements
+    *   
+    *  
+*   FOSSA meeting set for Friday June 15 @ 2pm PDT [Christoph]
+*   Final push for contrib guide - help appreciated
+    *   Guin’s going to round up the existing issues, clean and close old ones as appropriate and do new issue(s?) for remaining bits
+    *   Which website target?  Jorge knows details on upcoming contributor site
+    *   Probably 30-60days out for setting things up on web
+
+
+## June 6 (Recording)
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Jonas Rosland, VMware
+*   Guinevere Saenger
+*   Sahdev Zala
+*   Bob Killen
+*   Christoph Blecker
+*   Łukasz Gryglicki
+*   Vlad Shlosberg
+*   Noah Abrahams
+
+Agenda:
+
+
+
+*   Non-Code Guide Meeting (Noah, Bob, Jonas, Tim)
+    *   Notes: https://docs.google.com/document/d/1gdFWfkrapQclZ4-z4Lx2JwqKsJjXXUOVoLhBzZiZgSk/edit?usp=sharing
+    *   Renamed to get away from pretense that code is the only ave to get into the project
+    *   Wants to turn it into a subproject
+        *   Conversation around why it should be under the contributor guide subproject
+        *   Agreement from crew about above
+    *   Moderation
+        *   Need to figure out crew for moderating the mailing lists
+        *   Jorge, paris, ihor, jaice - same crew from slack?
+        *   Need mailing list guidelines updated in the main doc [link]
+        *   Establish “sig liaisons” who are already a part of the sig to handle spam
+*   Foqal bot Status
+    *   Installed a week ago
+    *   Fixed some copy and some display features
+    *   Created a muting feature
+    *   Vlad will be here every week to update us; July 31st is our evaluation date
+    *   Stats (6/6/2018):
+*   “good first issue” + labelling update [Christoph]
+    *   Standardized labels are now across repos
+    *   Carolyn, et al are working on the policy and addition to issue triage guidelines; potential workshop to come out of this
+*   discuss.k8s.io stats [would like to go last]
+
+
+## May 30 (Recording)
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Elsie Phillips, Red Hat
+*   Vlad Shlosberg, Foqal
+*   Sahdev Zala, IBM
+*   Garrett Rodrigues, Google
+*   Jonas Rosland, VMware
+*   Jorge Castro, Heptio
+*   Noah Abrahams
+*   Christoph Blecker
+*   Ihor Dvoretskyi, CNCF
+*   Guinevere Saenger, Samsung SDS (sorry; late again!)
+
+Agenda:
+
+
+
+*   New contributor intros/welcome
+*   Pick hosts for community meeting
+*   Choose graph for community meeting Graph of the Week! 
+*   Reminder: KEP @ Community Meeting - Caleb will intro
+    *   What is the process?
+    *   Going forward highlight 2 KEPs in the meeting
+*   Security Contacts - are we all set? 
+    *   For community repo, we’re set
+    *   Jess frazelle has opened issues against every repo in K8s
+    *   Documented here: https://github.com/kubernetes/community/commit/4571dbe443b0bff3ad25ca9697c5e75315db6483
+    *   https://github.com/kubernetes/community/pull/2181
+*   Installing Foqal (foqal.io/support) on Kubernetes Slack - Vlad Shlosberg
+    *   Similar to the pensieve.io extension we tried a few months ago.
+    *   Has been training the model for a few months. 
+    *   Looks at conversations, asks if the question and answer would be useful to store
+    *   Also can scrape K8s docs
+    *   Can also suggest people to ask if the answer isn’t known
+    *   Slowly ramp up
+    *   Move discussion to list, then give it a shot, perhaps on #kubernetes-novice first? 
+*   Non-Dev Guide meeting scheduled for June 5th at 1:30PM EST, led by Noah Abrahams (Jonas)
+    *   Link for meeting: https://vmware.zoom.us/my/jonasrosland
+*   Label descriptions update [Christoph]
+    *   https://github.com/kubernetes/test-infra/pull/8128
+        *   Looking for reviews on the definitions
+        *   Merging by EOD
+    *   https://github.com/kubernetes/test-infra/pull/8129
+*   Discuss Stats [Would like to go last] (Jorge)
+    *   Post your content on discuss.kubernetes.io, and let a friend know!
+*   
+
+
+## May 23 ([Recording](https://youtu.be/k4h5-vL4XLY))
+
+Attendees:
+
+Łukasz Gryglicki - CNCF
+
+Tim Pepper - VMware
+
+Christoph Blecker
+
+Sahdev Zala 
+
+Josh Berkus
+
+Paris Pittman
+
+Jaice Singer DuMars
+
+Bob Killen - University of Michigan
+
+Guinevere Saenger (super late)
+
+Agenda:
+
+
+
+*   KEP @ Community Meeting (Jorge)
+    *   Caleb will kick it off on the May 31 community meeting
+*   K8sport 
+    *   Ryan Quackenberger - DA @ Apprenda
+    *   Started K8sport after convo with sarah novotny
+    *   Community lacked a way to track contributions at the time from multiple sources (SO, etc.)
+    *   Kubeweekly is by the same creators
+    *   Create challenges based off of meetup events; when they check in, they would get challenges
+    *   1600 developers globally; 1000 active in the hub
+    *   [https://kubernetes.io/blog/2017/03/k8sport-engaging-the-kubernetes-community/](https://kubernetes.io/blog/2017/03/k8sport-engaging-the-kubernetes-community/)
+    *   Cblecker: do we have stats on return engagement vs initial challenges?
+        *   Ryan will find some more stats on this 
+    *   Will 
+*   GDPR compliance (deadline Friday)
+    *   Discuss.kubernetes.io
+    *   Docs?
+    *   Devstats
+        *   Devstats and cncf/gitdm (devstats affiliations sources) both already have an option to opt-out. Devstats supports anonymising data
+        *   [https://github.com/cncf/devstats/blob/master/HIDE_DATA.md](https://github.com/cncf/devstats/blob/master/HIDE_DATA.md)
+        *   [https://github.com/cncf/gitdm/blob/master/FORBIDDEN_DATA.md](https://github.com/cncf/gitdm/blob/master/FORBIDDEN_DATA.md)
+        *   And this is a config file that lists removed data in cncf/gitdm. Data is not directly available, we’re keeping data’s SHA. All data references are also removed from repo’s commit history
+        *   https://github.com/cncf/gitdm/blob/master/cncf-config/forbidden.csv
+    *   Get LF lawyers to weigh in on exact copy needed on our platforms and other actions that we may be missing 
+    *   Find out what google is doing re: google groups or if we have to control the lists
+*   Hosts for the next few community meetings (we’ve only planned out to Josh this week, all empty after that!)
+*   [https://github.com/kubernetes/community/SECURITY_CONTACTS](https://github.com/kubernetes/community/SECURITY_CONTACTS) file and charter words on security contacts [as per k/dev discussion](https://groups.google.com/d/msg/kubernetes-dev/codeiIoQ6QE/OGJtv26JDAAJ)?
+    *   Cblecker will volunteer for our security contact
+
+
+## May 16 ([RECORDING](https://youtu.be/1CB5VTs-TCI))
+
+Attendees:
+
+Elsie Phillips- Red Hat
+
+Łukasz Gryglicki - CNCF
+
+Paris Pittman - Goog
+
+Tim Pepper - VMware
+
+Christoph Blecker
+
+Bob Killen - University of Michigan
+
+Sahdev Zala - IBM
+
+Erick Fejta - Google
+
+Jaice Singer DuMars - Google
+
+Noah Abrahams
+
+Josh Berkus
+
+Matt Farina - Samsung SDS
+
+Agenda:
+
+
+
+*   OSS Licence Verification [Christoph/Tim]
+    *   [https://github.com/kubernetes/kubernetes/issues/44505](https://github.com/kubernetes/kubernetes/issues/44505)
+    *   [https://app.fossa.io/projects/git%2Bgithub.com%2Fcontainerd%2Fcontainerd/](https://app.fossa.io/projects/git%2Bgithub.com%2Fcontainerd%2Fcontainerd/)
+    *   CNCF has negotiated a free plan for their projects
+    *   These exists: [https://spdx.org/](https://spdx.org/) - [https://www.fossology.org/](https://www.fossology.org/)
+    *   Testing has also created something that compares licenses as a homegrown solution - very kubernetes specific - would be another batch of work to make it portable. Would need continued upkeep. 
+    *   If there is something off the shelf and CNCF has already paid for it, why not - cblecker (good fall back option is the homegrown bullet above)
+    *   Cblecker wants to make sure that no tool breaks our current infra, esp prow, etc.
+    *   Cncf is the legal entity so we should go with their path (mattfarina) matt recommended fossology
+    *   Cblecker asking for objections to approach of analyzing cncf tool and then if homegrown tool could be better, maybe go with that
+        *   Tpepper and mattfarina say “better” is subjective
+        *   Mattfarina thinks we should go with cncf guidance
+*   KEP Section for community meeting (Jorge)
+    *   Jorge - should we put out a call for volunteers?
+    *   Jaice - concerned about decision making
+    *   Jorge to talk to calebmiles
+    *   Jorge - we’re here to give visibility to KEPs, not make decisions
+*   Streamlined SIG Update (Jorge)
+    *   Should we make them a quick template?
+        *   Yes (paris)
+*   DockerCon - last call? (paris)
+    *   We are doing a 3 hour contributor office hours; no structure other than a slide with new contributor workshop links, etc. 
+    *   Paris is going; (Josh Berkus is, too but not confirmed for office hours) (Thockin has a keynote but will stick around for it if it works out, saadali [storage] will come by) (Noah is going)
+*   [Declarative Org Admin](https://docs.google.com/document/d/18Kw8InxYk4OF14iTXXfvD2oy3AuoDxfqAmtvf6NbwBI/edit?ts=5aecac61) (fetja)
+    *   Make sure the actual org member list is what we need
+    *   Design doc out and if you have feedback please put it on there
+    *   Erick to visit sig arch office hours tomorrow 
+    *   Names are github ids that we are tracking 
+    *   Erick - will want to put this into a private repo; wants to make something portable 
+*   discuss.kubernetes.io stats! (jorge)
+    *   250+ users
+    *   Please post here, too, so we can get a gauge if this is working
+    *   Announcements, content, etc. all wanted! 
+*   Contributor summits
+    *   Proposing a “release team” for events
+    *   Shanghai will be new contributor workshop only with josh leading. Jorge is second, ihor is going, paris will go if it’s not too much, and then tpepper if we need another.
+    *   Seattle will need a very large team  
+
+
+## May 9 ([RECORDING](https://www.youtube.com/edit?o=U&video_id=jgEao16wtOw))
+
+Attendees:
+
+Paris Pittman
+
+Jonas Rosland
+
+Chris Short
+
+Noah Abrahams
+
+Tim Pepper
+
+Guinevere Saenger
+
+Chris Hoge
+
+Sahdev Zala
+
+Zach Arnold
+
+Garrett Rodrigues
+
+Aaron Crickenberger
+
+Bob Killen
+
+Agenda:
+
+
+
+*   KEP updates [Jorge]
+    *   Contributor site - KEP 0005
+        *   Jorge is now working on it 
+        *   Contributor portal
+    *   Discourse
+        *   100 new users
+        *   Wants feedback
+        *   [Discuss.kubernetes.io](https://discuss.kubernetes.io)
+        *   Need folks to start using it 
+*   Deep Dive Dev Guide
+    *   30min video of discussion: [https://www.youtube.com/watch?v=2oPHolzhZHc](https://www.youtube.com/watch?v=2oPHolzhZHc) 
+    *   Tpepper - voluntold to turn notes into an action plan 
+    *   Pwittroc and tpepper - git book / dev guide
+    *   Umbrella issue: [https://github.com/kubernetes/community/issues/1919](https://github.com/kubernetes/community/issues/1919) 
+    *   Make sure folks are in OWNERs file (devel) that need to be - eg tpepper, et al
+*   Non-Dev Guide [Noah]
+    *   Wants to document all of the non-coding roles of the project and how to help out with those 
+    *   Starting with a section in the contributor guide 
+    *   Interested folks: Noah, Jonas, Bob, tpepper’s always down for helping explain git
+    *   [maybe start here?](https://github.com/kubernetes/community/blob/master/contributors/guide/README.md#find-something-to-work-on)
+*   Contrib Summit new contributor track:
+    *   Video:
+        *   need to post it online
+            *   Done: [https://www.youtube.com/playlist?list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx](https://www.youtube.com/playlist?list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx)
+        *   break it up into sections/chapters, youtube short url links to specific time points for specific topics
+        *   share the slides
+    *   Next steps to re-use materials?  We need to all go to Milan.
+    *   Jonas to edit the video before posting?
+*   Mentoring automation [grod/Garrett]
+    *   Goal: automate the mentor/mentee logistics.  Connect people automatically.  Less human involvement in coordinating mentorship
+    *   Grod working on this in small steps 
+    *   Chris short wants to get involved
+    *   Bob can help as well
+    *   Slack tool exists for connecting people: [donut](http://slack.com/apps/A11MJ51SR-donut)
+
+
+## MAY 3, 2018 
+
+No meeting - KubeConEU
+
+
+## APRIL 25, 2018 (Recording)
+
+Attendees:
+
+Elsie Phillips
+
+Paris Pittman
+
+Jonas Rosland
+
+Chris Short
+
+Josh Berkus
+
+Christoph Blecker
+
+Sahdev Zala
+
+Tim Pepper
+
+Agenda:
+
+
+
+*   Recurring items from the top
+    *   Paris to do Slack analytics at the Community meeting tomorrow
+*   Stand up - [projects.md review](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/projects.md) [10 mins]
+    *   Elsie and Paris will look into using GitHub projects mid-May
+    *   Changing “communication channels” to “community management” (paris to PR today but as always - PRs welcome!)
+    *   The buddy program has now been named to The 1:1 hour (paris to PR today but same story as above)
+    *   Add your projects to this and/or update the projects you have in there
+    *   Moderation guidelines: [https://github.com/kubernetes/community/pull/2069](https://github.com/kubernetes/community/pull/2069)
+    *   Possible events rotation; implement release team model
+    *   Add discourse information to the project list
+*   KubeCon [Update Planning](https://docs.google.com/presentation/d/1KUbnP_Bl7ulLJ1evo-X_TdXhlvQWUyru4GuZm51YfjY/edit#slide=id.p) [10 mins; paris]
+    *   What should we highlight for the update?
+*   [KubeCon Deep Dive Planning](https://docs.google.com/document/d/1mcl1OlvwglShzcG-6KEDGuojpdkZ6brqaPsodCHzisM/edit?hl=en) [10 mins; paris]
+*   [Contributor Experience MidYear Survey](https://docs.google.com/document/d/1s8op9D-qjNczDiFHIS01-2kDxyiLJHPB3qzW889f-W0/edit?hl=en) [5 mins; paris]
+    *   Sending out mid-June
+    *   Need your question suggestions and feedback 
+*   Quick discuss.k8s.io update [Jorge Castro]
+    *   [http://kubernetes.trydiscourse.com](http://kubernetes.trydiscourse.com) - current URL
+    *   Should we just be a section of discuss.cncf.io?
+        *   Overwhelming votes for standalone site for now.
+    *   Not moving forward until SSO and logos, etc is set up
+*   Kind label normalization: [https://github.com/kubernetes/community/issues/2032](https://github.com/kubernetes/community/issues/2032)
+    *   Next step is to get a proposal out to contribex/k-dev.
+    *   Also, open a PR against test-infra to execute the change.
+*   FYI: Tide-related changes to Milestone Munger: [https://docs.google.com/document/d/1Wn5NzEzy3eMbXXpkDc_aFY3cuqYsFaPsFUiuLcLthIo](https://docs.google.com/document/d/1Wn5NzEzy3eMbXXpkDc_aFY3cuqYsFaPsFUiuLcLthIo)
+*   
+
+
+## APRIL 18 ([Recording](https://www.youtube.com/watch?v=K4scQCngjUk))
+
+Attendees:
+
+
+
+*   Aaron Crickenberger
+*   Elsie Phillips
+*   Christoph Blecker
+*   Jorge Castro
+*   Paris Pittman
+*   Sahdev Zala
+*   Jaice Singer DuMars
+*   Tim Pepper
+
+Agenda:
+
+
+
+*   Recurring items at the top
+    *   [Community Meeting Tracking Sheet](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895)
+    *   Reach out to Jorge or Paris for Office Hours or Meet Our Contributors 
+    *   Jorge to do graph of the week- youtube stats
+*   [ContribEx Update slide template for KubeCon](https://docs.google.com/presentation/d/1KUbnP_Bl7ulLJ1evo-X_TdXhlvQWUyru4GuZm51YfjY/edit?usp=sharing)
+    *   if you are a subproject owner, create a slide but don’t worry about formatting
+    *   Due Friday by EOBD 
+*   Current Contributor Track session voting email is going out COB today
+    *   14 proposed topics
+    *   Voting will end next week at the same time
+*   Update on KEP 0005 [Jorge]
+    *   No updates this week, Joe was on holiday
+*   Update on Discourse KEP 0007 [Jorge]
+    *   [Prototype](http://kubernetes.trydiscourse.com/)
+    *   Need to handover SSO creds to someone responsible
+*   Devstats ad-hoc query access (josh)
+    *   Access to test copy postgres database granted
+    *   Pm Josh for access 
+*   Call for recommendations with new contributor workshop
+    *   Build & Test
+        *   PM Josh Berkus
+    *   Public Tests- Aaron 
+*   Ingress OWNERs files - what is going on?
+    *   People LGTM’ing weren’t in the owners files
+    *   Need to get people to be org members
+
+
+## APRIL 11 ([Recording](https://www.youtube.com/watch?v=Dq4PP9GUXm8))
+
+Attendees:
+
+
+
+*   Paris Pittman 
+*   Aaron Crickenberger
+*   Tim Pepper
+*   Jorge Castro (Founder and President, Tim Pepper Fan Club)
+*   Elsie Phillips 
+*   Sahdev Zala
+*   Matt Farina
+*   Garrett Rodrigues
+*   Ihor Dvoretskyi
+
+Agenda:
+
+
+
+*   Recurring items
+*   Some feedback from SIG AWS Roadshow I’d like to discuss and get clarification on (Jorge):
+    *   help-wanted tag, see [https://github.com/kubernetes/community/issues/1959](https://github.com/kubernetes/community/issues/1959)
+        *   There are issues good for first contribution from novices and issues good first contribution from non-novices.  Discussion in issue 1959 hasn’t resolved to a specific direction.
+        *   Could add a role (eg: “issue sherpa”) to the contribx charter to triage help wanted issues for community repo issues.
+        *   The issue volume across kubernetes/* repos in the org is large.  SIG leads need to also contribute to this issue triage.
+        *   Maybe for discussion by steering:  https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance-template-short.md  doesn’t explicitly say anything like “do issue triage and help wanted / good first issue labelling for new sig issues”.  Should it?
+    *   Get a better definition for it perhaps?
+    *   Specifically a difference between “I need help from anyone who knows this with a few hours” vs. “this would be great for new contributors” 
+    *    Subprojects, how to do them?
+    *    Guidelines for what is a subproject
+    *   We need to put this in our charter, how loose is it? Do we just all lazy consensus and make a subproject?
+*   Proposed updates to community demo / hosting guide (Jorge)
+    *   Need host to ask demo owners to [review guidelines](https://github.com/kubernetes/community/blob/master/events/community-meeting.md#demos)
+        *   Goal is to avoid irrelevant/too commercial demos
+*   PR and Issue queue - should we set up an SLO/A? (paris)
+    *   For our k/community queues only
+        *   Currently at 90+ PRs and 100+ Issues
+    *   Group doesn’t feel like this is an issue - no SLO/A for right now
+*   Lgtm, approve, and PR reviews
+    *   [Notes from sig-testing breakout](https://docs.google.com/document/d/1hTw5on7tyVFmTfXIGeXRTA-6ba-ABwDRzzmG3Hu71ak/edit)
+    *   [Summary comment](https://github.com/kubernetes/test-infra/pull/7504#issuecomment-380257055) on what /lgtm, /approve, and github reviews do today, and what we want them to do
+    *   [Issue that kicked off this discussion](https://github.com/kubernetes/test-infra/issues/6589)
+    *   tl;dr violent agreement over /lgtm only applying lgtm, /approve only applying approve
+    *   Canary out the lgtm change through community and then other repos
+    *   Notify of intent to have common default across kubernetes org repos
+*   Ihors proposal about community (Ihor)
+    *   [Email link](https://groups.google.com/d/msgid/kubernetes-wg-contribex/CAJRwiqQn_zvVCE5OPUMyE_YwwVG-BJZH6n82wjqEa9XQc0zAsQ%40mail.gmail.com?utm_medium=email&utm_source=footer)
+    *   Set up a googlegroups or ask how we can use the k8s domain (aaron will ask steering)
+*   Documentation requests (paris)
+    *    for sunsetting SIGs/WGs [https://github.com/kubernetes/community/issues/2029](https://github.com/kubernetes/community/issues/2029)
+    *   Moderation guidelines [https://github.com/kubernetes/community/issues/2028](https://github.com/kubernetes/community/issues/2028)
+*   Feedback wanted on KEP-0007 proposal for a community forum: [https://github.com/kubernetes/community/pull/2011](https://github.com/kubernetes/community/pull/2011)
+*   
+
+Other actions:
+
+Set up more workshops and education around issue grooming and other topics that will help sig members (paris)
+
+
+## April 4 ([Recording](https://www.youtube.com/watch?v=PQ1tJalX54o))
+
+Attendees:
+
+
+
+*   Elsie (will kick off)
+*   Paris (will be late)
+*   Aaron Crickenberger (Samsung SDS)
+*   Christoph Blecker
+*   Sahdev Zala
+*   Ryan Jarvinen
+*   Josh Berkus
+*   Jorge Castro (President and Founder, Aaron Crickenberger Fan Club)..Sahdev’s a member of the fan club :). 
+*   Noah Abrahams
+*   Jaice Singer DuMars (ronin for 2 weeks)
+
+Agenda:
+
+
+
+*   New contributor intros/welcome
+*   Pick hosts for community meeting
+    *   We are set for hosting for the next 3 weeks
+    *   Set for Kubecon, but need hosts after
+    *   Sign up on spreadsheet that is linked from the top of the community meeting notes
+    *   Sign up form will also be in contrib-x slack
+*   Outreach for Meet-our-Contributors/Office Hours
+    *   Need help promoting to get contributors to help 
+    *   CNCF tweeting the week before 
+    *   PM Paris or Jorge with volunteer names
+*   [Cherry Pick Process](https://groups.google.com/d/msg/kubernetes-wg-contribex/XxYn02YQcV0/PHd1kHchAgAJ) (Aaron)
+    *   V 1.11 timeframe
+*   /lgtm, /approve, and PR reviews
+    *   Add option to toggle whether /lgtm can also mean /approve [https://github.com/kubernetes/test-infra/pull/7504](https://github.com/kubernetes/test-infra/pull/7504) (cblecker)
+    *   sig-testing breakout session TBD to discuss ideal defaults for prow, and ideal defaults for kubernetes
+*   penseive.ai update (Jorge)
+    *   Data not great 
+*   [Developer Tools Working Group Proposal](https://groups.google.com/forum/#!topic/kubernetes-dev/YcjXRDrCdbI) (Matt Rickard)
+    *   Scoping as a first step, discovering where there is overlap w/ existing SIGs (potentially SIG Apps) 
+    *   Best place to leave feedback is the kubernetes-dev thread 
+*   KubeCon EU Update and Deep Dive (paris)
+    *   2 slots (30 minutes) 
+        *   Update: roadshow content (Paris + Elsie)
+            *   Expect update a week before
+        *   Deep dive: go into one of our projects and get audience feedback/work
+            *   Developer guide- Tim Pepper, Ryan J, or Jorge potential presenters
+*   Mentor names! Put your creative hat on! (paris)
+    *   5 different projects, individuals helping upstream contribs 
+    *   Want to give these mentors names to recognize them and give them an identity 
+    *   Names:
+        *   Kubernetes Pilot (in greek those terms mean kind of the same thing; also sounds like they are testing something) , Kubernetes Skipper , Kubernetes Mentor (mentor is a greek term but feels bland here and like they are mentoring users) , Kubernetes Contributor (Mentor or Guide or Advisor) , Kubernetes Ladder (Mentor or Guide or Advisor),   Kubernetes Upstream (Advisor or Guide),  kube-mentor,  kubemntr,  kubuddy, k8smate, kubemate, bosun, Kampeones, khampions, Nafpigos, Konductor, Lighthouse, Beacon, Heliograph, Ko-ordinator, Koach
+        *   Mentors (greek word) 
+            *   Not great because they’re not mentoring users
+        *   DM/PM Paris w/ ideas by this afternoon
+*   Taking on moderation for k-users and k-dev mailing lists (and other random mailing lists that aren’t SIG/WG related) (paris)
+    *   Brian Grant and a few other people who started the project own these lists
+    *   Contrib-X moderates most other communication channels
+    *   Get a team together to moderate
+        *   Super light moderation 
+            *   Delete spam
+            *   Make sure abuse isn’t happening
+            *   Assigned to community management subproject
+            *   Good candidates are people who’ve been with the project for a while, understand code of conduct and have no violations themselves
+            *   Paris to follow up next week on moderation guidelines proposal
+*   [https://github.com/kubernetes/community/pull/1970](https://github.com/kubernetes/community/pull/1970) - issue triage (sahdev)
+    *   Updating the triage guidelines showing the usage of the new labels
+    *   [Aaron comments on what the intended use cases are for these labels / bot command support](https://github.com/kubernetes/test-infra/issues/7251#issuecomment-374783541)
+        *   Aaron suggests ‘triage’ instead of ‘close’ for the label
+*   Update meeting as weekly in sigs.yaml? (Aaron)
+    *   kubernetes/community docs don’t reflect the updated meeting cadence / schedule
+    *   cblecker will handle opening PR for this
+*   Community Maintenance Tasks (Jorge)
+    *   [https://github.com/kubernetes/community/issues/1999](https://github.com/kubernetes/community/issues/1999)
+    *   Feel free to put your name by an item in the doc if you want to help with it
+*   Community Forum for k8s? (Jorge)
+    *   [KEP in draft, thoughts](https://github.com/castrojo/community/blob/community-forum/keps/sig-contributor-experience/0007-20180403-community-forum.md)?
+    *   I know, I know, I owe you the review section of the contrib guide first 
+*   [http://go.k8s.io/github-labels](http://go.k8s.io/github-labels) (Aaron)
+    *   Place to go to find definitions of github labels
+*   DevStats
+    *   Priority Queue for requests to be implemented 
+    *   
+
+
+## March 28 ([Recording](https://www.youtube.com/watch?v=8K6L-HxqnWY)) *people only meeting*
+
+Attendees:
+
+	Guinevere Saenger
+
+	Paris Pittman
+
+	Josh Berkus
+
+	Tim Pepper
+
+	Ihor Dvoretskyi
+
+	Sahdev Zala
+
+	Chris Hoge
+
+Agenda:
+
+Mentoring
+
+
+
+*   Google Summer of Code (Nikhita/Ihor)
+    *   No control over infrastructure
+*   Outreachy (completed - 2 semesters a year, we’re done with it)
+    *   No control over infrastructure
+*   Group mentoring and buddy program, these our ours
+    *   Spinning up another cohort
+    *   About 40% completion
+    *   Current member to reviewer in 3 SIGs (Apps, Lifecycle, and ???)
+    *   Cannot pair mentors across 8 TZs
+    *   How can we make this self-service?  Vision for automation matching mentor need with mentee, set calendar meeting for them.  Having one person who tracks all the potential mentor abilities and mentee needs is not scalable.  Tools ideas?
+        *   IFTTT: could plumb something minimally janky together, but can we do better?
+        *   Do academic office hours scheduling tools exist or academic peer study session coordinators?
+*   [Meet-Our-Contributors](https://github.com/kubernetes/community/blob/master/mentoring/meet-our-contributors.md) meetings
+*   Mentor guide ready for review: {PARIS ADD LINK}
+*   Mentor form
+    *   [https://goo.gl/forms/39mIyzpAyjBb4Zgg1](https://goo.gl/forms/39mIyzpAyjBb4Zgg1)
+    *   Test this -> make sure to include some kind of test language so I know it’s you and can delete the data
+*   Check in with SIG Scalability re: growing contributors
+    *   Josh and Paris will meet with them to discuss more
+
+
+## March 21 ([Recording](https://www.youtube.com/watch?v=wzoB9i6gx5k)) *full meeting - automation, workflow, and people!*
+
+Attendees:
+
+	Paris Pittman
+
+	Tim Pepper
+
+	Jeff Grafton
+
+	Chris Short
+
+Chris Hoge
+
+Christoph Blecker
+
+Ryan Jarvinen
+
+Agenda:
+
+-Recurring items (from the top)
+
+	-Hi Rob and Chris!
+
+-Any open automation or workflow issues?
+
+	-Bot configuration change for k/community [@cblecker]
+
+	-change the way /approve works
+
+	-by default right now, if you are the author, you explicitly approve the PR by being the author
+
+	-also creating a bot to squash
+
+	-most folks on the call are in agreement to both
+
+	-@tpepper - suggesting a bigger change to create commands that match the behavior better (eg: /reviewed-ok; /reviewed-needs-changes; /approved-for-merge)
+
+	-@cblecker - maybe ^^ will be better once we have run a test in k/community for 30 days
+
+	-@ixdy - is anyone familiar with the gerrit process?
+
+	-Chris Hoge - likes gerrit process because it’s explicit
+
+-Next steps for READMEs from last weeks discussion
+
+	-@cblecker - taking to SIG Architecture; 
+
+-”Buddy Program”
+
+	-parispittman@ and chrisshort@ are leading 
+
+	-hope to have a test out in 2-3 weeks
+
+-”Developer Guide” work is ongoing 
+
+	-led by @ryanj \
+	-Get involved here: https://github.com/kubernetes/community/issues/1919
+
+-Charter 
+
+	-parispittman@ to add in new TL (hi christoph!) and add in all subproject OWNER changes, etc. 
+
+-update from jbeda@ on KEP-5 (new contributor site)
+
+	(I can't make it today to the meeting but I'm going to (a) update KEP-5 with a few more details and move it to `implementable`.  That'll land on you Paris to publicize and review as you see fit.  I'll also start prototyping  in the meantime but won't submit anything until we can lock down the KEP.)
+
+
+## March 14 ([Recording](https://www.youtube.com/watch?v=dhZfG61EOdY)) *NOTE: This is a “people only” meeting. If the agenda topics have been exhausted, we will do automation and workflow at the end
+
+Attendees:
+
+	Paris Pittman
+
+	Jorge Castro
+
+	Joe Beda (had to leave 30m in)
+
+	Guinevere Saenger
+
+John Harris
+
+Elsie Phillips
+
+Tim Pepper (also only for first 30m)
+
+Agenda:
+
+
+
+*   Recurring meeting topics
+*   Leadership and SIG composition changes
+    *   Check the email
+    *   Time boxed for Friday COB PT (midnight UTC); will update changes to sigs.yaml and others on Monday given there are no objections
+*   [Contributor Site KEP](https://github.com/kubernetes/community/pull/1904)
+    *   Jbeda to make edits to proposal
+    *   Group to socialize final call for comments on KEP to go to prototype stage
+    *   Jbeda to do prototype
+    *   Socialize prototype with contributor experience group first and make edits/iterate from there
+*   Thomas Koch: READMEs in git
+    *   Proposal: README for every owners file
+    *   A README should (examples):
+        *   explain what a folder and its subfolders contain 
+        *   point to entry points into the code 
+        *   provide examples how the code is used by other components (or could be used) 
+        *   describe important flows implemented by the code 
+        *   identify individual components and describe how they interact 
+        *   point our planned future development, roadmap or milestones for this code 
+    *   This is an example for what information would help to have in the code tree: \
+[http://alexandrutopliceanu.ro/post/scheduling-in-kubernetes](http://alexandrutopliceanu.ro/post/scheduling-in-kubernetes) This poor soul had to deep dive the code just for the most basic understanding of the scheduler
+    *   The linux kernel maintains design and overview documentation in its source tree: \
+[https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation) which is partly rendered here: [https://www.kernel.org/doc/html/latest](https://www.kernel.org/doc/html/latest) \
+Examples for good or detailed kernel docs below Documentation/: \
+cgroup-v1/ \
+cgroup-v2.txt \
+kprobes.txt \
+memory-barriers.txt \
+scheduler/sched-design-CFS.txt
+    *   For the kernel, documentation is part of the coding process: \
+[https://www.kernel.org/doc/html/latest/process/4.Coding.html#documentation](https://www.kernel.org/doc/html/latest/process/4.Coding.html#documentation)
+    *   What are the code documentation guidelines for kubernetes code? The linux kernel has \
+[https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/doc-guide/kernel-doc.rst](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/doc-guide/kernel-doc.rst)
+    *   The Kernel community writes elaborate commit messages that justify and document changes, which is described here: \
+[https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#describe-your-changes) (Commit messages are not important for me, it’s just a related topic.)
+
+
+## March 7 ([Recording]( https://youtu.be/iSWtqbRjE1o)) *NOTE: This is a workflow/automation AND people meeting*
+
+Attendees:
+
+
+
+*   Jorge Castro
+*   Paris Pittman
+*   Christoph Blecker
+*   Sahdev Zala
+*   Tim Pepper
+*   Joe Beda
+*   Łukasz Gryglicki, CNCF
+*   Guinevere Saenger
+*   Garrett Rodrigues, Google
+
+
+#### Agenda:
+
+
+
+*   Recurring tasks above
+*   Community site KEP
+    *   Assign reviewer/approver: [https://github.com/kubernetes/community/pull/1903](https://github.com/kubernetes/community/pull/1903)
+    *   [Add a concrete proposal along with justification and alternative analysis: https://github.com/kubernetes/community/pull/1904](https://github.com/kubernetes/community/pull/1903)
+    *   
+*   Automation stuff:
+    *   [https://github.com/kubernetes/kubernetes/issues/44505#issuecomment-360680208](https://github.com/kubernetes/kubernetes/issues/44505#issuecomment-360680208)
+        *   Dependencies in core in particular that do not have a license or have a license that is incompatible with the K8s apache license
+        *   Process for license check is very manual (e.g thockin checks these things)
+        *   Important we get this done as the project matures
+        *   Scan deps and looks for a whitelisted set of license
+        *   Matt farina: this software exists and there is already a SaaS ([FOSSA](https://fossa.io/) - [example embed for readme including issues](https://imgur.com/a/MEei6) - [works on pull requests](https://imgur.com/a/pB8aU) - [works with Go](https://fossa.io/docs/integrating-code/go/))
+    *   [https://github.com/kubernetes/test-infra/issues/4179#issuecomment-366363480](https://github.com/kubernetes/test-infra/issues/4179#issuecomment-366363480)
+    *   The revival of for-new-contributors label (or some other wording variety - eg: good first issue (GH standard), etc.)
+        *   NEED: to file issue, naming convention for label to include /remove, education around how to use this 
+        *   Why: Because help-wanted is producing experienced contributor asks and we need to have something for new folks, regardless of their experience level 
+    *   Anyone from testing on the line - anything that we missed?
+    *   Wohoo.  We can set the milestone with a new a [prow plugin](https://github.com/kubernetes/test-infra/pull/6982)
+        *   /milestone clear
+        *   /milestone v1.10 
+*   Charter - new outline of how we communicate and make decisions with process/workflow/org wide changes
+    *   Lazy consensus with a time box of at least 72 hours to the following mailing lists with the GitHub issue link including the subject [NOTICE]: foobar to the following mailing lists:
+        *   kubernetes-dev@
+        *   sig-leads@
+        *   kubernetes-wg-contribex@
+    *   Announce at weekly Kubernetes Community Meeting on Thursdays
+*   [New roles and responsibilities for SIG Leads and others per SC](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance-template-short.md)
+
+[	](https://github.com/kubernetes/community/pull/1903)
+
+
+## Feb 28 - ([Recording](https://youtu.be/21e67PsGpq8))
+
+
+### *NOTE: THIS IS A “PEOPLE OF THE PROJECT” MEETING; WE DISCUSSION AUTOMATION AND WORKFLOW BIWEEKLY AND/OR MAILING LIST.
+
+
+#### Attendees
+
+
+
+*   Paris Pittman
+*   Sahdev Zala 
+*   Christoph Blecker
+*   Jorge Castro
+*   Chris Love
+*   Jose Palafox
+
+
+#### Agenda:
+
+
+
+*   New contributors on call? Introduce yourself if you are comfortable with it!
+*   Pick hosts for community meeting
+    *   WE HAVE A FIXED SCHEDULE NOW!! 
+    *   Hosts are responsible for chasing down sigs, demos, chart of the week
+*   Outreach for Meet-our-Contributors/Office Hours
+    *   [mentoring sign up sheet incl meet our contrib](https://docs.google.com/spreadsheets/d/1OKc4h-0QLKCbncSloRf_gYklpHYVyNxZmfEM9hlK1xQ/edit#gid=0)
+    *   [insert office hours sign up]
+    *   CNCF is ramping up marketing efforts
+*   sunset maintainers team
+    *   [https://github.com/kubernetes/community/pull/1861](https://github.com/kubernetes/community/pull/1861)
+    *   Less need for write access to the repo
+    *   ACTION: can steering committee post changes to mailing lists; can they post meetings notes; contribex to help with reminding them about comm channels
+*   [Projects.md](https://github.com/kubernetes/community/pull/1860)
+    *   Fixing nits today
+    *   Making headers the same as our subprojects in sigs.yaml
+    *   Elise is now the Product Owner of DevStats! :tada:
+*   [Charter](https://github.com/kubernetes/community/pull/1847)
+    *   Waiting for last review today - leave comments. 
+    *   Fixed all nits as of yesterday 
+    *   How are collecting 
+*   Graph o’ the Week
+*   Pensieve for k-users (jorge)
+*   Group Mentoring
+    *   New cohort forming
+    *   Lessons learned
+*   Roadshow working session (if we have time)
+
+If time for automation and workflow:
+
+
+
+*   Reviewable, who’s using it? 
+    *   [Feedback](https://github.com/kubernetes/website/pull/7410)
+*   Future topics above
+
+Feb 21 2018
+
+Attendees
+
+
+
+*   Jaice Singer DuMars, Microsoft, various SIGs
+*   Garrett, Paris -- Google
+*   Elsie Phillips- Red Hat 
+*   Ellen Körbes
+*   Christoph Blecker
+*   Mark Ayers - Samsung CNCT
+*   Noah Abrahams
+*   Steve Kuznetsov - Red Hat, SIG Testing
+*   Guinevere Saenger - Samsung CNCT
+*   Paris Pittman
+*   Benjamin Elder - Google, SIG Testing
+
+Agenda
+
+
+
+*   [1.10 goals](https://docs.google.com/spreadsheets/d/1EDmA7e1xiwAqjXlAgzfxeiJ4gMLuRLkisr--wh6sRHQ/edit#gid=558557015) stand up
+    *   Committing these to github (community in our [sig directory](https://github.com/kubernetes/community/tree/master/sig-contributor-experience)) Making this more public and discoverable
+*   1.11 goals
+    *   Write down -- tooling to be able to sync github teams from something committed in the repo [nice to have][cblecker]
+        *   Need someone to write a proposal
+        *   And a tool to do the sync
+        *   Centrally for the whole org or per repo
+    *   Tooling for initializing repos consistently [cross team effort with sig-testing]
+*   Youtube [jorge]
+    *    Ability to add community meetings to youtube
+    *   Jorge to document the process	
+*   Kubecon Deepdive Intro
+    *   Schedule for KubeCon EU available
+    *   ContribX Scheduled for 30 min intro session for attendees interested in current state of ContribX
+    *   Another 30 minutes for deep dive -- interact with community in WG setting and pick a few problems and tackle it
+    *   Get feedback from existing contributors
+    *   Qs?
+*   Getting feedback on and rolling out process changes [spiffxp]
+    *   I’m at helm summit so likely not around to give my 2c on this, so I commented on the opt-out issue that started this discussion in sig-testing
+    *   Opting out of commenter jobs that auto-/close and auto-/lifecycle inactive issues
+        *   [https://github.com/kubernetes/test-infra/issues/6903](https://github.com/kubernetes/test-infra/issues/6903)
+        *   Wait to hear back from spiffxp@ and discussion at Helm summit
+        *   Possible that we turn this off temporarily until we have discussion with helm.
+    *   Automatically requesting reviews instead of assigning
+        *   Was silently rolled out a while back, have there been any impacts?
+        *   [https://groups.google.com/forum/#!topic/kubernetes-dev/_9DOG0DPmlE](https://groups.google.com/forum/#!topic/kubernetes-dev/_9DOG0DPmlE) 
+        *   [https://github.com/kubernetes/test-infra/issues/4179](https://github.com/kubernetes/test-infra/issues/4179)
+    *    /lgtm, /approve, and the principle of least surprise
+        *   Have we gotten consensus on making things explicit? WDYT the next step should be here?
+        *   [https://groups.google.com/forum/#!topic/kubernetes-dev/PJJxV9roXI8](https://groups.google.com/forum/#!topic/kubernetes-dev/PJJxV9roXI8) 
+        *   [https://github.com/kubernetes/test-infra/issues/6589](https://github.com/kubernetes/test-infra/issues/6589) 
+    *   How does Testing and ContribX communicate effectively?
+        *   When design proposals come out, that would be a broad enough net 
+        *   Don’t want to throw every proposal out to K8s dev and wait for feedback -- take forever and still not be conclusive
+    *   Consistent experience while also accommodating different needs per sig/repo
+    *   Lazy consensus doesn’t always works
+        *   One objection can stall entirely proposal
+    *   Community meeting is a good place for visibility
+    *   Something like KEP but for K8s ContribX/Testing Process Improvements
+        *   Make proposals more formal
+        *   Also make them on a regular cadence.  Rolling things out monthly or biweekly
+    *   Need a way to present decision making process to people that are effective
+        *   Right now there are docs, issues, keps etc
+        *   Consistency
+    *   Communication Channel
+        *   Using ContribX as the forum for giving feedback
+        *   Maybe(?) a separate mailing list of process change announcements -- low volume communication channel for changes proposed to contributor workflow
+    *   Should every repo have a contributing.md
+        *   Show the differences between this repo and core K8s automation and tooling (e.g implicit self-approve is not enabled here)
+        *   A lot of them point back to contributor guide in community
+    *   Owner(s): 
+*   Documenting labels [spiffxp]
+    *   I’m at helm summit so likely not around to present this, but please let me know if I’m on the right path here. I shared this with grod yesterday and I gather it made the rounds at f2f.  Specifically interested in feedback on what information is missing, what the final output format should look like, and how it should be updated. [Talk amongst yourselves](https://media.giphy.com/media/l2SpQRuCQzY1RXHqM/giphy.gif)
+    *   [https://gist.github.com/spiffxp/24937d8478853054c088ffc298021214](https://gist.github.com/spiffxp/24937d8478853054c088ffc298021214) 
+*   [New Community Site KEP](https://github.com/kubernetes/community/pull/1814)
+    *   [ContribX Goals](https://github.com/kubernetes/community/pull/1814#issuecomment-367089671)
+
+
+## Feb 14 2018 ([recording](https://drive.google.com/file/d/1J6Yu8pXP2J1ZZirMMjof2nNi2qEScY47/view?usp=sharing))
+
+Attendees
+
+
+
+*   Aaron Crickenberger (@spiffxp) - Samsung SDS
+*   Paris Pittman
+*   Andrew Chen
+*   Josh Berkus
+*   Guinevere Saenger - Samsung SDS
+*   Sahdev Zala
+*   Jorge Castro
+*   Christoph Blecker
+*   Tim Pepper
+*   Joseph Heck
+*   Noah Abrahams
+*   Jose Palafox
+*   Garrett Rodrigues
+
+Agenda
+
+Any new contributors or new to Contributor Experience? Please introduce yourself! We are happy to help.
+
+
+
+*   /lgtm discussion - docs, testing
+    *   Do we need/want conformity across repos?
+    *   Does or should lgtm mean approve?  Current automation does implement lgtm as an approved and will now merge marker
+    *   Is clarity and least surprise in the process more important than requiring existing workflows to change toward a common workflow?
+    *   What is the code review process? (contrib guide is adding info, but approval/merge criteria is not documented)
+    *   [https://github.com/kubernetes/community/blob/203e3c09b0502151fcbc19d5323bfee49f92788f/contributors/guide/owners.md](https://github.com/kubernetes/community/blob/203e3c09b0502151fcbc19d5323bfee49f92788f/contributors/guide/owners.md)
+    *   [https://github.com/kubernetes/test-infra/issues/1744](https://github.com/kubernetes/test-infra/issues/1744)
+    *   [https://github.com/kubernetes/test-infra/issues/6589](https://github.com/kubernetes/test-infra/issues/6589)
+*   [Charter](https://docs.google.com/document/d/1pM0N8fpE2Xs7oqZtUygJoncwQXfVtqi4og6J_nTlEOg/edit?ts=5a836cc4) (DRAFT)
+    *   Open issues:
+        *   Moderation: steering committee considering splitting.  This should remain tied to slack admin’s.
+        *   Tighten distinction between contribx owning curating cross-k8s policy and procedures, with sig-testing owning the mechanisms of implementing policies
+*   [Roadshow](https://docs.google.com/spreadsheets/d/1Jn0ZOaWX5h5HYhbUP74mcBw9d-sQ2ARm0UFGcInD08Y/edit?usp=sharing):
+    *   quarterly contribx visit to each SIG to take messages to them and get feedback
+    *   There’s a core set of things that need periodic messaging, eg: KubeCon deep dive sessions, mentoring and SIG membership growth
+    *   There will be periodic topics in need of engagement driven, eg: the /lgtm vs /approve topic
+*   Determine priorities for DevStats feature requests [jberkus, lukasz]
+*   [Firm up F2F agenda](https://docs.google.com/document/d/1k10RAojhYj55KBe_dkRZNQY-M2q1B6vH0wCOzTIJWEs/edit) 
+
+Feb 7 2018 (recording)
+
+Attendees
+
+
+
+*   Jorge Castro
+*   Jaice Singer DuMars
+*   Garrett Rodrigues
+*   Paris Pittman
+*   Nikhita Raghunath
+*   Sahdev Zala
+*   Christoph Blecker
+*   Morgan Bauer
+*   Jose Palafox
+*   Chris Short
+*   Guinevere Saenger
+*   Tim Pepper
+
+Agenda:
+
+Any new contributors or new to Contributor Experience? Please introduce yourself! We are happy to help.
+
+
+
+*   Product Owner for DevStats
+    *   Role: What do the charts mean?  What’s missing?  What do sigs care about?  Charts from different perspectives?  How healthy is my sig?  How healthy is the overall community?  SLO’s (service level objective \
+...out metrics for ourselves in sig contribx)?
+    *   We have an excellent engineer will to extend devstats.  But he needs guidance on relevant metrics
+*   New labels [https://docs.google.com/document/d/1Bl965KDJb8xrVmf3o90aRQdwZZ9XU9g0lLkwmA8M1YQ/edit](https://docs.google.com/document/d/1Bl965KDJb8xrVmf3o90aRQdwZZ9XU9g0lLkwmA8M1YQ/edit) (Sahdev and Garrett) 
+    *   Provide feedback please!
+    *   Take to broader community - k/dev; helm and other subprojects
+    *   Any objections? 
+        *   Grod - might not need more bot commands. Need rationale for closing. Might modify the current command? Four new labels added - add more modify existing labels on devstats; modify the close command.
+        *   Cblecker - solicit feedback from helm
+        *   Labels are for all the repositories under kubernetes org, not necessarily every repos have to use them but adding new label may clutter some repos not wanting to use these labels  
+*   Bare metal developer kit - Jose (intel), Jorge (heptio)
+    *   Jose to follow up with Jaice Singer DuMars
+    *   Jose and Jorge to follow up with Lukas from Cluster Lifecycle
+    *   [NUC](https://en.wikipedia.org/wiki/Next_Unit_of_Computing) (similar to rpii); geared now towards MAKER market but maybe other users (enterprise+)
+    *   Would this be useful? Need feedback.
+    *   If you’ve seen blog posts from people about home set ups of k8s, please pass those to Jorge.(slack; jorge at heptio dot com)
+    *   Grod - have you talked to [lucas](https://luxaslabs.com/) from cluster lifecycle? Wants to make k8s accessible to students - could be a good approach
+*   Meet Our Contributors! \o/
+    *   [Need more volunteers to expand times](https://docs.google.com/spreadsheets/d/1OKc4h-0QLKCbncSloRf_gYklpHYVyNxZmfEM9hlK1xQ/edit#gid=0)
+    *   [ISSUE #1753](https://github.com/kubernetes/community/issues/1753)
+*   [Goals](https://docs.google.com/spreadsheets/d/1EDmA7e1xiwAqjXlAgzfxeiJ4gMLuRLkisr--wh6sRHQ/edit#gid=0)
+*   Proposing another mentoring idea - Buddy program (paris)
+    *   Will file an issue
+    *   Event based and long term
+    *   Similar to 1:1 with more involvement and less process than group mentorship
+        *   Less structure
+        *   No recurring time commitment
+*   ContribEx Roadshow?
+    *   Join SIG/WG meetings on a certain time cadence to make sure everyone is on the same page with things like issue triage, etc.
+    *   Who wants to help?
+        *   parispittman, castrojo, tpepper
+
+
+## Jan 31 2018 ([recording](https://drive.google.com/file/d/1J6Yu8pXP2J1ZZirMMjof2nNi2qEScY47/view?usp=sharing))
+
+Attendees:
+
+
+
+*   Paris Pittman 
+*   Nikhita Raghunath
+*   Tim Pepper
+*   Joe Beda
+*   Christoph Blecker
+*   Sahdev Zala
+*   Noah Abrahams
+*   Jorge Castro
+*   Ihor Dvoretskyi
+*   Guinevere Saenger
+*   Ellen Korbes
+
+Agenda:
+
+
+
+*   Paris: This meeting is focused on user process and perception and not toolability.  This includes things like the contributor guide and new user experience and such. Tooling and process is reserved for alternate weeks.
+*   Face to Face meeting on Feb 20 in SF @ INDEX
+    *   [Agenda link](https://docs.google.com/document/d/1k10RAojhYj55KBe_dkRZNQY-M2q1B6vH0wCOzTIJWEs/edit)
+*   Use of the word Master in K8s [[issue](https://github.com/kubernetes/website/issues/6525)]
+    *   @jbeda - open to discussion and needs to fit arch of how this works
+    *   Come up with a word that is better 
+        *   “Control Plane” is a proposed replacement
+    *   Master may imply single point of failure so it may not be the best term anyway
+    *   Need to bring to Arch tomorrow - @mattfarina
+*   [Mentoring](https://github.com/kubernetes/community/tree/master/mentoring)
+    *   Soon: Meet Our Contributors on Feb 7. [GH](https://github.com/kubernetes/community/blob/master/mentoring/meet-our-contributors.md) for more details.
+*   NEED: Issue [1672](https://github.com/kubernetes/community/issues/1672)
+    *   Maybe do a SIG lead / approver+ training 
+*   Contributor Guide (Jorge)
+    *   What’s the TLDR on relative links? 
+    *   Rudimentary golang support help needed.
+    *   Reviewer’s guide next major piece we need.
+*   [Goal Planning](https://docs.google.com/spreadsheets/d/1EDmA7e1xiwAqjXlAgzfxeiJ4gMLuRLkisr--wh6sRHQ/edit?usp=sharing)
+*   [See kubernetes-dev for Q+A tool to integrate with slack](https://groups.google.com/forum/#!topic/kubernetes-dev/QpAlD1L2JP4) (Jorge)
+*   #shoutouts (Jorge)
+
+
+## 01/24/2018
+
+Attendees:
+
+
+
+*   Aaron Crickenberger (@spiffxp) - Samsung SDS
+*   Guinevere Saenger (@gsaenger) - Samsung SDS
+*   Elsie Phillips- CoreOS
+*   Chris Short (@ChrisShort) - SJ Technologies
+*   Sahdev Zala (IBM)
+*   Jorge Castro (Heptio)
+*   Ellen Körbes
+*   Noah Abrahams
+*   Tim Pepper (@tpepper) - VMware
+*   Christoph Blecker (@cblecker)
+*   Paris Pittman 
+
+Agenda:
+
+
+
+*   Suggest nomating Paris Pittman as SIG lead (@spiffxp)
+    *   As a steering committee member I’ve witnessed sig-scheduling change a lead with no objections
+    *   As a SIG lead I’ve added an additional lead to SIG testing with no objections
+    *   What process do we want to follow here?
+        *   We need to update sigs.yaml in the root of k/community and then follow these instructions: [https://github.com/kubernetes/community/tree/master/generator](https://github.com/kubernetes/community/tree/master/generator)
+    *   Need to send a courtesy email to the -dev mailing list.
+    *   Do we approve?
+        *   Current sig leads are both OK with this :) (grod)
+        *   There was much nodding of heads and +1’ing during this meeting (@spiffxp)
+    *   Will move ahead sending e-mail to kubernetes-dev, updating kubernetes/community sigs.yaml etc.
+*   Discuss formalizing three sub projects under this SIG (@spiffxp)
+    *   Mentorship
+    *   Contributor Guide 
+    *   Community Management
+        *   FIle bugs on all annoying community admin issues. :)
+*   F2F discussion
+*   Poll update and agenda for the F2F meeting (@spzala)
+    *   [https://docs.google.com/document/d/1k10RAojhYj55KBe_dkRZNQY-M2q1B6vH0wCOzTIJWEs/edit](https://docs.google.com/document/d/1k10RAojhYj55KBe_dkRZNQY-M2q1B6vH0wCOzTIJWEs/edit) 
+*   Mentoring update (@parispittman)
+*   Contributor Guide update (@castrojo)
+    *   PRs incoming
+    *   Moving docs from devel to the contrib guide. 
+*   Moving community meeting information to github (@castrojo)
+*   [Registering for an intro and deep dive for Kubecon EU](https://docs.google.com/forms/d/e/1FAIpQLSedSif6MwGfdI1-Rb33NRjTYwotQtIhNL7-ebtYQoDARPB2Tw/viewform)
+    *   Paris to do today
+*   [Q1 OKR Planning](https://docs.google.com/spreadsheets/d/1EDmA7e1xiwAqjXlAgzfxeiJ4gMLuRLkisr--wh6sRHQ/edit#gid=0)
+
+
+## 01/10/2018
+
+Attendees:
+
+
+
+1. Google -- Garrett Rodrigues, Caleb Miles (@calebamiles)
+2. Aaron Crickenberger (@spiffxp) - Samsung SDS
+3. Jorge Castro (@castrojo) - Heptio
+4. Christoph Blecker (@cblecker)
+5. Tim Pepper (@tpepper) - VMware
+6. Sahdev Zala (@spzala) - IBM
+7. Ihor Dvoretskyi (@idvoretskyi) - CNCF
+8. Guinevere Saenger (@gsaenger) - Samsung SDS
+9. Andrew Chen (@chenopis) - Google
+
+Agenda:
+
+
+
+*   30 second standup - what are you working on?
+    *   Liaison to VMWare new K8s contributors; contributor guide- Tim Pepper
+    *   Will finally get around to the contributor guide this week - Jorge Castro
+    *   Metrics for Issue triage; closed issue candidates, whos doing the triage - Sahdev Zala
+    *   Standardizing how we interact with all of our repos; remove write access - Aaron
+    *   User journeys.  Importing docs from other repos. Moving contrib docs to k8s.io for better discoverability - Andrew Chen
+        *   See: [https://github.com/kubernetes/website/pull/6863](https://github.com/kubernetes/website/pull/6863)
+    *   Mentorship program.  3 groups of 4 mentees and 4 mentors. - Chris Love
+*   Devstats discussion/review a chart - [devstats.k8s.io](http://devstats.k8s.io)
+    *   Define what measurements of velocity look like; LF wants this info, too
+    *   [Clarifying measurement of approvers](https://github.com/cncf/devstats/issues/34)
+    *   reviewer/approver is off right now - @spiffxp working on it; problem with pointing to any chart that talks about reviewer/approver
+    *   Every other week devstats standup on Friday for 15 mins - we pick a chart and define it
+*   Working with sig-testing to roll out developer workflow changes [Steve Kuznetsov]
+    *   as the tooling evolves developer workflows for repos with the Kubernetes robots may change
+    *   we need a simple and straightforward way for these two SIGs to bounce ideas off of each other in these situations and to give a voice/comment ability to the larger developer community
+    *   SIG Contribex and Testing have a lot of overlap
+*   Andrew Chen/Jorge Castro - user journeys in the docs
+    *   Should we turn on user-facing generator pages for the community repo?
+    *   Importing into kubernetes.io [PR #6863](https://github.com/kubernetes/website/pull/6863) [Preview](https://deploy-preview-6863--kubernetes-io-master-staging.netlify.com/docs/imported/) 
+    *   TODO: Need to get joe’s prototype info in here (needs followup)
+    *   TODO: CNCF wants something like this too, need to figure that out. 
+        *   CNCF-wide will land at [https://github.com/cncf/contribute](https://github.com/cncf/contribute) 
+*   Mentoring update [paris]
+    *   Need workshop curriculum
+        *   Subjects that we should do deep dives on with all roles of the ladder? member, reviewer, approver, etc.
+        *   Development content 
+*   Google Summer of Code 2018 -
+    *   [https://github.com/cncf/soc](https://github.com/cncf/soc)  	
+    *   Does anyone want to help?
+*   SIG f2f planning session in Q1? [paris]
+    *   Josh may be ok with organizing
+    *   Sending out poll with location
+        *   There’s an open option for Feb 20, San Francisco
+*   KubeCon EU
+    *   At least 30 mins for update
+    *   Kubecon deadline approaching! (1/12)
+*   Misc suggestions for 1.10 [spiffxp]
+    *   Grod will help with putting this together
+    *   [Document github labels](https://github.com/kubernetes/kubernetes/issues/34255)
+    *   [Remove nonstandard undocumented github labels](https://github.com/kubernetes/kubernetes/issues/57911)
+    *   [Replace priority/failing-test with kind/failing-test](https://github.com/kubernetes/community/issues/1579)
+    *   [Remove outside collaborator role in favor of lower requirements for membership](https://github.com/kubernetes/community/issues/1565)
+    *   [Revoke direct write access to kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/issues/57667)
+        *   Need to revisit how cherry picking is done
+        *   Need to facilitate use cases that involve editing PR’s (release notes, fixes #foo)
+        *   Need to implement /milestone
+    *   [Files in kubernetes/kubernetes/staging are authoritative](https://github.com/kubernetes/kubernetes/issues/57559)
+    *   Suggest that wikis go away?
+        *   [Removed the kubernetes/kubernetes wiki](https://github.com/kubernetes/kubernetes/issues/57689)
+        *   [Removed the kubernetes/community wiki](https://github.com/kubernetes/community/issues/116)
+*   Steering committee-related work [spiffxp]
+    *   [Document list of github orgs that are part of the project](https://github.com/kubernetes/community/issues/1407)
+    *   [Standards for github orgs](https://github.com/kubernetes/community/pull/1569)
+    *   [Refer to kubernetes/community as authoritative source for code of conduct](https://github.com/kubernetes/community/issues/1527)
+    *   (no issue yet) assign ownership of repos/subprojects to sigs via updates to kubernetes/community/sigs.yaml
+    *   (no issue yet) add an “owner” role to OWNERS files (separate from “approver” role)
+*   [1.9 Goals Review](https://docs.google.com/document/d/1_btBffFlskeBk9ldrZUy9cmCjQUwfl4YHmZ3iZwfwrA/edit?ts=59e6bf2d#) [grod]
+    *   Measuring Contrib Value [quinton]
+    *   Better Triage and Visibility into K8s Issue situation [sahdev]
+    *   Documentation
+    *   Removing the need for write access 
+        *   Adding milestone is the only thing missing, right? [dankohn]

--- a/sig-contributor-experience/meeting-notes-archive/2019-meeting-notes.md
+++ b/sig-contributor-experience/meeting-notes-archive/2019-meeting-notes.md
@@ -1,0 +1,5877 @@
+
+# 2019
+
+
+## December 19  (APAC)
+
+Attendees:
+
+
+
+*   Yang Li
+*   Peeyush Gupta
+*   Ilayaperumal Gopinathan
+
+Canceled due to no agenda. Feel free to chat on slack [https://kubernetes.slack.com/archives/C1TU9EB9S/p1576731173001900](https://kubernetes.slack.com/archives/C1TU9EB9S/p1576731173001900)
+
+
+## December 5  (APAC)
+
+Attendees:
+
+
+
+*   Yang Li
+*   Saiyam Pathak
+*   Peeyush Gupta
+*   Ilayaperumal Gopinathan
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Recent contributions/meetups/blogs from community
+*   [yang] KubeCon / Contributor Summit NA
+    *   Recap the event
+    *   Discussed with some contributors from Japan and Nikhita, blog posts might be a better idea than video streaming session.
+    *   [peeyush] that’s a good start for us
+    *   [saiyam] Podcast may work well too - TBD on the details
+    *   [yang] +1 from a podcast lover, we don’t have a community one, but there are lots of them from different companies
+    *   [yang] (added after the meeting) I’ll try to open an issue for this later
+*   [saiyam] Contributor session Kubernetes Forum India
+    *   [Ilaya] What’s the plan for K8s forum India co-located events?
+    *   [yang] Nikhita haven’t heard back from CNCF yet when we met at San Diego, let’s start a thread on slack later with her
+    *   [peeyush] - contributors’ social meet in Bangalore
+*   [saiyam] Kubecon Amsterdam Contributor summit discussion
+    *   [yang] Jeffery will be leading [https://github.com/kubernetes/community/issues/4022](https://github.com/kubernetes/community/issues/4022)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   [Ilaya] Resources for debugging kubernetes core components?
+        *   [saiyam] Kubernetes Code Walkthrough videos:  [https://www.youtube.com/watch?v=Q91iZywBzew](https://www.youtube.com/watch?v=Q91iZywBzew)  - Kubecon2018 \
+[https://www.youtube.com/playlist?list=PL69nYSiGNLP0gugLYzpNR1ueyUj9GjzpK](https://www.youtube.com/playlist?list=PL69nYSiGNLP0gugLYzpNR1ueyUj9GjzpK) - Kubernetes code walkthrough playlist
+
+
+## December 4 (Update Meeting)
+
+Attendees:
+
+
+
+*   Jorge Castro
+*   Jonas Rosland
+*   Dawn Foster
+*   Jason DeTiberus
+*   Eduar Tua
+*   Josh Berkus, el Capitan
+*   Rin Oliver
+*   Ihor Dvoretskyie
+*   Amanda Katona
+*   Guin Saenger
+*   Elsie Phillips
+*   Laura Santamaria
+*   Michael Roy
+*   Mani 
+
+Others:
+
+
+
+*   Events (currently San Diego Summit) 
+    *   Every Monday at 10a PT 
+    *   [Project Board ; Agenda and notes](https://github.com/orgs/kubernetes/projects/21)
+    *   [Points of contact](https://github.com/kubernetes/community/blob/master/events/OWNERS)
+    *   [Retro for contrib summit](https://docs.google.com/document/d/1mDHxPAbwyy7CSrk7G__Qts6FkhuwuCUQ23RnHpJpVUQ/edit#) San Diego
+    *   Next steps - Jeefy is putting together the AMS Contrib Summit team and will kick off new planning meetings when we have the team put together. 
+*   Community-management
+    *   Community meetings set for the year, jorge to send monthly cadence change to the -dev list on Monday
+    *   MoC, Office hours all set for 2k19
+    *   Points of contact: castrojo
+*   Github-management: No status this week
+    *   Points of contact: Christoph, Aaron, Nikhita, Bob, others
+*   Slack-infra: 
+    *   Always looking for new volunteers, ping castrojo if you’re interested
+    *   Points of contact: (on slack): #slack-admins
+*   Contributor-documentation: Not much new, adding sections for release notes in the contributor summit. 
+    *   Fourth Wednesday of the month @ 11am PT
+    *   [Project Board](https://github.com/orgs/kubernetes/projects/17) ; Agenda and notes inline with main meeting below
+    *   [Points of contact](https://github.com/kubernetes/community/blob/master/contributors/guide/OWNERS)
+*   Mentoring
+    *   Second Thursday of the month @ 830a PT 
+    *   [Project Board](https://github.com/orgs/kubernetes/projects/18) ; Agenda and notes inline with main meeting below
+    *   [Points of contact](https://github.com/kubernetes/community/blob/master/mentoring/OWNERS)
+    *   Discussion on Zoom reviews process and whether it might help mentoring. Laura offered to ask a friend for his process docs. Jay said yes! [https://gist.github.com/parlarjb/07aeb0efafde2a23fc43dfdd5be11c2e](https://gist.github.com/parlarjb/07aeb0efafde2a23fc43dfdd5be11c2e)
+
+
+## November 20/21 - APAC Meeting
+
+Canceled because some regular attendees will be at KubeCon NA 2019
+
+
+## November 14 - mentoring
+
+Attendees:
+
+
+
+*   Paris
+*   Marky
+*   Mani
+*   Ihor
+
+Agenda:
+
+
+
+*   Outreachy
+    *   Need to pick the interns! \o/
+*   Onsite f2f mentoring @ kubecon
+    *   Paris to run the AM with Marky assisting in the PM. Tpep to float between.
+*   Light triage mentoring board
+
+
+## November 6/7 - APAC Meeting
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Alison Dowdney
+*   Yang Li
+*   Peeyush Gupta
+*   Nabarun Pal
+*   Ilayaperumal Gopinathan
+*   (and some new folks did not wrote their names)
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   [yang] Contributor focused sessions in APAC time zones
+    *   [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086) 
+    *   Asked in regional slack channels
+    *   What time to have it? The meeting time is probably good, but we will create a doodle to see more opinions (Alison & Nikhita)
+    *   Yang will ask others how the youtube streaming works
+    *   Topics? Introduction for new folks at first, and code walk through, also interview with contributors and issues deep-dive
+*   [nikhita] CNCF is looking into if we can have a contributor-specific unconference-like session on Day 2 for Kubernetes Forum India.
+    *   Next step is waiting for answers from CNCF
+    *   Will there be any contributor related talks in Seoul or Sydney?
+        *   [https://k8sforumseoul19eng.sched.com/event/WIRH/](https://k8sforumseoul19eng.sched.com/event/WIRH/) in Seoul
+*   [nikhita] Who is going to San Diego? We should meet up
+    *   Nikhita, Yang, Peeyush, Alison, Nabarun
+    *   Post to #contributor-summit about meeting up at the summit. Cross link to regional channels.
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   [Ilaya] What are other SIG meetings occur at APAC-friendly time zones?
+        *   sig-node (maybe not anymore), sig-docs (monthly), sig-cluster-lifecycle (kubeadm bi-weekly), wg-iot-edge (monthly)
+        *   we should probably make a list of all such meetings
+    *   [Ilaya] The purpose of this meeting?
+        *   This is a meeting of APAC coordinators ([https://github.com/kubernetes/community/blob/master/sig-contributor-experience/role-handbooks/apac-coordinator.md](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/role-handbooks/apac-coordinator.md)), but we can also have usual contribex topics
+
+
+## November 6 - ContribEx Issue Triage Update
+
+Attendees:
+
+
+
+*   Arnaud Meukam 
+*   Rin Oliver
+*   Sahdev Zala
+*   Savitha Raghunathan
+*   Alexandra McCoy
+
+Minutes:
+
+
+
+*   No blockers  
+*   Current focus is on the community repo 
+*   We will start tracking triaging work after the kubecon 
+*   No next bi-weekly meeting due to kubecon
+
+Action Items:
+
+
+
+*   Attempt to manage remaining issues with label “lifecycle/stale” before next meeting
+*   May not be able to address #2696 & #3806 but plan to discuss at KubeCon
+
+
+## November 6 - ContribEx Update
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Bart Smykla
+*   Jason DeTiberus
+*   Bob Killen
+*   Rin Oliver
+*   Sahdev Zala
+*   Tim Pepper
+*   Ihor Dvoretskyi (CNCF)
+*   Jorge Castro
+*   Taylor Martin
+*   Łukasz Gryglicki, CNCF (a bit late due to meeting conflict).
+*   Alexandra McCoy
+*   Savitha Raghunathan
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+            *   Community Meeting [jorge]
+            *   Contributor Summit(s) [paris]
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+            *   Other/Discussion [playground, gsoc, outreachy]:
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   Enabled contributor-flagged reporting feature on k/k
+        *   Slack-infra:
+        *   Contributor-documentation:
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Coffee Tuesday morning @ Kubecon [jorge] 
+        *   [Ihor] Please, note that the CNCF Ambassadors breakfast will happen on Tuesday morning - multiple CNCF Ambassadors are the active participations at ContribX
+    *   Recordings from meetings as podcasts ([https://github.com/kubernetes/k8s.io/issues/449](https://github.com/kubernetes/k8s.io/issues/449)) [bartsmykla]
+
+
+## October 23/24 - APAC Meeting
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Yang Li
+*   Josh Berkus
+*   Peeyush Gupta
+*   Saiyam Pathak	
+
+Agenda:
+
+
+
+*   Kubernetes Seoul & Sydney
+    *   [https://events19.linuxfoundation.org/events/kubernetes-forum-seoul-2019/](https://events19.linuxfoundation.org/events/kubernetes-forum-seoul-2019/) & [https://events19.linuxfoundation.org/events/kubernetes-forum-sydney-2019/](https://events19.linuxfoundation.org/events/kubernetes-forum-sydney-2019/) 
+    *   Also Bangalore & Delhi
+        *   [https://events19.linuxfoundation.org/events/kubernetes-forum-bengaluru-2020/](https://events19.linuxfoundation.org/events/kubernetes-forum-bengaluru-2020/)
+        *   [https://events19.linuxfoundation.org/events/kubernetes-forum-delhi-2020/](https://events19.linuxfoundation.org/events/kubernetes-forum-delhi-2020/)
+    *   Any contributor activity?
+        *   Day 2 activities are all sponsored
+        *   Nothing scheduled by CNCF
+        *   AI: Nikhita will ask Dims if we can have contributor focused unconference sessions
+        *   [https://groups.google.com/forum/#!forum/kubernetes-forums-india-2020-unofficial](https://groups.google.com/forum/#!forum/kubernetes-forums-india-2020-unofficial) - unofficial google group for Kubernetes Forum India
+        *   Josh can help organize something in Bangalore (probably remotely)
+        *   Because of San Diego, Seoul & Sydney will be like less popular than Bangalore & Delhi
+    *   Nikhita: we should advertise this meeting in SIG-Docs which has a larger Asian contributor group.
+    *   We will have a full contributor day at KubeCon Shanghai 2020, we should be able to start planning after San Diego, although much work may be done after Amsterdam
+*   Webinars
+    *   [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086) 
+    *   Want to have CNCF Webinar things for the APAC time zones, but more contributor-focused
+        *   Like contributor 101
+        *   Also “meet our contributors”
+            *   Could get US-based Owners to dial in a couple times a year
+    *   Can we use the CNCF tooling?
+        *   Why not use Meet Our Contributor setup?
+            *   Does zoom work in China? Yes, there’s a China client
+            *   Nikhita to ask Jorge & Paris
+    *   Maybe have some in the afternoon Asia time, which would pick up europe as well.
+        *   Survey to time zones? (Josh can arrange)
+        *   Just hold them and try?
+*   Anyone on Contribex Triage team?
+    *   #sig-contribex-triage channel [https://app.slack.com/client/T09NY5SBT/CNGLDBL5N/activity](https://app.slack.com/client/T09NY5SBT/CNGLDBL5N/activity)
+    *   Expanding this effort to more SIGs? Have more documation first
+
+
+## October 23 - ContribEx Triage Issue Meeting
+
+Attendees:
+
+
+
+*   Arnaud Meukam
+*   Jorge Alarcon
+*   Marky Jackson
+*   Savitha Raghunathan
+
+Topics:
+
+
+
+*   [AI: marky] build spreadsheet to keep track of issues
+*   Dedicated issue triage for k/k
+    *   Work on [https://github.com/kubernetes/community/blob/master/sig-contributor-experience/triage-team/triage.md](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/triage-team/triage.md)
+    *   We want a good set of guidelines
+*   [AI] Let’s start by triaging older issues
+    *   preference on /lifecycle rotten and go from there
+
+
+## October 23 - ContribEx Update
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Jonas Rosland
+*   Bob Killen
+*   Rin Oliver
+*   Jorge Castro
+*   Jorge Alarcon
+*   Josh Berkus
+*   Tim Pepper
+*   Sahdev Zala
+*   Paris
+*   Eddie Zaneski
+*   Łukasz Gryglicki
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   150 live attendees last time
+                *   Break for this month because of KubeCon - start up again in December
+            *   Community Meeting [jorge]
+                *   9 people last week - are we wasting other people’s time?
+                *   One SIG showed up, the second didn’t, and the third didn’t respond to our request
+                *   Should we move this to bi-weekly, once a month perhaps?
+                    *   Try bi-weekly
+                    *   Restrict demos to be about new core/SIG functionality, instead of external tools
+                *   Finish out the year with the existing format, and then revamp after the new year
+            *   Contributor Summit(s) [paris]
+                *   Starting on “know before you go” info! It’s happening!! 
+                *   ~220 current contributors
+                    *   Still room for ~100 more
+                *   NCW is cap (waitlist is huge)
+                *   Sunday night will be fun! Karaoke
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Pre KubeCon November edition with paul morie and need two more
+            *   Other/Discussion [playground, gsoc, outreachy]:
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Contrib summit, triage team, conformance, ??
+                *   Triage team - possible unconference track - [Rin]
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   [Owner cleanup almost complete.](https://github.com/kubernetes/kubernetes/issues/76269)
+            *   Cleanup of outside collaborators 
+        *   Slack-infra:
+            *   Discussion/Update
+            *   Public channel for steering committee
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Jorge - Community Meeting 
+        *   [Declining community meeting attendance](https://github.com/kubernetes/community/issues/4019)
+        *   Move to biweekly starting 2020
+        *   Demos are from SIGs/core features only
+        *   2019 schedule will remain as is.
+    *   tpepper - WG K8s Infra & [https://twitter.com/thockin/status/1184509308169379840](https://twitter.com/thockin/status/1184509308169379840) 
+    *   Rin - [https://github.com/kubernetes/community/issues/4149](https://github.com/kubernetes/community/issues/4149) Happy to work with whoever else may be interested on setting this up as an unconference event at the Summit, could be a great way for those who are interested in getting involved with the project but aren't sure where to start/how to contribute :) If there's a point of contact I can get in touch with to secure a space for it/someone I can talk to to get it on the contributor site schedule I'll make it happen!
+    *   [https://github.com/kubernetes/community/issues/4149](https://github.com/kubernetes/community/issues/4149)
+
+
+## October 10 - mentoring
+
+Attendees
+
+
+
+*   Paris
+*   Bob Killen
+*   Marky Jackson
+*   Dawn Foster
+*   Jorge Alarcon
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   Outreachy
+    *   3 positions
+    *   Need help in #outreachy-apps
+*   KubeCon face to faces 1:1
+    *   Marky can’t take on right now
+    *   Paris will resume
+*   Project board https://github.com/orgs/kubernetes/projects/18
+
+
+## October 10 - APAC Planning
+
+Attendees
+
+
+
+*   Yang Li
+*   Peeyush Gupta
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   GitHub team for APAC coordinators
+    *   All members on board and team created
+*   Kubernetes Community Days [https://github.com/cncf/kubernetes-community-days/issues](https://github.com/cncf/kubernetes-community-days/issues)
+    *   We are able to help with APAC events
+*   Kubernetes Forums
+    *   Schedule not announced yet, both CNCF and ContribEx are busy with San Diego
+    *   We need at least one month if ContribEx is going to do a workshop or sth.
+
+
+## October 9 - ContribEx Triage Issue Meeting
+
+Attendees
+
+
+
+*   Paris Pittman
+*   Arnaud Meukam
+*   Marky Jackson
+*   Savitha Raghunathan
+*   Rin Oliver
+
+Topics
+
+
+
+*   
+
+
+## October 9 - ContribEx Meeting
+
+Attendees
+
+
+
+*   Paris Pittman
+*   Nikhita Raghunath
+*   Jason DeTiberus
+*   Bob Killen
+*   Dawn Foster
+*   Chris Short
+*   Jonas Rosland
+*   Marky Jackson
+*   Eduar Tua
+*   Tim Pepper
+*   Łukasz Gryglicki
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   Last office hours until kubecon next week
+            *   Community Meeting [jorge]
+                *   Marky is doing this week
+                *   We still need hosts!! Check the meeting tracker
+                *   Reach out and help us with finding hosts! 
+            *   Contributor Summit(s) [paris]
+                *   Blog post to go live today along with several other outlets
+                *   Schedule is now live; adding some sessions this week
+                *   Amsterdam contributor summit team 
+            *   Steering Committee Election
+                *   Jorge did some retro fixes
+                *   [https://github.com/kubernetes/community/pull/4148](https://github.com/kubernetes/community/pull/4148)
+                *   Lets get more election officials in the mix!! Anyone interested in next year??
+                *   Should we do a retro? At steering level?
+                *   CIVS can’t scale with us
+                    *   Wants to move to something that is directly tied to github
+                    *   Or web based
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   How to get the best out of kubecon - ask that 
+            *   Other/Discussion [playground, gsoc, outreachy]:
+                *   Outreachy is live!
+                *   Marky is helping with issue triage and breaking down some projects
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Contributor summit 
+                *   Reminder about owners stuff/audit - most recent kdev email
+            *   APAC coordinator update:
+                *   Discussion about organizing a webinar targeting APAC timezones.
+        *   GitHub-management:
+            *   OWNER clean up on track for next week
+                *   A few sig leads are cleaning up ahead of time
+            *   [Moving forward with incubator clean up](https://github.com/kubernetes/community/issues/1922)
+            *   Cleaning up outside collaborators
+        *   Slack-infra:
+            *   Discussion/Update
+                *   No updates
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+                *   Marky is still working on five issues 
+                *   Release team edits that came out of the retro 
+            *   Non Code Guide
+            *   Contributor Site
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Concerns about our PR lifecycle:
+        *   [https://github.com/kubernetes/community/issues/4149](https://github.com/kubernetes/community/issues/4149)
+
+
+## September 26 - APAC Planning
+
+Attendees
+
+
+
+*   Yang Li
+*   Saiyam Pathak
+*   Alison Dowdney
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   Zoom in China
+    *   [https://status.zoom.us/incidents/xbmxyfpnv4jq](https://status.zoom.us/incidents/xbmxyfpnv4jq)
+    *   [https://zoomcloud.cn/download.html](https://zoomcloud.cn/download.html) China Zoom client, should works since 
+*   GitHub team for APAC coordinators
+    *   Team for APAC Coordinators to get better signals on GitHub [idealhack]
+*   Webinar issue created(assigned to Saiyam and Yang) Next steps ? (issue link - [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086))
+    *   Get form created - Look at past forms, use that as a reference for APAC
+    *   [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086)
+    *   Looking at where to find existing webinars [idealhack]
+*   Community introduction slides for Kubernetes Workshop?
+    *   Look at past contributor summit workshop slides
+        *   Barcelona [https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit](https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit)
+        *   Shanghai [https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit](https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit)
+        *   San Diego [https://docs.google.com/presentation/d/18LcwvqyNn74HgqIk7O-ChgfSsJAqDIYm7obguEXto4Q/edit](https://docs.google.com/presentation/d/18LcwvqyNn74HgqIk7O-ChgfSsJAqDIYm7obguEXto4Q/edit)
+        *   It would be nice if anyone can update this in the playground repo :) [https://github.com/kubernetes-sigs/contributor-playground/tree/master/presentations](https://github.com/kubernetes-sigs/contributor-playground/tree/master/presentations)
+    *   Videos: [https://www.youtube.com/playlist?list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx](https://www.youtube.com/playlist?list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx)
+*   Other teams in SIG contribex
+    *   Marketing: [https://github.com/kubernetes/community/issues/4044](https://github.com/kubernetes/community/issues/4044)
+        *   Doodle link- [https://www.doodle.com/poll/6682kfq36wttq6fa](https://www.doodle.com/poll/6682kfq36wttq6fa)
+    *   Moderators: [https://github.com/kubernetes/community/issues/4011](https://github.com/kubernetes/community/issues/4011) , [https://github.com/kubernetes/community/issues/4112](https://github.com/kubernetes/community/issues/4112)
+
+
+## September 25 - ContribEx Meeting
+
+Attendees
+
+
+
+*   Paris
+*   Jorge
+*   Jonas
+*   Jason
+*   Nikhita
+*   Dawn
+*   Jberkus
+*   Christoph
+*   Guin
+*   Sahdev
+*   Jorge
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   150 live participants
+            *   Community Meeting [jorge]
+                *   Looking for new hosts [link for spread]
+                *   Timpep is hosting this week; working groups are going this week for the first time
+            *   Contributor Summit(s) [paris]
+                *   San Diego - registration is live.
+                *   NCW is at capacity
+                *   We need an idea for entertainment for Sunday Night. We have a stage. No amps though. Projector screen, mic, laptop hook up, etc. We didn’t get many people who want to do a talent show. Womp womp. 
+                *   Schedule is out next week
+            *   Steering Committee Election [jorge/bob]
+                *   50% through, deadline Oct 2!
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Need two people for next Weds
+                    *   Christoph is a maybe
+            *   Other/Discussion [playground, gsoc, outreachy]:
+                *   Need help with forming job blurbs for the four outreachy interns we are recruiting. See github issue for the four. 
+                *   Marky is going to help out with issue triage and getting some of the 1:1 and group mentoring projects off the ground to help me - yay thank you!
+                *   KubeCon face to face pod mentoring registration will go live in the next week. More soon.
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   1-contributor summit
+                *   2- governance stuff like youtube playlists
+                *   3- owners file clean up stuff
+                *   //could have one more
+            *   APAC coordinator update:
+                *   Kubernetes Summit Seoul + Sydney [idealhack]
+                    *   CFP closed, we may see folks who are going later
+                    *   Decide whether to have a new contributor workshop or other sessions or not, APAC coordinator can help if we are going to form a team
+            *   Discuss.k8s.io updates [jorge]
+                *   Marketing for Kubecon [jorge]
+            *   YouTube updates [jorge]
+            *   Survey [paris]
+                *   [https://github.com/kubernetes/community/issues/3969#issuecomment-535051744](https://github.com/kubernetes/community/issues/3969#issuecomment-535051744)
+                *   Draft of the questions is linked here. We can afford ONE more question to hit the goal of 25. (We had 32 last year and needed to trim based on feedback)
+                *   Pending christoph and test infra
+            *   Other Discussions:
+                *   [https://github.com/kubernetes/community/issues/4044](https://github.com/kubernetes/community/issues/4044) - marketing team doodle just went out [paris]
+                *   [https://github.com/kubernetes/community/issues/4011](https://github.com/kubernetes/community/issues/4011) - help wanted to make moderators@ whole [paris]
+                *   Zoom in china [paris]
+                    *   Check on bluejeans
+                    *   Wechat
+                    *   Will we run into the case of $platform getting blocked too
+                    *   There is a zoom client that you can download in china
+                        *   Please access https://zoomcloud.cn/download.html and download the China Zoom client. After installing, users can enter the meeting ID to join a Zoom meeting.
+        *   GitHub-management:
+            *   Discussion/Update:
+                *   Had a call with Jacob Palmer from LF about easycla. Have some concerns about behaviour during transition from the current bot to the new one. Going to follow-up with them + SIG Testing later. [nikhita]
+                *   Will be replacing [fejta-bot with k8s-triage-robot](https://groups.google.com/forum/#!topic/kubernetes-dev/31oiPVzITJw) today. [nikhita]
+        *   Slack-infra:
+            *   Discussion/Update:
+                *   No updates
+        *   Contributor-documentation: second meeting is today!
+            *   Contributor Guide
+            *   Developer Guide
+                *   Need to write outreachy blurb //help wanted
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [Guin] 1.17 release cycle has started. Prepare your KEPs!
+    *   Silly Hat meetings? [Josh]
+    *   [Your name and topic here. Should this be an issue against kubernetes/community?]
+
+
+## September 12 - Mentoring
+
+Attendees
+
+
+
+*   Bob Killen
+*   Paris
+*   Dawn Foster
+*   Marky Jackson
+*   Nikhita Raghunath
+*   Naeil Ezzoueidi
+*   Jorge Alarcon
+*   Maria Ntalla
+*   Saiyam Pathak
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   Outreachy
+    *   Announcement to k-dev
+    *   Last year’s announcement - [link](https://docs.google.com/document/d/1HrirvVoH3hLnz2IZORAGqGq9Aaj_tQFdEjeesI_Jjas/edit?usp=sharing)
+    *   Possibly owners file work; will need to flesh out policies
+*   Open Mic/Discussion
+    *   [Your name and topic here. Should this be an issue against kubernetes/community?]
+    *   Script that would aggregate who is doing work in a file 
+    *   Marky to help with issue triage and getting some of the programs off the ground
+
+
+## September 12 - APAC Planning
+
+Attendees
+
+
+
+*   Yang Li
+*   Peeyush Gupta
+*   Saiyam Pathak
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   #aus-nz-dev channel created for Oceania contributors
+*   Kubernetes Summit Seoul + Sydney
+    *   CFP closed, we may see folks who are going when the schedule announced
+    *   Decide whether to have a new contributor workshop or not
+    *   how can we be part of that - if we are going to do it, we will form a team
+*   KubeCon Shanghai 2020
+    *   Contributor Summit team will be formed later
+*   CFP form/google form for APAC webinar
+    *   Contact CNCF?
+    *   Create a GitHub Issue (Saiyam) [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086)
+    *   We talked about this [before](#bookmark=kix.9gw9zebyuuu) but forgot it
+*   How can we update the contibex community about the talks around kubernetes ecosystem (eg kubernetes workshop, kubernetes security , k3s etc) that contributors are giving at local meetups (that might not be part of cncf) 
+    *   If they are users talks, share them at [http://discuss.k8s.io](http://discuss.k8s.io/) / slack etc.
+    *   If they are contributors talks, share them at contributors channels on slack etc.
+*   How to find data around APAC contributors?
+    *   devstats is the first place to go: [https://k8s.devstats.cncf.io/d/50/countries-stats?orgId=1](https://k8s.devstats.cncf.io/d/50/countries-stats?orgId=1)
+    *   Could not find sth? Ask in #sig-contribex or open an issue at [https://github.com/cncf/devstats](https://github.com/cncf/devstats)
+
+
+## September 11 - ContribEx Meeting
+
+Attendees
+
+
+
+*   Elsie Phillips
+*   Bob Killen
+*   Marky Jackson
+*   Paris Pittman
+*   Jorge Castro
+*   Dawn Foster
+*   Guinevere Saenger
+*   Jacob Palmer
+*   Tim Pepper
+*   Christoph Blecker
+*   Jorge Alarcon Ochoa
+*   Łukasz Gryglicki
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   fine
+            *   Community Meeting [jorge]
+                *   Doesn’t have enough hosts - please volunteer
+                *   Issue open to change formatting 
+            *   Contributor Summit(s) [paris]
+                *   REG IS LIVE - TELL YOUR FRIENDS
+                    *   150 RSVPs already
+                *   Meta request - We need two sig meet and greet reps for ContribEx
+                    *   Elsie is volunteering for one slot; NEED ONE MORE; tim pepper (offered but also doing sig-release) - [Form to volunteer](https://forms.gle/hxx1qz8XtwtXEBMm8) to rep our SIG & details about who has volunteered for each SIG are [in the Issue](https://github.com/kubernetes/community/issues/3896).
+            *   Steering Committee Election [jorge]
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Need folks for October 2nd - need to send an email to k-dev and chairs
+            *   Other/Discussion [playground, gsoc, outreachy]:
+                *   Outreachy - 1: content for dev guide 2: contributor guide content
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   All contributor summit updates today; ready to roll with an email so if you have something speak now or wait until the next three 
+            *   APAC coordinator update:
+                *   See notes below for aug 29th date
+        *   GitHub-management:
+            *   Discussion/Update:
+                *   [justinsb] FYI single assignee to PRs: [https://github.com/kubernetes/test-infra/pull/14264](https://github.com/kubernetes/test-infra/pull/14264)
+        *   Slack-infra:
+            *   Discussion/Update
+                *   No update
+        *   Contributor-documentation:
+            *   We had our first meeting!!! \o/
+            *   Contributor Guide
+                *   Contributor site outreachy intern coming to help write web content 
+            *   Developer Guide
+                *   Thanks marky!! Starting to collect more content issues and build it out. Outreachy intern on the way. 
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [Demo of easyCLA tool](https://github.com/communitybridge/easycla)
+    *   FYI single assignee to PRs: [https://github.com/kubernetes/test-infra/pull/14264](https://github.com/kubernetes/test-infra/pull/14264)
+        *   Data needed:
+            *   Response times on 1 assignee vs 2 
+                *   Time to first response on a PR
+            *   We could run a 1 release trial 
+            *   
+
+
+## August 29th - APAC Planning
+
+Attendees
+
+
+
+*   Yang Li
+*   Peeyush Gupta
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   [idealhack] Slack channels?
+    *   #aus-nz-users may want to have a #aus-nz-dev channel? I will create one for them
+    *   [peeyush] A channel for APAC contributors? Thought about it but not sure if it’s a good idea given that we have many regional channels now. 
+*   [idealhack] Kubernetes Summit Seoul + Sydney
+    *   New contributor workshop should more useful than SIG intros
+    *   How we can staff this? Ask in SIG contribex how many folks are going
+*   [peeyush] Convert new contributors to active contributors
+    *   [idealhack] Connect your contributions with your daily work
+    *   Specific guide in community repo for them? Like the contributor cheat sheet which was translated to many languages.
+
+
+## August 28th (contributor-documentation)
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Marky Jackson
+*   Arnaud Meukam
+*   Josh Berkus
+*   Jonas Rosland
+*   Kaitlyn Barnard
+*   Kiran Oliver
+*   nzouedi
+
+Agenda:
+
+
+
+*   Contributor site
+    *   Need to do more project management; tech writers want to have punch cards, issues per pages, etc.
+    *   Project board in main org doesn’t connect to k-sigs; k-sigs doesn’t allow for project boards
+    *   Launching events, contributor guide, and a homepage
+    *   Kiran is helping with homepage content; hope to be done in 1-2 weeks for a soft launch; want some kind of project board up, too, when we launch
+*   Contributor-documentation project board triage
+    *   Cleaned up board
+    *   Assigned owners
+
+
+## August 28th
+
+Attendees:
+
+
+
+*   Bob Killen
+*   Jorge Castro
+*   Sahdev Zala (leaving early - may be not as we ended call early :-))
+*   Christoph Blecker
+*   Jason DeTiberus
+*   Elsie Phillips (cochair) 
+*   Ihor Dvoretskyi
+
+Topics:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+    *   Subprojects:
+        *   Events:
+            *   Office hours [jorge]
+                *   All good
+                *   High attendance today
+            *   Contributor Summit(s) [paris]
+                *   Registration opens next Week (September 4th)
+            *   Steering Committee Election [jorge/bob/ihor/bgrant]
+                *   Status update going out next week
+                    *   Reminder to check eligibility  
+                    *   Reminder to people that are going to run 
+                    *   Next deadline: Sept 11th
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Election stuff, see above
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   Discussion/Update:
+                *   First meeting last week
+                *   Monthly cadence
+                *   Next meeting, open to entire SIG
+        *   Slack-infra:
+            *   Discussion/Update
+            *   Moderator training w/ Sage Sharp
+                *   next training session September 16th
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+            *   First call for this subproject today at 11AM PT - if you’re interested, please attend
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic:
+    *   Kubecon planning for ContribX
+        *   Intro got same content
+        *   Need to figure out what to do for deepdive
+            *   Working Session?
+        *   Anything else we want to do?
+    *   Contributor Survey
+        *   Need to generate questions
+    *   Issue filed for declining attendance in Thur community meeting
+        *   Should we intervene?
+        *   Leave feedback in that thread
+
+
+## August 14th - ContribEx Bi-Weekly
+
+Attendees:
+
+
+
+*   Jeffrey Sica
+*   Dawn Foster
+*   Elsie Phillips
+*   Jonas Rosland
+*   Bob Killen
+*   Josh Berkus
+*   Chris Short
+*   Tim Pepper
+*   Guinevere Saenger
+*   Jorge Castro
+
+Topics:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+            *   Community Meeting [jorge]
+                *   Everyone’s confirmed for this week
+                *   Need to schedule the SIGs for the rest of the year
+                *   If there’s no KEP, add in election status instead
+            *   Contributor Summit(s) [paris]
+                *   Team is full right now for SD
+                *   Need to surface leads for next years planning (jeff is one)
+                *   Need ContribEx content - at least five sessions we should be able to pull together on sustainability and current contributor topics. Please suggest or think about leading one. 
+                    *   Look at #contribex Slack for suggestions - Elsie
+                *   We need an events team for Amsterdam’s CS before SD is finished -- by September, really
+            *   Steering Committee Election [jorge/bob/ihor/bgrant]
+                *   Email has been sent out, PRs have been made to the right repos, everything’s scheduled, elections will happen on August 21st.
+                *   Big thing this time, all of bootstrap is being retired, so it will go down to 7 steering members.
+                *   [PR in to separate steering election captains from community managers](https://github.com/kubernetes/steering/issues/120)
+                *   [https://github.com/kubernetes/steering/pull/119](https://github.com/kubernetes/steering/pull/119)
+                *   [https://github.com/kubernetes/community/pull/3991](https://github.com/kubernetes/community/pull/3991)
+                *   [https://github.com/kubernetes/steering/issues/120](https://github.com/kubernetes/steering/issues/120)
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Need a full panel for Sept; haven’t started recruitment yet
+                *   Still looking for help with building this out
+            *   Other/Discussion [playground, gsoc, outreachy]:
+                *   We had our first mentoring meeting! Will see more activity here in the next few weeks. 
+                *   Gsoc interns need to be scheduled for demos at the community meeting
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   One was sent yesterday (contrib summit, group mentoring, 
+                *   Start collecting actions in the ondeck section please
+            *   ContribEx Survey is kicking up - I’d like to see suggestions, plus ones, and other comments on the issue. [https://github.com/kubernetes/community/issues/3969](https://github.com/kubernetes/community/issues/3969)
+                *   Ihor - can you give me access to surveymonkey so I can build it out this year? [paris]
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   Discussion/Update:
+            *   Kubernetes and kubernetes-sigs org membership should be equivalent: [https://github.com/kubernetes/org/issues/966](https://github.com/kubernetes/org/issues/966)
+            *   [https://github.com/orgs/kubernetes/projects/25](https://github.com/orgs/kubernetes/projects/25)
+        *   Slack-infra:
+            *   Discussion/Update
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community? Should this be in the update section against one of the subprojects? Everything else here.]
+    *   Markdown linter for more of K8s org: [https://github.com/kubernetes/community/issues/3899](https://github.com/kubernetes/community/issues/3899)
+
+
+## August 8th - Mentoring 
+
+Attendees
+
+
+
+*   Nikhita Raghunath
+*   Paris
+*   Marky
+*   Bob
+*   Ihor
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG or subproject) like to give a brief introduction?
+*   Open Mic
+    *   Our first meeting! 
+    *   How can we break this work down? How can we recruit others?
+    *   Meet Our Contributors
+    *   Travel and KubeCon tickets for interns 
+        *   Make sure this happens 
+        *   Make sure we tell interns to fill out the forms when they are onboarded 
+    *   Outreachy
+        *   Deadline is coming up to apply for projects
+        *   Use communications from past k-dev for interest - friday; call for mentors and projects of interest 
+    *   KubeCon face to face mentoring - need to start
+        *   Marky, Paris 
+        *   Ask tim pep and others - get the word on k-dev 
+        *   Kick up convo with cncf about mentoring 
+    *   New Contributor Workshop/SIG Meet and Greet
+        *   Business as usual
+    *   Google Summer of Code 
+        *   Get a list PRed onto the gsoc page for recognition 
+        *   Scheduled to a demo at the community meeting after their assignment
+            *   Possible september 
+        *   7 students working on Kubernetes project this year (17 total for CNCF)
+    *   Community Bridge
+        *   Program that is developed by the linux foundation
+        *   Goal is to have different projects sign up with students
+        *   Organizations can donate 
+        *   CNCF Program isn’t officially launched yet
+        *   The students are from google summer of code (those who signed up for GSoC but haven’t received their slot)
+        *   Pilot deadline: plans to finish by Q4 - don’t have a defined timeline
+    *   AI for group:
+        *   Groom our project board 
+            *   Break down the issues that are already set into tasks
+        *   Make sure all issues relating to mentoring are there; triaging community
+        *   Reward and Recognition 
+        *   Written goals and objectives 
+
+
+## August 1st - APAC Planning
+
+Attendees
+
+
+
+*   Nikhita Raghunath
+*   Saiyam Pathak
+*   Peeyush Gupta
+*   Yang Li
+*   Alison Dowdney
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+        *   5 attendees did introductions
+*   Kubernetes Summit Seoul + Sydney
+    *   [Official announcement](https://www.cncf.io/blog/2019/07/31/announcing-kubernetes-summits-seoul-and-sydney-expanding-cloud-native-engagement-across-the-globe/)
+    *   Contribex Intro + APAC Coordinators
+    *   Still early, but think about CFPs
+*   Webinar
+    *   Reach out to CNCF for support with APAC specific webinars
+    *   AI(alison): Create an issue for this in community repo
+*   Open Mic/Discussion
+    *   [Your name and topic here. Should this be an issue against kubernetes/community?]
+    *   [nikhita] Can we close [https://github.com/kubernetes/community/issues/3693](https://github.com/kubernetes/community/issues/3693)? 
+        *   close it, and introduce our meeting to border community
+    *   [idealhack] do we need to move this meeting notes to a new doc?
+        *   It’s ok for now, think about this later
+    *   [idelahack] update on contributor summit shanghai retro from last meeting ([July 18](#bookmark=kix.nbsxrcmih3m))
+        *   Retro doc: [https://docs.google.com/document/d/13aeCb6Rfy0XM2uOhEhIZJZM2ykg-j2IgxsTdNbt2_TI/edit](https://docs.google.com/document/d/13aeCb6Rfy0XM2uOhEhIZJZM2ykg-j2IgxsTdNbt2_TI/edit)
+    *   [idealhack] git.k8s.io links don’t work in China
+        *   [https://github.com/kubernetes/k8s.io/issues/325](https://github.com/kubernetes/k8s.io/issues/325)
+
+
+## July 31th - ContribEx
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Elsie Phillips
+*   Bob Killen
+*   Nikhita Raghunath
+*   Chris Short
+*   Josh Berkus
+*   Jorge Castro
+*   Ihor Dvoretskyi
+*   Christoph Blecker
+*   Tim Pepper
+*   Naeil Ezzoueidi
+*   Alison Dowdney
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   Good for the next 2 weeks
+                *   Using ‘@here’ in channel before event lead to very good engagement.
+            *   Community Meeting [jorge]
+                *   Need hosts after this week
+                *   Get ahold of Jorge if interested
+                *   Scheduling SIGS for the rest of the year
+            *   Contributor Summit(s) [jonas/josh/paris]
+                *   North America 2019
+                    *   aside from not having venue contracts, things are great
+                    *   we have a ton of volunteers, so we can have handoff next year
+                    *   session proposal form going out today or tomorrow
+                *   China 2020 is still tbd on location/date
+            *   Steering Committee Election [paris]
+                *   Coming soon in August, election committee needs decided/announced
+                *   Announcing Aug 20th
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Next week
+                *   Looking for help scaling 
+            *   Other/Discussion:
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Host guide on top  
+                *   Holding off on emails untl there's 3 action items to cut down on too much email to Leads so they read it
+                    *   That way anyone can send when there's enough stuff
+            *   APAC coordinator update:
+                *   Meeting today- 11 pm PT
+                *   Still working on format
+                *   Contact CNCF about communication channels for APAC
+        *   GitHub-management:
+            *   Discussion/Update:
+                *   Once a month public call
+                *   Rename Fejta bot 
+        *   Slack-infra:
+            *   Discussion/Update
+                *   Incident management training being planned
+                *   Almost all moderators in one of two sessions
+                *   Should we make this required for moderators
+                *   4 seats available for Aug 26th class
+                *   SIG chairs should be invited as optional (if not required) as they moderate their lists and meetings
+        *   Contributor-documentation:
+            *   Meeting cadence? 
+                *   Monthly, 30 min
+                *   Please respond to the doodle! [https://doodle.com/poll/rgcuwm35k889pfzb](https://doodle.com/poll/rgcuwm35k889pfzb)
+                *   we could also stop using github as a CMS
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+            *   Contributor site ([https://kubernetes-contributor.netlify.com/](https://kubernetes-contributor.netlify.com/))
+                *   Intend to go live (eventually) with:
+                    *   Contributor guide (missing developer guide)
+                    *   Events
+                    *   Calendar: definitely
+                    *   CoC
+                    *   Role board
+                *   Home page:  what is the key top level content to start with for a simplified landing page?  Polishing needed here especially.
+                *   Content curation plan: map this out for the next...3-6mo’s?  Action Item for next Contributor-documentation meeting
+                *   Will late in the cycle need to get the CNAME into DNS and then share that in an announcement.
+            *   Non-ContribEx people are doing community proposals in the KubeCon CFP which mesh up with our contribution documentation effort.  Tim Pepper’s reached out to Bryan Liles and got a thumbs up on contacting folks 1:1 who submitted and didn’t get accepted after the program is announced and working to bring them into our effort.  Good ideas shouldn’t get lost.  CNCF can dump a spreadsheet of Community Track proposals (eg: abstract text, contact name/email).
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [Your name and topic here. Should this be an issue against kubernetes/community?]
+    *   [ihor] Discussion regarding keeping placeholder files: [https://github.com/kubernetes/community/pull/3874#issuecomment-508844027](https://github.com/kubernetes/community/pull/3874#issuecomment-508844027) 
+        *   Do we need to remove expired placeholder files?
+        *   Ihor says that placeholder files are helpful
+    *   [jorge] contribex status at community meeting is next week. 
+    *   [jorge] Oh hey SIG Usability is a thing
+
+
+## July 18th APAC Planning
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Saiyam Pathak
+*   Peeyush Gupta
+*   Jintao Zhang
+
+Topics:
+
+
+
+*   Open Mic/Discussion
+    *   APAC friendly webinar is planned. We might do something similar to APAC friendly office hours as well.
+    *   Yang, Saiyam and others to update on the Shanghai contributor summit retro in the next meeting.
+    *   [saiyam] Need to find a place to submit all presentation and work related to end user kubernetes meetups.
+        *   [nikhita] [https://github.com/cncf/presentations](https://github.com/cncf/presentations) is a good place for that.
+
+
+## July 17th
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Elsie Phillips
+*   Bob Killen
+*   Jonas Rosland
+*   Ihor Dvoretskyi
+
+Topics:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   Tip of the week - updated kubernetes/test-infra readme and this one weird trick to get your job changes to merge faster [spiffxp]
+            *   Community Meeting [jorge]
+            *   Contributor Summit(s) [jonas/josh/paris]
+                *   Content proposal has gone to steering committee for approval.
+                *   General theme with more structured content.
+                *   Separate venue has been secured.
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+            *   Other/Discussion:
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Community meeting
+                *   Contributor Summit
+                *   Merged code of conduct charter
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   [Looking into reconciling membership between kubernetes and kubernetes-sigs](https://github.com/kubernetes/org/issues/966)
+            *   Still looking into what dependabot.
+            *   CLABot will be open sourced soon.
+        *   Slack-infra:
+            *   no update
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [justinsb - unable to attend] What should the github action on PR merge be - rebase, squash, merge commit etc?  We had an incompatible pairing in etcdadm, and debated for a while which the “right mode” was, but this feels like something that should be consistent across all the repos: [https://github.com/kubernetes-sigs/etcdadm/issues/112#issuecomment-509295085](https://github.com/kubernetes-sigs/etcdadm/issues/112#issuecomment-509295085) 
+        *   by default “merge” commits are used.
+        *   repo maintainers may request a change to an alternative default for their specific repo.
+    *   [https://github.com/kubernetes/community/issues/2951](https://github.com/kubernetes/community/issues/2951) -- soliciting feedback for a SIG Chair Handbook
+        *   Reverse engineer the sig-wg-lifecycle.md? [paris] 
+    *   Markdown linter for all of k org? [jonas/cblecker]
+        *   [https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/425](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/425)
+        *   [https://github.com/kubernetes/test-infra/pull/13363](https://github.com/kubernetes/test-infra/pull/13363)
+        *   Created issue here: [https://github.com/kubernetes/community/issues/3899](https://github.com/kubernetes/community/issues/3899)
+
+
+## July 4 - APAC topics
+
+Attendees:
+
+
+
+*   Yang Li
+*   Alison Dowdney
+*   Saiyam Pathak
+*   Aravind Putrevu
+*   Welcome and recurring business 
+    *   CoC
+*   KubeCon and Contributor Summit Shanghai
+    *   Had current contributor day, new contributor workshop, doc sprints, it was great
+    *   CS Retro meeting next week, ask Yang if you want to join
+    *   SIG intro has got some feedback from contributors too
+*   APAC coordinator role handbook (link [here](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/role-handbooks/apac-coordinator.md))
+    *   Discussion, anything we would like to change/add
+    *   Feel free to make a pull request if there's anything you would like to add/change
+*   Office hours, Meet our contributors, Online events
+    *   Would there be interest in an APAC stream?
+    *   Need to find contributors to interview
+    *   Survey our contributor base, See how many people would be interested
+    *   Start the Online Webinar sessions for APAC region
+*   How we can grow our team?
+    *   They are interested in helping, but we need to define tasks to take actions
+    *   Outline strategy of onboarding, and involving more people
+    *   Create a GitHub issue and share it to slack channels
+*   Community Outreach
+    *   Work on presentations, talks we can give to our local developer communities
+*   Sync better with the SIG
+    *   Try to join the SIG meetings or watch videos to get better understandings and communications
+    *   Remember the goal to bring the APAC meeting back
+
+
+## July 3
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Dawn Foster
+*   Paris Pittman
+*   Jay Pipes
+*   Nikhita Raghunath
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   [SIG Meet & Greet / SIG F2F PR](https://github.com/kubernetes/community/pull/3859) - Dawn
+    *   Issue Triage
+    *   Charter 
+
+
+## June 27 - APAC topics
+
+Canceled due to no agenda and Yang’s conflict
+
+
+## June 26
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Jeffrey Sica
+*   Nikhita Raghunath
+*   Dawn Foster
+*   Bob Killen
+*   Paris Pittman
+*   Jay Pipes
+*   Naeil Ezzoueidi
+*   Łukasz Gryglicki, CNCF
+*   Jorge Castro
+*   Jonas Rosland
+*   Aaron Crickenberger
+*   Sahdev Zala
+*   Arnaud Meukam
+*   Christoph Blecker
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+            *   Halfway through doc on how to do it
+        *   Community Meeting [jorge]
+            *   Scheduled out through July 18th, including demos
+            *   [Leads scheduling spreadsheet](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895)
+            *   Ihor running July 4th with cli and node
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/paris/josh]
+            *   Josh to provide update on (apparently awesome) summit in Shanghai
+            *   All good to go in planning on San Diego contributor summit
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Schedule for July meetings
+        *   1st and 3rd for biweekly meetings
+    *   FYI: updated docs in test-infra
+        *   [https://github.com/kubernetes/test-infra](https://github.com/kubernetes/test-infra)
+        *   [https://github.com/kubernetes/test-infra/tree/master/config/jobs](https://github.com/kubernetes/test-infra/tree/master/config/jobs)
+        *   Please provide feedback on above updated docs
+    *   DevStats dashboard for New Contributor Workshop attendees? [Jonas]
+        *   Take this as part of the [mentorship program](https://github.com/kubernetes/community/tree/master/mentoring)?
+        *   Jonas will work with Bob on getting raw data, and then go from there.
+    *   Subprojects expecting to get updates from next meeting
+        *   help :)
+    *   Discussion around the grey area/scope for slack-infra versus contrib-ex. Tooling versus policy. Who owns what? Table discussion for later
+
+
+## June 19 (recording)
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Paris Pittman
+*   Bob Killen
+*   Jeffrey Sica
+*   Chris Short
+*   Jonas Rosland
+*   Sahdev Zala
+*   Naeil Ezzoueidi
+*   Jorge Castro
+*   Vonguard
+*   Christoph Blecker
+*   Josh Berkus
+*   Imran Pochi
+*   Meukam Arnaud
+*   Saiyam Pathak
+*   Guinevere Saenger
+*   Dawn Foster
+*   Yang Li
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Need to update invite
+            *   No longer doing “west coast edition” till better time can be arranged.
+        *   Meet Our Contributors [paris]
+            *   Still working on docs for hosting
+            *   Good for July session
+        *   Community Meeting [jorge]
+            *   Good for release team retro tomorrow.
+            *   Seeking replacement for a few weeks in July (jorge on vacation).
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Reminder to sigs for community meeting sig updates
+                *   setup calendar appointments to sigs for their scheduled update?
+                    *   put on shared sig calendar?
+                *   Does not need to be a chair to give an update.
+                *   Make it clear that “no update since last update” is still an update.
+                *   Update slide template with suggested guidelines from community repo.
+                *   Update community template itself with suggested guidelines.
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Shanghai:
+                *   Had to adjust schedule due to complications with the Conference center.
+                *   Making a few changes to the NCW
+                *   “Harbor box” will be there
+                    *   For future, it must be hw there or hand carried in to avoid problems with customs.
+                *   “Current” contributor track will be more aligned to 201.
+                *   Yang will tackle the contribex intro session.
+            *   San Diego:
+                *   1st meeting kicked off this Monday.
+                *   More roles opening up in the future.
+                *   Content proposal will be coming up next week.
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   APAC Meeting [paris]
+        *   Working on recruiting for more APAC members.
+        *   Eventual goal is to have their own meeting.
+    *   Subproject meetings [paris]
+        *   Reaching out to subproject owners for scheduling other meetings.
+        *   “Documentation” could be moved to non-code contributing timeslot or do a “slack” standup.
+    *   [Review request](https://github.com/kubernetes/community/pull/3622) [sahdev]
+        *   Need to create guidelines on what defines a milestone.
+        *   Looking for more input on labels.
+        *   Going to merge and iterate.
+    *   Bloggers [paris]
+        *   Looking for more bloggers.
+        *   Need to write the rolebook.  
+    *   Travel support program - 
+        *   [https://github.com/kubernetes/community/issues/3783](https://github.com/kubernetes/community/issues/3783)
+            *   jorge going to assist
+        *   Looking to write up procedure or questions as a MVP
+            *   Discuss sharing/working with CNCF on storing data (GDPR etc)
+        *   Information gathered will help with future events and planning.
+    *   Heads up - SIG Usability is at steering
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Triage issues without assignees or milestone
+
+
+## June 13 - APAC topics (bootstrap)
+
+Attendees:
+
+
+
+*   Yang Li
+*   Alison Dowdney
+*   Aravind Putrevu
+*   Saiyam Pathak
+*   Welcome
+    *   CoC
+    *   Introduction to this meeting, Purpose
+        *   APAC contributors not very active to rest of kubernetes community
+            *   Timezones, Languages
+        *   Make specific effort to address these issues
+    *   Introduction to contributors of this effort
+*   APAC coordinator (issue: [https://github.com/kubernetes/community/issues/3693](https://github.com/kubernetes/community/issues/3693))
+    *   speaking at meetups and local events about the work that happens in contributor experience
+        *   Getting the word out there about how to contribute
+    *   writing blog posts about the same in multiple languages (coordinating translation when necessary)
+    *   Translation for the community website
+        *   A large number of contributors from China, helping extend the docs, encouraging other people to join.
+        *   More visibility on contributions/How to get involved, for APAC.
+    *   helping us with regional boards on discuss.kubernetes.io
+        *   Promote topics on discuss within slack
+    *   APAC Slack Channels
+        *   Post more help-wanted issues within apac channels to get more people involved
+    *   helping us to run the APAC Contributor Experience update meeting
+        *   We can resume the APAC version of SIG meeting after we got enough attendees
+    *   writing the role book for this role that will live under /community/sig-contributor-experience
+        *   Work on ideas together within a google doc
+*   Open Discussion
+    *   Raising visibility of what apac coordinators are doing within kubernetes at meetups
+
+
+## June 12
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Chris Short, Red Hat
+*   Jonas Rosland, VMware
+*   Paris Pittman, Google
+*   Noah Abrahams, Ticketmaster
+*   Christoph Blecker, Red Hat
+*   Niko Pen, Freelancer
+*   Jorge Castro, VMware
+*   Stephen Augustus, VMware
+*   Jeffrey Sica, University of Michigan
+*   Marko Mudrinić, Loodse
+*   Naeil Ezzoueidi
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+            *   July volunteers needed!!! 730am
+        *   Community Meeting [jorge]
+            *   Lachie is tomorrow 
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Stephen email 
+        *   Contributor Summit(s) [jonas/josh/paris]
+
+			Barcelona:
+
+
+
+            *   Getting attendance numbers this week
+            *   Venue was really good for content 
+            *   Retro is tomorrow 
+            *   Deb Giles was a great help
+
+            Shanghai:
+
+*   Almost has a schedule 
+*   Needs to do social media pushes
+*   Blog needs to be approved
+
+            San Diego: 
+
+*   Mondays @ 10am - first meeting this monday
+*   [https://github.com/kubernetes/community/tree/master/events/events-team](https://github.com/kubernetes/community/tree/master/events/events-team)
+*   Team is formed!!
+*   [https://github.com/kubernetes/community/issues/3792](https://github.com/kubernetes/community/issues/3792)
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Project-wide Triage Workflow [nikopen] [https://github.com/kubernetes/community/issues/3456](https://github.com/kubernetes/community/issues/3456) 
+*   Why do we need this: Explicitly desired by many SIG Chairs. [https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/BvGmOQ0v5f0](https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/BvGmOQ0v5f0)
+*   Triage workflow overview, new automation and labels to help with that. \
+needs-triage [https://github.com/kubernetes/test-infra/pull/11818](https://github.com/kubernetes/test-infra/pull/11818) \
+Label rework | purge ‘triage’ labels [https://github.com/kubernetes/test-infra/pull/12814](https://github.com/kubernetes/test-infra/pull/12814)  \
+Standardization of project boards **guidelines **and a template project board. \
+Each SIG should have their own board, _however_ it should **not **be mandatory. \
+Example from SIG-Windows: [https://github.com/orgs/kubernetes/projects/8](https://github.com/orgs/kubernetes/projects/8)
+*   Automation on project boards for issues to receive labels automatically while shifting through columns & shift columns automatically while changing labels on issue directly. \
+As per [Hamel Husain](https://github.com/kubernetes/community/issues/3672#issuecomment-496672458 ) from Github this is easily achievable and they’re happy to help - it just needs to be hosted somewhere. \
+Any leads on hosting a bot like this?
+*   Milestone-specific improvements: \
+1. SIGs themselves should be deciding on what Enhancements and Bugfixes they are able to handle on an upcoming release beforehand. They should be able to determine their current workforce and schedule on a proactive basis. \
+2. Auto-apply current milestone on a merged PR. This is almost ready as a GitHub Action and as a Prow Plugin: [https://github.com/kubernetes/test-infra/issues/11611](https://github.com/kubernetes/test-infra/issues/11611) \
+[https://github.com/kubernetes/test-infra/pull/12968](https://github.com/kubernetes/test-infra/pull/12968)
+*   Documentation: Given consensus is reached and changes are implemented, old documents such as [issue-triage.md](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md ) should be updated to reflect the current state of world. \
+Docs should be short, concise and presented as guidelines to follow and utilize the mechanisms that are in place for the benefit of everyone.
+*   Release team specifics: \
+Given all above are implemented, Bug Triage role will be mostly automated and a very few responsibilities could be delegated to another role.  \
+A dashboard that combines views of all SIG boards would be ideal to have for a birds-eye view of on-going work status on a given release, but IMO not necessary as Github search / milestones are pretty much ok.
+*   Various other improvements listed at the [bottom of first post in umbrella issue](https://github.com/kubernetes/community/issues/3456) , can be looked on at a later time to optimize flows.
+*   Proposed Actions: \
+1.  Merge needs-triage & label rework \
+[https://github.com/kubernetes/test-infra/pull/11818](https://github.com/kubernetes/test-infra/pull/11818) \
+[https://github.com/kubernetes/test-infra/pull/12814](https://github.com/kubernetes/test-infra/pull/12814)  \
+Global announcement on new changes, starting on gap period until 1.16 cycle begins \
+2. Project board template, automation and renewed docs on triage \
++ announcement \
+ \
+(A KEP structure has been proposed for all this but not sure about it - it’s meta changes for upstream, not for k8s the product per se.
+
+[convo notes: potentially make scope smaller, 
+
+
+
+*   Dawn and I wanna submit a community/contributor-related CFP for kubecon, would it be ok if we all just sync on what people are submitting so we can complement each other’s sessions? (Jorge) 
+
+
+## June 5 (recording)
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Elsie Phillips, Red Hat
+*   Dawn Foster, Pivotal
+*   Nikhita Raghunath, Loodse
+*   Hamel Husain, GitHub
+*   Paris Pittman, Googs
+*   Jeffrey Sica, UMich~
+*   Bob Killen, UMich
+*   Jorge Castro, VMware
+*   Sahdev Zala, IBM
+*   Nabarun Pal, rorodata
+*   Christoph Blecker, Red Hat
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Moving west coast office hours to another time
+        *   Meet Our Contributors [paris]
+            *   Same as office hours with time moving to a later one tbd
+            *   Want to be a panelist? Get in touch with paris or #contribex slack channel
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   San Diego Summit planning has begun
+                *   Shadow roles available
+
+                    [https://github.com/kubernetes/community/issues/3445](https://github.com/kubernetes/community/issues/3445)
+
+            *   Shanghai Contrib Summit
+                *   Current and new contrib workshop 
+                *   Blogpost this week to let people know
+                *   Still need help/missing test/infra topics
+                *   
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   [Issue Label Bot](https://github.com/marketplace/issue-label-bot) Demo/Discussion [Hamel Husain - GitHub] (Issue [3672](https://github.com/kubernetes/community/issues/3672))
+    *   Custom slack loading messages [jorge]
+        *   Add helpful tips
+    *   Meeting Proposal [paris]
+    *   Roles are being created - please join us
+        *   Events team
+        *   Triage team
+        *   Marketing team 
+
+
+## May 22 ([LIVE @ KUBECON](https://youtu.be/R4AX1W18kSI))
+
+Attendees:
+
+
+
+*   Jonas Rosland
+*   Paris Pittman
+*   Elsie Phillips
+*   Dawn Foster
+*   Bob
+*   Jeff
+*   Noah
+*   Jorge
+*   Nikhita
+*   Christoph
+*   Guin
+*   Josh
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Should we have more east coast friendly times? 
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   
+        *   Contributor Summit(s) [jonas/josh/paris]
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Contributor summit retro
+        *   New contributor track
+            *   101: 
+                *   Tim Pepper Led
+                *   62 ppl registered
+            *   201:
+                *   Guin led
+                *   74 people registered
+        *   Current contributors track
+            *   SIG F2F - 13 SIGs participated
+            *   199 people registered
+        *   SIG meet and greet
+            *   Speed date SIGs
+        *   Location, communication, registration to improve for next time
+        *   Full retro later 
+*   GitHub Bots:
+    *   At the scale that k8s uses GitHub, having bots helps us scale and offload some tasks to our bot minions and frees up more time for real work.
+    *   GitHub status set to busy is now used by out GitHub bot so that people who are on vacation, away, or otherwise unable to review PRs will not be assigned new PRs. 
+    *   We developed a plugin that triggers when someone contributes their first PR to put an extra welcome message with a link to guides and other info to help people make that first contribution. This is now implemented across all k8s repos.
+    *   We have 5 orgs, 190 repos, 900+ unique members. K8s repo alone has 1000+ open PRs, 2000+ issues, which is why we need tools / bots to help us scale. 
+    *   We collaborate with SIG Testing on our infrastructure / CI tooling. 
+*   Mentoring tomorrow!!!
+    *   730am session with Paris
+    *   330pm session with Tim Pepper
+
+
+## May 15 ([recording](https://youtu.be/E8wsDVjAvjM))
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Dawn Foster
+*   Łukasz Gryglicki, CNCF
+*   Jonas Rosland
+*   Paris Pittman
+*   Jorge Castro
+*   Chris Short
+*   Elsie Phillips
+*   Christoph Blecker
+
+Agendas:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Finding a time that works with west coast folks 
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+            *   Dawns first meeting is tomorrow for hosting! \o/
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   BARCELONA IS IN A FEW DAYS!!!!!!!!!
+*   Open Mic/Discussion
+    *   [Intro for KubeCon](https://docs.google.com/presentation/d/1mlIdjFYC0ZXhKvDAyCCvVnBwWMddupu3RHVdyE1UuKQ/edit?usp=sharing)
+    *   Extend milestone
+
+
+## May 8 (Recording)
+
+Attendees:
+
+
+
+*   Paris (will be 5 mins late)
+*   Łukasz Gryglicki, CNCF
+*   Nikhita Raghunath
+*   Jeffrey Sica
+*   Jorge Castro
+*   Bob Killen
+*   Guin Saenger
+*   Sahdev Zala
+*   Tim Pepper
+*   Dawn Foster
+*   Ihor Dvoretskyi
+*   Aaron of SIG Beard
+*   Rael Garcia Arnes
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   West Coast Scheduling
+        *   Meet Our Contributors [paris]
+        *   Community meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Barcelona Contributor Summit
+                *   SIG Meet and Greet -> send people with good first issue 
+                *   Maybe clarify goals for each track 
+                *   Rooms will have preso screen - woo rah \o/ thanks to dawn and deb
+            *   nikhita : 
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   San Diego Summit planning punt until post Barcelona 
+*   Review [May Milestone](https://github.com/kubernetes/community/milestone/1)
+*   Open Mic/Discussion
+        *   [your name and topic here - should this be an issue against kubernetes/community?]
+        *   [We have an update tomorrow at the community meeting](https://github.com/kubernetes/community/issues/3661) - what should we highlight?
+            *   Mentoring, succession planning, creating roles/teams, owners files emeritus/clean up [paris]
+            *   We are trying to find better homes for things [paris]
+            *   Contributor summits [paris]
+                *   Reg still open for new contrib workshop in barcelona - spread the word
+            *   What else?
+        *   We also have an Intro that we will use mostly this same update \o/
+        *   Contrib Site [jorge]
+        *   Charter [jorge]
+
+
+## May 1 ([Recording](https://youtu.be/cLQgFGaSiqs))
+
+Attendees:
+
+
+
+*   Jonas Rosland
+*   Eduar Tua
+*   Paris Pittman
+*   Bob Killen
+*   Jeff Sica
+*   Dawn Foster
+*   Elsie Phillips
+*   Nikhita Raghunath
+*   Alex Handy
+*   Aaron Crickenberger
+*   Arnaud Meukam
+*   Sahdev Zala
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   There **WILL** be one pre-kubecon.
+        *   Meet Our Contributors [paris]
+            *   Morning session went really well.
+            *   Did code-base tour for kubectl
+            *   100 people tuned in.
+        *   Community Meeting [jorge]
+            *   Need more hosts, sign up [here](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895).
+            *   GCP backing out to go under cloud provider
+            *   Lots of space freed up once cloud providers roll under sig-cloud-provider
+            *   Should working groups etc present?
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Reminder for contrib summit.
+            *   Note on docker images being removed.
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Barcelona:
+                *   finalizing comms to go out next week
+                *   248 people registered as of 4/30
+                *   current contributor track is close to capacity
+                *   harbor box as an artifact mirror is a go
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   k/k-wide triage workflow
+        *   Plan to revisit, but no traction at the moment.
+        *   moved to backlog
+    *   Umbrella issue for Reviews
+        *   moved to backlog
+    *   Umbrella issue for Community Maintenance Tasks
+        *   AI: Migrate to doc under contributor-experience directory instead of long-open task
+        *   address quarterly? annually?
+    *   Create more roles for contribex
+        *   Close to being done (everything in flight)
+        *   APAC meeting:
+            *   Low turn-out
+            *   Look for APAC coordinator to help advertise and facilitate interest in the APAC region.
+                *   Possibly reach out to sig-docs teams in APAC regions.
+            *   APAC task being spun out from ‘create more roles for contribex’
+    *   Revamp developer guide
+        *   Close to being done.
+        *   7 issues remain.
+*   Open Mic/Discussion
+        *   [your name and topic here - should this be an issue against kubernetes/community?]
+        *   Contrib Site update [jorge and b0b]
+            *   [Preview](https://kubernetes-contributor.netlify.com/)
+            *   [Code](https://github.com/kubernetes-sigs/contributor-site)
+            *   No longer being auto-generated from the community repo.
+                *   For content that will live on contributor site (e.g. contributor guide) a date will have to be picked to migrate over.
+            *   Current iteration is just various PoC content.
+            *   Look of the site is actively being improved.
+            *   AI: Send note to leads regarding formatting of calendar event names.
+            *   Content to move over before EU:
+                *   Contributor Guide
+                *   Events
+                *   Code of Conduct
+        *   Kubernetes Velocity Report? (Jonas)
+            *   [https://app.trendkite.com/report?id=70270dee-d7e1-4b1d-8948-12feec612055](https://app.trendkite.com/report?id=70270dee-d7e1-4b1d-8948-12feec612055)
+
+
+## April 24th (Recording)
+
+**APAC friendly timezone - 8pm PT!!!**
+
+**Meeting canceled @ 8:10pm PT**
+
+Attendees:
+
+	Paris Pittman
+
+	Bob Killen
+
+	Nikhita R
+
+	Christoph Blecker
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   Intro @ KubeCon and Community Meeting Update are coming up
+        *   Yay for being able to use similar decks [paris]
+        *   What do we want to highlight? 
+*   
+
+
+## April 17th ([Recording](https://youtu.be/1aQ_J0VnQOg))
+
+Attendees
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Eduar Tua
+*   Bob Killen
+*   Nikhita Raghunath
+*   Jonas Rosland
+*   Alex Handy
+*   Chris Short
+*   Dawn Foster
+*   Christoph Blecker
+*   Jeffrey Sica
+*   Sahdev Zala
+*   Aaron Crickenberger (@spiffxp), Google
+
+Agenda
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Barcelona Contributor summit
+        *   Contributor Summit(s) BCN [jonas/josh/paris]
+            *   F2F sessions confirmed and times locked in.
+            *   Invites for sched sent out to speakers.
+            *   202 current attendees approved.
+        *   Contributor Summit CN
+            *   Need additional people for current contributor sessions.
+            *   Contact jberkus if interested
+            *   WIll reach out to general speakers soon.
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Slack Infra (tempelis)
+        *   Need last sign off from leads [[PR](https://github.com/kubernetes/community/pull/3532)]
+        *   Slack[ guidelines](https://github.com/kubernetes/community/blob/master/communication/slack-guidelines.md) updated with new instructions. 
+        *   Slack management can be delegated (docs can manage docs channels)
+        *   looking into linking github ID -> slack ID for user group management
+    *   Commit msg prow plugin
+        *   waiting for consensus on ML, but should be enabled soon
+    *   enabling feja-bot org wide
+        *   waiting for consensus on ML
+    *   subproject details in sigs.yaml
+        *   need sign-off from steering on closing last issue
+            *   Aaaron will close.
+        *   2 PRs left to merge
+    *   add new roles to contribex
+        *   Needs final look over / hold release
+            *   Chirstoph will look at it
+    *   Building an issue triage team
+        *   4 person team assembled
+        *   Sahdev working on triage guidelines
+            *   Basing it off k/k triage guidelines along with release team triage guidelines.
+    *   contributor summit role book
+            *   In progress, folks are working on individual roles 
+                *   Bob working on reg role
+    *   Contributor workflow doc
+        *   Eduar should complete soon
+    *   link checker
+        *   Aaaron and Cristoph will double check on issue,, might be unblocked going forward.
+*   Open Mic/Discussion
+    *   YouTube
+        *   Karen Chu (kchu) is "taking a crack" at YouTube bumpers
+        *   Need to get time to get git good (I might reach out for help on fixing [PR 3542](https://github.com/kubernetes/community/pull/3542/); first time with a commit in this [workflow](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md))
+        *   Chris will close and reopen with new PR.
+    *   [New triage workflow](https://github.com/kubernetes/community/issues/3456)
+        *   No progress
+    *   Needs rebase will now be red like other blocking labels.
+    *   OWNERS cleanup
+        *   Need to craft language and sort out what defines emeritus inactive etc.
+    *   Charter
+        *   Jorge will follow-up with Michelle and Brandon
+
+
+## April 10th ([Recording](https://youtu.be/MS0AB0Sm6iA))
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Paris 
+*   Eduar Tua
+*   Nikhita
+*   Jeff Sica
+*   Bob Killen
+*   Łukasz Gryglicki, CNCF
+*   Jorge Castro
+*   Alex Handy
+*   Christoph Blecker
+*   Dawn Foster
+*   Aaron Crickenberger (@spiffxp), Google
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Sig-windows and sig-cluster-lifecycle is doing an out of band Office Hours
+        *   Meet Our Contributors [paris]
+            *   Kubectl code base in may
+            *   Good for may - yay
+        *   Community Meeting [jorge]
+            *   All set through KubeCon EU
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Summit - full on sig f2f
+            *   Surveys - how to get access
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   working on outline for NCW content
+            *   sig f2f are booked
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   update wg sigs.yaml with more info - in progress
+        *   waiting for chairs to sign off
+    *   sub-project details in sigs.yaml
+        *   subprojects have a slack channel / mailing list / calendar 
+*   Open Mic/Discussion
+    *   OWNERs files
+    *   Charter proposal (Jorge) 
+
+
+## April 3 ([recording](https://youtu.be/09jDT6Nu9C8))
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Elsie Phillips
+*   Jorge Castro
+*   Bob Killen
+*   Jeffrey Sica
+*   Alex Handy
+*   Eduar Tua
+*   Chris Short
+*   Łukasz Gryglicki
+*   Jorge Alarcon
+*   Christoph Blecker
+*   Arnaud Meukam
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]
+        *   Community Meeting [jorge]
+        *   Meet Our Contributors [paris]
+            *   Morning session went well afternoon session is lined up
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Putting sig f2f on repeat until deadlines / space is full
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   BCN:
+                *   NCW - guin looking for someone to do code base tour
+                *   Need more room facilitators - ping jonas if interested
+            *   Shanghai:
+                *   English app done, sent off to CNCF translators
+                *   Need to sort out how to advertise contributor summit to the right audience.
+                *   Need to attract people for current contribor track 
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+
+Open Mic:
+
+
+
+*   [bob] Owners file audit
+    *   AI: open a PR against community membership to propose emeritus status to define approver/reviewer/emeritus
+*   [jorge] Would like to propose changes to our charter: [https://github.com/kubernetes/community/pull/3526](https://github.com/kubernetes/community/pull/3526)
+*   [Josh] New application form for joining the release team 
+    *   Ready for the next cycle
+*   [Alex] Requirements doc for blogs
+
+
+### March 27 (Recording)
+
+Attendees:
+
+
+
+*   Jonas Rosland
+*   Paris Pittman
+*   Chris Short
+*   Dawn Foster
+*   Bob Killen
+*   Josh Berkus
+*   Elsie Phillips
+*   Tim Pepper
+*   Jorge Castro
+*   Vonguard
+*   Łukasz Gryglicki
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]
+        *   Community Meeting [jorge]
+        *   Meet Our Contributors [paris]
+            *   Next Wednesday - have a great lineup, very excited
+            *   Will send out tweets next week
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Putting sig f2f on repeat until deadlines / space is full
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Jonas - barca - swag update from jorge: luggage tags
+                *   Reg - 115 rsvps now
+                *   Hosting local container images for workshops - possibly using Harbor; will help scale events
+                *   Sched is up but filling out as we go; four sigs signed up for f2f time
+            *   Josh - shanghai 
+                *   Reg hasn’t opened yet; working on form 
+            *   Paris - San Diego
+                *   Full steam ahead with BCN and Shanghai, not much to update here yet
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Milestone May: [https://github.com/kubernetes/community/milestone/1](https://github.com/kubernetes/community/milestone/1)
+    *   Need some help with creating process doc: [https://github.com/kubernetes/community/issues/3175](https://github.com/kubernetes/community/issues/3175)
+    *   Need some immediate help with the community site: [https://github.com/kubernetes/community/issues/3388](https://github.com/kubernetes/community/issues/3388)
+    *   Need someone to write up a blog post regarding survey results - Alex and Chris on point \
+[https://github.com/kubernetes/community/issues/2802](https://github.com/kubernetes/community/issues/2802)
+    *   Revision of community meeting invite workflow: [https://github.com/kubernetes/community/issues/1665](https://github.com/kubernetes/community/issues/1665)
+    *   Waiting on steering to resolve the working groups sigs.yaml, as the owners of the last WG is unresponsive: [https://github.com/kubernetes/community/issues/3188](https://github.com/kubernetes/community/issues/3188)
+    *   Sahdev and Nikhita - Building a team for triage handling, 3-4 people
+        *   Creating a PR to get some information around triage guidelines, triage captain responsibilities with shadow, and more: [https://github.com/kubernetes/community/issues/3364](https://github.com/kubernetes/community/issues/3364)
+    *   Create more roles for contribex (event-team, marketing-team etc): [https://github.com/kubernetes/community/issues/3076](https://github.com/kubernetes/community/issues/3076)
+        *   Adding marketing + new contrib ambassador: [https://github.com/kubernetes/community/pull/3460](https://github.com/kubernetes/community/pull/3460)
+*   Open Mic/Discussion
+    *   [spiffxp] Proposal to enable `review_acts_as_lgtm` in the kubernetes/test-infra repo. See the [slack post](https://kubernetes.slack.com/archives/C09QZ4DQB/p1553208058692200) for details
+        *   GitHub reviews approve will now act as both /lgtm and /approve
+        *   General approval, will be run by contrib-x
+        *   /lgtm cancel will still remove the lgtm label
+    *   [jorge] - Can we turn the contributor site back on?
+        *   Just need contributor/developer guide, comms folder
+        *   Josh would like it to just be a standalone hugo site with the few pages there, not generating from k/community. SGTM.
+    *   [jeefy] - Moving @Katharine’s awesome slack-ops out of test-infra into some contribex repo
+        *   Aaron will send out a message to the mailing list to get this started
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+
+
+### March 20 (Recording)
+
+Attendees:
+
+
+
+*   Parispittman
+*   Bob Killen
+*   Nikhita Raghunath
+*   Jeffrey Sica
+*   Jonas Rosland
+*   Vlad Shlosberg
+*   Łukasz Gryglicki
+*   Noah Abrahams
+*   Eduar Tua
+*   Aaron Crickenberger
+*   Jorge Castro
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge] - all set, need to move calendar to the community calendar + still need help wrt. diversity.
+        *   Meet Our Contributors [paris] 
+            *   Stream of volunteers seems to be getting better - as always - need more
+            *   
+        *   Community Meeting [jorge] - all set
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Contributor summit f2f [again] barcelona; more info about reg
+            *   Slack is open
+            *   Calendar problems/calendar guideline updates 
+            *   
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Barcelona -
+                *   Blog post is live!
+                *   [https://kubernetes.io/blog/2019/03/14/a-look-back-and-whats-in-store-for-kubernetes-contributor-summits/](https://kubernetes.io/blog/2019/03/14/a-look-back-and-whats-in-store-for-kubernetes-contributor-summits/)
+                *   Registration is live!
+                *   [https://events.linuxfoundation.org/events/contributor-summit-europe-2019/](https://events.linuxfoundation.org/events/contributor-summit-europe-2019/)
+                *   Tweets will go out tomorrow, Jonas will send out to k-dev and Discuss today.
+                *   Volunteers needed for TAs, registration desk, and SIG F2F facilitation
+            *   Shanghai - 
+                *   Have team!! \o/
+                *   Wants to do a social blitz
+                *   Be explicit about location when we are advertising so there is no confusion  
+                *   Put up registration 
+                *   NCW survey results - looking for changes to content; what goes in 101 vs 201
+            *   SD - building a team issue is live - [https://github.com/kubernetes/community/issues/3445](https://github.com/kubernetes/community/issues/3445)
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   No open mic discussion this week unless we can get through the project board
+
+
+### March 13 ([Recording](https://www.youtube.com/edit?o=U&video_id=2wcpj2oip7E))
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Jorge Castro
+*   Noah Abrahams
+*   Alex Handy 
+*   Vlad Shlosberg
+*   Tim Pepper
+*   Łukasz Gryglicki
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   W55ould any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge] - all set
+        *   Meet Our Contributors [paris] 
+        *   Community Meeting [jorge] - all set
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [nikhita] PSA: we have a new channel on slack #pr-reviews to help people find reviewers.
+        *   Tim - we should pin a summary doc in that channel. 
+    *   Slack is back \o/ - new moderator process still processing new people. 
+
+
+### March 6 (Recording)
+
+Attendees:
+
+
+
+*   Elsie Phillips- Red Hat
+*   Bob Killen - University of Michigan
+*   Dawn Foster - Pivotal
+*   Łukasz Gryglicki, CNCF
+*   Nikhita Raghunath, Loodse
+*   Jonas Rosland, Tim Pepper, Jorge Castro - VMware
+*   Vlad Shlosberg, Foqal
+*   Ihor Dvoretskyi, CNCF
+*   Eduar Tua
+*   Paris Pittman, googs
+*   Sahdev Zala - IBM
+*   Alex Handy - Red Hat
+*   Arnaud Meukam - Alter Way
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge] - set for the week
+        *   Meet Our Contributors [paris]
+            *   Updating the docs next week 
+            *   Need help figuring out transcripting 
+            *   Always need more people to volunteer for one hour (help 100!)
+        *   Community Meeting [jorge]
+            *   Moderator set for this week and next (Paris this week & Jonas next)
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Backlog grooming / issue triage doc - do you have one? If so, link it to us; we can make a template.  Example from SIG Cluster Lifecycle: [https://github.com/kubernetes/community/blob/master/sig-cluster-lifecycle/grooming.md](https://github.com/kubernetes/community/blob/master/sig-cluster-lifecycle/grooming.md) 
+            *   [API Review process](https://git.k8s.io/community/sig-architecture/api-review-process.md) - put it in your meeting notes, provide comments
+            *   Shoutouts channel on slack #shoutouts to name and recognize helpful folks’ actions
+            *   OWNERs file graduation gifts: a contributor coming into an OWNERS file as reviewer or approver can receive a contributor patch
+            *   Maybe one more?
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Jonas
+                *   [Email](https://groups.google.com/a/kubernetes.io/forum/#!topic/steering/cWBW76Fydec) went out to Steering on Monday with the content proposal
+                *   Event website will be live early next week, pending design by CNCF
+                    *   Blog post will be published to announce the BCN Summit and event website
+                *   Registration will be live shortly, targeting at the latest late March - will also have branding completed by then
+                *   Josh doing t-shirt design for Barcelona
+            *   Paris
+                *   San Diego - starting to form team of volunteers
+            *   Josh
+        *   Issue triage update
+            *   3-5 people team 
+            *   If interested, get in contact with Sahdev or add name below 
+            *   [https://github.com/kubernetes/community/issues/3364](https://github.com/kubernetes/community/issues/3364)
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Gsuite
+        *   Moderators in place \0/
+
+
+### Feb 27 (Recording)
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Eduar Tua
+*   Noah Kantrowitz
+*   Christoph Blecker
+*   Josh Berkus
+*   Yang Li
+*   Rui Chen
+*   Chris Short
+*   Ming Hsieh
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+*   Open Mic/Discussion
+    *   Slack update if people are interested [noah k]
+    *   Doing a small change to the kubernetes codebase - Tutorial [Eduar T]
+    *   Contributor Summit Shanghai work meeting in 10 hours [jberkus]
+    *   Chirstoph’s going to take a vacation next month [cblecker]
+
+
+### Feb 20 (Recording)
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Bob Killen
+*   Noah Abrahams
+*   Noah Kantrowitz
+*   Paris Pittman
+*   Dawn Foster
+*   Vlad Shlosberg
+*   Tim Pepper
+*   Arnaud Meukam
+*   Aaron Crickenberger (@spiffxp)
+*   Eduar Tua
+*   Sahdev Zala 
+*   Jonas Rosland
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]
+            *   Could always use more people 
+            *   Diversity issue -> need to figure this out
+            *   Things are going good though
+        *   Meet Our Contributors [paris]
+            *   Could always use more people
+            *   Mentors on demand!!
+        *   Community Meeting [jorge]
+            *   Contribex is up this week! What should we share? We will give our usual subproject updates. 
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Jonas: third meeting happened on Monday for Barcelona. Jorge is taking swag; Paris is taking marketing lead. Still need some more folks to help out. Paris is looking at an events landing page. Bob is looking at reg process/workflow. Dawn is working on content proposal right now. Ihor created a project board for contrib summits - yay! Photographer will be onsite.
+            *   Josh: told cncf about rooms for Shanghai. Will most likely convene first meeting next week. Core team is in place. May or may not need volunteers but will know more in the upcoming weeks. 
+            *   Paris: San Diego is almost underway. CNCF has been notified as to light space requirements. A call for a team of volunteers will be underway next week. 
+            *   EU project board:
+                *   [https://github.com/kubernetes/community/projects/4](https://github.com/kubernetes/community/projects/4)
+            *   CN project board:
+                *   [https://github.com/kubernetes/community/projects/5](https://github.com/kubernetes/community/projects/5)
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+            *   If you need something from christoph, ping him now.
+            *   Github management is working on documenting processes
+*   Open Mic/Discussion
+    *   [Deprecating Gubernator in favor of Spyglass](https://github.com/kubernetes/test-infra/pull/11302) [Katharine Berry]
+        *   Will send a note to k-dev when they are there
+    *   [SIG Roles](https://github.com/kubernetes/community/issues/3076)
+        *   volunteers:
+            *   issue triage: Arnaud, Bob, Paris, Nikhita
+            *   events: Jonas, Bob, Paris
+            *   blog: Noah A, Elsie
+            *   moderation: Jeff, Bob
+    *   Developers guide update [WIP] PR [[3245](https://github.com/kubernetes/community/pull/3245)]
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Shutting down old WGs
+        *   [Umbrella issue](https://github.com/kubernetes/community/issues/3188)
+        *   
+
+
+### Feb 13 ([Recording](https://youtu.be/avq0R5-4lGY))
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Nikhita Raghunath
+*   Bob Killen
+*   Tim Pepper
+*   Jeffrey Sica
+*   Jonas Rosland
+*   Vlad Shlosberg
+*   Eduar Tua
+*   Jorge Castro!
+*   Noah Abrahams
+*   Rui Chen
+*   Lindsey Tulloch
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris] - need more volunteers
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris] - need more tips
+        *   Contributor Summit(s) [paris/whoever]
+            *   1st meetings kicked off
+                *   Shanghai: Josh Berkus running
+                *   Barcelona:
+                    *   Jonas Rosland running
+                    *   [https://docs.google.com/document/d/1l9Po3kE2J7QOfflH5dPQgfHTpXmweUNEcNBDIPj8VtA/edit](https://docs.google.com/document/d/1l9Po3kE2J7QOfflH5dPQgfHTpXmweUNEcNBDIPj8VtA/edit) 
+                    *   Need Marketing & Comms lead + Swag lead - reach out to jonas on slack - @jonasrosland 
+            *   CNCF event planners are on site in Barcelona
+            *   CNCF event staff contact - Deb Giles 
+                *   slack: @Deb Giles
+                *   email: dgiles@linuxfoundation.org
+*   Slack incident follow-up
+    *   Sign-ups remain offline
+    *   Webhooks and api integrations are offline excluding a very selective few (GitHub)
+    *   No confirmation from Slack that they are fixing the notification bug
+    *   Reaching out to end-user community to discuss Slack moderation.
+        *   Goes beyond contributor experience -> end user, community, consumer experience
+        *   Use slack for contributor activity, but not end-user activity
+        *   Need more moderators, at least for the duration to help combat possible spam/trolls
+        *   Need at least 3 moderators online around the clock
+        *   CNCF will provide 1 additional moderator, but are the stance that it should be handled by the community
+    *   Many more communities in kubernetes slack beyond “just” kubernetes e.g. Helm and other projects.
+    *   Need to do a risk assessment of Slack itself and what is reasonable response/level of moderation.
+        *   Group that did the initial attack has a pattern history of repeatedly going after the same channels and groups.
+        *   Is the risk tolerable to keep things open.
+        *   Need to protect our user-base from potential harassment
+            *   Repeated targeted harassment completely negates the trust for the community. 
+    *   Moderation Tools
+        *   Slack doesn’t support an IRC Channel Moderator role
+        *   Could build something; don’t have resources
+        *   Sign-ups
+            *   block certain known “bad” domains and gateways (done)
+                *   Block list deployed to other slacks has been effective “so far”
+            *   Moderation: what questions would we ask people to prove they’re legit?  Easier for developer/community than end user/consumer?
+        *   Restrict users from joining specific channels e.g. restrict to #kubernetes-users
+            *   [single channel guests](https://get.slack.help/hc/en-us/articles/202518103-Multi-Channel-and-Single-Channel-Guests)
+        *   Discuss (discourse) has significantly better moderation tools
+        *   What are Slack’s permissions for moderators?  Moderator gets a lot of access/power on the Slack instance.  Real risk in having a bad moderator.  Today though they have to be a community member.  Risk of their login being stolen.
+        *   CNCF can potentially fund the development of tools, but it’d be contract work and would require being very spec’ed out.
+    *   Plan: 
+        *   Bring up end user group and user representation with SC
+        *   Reach out to end user community and ToC to get more moderators (currently restricted to org members)
+        *   Open up registration once we have enough moderators to cover all timezones etc
+        *   If it continues to be a problem, slack moves to contributor only and end-users are routed to discuss.
+*   Open discussion:
+    *   contribex F2F: KubeCon Barcelona
+    *   Mailing List Moderation Changes: 
+        *   Google group changes going through in May will remove new user moderation queue. Moderation will be either ON or OFF.
+        *   Paris investigating options internally at Google.
+
+
+### Feb 6 (Recording)
+
+Attendees:
+
+
+
+*   Josh Berkus
+*   Paris Pittman
+*   Tim Pepper
+*   Sahdev Zala (leaving early - 30 mins)
+*   Noah Kantrowitz
+*   Eduar Tua
+*   Noah Abrahams
+*   Jonas Rosland (only first 30 minutes)
+*   Christoph Blecker
+*   Jorge Castro
+*   Vlad Shlosberg
+*   Dawn Foster
+*   Elsie Phillips
+
+Agenda:
+
+
+
+*    Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]: nothing new to report, is coming next month
+        *   Meet Our Contributors [paris]: redoing relative to public steering committee.  Need to poll k-dev for folks inputs on times that work best for community.  Add evening edition?  This morning’s had speakers need to cancel, so meeting cancelled.  Have full set of folks for today’s midday call.  As always looking for next speakers
+        *   Community Meeting [jorge]: continuing to have good stream of folks volunteering.  Demo (GitLab demo flaked, again) shifted to backup alternate demo.  No KEP for this week.
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [paris/whoever]
+            *   Meetings are scheduled, next week kick off
+            *   Fully staffed (~10 people) for Barcelona
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   SIG Networking Meeting tomorrow
+    *   Non-Code meeting at 11 today
+    *   [RETRO - SLACK INCIDENT](https://docs.google.com/document/d/1R96x3jUXQYPduJ0gsWiZ1KBFGQGizZH1_RX_CU4ueZk/edit?usp=sharing) (see that link for detailed info)
+        *   Timeline:
+            *   Late Pacific time Kubernetes users channel had an @ all of 50k people
+            *   Paris ping’d the person to check why they were @’ing channel
+            *   At same time porn started coming in too
+            *   #kubernetes-users, #helm, and multiple major open source communities were targeted, probably because they have large number of users.
+            *   Paris removed the person and pinged our moderators/admins for additional help
+            *   More griefers/bots arrived, bigger problem than typical small scale maliciousness
+            *   Set of admin’s worked to contain
+        *   Next actions:
+            *   <span style="text-decoration:underline;">Jorge has a PR</span> for moderator improvements we could do: [https://github.com/kubernetes/community/pull/3212](https://github.com/kubernetes/community/pull/3212)
+            *   Formalize ‘incident coordinator’ role to split comm’s and organizing from those who are actively squashing things in the moment
+    *   SIG Intro / Deep Dive session proposals for Barcelona? (Due Friday this week)
+        *   Elsie will submit
+
+
+### Jan 30 (Recording)
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Noah Abrahams
+*   Bob Killen
+*   Nikhita Raghunath
+*   Eduar Tua
+*   Jeffrey Sica
+*   Brian Topping
+*   Noah Kantrowitz
+*   Yang Li
+*   Christoph Blecker
+*   Benjamin Elder
+*   Aaron Crickenberger
+*   Chris Short
+
+Welcome and recurring business 
+
+
+
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates:
+        *   Office hours [jorge]
+            *   Feb 20th 
+        *   Meet Our Contributors [paris]
+            *   Feb 7th
+        *   Community Meeting [jorge]
+            *   Jeff this week
+            *   Josh next week
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Mailing list moderation
+            *   SIG Roles
+            *   F2F meetings
+            *   Need more mentors
+            *   Maybe one more that is short and sweet?
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Open Mic/Discussion
+            *   Picking up operations of bi-weekly public Steering Committee meetings
+            *   Create more roles for contribex - anything I’m missing? [https://github.com/kubernetes/community/issues/3076](https://github.com/kubernetes/community/issues/3076)
+            *   Last call for review on style guide? - [https://github.com/kubernetes/community/pull/3125](https://github.com/kubernetes/community/pull/3125)
+            *   Follow-up on contribex f2f - [https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/9olx_nDmogs](https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/9olx_nDmogs)
+            *   Meta APAC meeting talk:
+                *   Where do we advertise?
+
+
+### Jan 23 [(Recording)](https://youtu.be/xrgkuARpAS4)
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Bob Killen
+*   Jeffrey Sica
+*   Paris Pittman
+*   Nikhita Raghunath
+*   Jonas Rosland, VMware
+*   Chris Short, Red Hat (because Jonas did it)
+*   Lindsey Tulloch
+*   Dawn Foster
+*   Sahdev Zala
+*   Jorge Castro (so happy to be here!)
+*   Christoph Blecker
+*   Eduar Tua
+*   Guinevere Saenger
+*   Marky Jackson (sysdig)
+*   Tim Pepper
+*   Hannes Hoerl
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Office Hours [jorge]
+            *   Needs more voices and diverse 
+            *   Ideally 3 office hours (including EMEA)
+            *   Things are pre-packaged, we could hand off scripts and whatnot. 
+            *   Do we want to try to do native-language OHs?
+        *   Meet Our Contributors [paris]
+            *   Need folks for Feb edition @ 730a PT [emea friendly]
+            *   Thinking about doing a 7pm PT - would that have impact/value?
+            *   Would we benefit from an “evening” MoC?
+                *   Evening Contribex meeting is well attended
+                *   Currently have a 7:30AM PST and 1PM PST
+        *   Community Meeting [jorge]
+            *   SIGs scheduled through August (Leads contacted)
+            *   Penciled in when (potentially) the release retros would be
+            *   Volunteers for hosts are appreciated. 
+        *   Weekly Need to Know email for chairs and TLs [what topics do we hit?]
+            *   Meet our contributors
+            *   Create roles
+            *   ?
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion 
+    *   [welcome to all; add your name and topic suggestion below]
+    *   [should this be an issue against k/community?]
+    *   Bob - [Style Guide](https://github.com/kubernetes/community/pull/3125) Discussion and Review
+        *   From the contrib site work, it was realized that a lot of docs are out of date. 
+        *   For future docs, a style guide is needed before more work can happen
+        *   Based on the style guide from Kubernetes.io, but slightly more firm (with inspiration from other various high level guides)
+        *   Timezones are hard. 
+            *   GMT over UTC? Let’s not Bikeshed
+        *   Top big things of note:
+            *   Use reference links
+            *   Preference on Line Length
+    *   Anita - OSU
+        *   [https://opensource.com/article/18/8/inclusivity-bugs-open-source-software](https://opensource.com/article/18/8/inclusivity-bugs-open-source-software)
+        *   Can the tools we use impact inclusivity? How do gender and software relate? (Gender bias bugs)
+        *   Curb cuts -- by addressing this now we help more than just the immediate biases 
+        *   GenderMag - Gender Inclusiveness Magnifier. Evaluate your tools’ inclusiveness. 5 cognitive facets identified.
+            *   Motivations
+            *   Information processing style
+            *   Computer self-efficacy
+            *   Risk averseness
+            *   Tech learning style (tinkering)
+        *   Ignoring different facets leaves behind a lot of talent.
+        *   Field study with 5 different OSS projects 
+            *   Walked through all use cases
+            *   Collected all facets
+            *   >50% # with gender bias
+    *   [spiffxp] - [https://github.com/kubernetes/test-infra/issues/10846](https://github.com/kubernetes/test-infra/issues/10846) - how should we handle tide vs staging repos [spiffxp]
+    *   [spiffxp] - [https://github.com/kubernetes/k8s.io/pull/169](https://github.com/kubernetes/k8s.io/pull/169) - added sig contribex TL’s to k8s.io root OWNERS ([k8s.io is listed as a contribex subproject](https://github.com/kubernetes/community/tree/master/sig-contributor-experience#subprojects))
+    *   [spiffxp] - I’ve heard no objections about [nikhita for github admin team](https://groups.google.com/d/msg/kubernetes-sig-contribex/Oin3mGNRwNg/2gDnVdqFFAAJ) 
+    *   [spiffxp] - [https://github.com/kubernetes/test-infra/issues/10834](https://github.com/kubernetes/test-infra/issues/10834) - enable owners-label for all
+    *   [Guin] Barcelona New Contributor workshop: who, what, when?
+        *   Jonas will gladly help out here (had to step out early)
+    *   [Eduar] Developer Guide progress.
+
+
+### Jan 16 ([Recording](https://youtu.be/QMCGb5un8Gw))
+
+Attendees:
+
+
+
+*   Paris - not attending but acting as a ghost on this doc
+*   Eduar Tua
+*   Bob Killen
+*   Hannes Hoerl
+*   Elsie Phillips
+*   Lindsey Tulloch
+*   Łukasz Gryglicki, CNCF
+*   Dawn Foster
+*   Matt Jarvis
+*   Guinevere Saenger
+*   Noah Abrahams
+*   Tim Pepper
+*   Ibrahim AshShohail
+*   Yang Li
+*   Nikhita Raghunath
+*   Christoph Blecker
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Need to know email for chairs and tls - weekly - paris
+            *   What should we share with them this week?
+            *   Maintainer track form for eu (Paris)
+            *   Meet our contributors (Paris)
+            *   Our charter was merged and read how we (contribex) communicate (Paris)
+            *   Carving out roles for your sig (Paris)
+            *   ?
+        *   Office Hours
+        *   Meet Our Contributors - Need more always - reach out to Paris
+        *   Community Meeting
+            *   [Host schedule](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895), please volunteer
+            *   Need more demos
+            *   Contributor Tip of the Week for community meeting?
+                *   Need more tips from the general community (contribex)
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+        *   Review blocked column. 
+            *   [subproject details](https://github.com/kubernetes/community/issues/2619)
+                *   debate still going on sigs.yaml and subprojects / subproject details
+                *   Looking for someone else to take on
+                *   Needs steering committee support
+        *   [update sigs.yaml with more wg info](https://github.com/kubernetes/community/issues/2176) - **no longer blocked**
+            *   progress made by nikhita
+        *   Working on a live contribex project - Do a quick standup?
+*   Open Mic/Discussion
+    *   [should this be an issue?]
+    *   [your name and topic here]
+    *   Jose Palafox, Intel - Contributor mentorship program at Intel for OSS release?
+        *   Intel built internal mentorship program
+        *   Has a good amount of material, slides etc that could be donated to Kubernetes community.
+        *   They can demo some of the material they have at the **meeting on the 30th** 
+    *   Our charter was merged as mentioned above. Please read the [how we communicate](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/charter.md#cross-cutting-and-externally-facing-processes) changes please. Charter will be revisited on July 1st. 
+    *   KubeCon EU-Intro? Deep dive?
+        *   Merged might be a problem with 80min to block out
+            *   Could become ‘face-to-face’ meeting with contributors who may not be able to often make the weekly meeting.
+        *   Turn it into a working session
+            *   work on the developer guide, wrangle other documents in the community repo.
+        *   **AI: **Discuss over the mailing list, come to a conclusion on it in 2 weeks (Jan 30th meeting)
+    *   KubeCon ShangHai - intro only
+    *   Face to face meeting?
+        *   Host during another conference? (IndexCon)
+            *   Previous one was not very productive, but little lead time.
+            *   Possibly try and attach it to one of the other kubernetes related events (non KubeCon)
+            *   Conference Ideas:
+                *   OSCon (July 15-18)
+                *   Google Next (April 9-11th)
+                *   Scale (March 7-10)
+                *   Prefer before Barcelona
+        *   **AI: **Take dates and ideas to mailing list
+    *   DevStats separate meeting has been getting less people, should be brought into main ContribEx meeting
+    *   Oops implicit self-approve got rolled out [spiffxp]
+        *   **AI: **I’m totally not sure of this timeline, suggest an issue and someone with more time than me to followup
+        *   [Sig-testing’s deploy policy](https://github.com/kubernetes/community/blob/master/sig-testing/charter.md#deploying-changes)
+        *   [Sig-contribex’s deploy policy](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/charter.md#cross-cutting-and-externally-facing-processes)
+        *   Dec 10 not sure if this is the root cause PR? [https://github.com/kubernetes/test-infra/pull/10435](https://github.com/kubernetes/test-infra/pull/10435) 
+        *   Dec 10 notify k-dev@ of k/community change [https://groups.google.com/forum/#!msg/kubernetes-dev/oWbV6uiQMIM/0ku8cvSZBgAJ](https://groups.google.com/forum/#!msg/kubernetes-dev/oWbV6uiQMIM/0ku8cvSZBgAJ) 
+        *   cblecker rolled the change into test-infra
+        *   Dec 19 last prow deploy before holiday lull [https://github.com/kubernetes/test-infra/pull/10504](https://github.com/kubernetes/test-infra/pull/10504) 
+        *   Jan 7 first prow deploy after holiday lull [https://github.com/kubernetes/test-infra/pull/10532](https://github.com/kubernetes/test-infra/pull/10532)
+        *   ??? - another change landed in test-infra that modified the default behavior to mimic the change
+        *   Jan 9 Change went in 6 days ago that pushed the new-default live
+        *   Jan 15 reports of something amiss in #sig-testing
+        *   Jan 15 Rollbackish PR (still not deployed) [https://github.com/kubernetes/test-infra/pull/10782](https://github.com/kubernetes/test-infra/pull/10782)
+        *   **AI: **No documentation on policy for rollback, how fast things should be rolled back etc
+        *   This instance was completely unintentional -- no notification / communication sent out
+        *   Long term goal to separate the prow codebase from the kubernetes prow configuration.
+            *   contribex could become the long term owners of the kubernetes prow config.
+            *   Discussion should be taken to the #prow channel.
+
+	
+
+
+
+    *   Eduar Tua -  Cleaning the /devel folder
+        *   Could we add a line that says `**Owner: SIG-name** `to docs that are not part of a SIG folder?
+            *   Move to design proposal layout so that they may have rights assigned via owners files.
+
+
+### Jan 9 ([Recording](https://youtu.be/KWbNnmxJ3Xg))
+
+Attendees:
+
+
+
+*   Josh Berkus
+*   Łukasz Gryglicki, CNCF
+*   Tim Pepper - VMware
+*   Bob Killen
+*   Jeffrey Sica
+*   Paris Pittman
+*   Dawn Foster
+*   Aaron Crickenberger
+*   Chris Short
+*   Nikhita Raghunath
+*   Jorge Castro
+*   Sahdev Zala 
+*   Matt Jarvis
+*   Christoph Blecker
+*   Yang Li
+*   Noah Abrahams
+*   Arnaud Meukam
+*   Ibrahim AshShohail
+*   Eduar Tua
+*   Guinevere Saenger
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Office Hours 
+            *   All set for next week
+        *   Meet Our Contributors - Need more always - reach out to Paris
+        *   Community Meeting
+            *   [Host schedule](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895), please volunteer
+            *   Need more demos
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+        *   Ping Aaron today re: periobols
+
+Open Mic/Discussion
+
+
+
+*   Staffing Contributor Summits for Barcelona and Shanghai
+    *   Barcelona: lots of contribex folks intending to go
+    *   Shanghai: few contribex folks intending to go..Josh Berkus & Chris Short & Yang Li & ??
+*   Contributor Summit Feedback status
+*   Team management via Peribolos [Christoph]
+    *   [https://groups.google.com/d/topic/kubernetes-dev/dwHkzW6QyTU/discussion](https://groups.google.com/d/topic/kubernetes-dev/dwHkzW6QyTU/discussion) 
+*   Non-Code call at 11am PST
+*   Clarity of purpose for Contributor Playground: [https://github.com/kubernetes-sigs/contributor-playground/pull/216](https://github.com/kubernetes-sigs/contributor-playground/pull/216) - is this potentially a Chinese workaround? Not sure how to proceed
+
+
+### Jan 2
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Łukasz Gryglicki, CNCF
+*   Matt Jarvis
+*   Sahdev Zala
+*   Dawn Foster 
+*   Noah Abrahams
+*   John Harris
+*   Eduar Tua
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Office Hours 
+        *   Meet Our Contributors - I need someone for 9pm UTC TODAY!
+            *   Just kidding - both of the livestreamers are ill and I’m canceling [paris]
+            *   But I do need more mentors for upcoming sessions!! 1 hour of your time for 1 year - not bad!! [paris]
+        *   Community Meeting - paris checking since Jorge is out
+            *   [ihor] this is on, and SIG UI, SIG Apps, and SIG VMWare will be updating us.
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Open Mic / Discussion
+        *   [noah] Non-code contributor’s guide is going to ramp up efforts again after conferences/end-of-year hiatus
+
+
+## December 19  (APAC)
+
+Attendees:
+
+
+
+*   Yang Li
+*   Peeyush Gupta
+*   Ilayaperumal Gopinathan
+
+Canceled due to no agenda. Feel free to chat on slack [https://kubernetes.slack.com/archives/C1TU9EB9S/p1576731173001900](https://kubernetes.slack.com/archives/C1TU9EB9S/p1576731173001900)
+
+
+## December 5  (APAC)
+
+Attendees:
+
+
+
+*   Yang Li
+*   Saiyam Pathak
+*   Peeyush Gupta
+*   Ilayaperumal Gopinathan
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Recent contributions/meetups/blogs from community
+*   [yang] KubeCon / Contributor Summit NA
+    *   Recap the event
+    *   Discussed with some contributors from Japan and Nikhita, blog posts might be a better idea than video streaming session.
+    *   [peeyush] that’s a good start for us
+    *   [saiyam] Podcast may work well too - TBD on the details
+    *   [yang] +1 from a podcast lover, we don’t have a community one, but there are lots of them from different companies
+    *   [yang] (added after the meeting) I’ll try to open an issue for this later
+*   [saiyam] Contributor session Kubernetes Forum India
+    *   [Ilaya] What’s the plan for K8s forum India co-located events?
+    *   [yang] Nikhita haven’t heard back from CNCF yet when we met at San Diego, let’s start a thread on slack later with her
+    *   [peeyush] - contributors’ social meet in Bangalore
+*   [saiyam] Kubecon Amsterdam Contributor summit discussion
+    *   [yang] Jeffery will be leading [https://github.com/kubernetes/community/issues/4022](https://github.com/kubernetes/community/issues/4022)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   [Ilaya] Resources for debugging kubernetes core components?
+        *   [saiyam] Kubernetes Code Walkthrough videos:  [https://www.youtube.com/watch?v=Q91iZywBzew](https://www.youtube.com/watch?v=Q91iZywBzew)  - Kubecon2018 \
+[https://www.youtube.com/playlist?list=PL69nYSiGNLP0gugLYzpNR1ueyUj9GjzpK](https://www.youtube.com/playlist?list=PL69nYSiGNLP0gugLYzpNR1ueyUj9GjzpK) - Kubernetes code walkthrough playlist
+
+
+## December 4 (Update Meeting)
+
+Attendees:
+
+
+
+*   Jorge Castro
+*   Jonas Rosland
+*   Dawn Foster
+*   Jason DeTiberus
+*   Eduar Tua
+*   Josh Berkus, el Capitan
+*   Rin Oliver
+*   Ihor Dvoretskyie
+*   Amanda Katona
+*   Guin Saenger
+*   Elsie Phillips
+*   Laura Santamaria
+*   Michael Roy
+*   Mani 
+
+Others:
+
+
+
+*   Events (currently San Diego Summit) 
+    *   Every Monday at 10a PT 
+    *   [Project Board ; Agenda and notes](https://github.com/orgs/kubernetes/projects/21)
+    *   [Points of contact](https://github.com/kubernetes/community/blob/master/events/OWNERS)
+    *   [Retro for contrib summit](https://docs.google.com/document/d/1mDHxPAbwyy7CSrk7G__Qts6FkhuwuCUQ23RnHpJpVUQ/edit#) San Diego
+    *   Next steps - Jeefy is putting together the AMS Contrib Summit team and will kick off new planning meetings when we have the team put together. 
+*   Community-management
+    *   Community meetings set for the year, jorge to send monthly cadence change to the -dev list on Monday
+    *   MoC, Office hours all set for 2k19
+    *   Points of contact: castrojo
+*   Github-management: No status this week
+    *   Points of contact: Christoph, Aaron, Nikhita, Bob, others
+*   Slack-infra: 
+    *   Always looking for new volunteers, ping castrojo if you’re interested
+    *   Points of contact: (on slack): #slack-admins
+*   Contributor-documentation: Not much new, adding sections for release notes in the contributor summit. 
+    *   Fourth Wednesday of the month @ 11am PT
+    *   [Project Board](https://github.com/orgs/kubernetes/projects/17) ; Agenda and notes inline with main meeting below
+    *   [Points of contact](https://github.com/kubernetes/community/blob/master/contributors/guide/OWNERS)
+*   Mentoring
+    *   Second Thursday of the month @ 830a PT 
+    *   [Project Board](https://github.com/orgs/kubernetes/projects/18) ; Agenda and notes inline with main meeting below
+    *   [Points of contact](https://github.com/kubernetes/community/blob/master/mentoring/OWNERS)
+    *   Discussion on Zoom reviews process and whether it might help mentoring. Laura offered to ask a friend for his process docs. Jay said yes! [https://gist.github.com/parlarjb/07aeb0efafde2a23fc43dfdd5be11c2e](https://gist.github.com/parlarjb/07aeb0efafde2a23fc43dfdd5be11c2e)
+
+
+## November 20/21 - APAC Meeting
+
+Canceled because some regular attendees will be at KubeCon NA 2019
+
+
+## November 14 - mentoring
+
+Attendees:
+
+
+
+*   Paris
+*   Marky
+*   Mani
+*   Ihor
+
+Agenda:
+
+
+
+*   Outreachy
+    *   Need to pick the interns! \o/
+*   Onsite f2f mentoring @ kubecon
+    *   Paris to run the AM with Marky assisting in the PM. Tpep to float between.
+*   Light triage mentoring board
+
+
+## November 6/7 - APAC Meeting
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Alison Dowdney
+*   Yang Li
+*   Peeyush Gupta
+*   Nabarun Pal
+*   Ilayaperumal Gopinathan
+*   (and some new folks did not wrote their names)
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   [yang] Contributor focused sessions in APAC time zones
+    *   [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086) 
+    *   Asked in regional slack channels
+    *   What time to have it? The meeting time is probably good, but we will create a doodle to see more opinions (Alison & Nikhita)
+    *   Yang will ask others how the youtube streaming works
+    *   Topics? Introduction for new folks at first, and code walk through, also interview with contributors and issues deep-dive
+*   [nikhita] CNCF is looking into if we can have a contributor-specific unconference-like session on Day 2 for Kubernetes Forum India.
+    *   Next step is waiting for answers from CNCF
+    *   Will there be any contributor related talks in Seoul or Sydney?
+        *   [https://k8sforumseoul19eng.sched.com/event/WIRH/](https://k8sforumseoul19eng.sched.com/event/WIRH/) in Seoul
+*   [nikhita] Who is going to San Diego? We should meet up
+    *   Nikhita, Yang, Peeyush, Alison, Nabarun
+    *   Post to #contributor-summit about meeting up at the summit. Cross link to regional channels.
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   [Ilaya] What are other SIG meetings occur at APAC-friendly time zones?
+        *   sig-node (maybe not anymore), sig-docs (monthly), sig-cluster-lifecycle (kubeadm bi-weekly), wg-iot-edge (monthly)
+        *   we should probably make a list of all such meetings
+    *   [Ilaya] The purpose of this meeting?
+        *   This is a meeting of APAC coordinators ([https://github.com/kubernetes/community/blob/master/sig-contributor-experience/role-handbooks/apac-coordinator.md](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/role-handbooks/apac-coordinator.md)), but we can also have usual contribex topics
+
+
+## November 6 - ContribEx Issue Triage Update
+
+Attendees:
+
+
+
+*   Arnaud Meukam 
+*   Rin Oliver
+*   Sahdev Zala
+*   Savitha Raghunathan
+*   Alexandra McCoy
+
+Minutes:
+
+
+
+*   No blockers  
+*   Current focus is on the community repo 
+*   We will start tracking triaging work after the kubecon 
+*   No next bi-weekly meeting due to kubecon
+
+Action Items:
+
+
+
+*   Attempt to manage remaining issues with label “lifecycle/stale” before next meeting
+*   May not be able to address #2696 & #3806 but plan to discuss at KubeCon
+
+
+## November 6 - ContribEx Update
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Bart Smykla
+*   Jason DeTiberus
+*   Bob Killen
+*   Rin Oliver
+*   Sahdev Zala
+*   Tim Pepper
+*   Ihor Dvoretskyi (CNCF)
+*   Jorge Castro
+*   Taylor Martin
+*   Łukasz Gryglicki, CNCF (a bit late due to meeting conflict).
+*   Alexandra McCoy
+*   Savitha Raghunathan
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+            *   Community Meeting [jorge]
+            *   Contributor Summit(s) [paris]
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+            *   Other/Discussion [playground, gsoc, outreachy]:
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   Enabled contributor-flagged reporting feature on k/k
+        *   Slack-infra:
+        *   Contributor-documentation:
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Coffee Tuesday morning @ Kubecon [jorge] 
+        *   [Ihor] Please, note that the CNCF Ambassadors breakfast will happen on Tuesday morning - multiple CNCF Ambassadors are the active participations at ContribX
+    *   Recordings from meetings as podcasts ([https://github.com/kubernetes/k8s.io/issues/449](https://github.com/kubernetes/k8s.io/issues/449)) [bartsmykla]
+
+
+## October 23/24 - APAC Meeting
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Yang Li
+*   Josh Berkus
+*   Peeyush Gupta
+*   Saiyam Pathak	
+
+Agenda:
+
+
+
+*   Kubernetes Seoul & Sydney
+    *   [https://events19.linuxfoundation.org/events/kubernetes-forum-seoul-2019/](https://events19.linuxfoundation.org/events/kubernetes-forum-seoul-2019/) & [https://events19.linuxfoundation.org/events/kubernetes-forum-sydney-2019/](https://events19.linuxfoundation.org/events/kubernetes-forum-sydney-2019/) 
+    *   Also Bangalore & Delhi
+        *   [https://events19.linuxfoundation.org/events/kubernetes-forum-bengaluru-2020/](https://events19.linuxfoundation.org/events/kubernetes-forum-bengaluru-2020/)
+        *   [https://events19.linuxfoundation.org/events/kubernetes-forum-delhi-2020/](https://events19.linuxfoundation.org/events/kubernetes-forum-delhi-2020/)
+    *   Any contributor activity?
+        *   Day 2 activities are all sponsored
+        *   Nothing scheduled by CNCF
+        *   AI: Nikhita will ask Dims if we can have contributor focused unconference sessions
+        *   [https://groups.google.com/forum/#!forum/kubernetes-forums-india-2020-unofficial](https://groups.google.com/forum/#!forum/kubernetes-forums-india-2020-unofficial) - unofficial google group for Kubernetes Forum India
+        *   Josh can help organize something in Bangalore (probably remotely)
+        *   Because of San Diego, Seoul & Sydney will be like less popular than Bangalore & Delhi
+    *   Nikhita: we should advertise this meeting in SIG-Docs which has a larger Asian contributor group.
+    *   We will have a full contributor day at KubeCon Shanghai 2020, we should be able to start planning after San Diego, although much work may be done after Amsterdam
+*   Webinars
+    *   [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086) 
+    *   Want to have CNCF Webinar things for the APAC time zones, but more contributor-focused
+        *   Like contributor 101
+        *   Also “meet our contributors”
+            *   Could get US-based Owners to dial in a couple times a year
+    *   Can we use the CNCF tooling?
+        *   Why not use Meet Our Contributor setup?
+            *   Does zoom work in China? Yes, there’s a China client
+            *   Nikhita to ask Jorge & Paris
+    *   Maybe have some in the afternoon Asia time, which would pick up europe as well.
+        *   Survey to time zones? (Josh can arrange)
+        *   Just hold them and try?
+*   Anyone on Contribex Triage team?
+    *   #sig-contribex-triage channel [https://app.slack.com/client/T09NY5SBT/CNGLDBL5N/activity](https://app.slack.com/client/T09NY5SBT/CNGLDBL5N/activity)
+    *   Expanding this effort to more SIGs? Have more documation first
+
+
+## October 23 - ContribEx Triage Issue Meeting
+
+Attendees:
+
+
+
+*   Arnaud Meukam
+*   Jorge Alarcon
+*   Marky Jackson
+*   Savitha Raghunathan
+
+Topics:
+
+
+
+*   [AI: marky] build spreadsheet to keep track of issues
+*   Dedicated issue triage for k/k
+    *   Work on [https://github.com/kubernetes/community/blob/master/sig-contributor-experience/triage-team/triage.md](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/triage-team/triage.md)
+    *   We want a good set of guidelines
+*   [AI] Let’s start by triaging older issues
+    *   preference on /lifecycle rotten and go from there
+
+
+## October 23 - ContribEx Update
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Jonas Rosland
+*   Bob Killen
+*   Rin Oliver
+*   Jorge Castro
+*   Jorge Alarcon
+*   Josh Berkus
+*   Tim Pepper
+*   Sahdev Zala
+*   Paris
+*   Eddie Zaneski
+*   Łukasz Gryglicki
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   150 live attendees last time
+                *   Break for this month because of KubeCon - start up again in December
+            *   Community Meeting [jorge]
+                *   9 people last week - are we wasting other people’s time?
+                *   One SIG showed up, the second didn’t, and the third didn’t respond to our request
+                *   Should we move this to bi-weekly, once a month perhaps?
+                    *   Try bi-weekly
+                    *   Restrict demos to be about new core/SIG functionality, instead of external tools
+                *   Finish out the year with the existing format, and then revamp after the new year
+            *   Contributor Summit(s) [paris]
+                *   Starting on “know before you go” info! It’s happening!! 
+                *   ~220 current contributors
+                    *   Still room for ~100 more
+                *   NCW is cap (waitlist is huge)
+                *   Sunday night will be fun! Karaoke
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Pre KubeCon November edition with paul morie and need two more
+            *   Other/Discussion [playground, gsoc, outreachy]:
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Contrib summit, triage team, conformance, ??
+                *   Triage team - possible unconference track - [Rin]
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   [Owner cleanup almost complete.](https://github.com/kubernetes/kubernetes/issues/76269)
+            *   Cleanup of outside collaborators 
+        *   Slack-infra:
+            *   Discussion/Update
+            *   Public channel for steering committee
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Jorge - Community Meeting 
+        *   [Declining community meeting attendance](https://github.com/kubernetes/community/issues/4019)
+        *   Move to biweekly starting 2020
+        *   Demos are from SIGs/core features only
+        *   2019 schedule will remain as is.
+    *   tpepper - WG K8s Infra & [https://twitter.com/thockin/status/1184509308169379840](https://twitter.com/thockin/status/1184509308169379840) 
+    *   Rin - [https://github.com/kubernetes/community/issues/4149](https://github.com/kubernetes/community/issues/4149) Happy to work with whoever else may be interested on setting this up as an unconference event at the Summit, could be a great way for those who are interested in getting involved with the project but aren't sure where to start/how to contribute :) If there's a point of contact I can get in touch with to secure a space for it/someone I can talk to to get it on the contributor site schedule I'll make it happen!
+    *   [https://github.com/kubernetes/community/issues/4149](https://github.com/kubernetes/community/issues/4149)
+
+
+## October 10 - mentoring
+
+Attendees
+
+
+
+*   Paris
+*   Bob Killen
+*   Marky Jackson
+*   Dawn Foster
+*   Jorge Alarcon
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   Outreachy
+    *   3 positions
+    *   Need help in #outreachy-apps
+*   KubeCon face to faces 1:1
+    *   Marky can’t take on right now
+    *   Paris will resume
+*   Project board https://github.com/orgs/kubernetes/projects/18
+
+
+## October 10 - APAC Planning
+
+Attendees
+
+
+
+*   Yang Li
+*   Peeyush Gupta
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   GitHub team for APAC coordinators
+    *   All members on board and team created
+*   Kubernetes Community Days [https://github.com/cncf/kubernetes-community-days/issues](https://github.com/cncf/kubernetes-community-days/issues)
+    *   We are able to help with APAC events
+*   Kubernetes Forums
+    *   Schedule not announced yet, both CNCF and ContribEx are busy with San Diego
+    *   We need at least one month if ContribEx is going to do a workshop or sth.
+
+
+## October 9 - ContribEx Triage Issue Meeting
+
+Attendees
+
+
+
+*   Paris Pittman
+*   Arnaud Meukam
+*   Marky Jackson
+*   Savitha Raghunathan
+*   Rin Oliver
+
+Topics
+
+
+
+*   
+
+
+## October 9 - ContribEx Meeting
+
+Attendees
+
+
+
+*   Paris Pittman
+*   Nikhita Raghunath
+*   Jason DeTiberus
+*   Bob Killen
+*   Dawn Foster
+*   Chris Short
+*   Jonas Rosland
+*   Marky Jackson
+*   Eduar Tua
+*   Tim Pepper
+*   Łukasz Gryglicki
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   Last office hours until kubecon next week
+            *   Community Meeting [jorge]
+                *   Marky is doing this week
+                *   We still need hosts!! Check the meeting tracker
+                *   Reach out and help us with finding hosts! 
+            *   Contributor Summit(s) [paris]
+                *   Blog post to go live today along with several other outlets
+                *   Schedule is now live; adding some sessions this week
+                *   Amsterdam contributor summit team 
+            *   Steering Committee Election
+                *   Jorge did some retro fixes
+                *   [https://github.com/kubernetes/community/pull/4148](https://github.com/kubernetes/community/pull/4148)
+                *   Lets get more election officials in the mix!! Anyone interested in next year??
+                *   Should we do a retro? At steering level?
+                *   CIVS can’t scale with us
+                    *   Wants to move to something that is directly tied to github
+                    *   Or web based
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   How to get the best out of kubecon - ask that 
+            *   Other/Discussion [playground, gsoc, outreachy]:
+                *   Outreachy is live!
+                *   Marky is helping with issue triage and breaking down some projects
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Contributor summit 
+                *   Reminder about owners stuff/audit - most recent kdev email
+            *   APAC coordinator update:
+                *   Discussion about organizing a webinar targeting APAC timezones.
+        *   GitHub-management:
+            *   OWNER clean up on track for next week
+                *   A few sig leads are cleaning up ahead of time
+            *   [Moving forward with incubator clean up](https://github.com/kubernetes/community/issues/1922)
+            *   Cleaning up outside collaborators
+        *   Slack-infra:
+            *   Discussion/Update
+                *   No updates
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+                *   Marky is still working on five issues 
+                *   Release team edits that came out of the retro 
+            *   Non Code Guide
+            *   Contributor Site
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Concerns about our PR lifecycle:
+        *   [https://github.com/kubernetes/community/issues/4149](https://github.com/kubernetes/community/issues/4149)
+
+
+## September 26 - APAC Planning
+
+Attendees
+
+
+
+*   Yang Li
+*   Saiyam Pathak
+*   Alison Dowdney
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   Zoom in China
+    *   [https://status.zoom.us/incidents/xbmxyfpnv4jq](https://status.zoom.us/incidents/xbmxyfpnv4jq)
+    *   [https://zoomcloud.cn/download.html](https://zoomcloud.cn/download.html) China Zoom client, should works since 
+*   GitHub team for APAC coordinators
+    *   Team for APAC Coordinators to get better signals on GitHub [idealhack]
+*   Webinar issue created(assigned to Saiyam and Yang) Next steps ? (issue link - [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086))
+    *   Get form created - Look at past forms, use that as a reference for APAC
+    *   [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086)
+    *   Looking at where to find existing webinars [idealhack]
+*   Community introduction slides for Kubernetes Workshop?
+    *   Look at past contributor summit workshop slides
+        *   Barcelona [https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit](https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit)
+        *   Shanghai [https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit](https://docs.google.com/presentation/d/1usEbwHMSC8vR7HvbxHJBOj2ISdTkw9rmufQUq7fkIl4/edit)
+        *   San Diego [https://docs.google.com/presentation/d/18LcwvqyNn74HgqIk7O-ChgfSsJAqDIYm7obguEXto4Q/edit](https://docs.google.com/presentation/d/18LcwvqyNn74HgqIk7O-ChgfSsJAqDIYm7obguEXto4Q/edit)
+        *   It would be nice if anyone can update this in the playground repo :) [https://github.com/kubernetes-sigs/contributor-playground/tree/master/presentations](https://github.com/kubernetes-sigs/contributor-playground/tree/master/presentations)
+    *   Videos: [https://www.youtube.com/playlist?list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx](https://www.youtube.com/playlist?list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx)
+*   Other teams in SIG contribex
+    *   Marketing: [https://github.com/kubernetes/community/issues/4044](https://github.com/kubernetes/community/issues/4044)
+        *   Doodle link- [https://www.doodle.com/poll/6682kfq36wttq6fa](https://www.doodle.com/poll/6682kfq36wttq6fa)
+    *   Moderators: [https://github.com/kubernetes/community/issues/4011](https://github.com/kubernetes/community/issues/4011) , [https://github.com/kubernetes/community/issues/4112](https://github.com/kubernetes/community/issues/4112)
+
+
+## September 25 - ContribEx Meeting
+
+Attendees
+
+
+
+*   Paris
+*   Jorge
+*   Jonas
+*   Jason
+*   Nikhita
+*   Dawn
+*   Jberkus
+*   Christoph
+*   Guin
+*   Sahdev
+*   Jorge
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   150 live participants
+            *   Community Meeting [jorge]
+                *   Looking for new hosts [link for spread]
+                *   Timpep is hosting this week; working groups are going this week for the first time
+            *   Contributor Summit(s) [paris]
+                *   San Diego - registration is live.
+                *   NCW is at capacity
+                *   We need an idea for entertainment for Sunday Night. We have a stage. No amps though. Projector screen, mic, laptop hook up, etc. We didn’t get many people who want to do a talent show. Womp womp. 
+                *   Schedule is out next week
+            *   Steering Committee Election [jorge/bob]
+                *   50% through, deadline Oct 2!
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Need two people for next Weds
+                    *   Christoph is a maybe
+            *   Other/Discussion [playground, gsoc, outreachy]:
+                *   Need help with forming job blurbs for the four outreachy interns we are recruiting. See github issue for the four. 
+                *   Marky is going to help out with issue triage and getting some of the 1:1 and group mentoring projects off the ground to help me - yay thank you!
+                *   KubeCon face to face pod mentoring registration will go live in the next week. More soon.
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   1-contributor summit
+                *   2- governance stuff like youtube playlists
+                *   3- owners file clean up stuff
+                *   //could have one more
+            *   APAC coordinator update:
+                *   Kubernetes Summit Seoul + Sydney [idealhack]
+                    *   CFP closed, we may see folks who are going later
+                    *   Decide whether to have a new contributor workshop or other sessions or not, APAC coordinator can help if we are going to form a team
+            *   Discuss.k8s.io updates [jorge]
+                *   Marketing for Kubecon [jorge]
+            *   YouTube updates [jorge]
+            *   Survey [paris]
+                *   [https://github.com/kubernetes/community/issues/3969#issuecomment-535051744](https://github.com/kubernetes/community/issues/3969#issuecomment-535051744)
+                *   Draft of the questions is linked here. We can afford ONE more question to hit the goal of 25. (We had 32 last year and needed to trim based on feedback)
+                *   Pending christoph and test infra
+            *   Other Discussions:
+                *   [https://github.com/kubernetes/community/issues/4044](https://github.com/kubernetes/community/issues/4044) - marketing team doodle just went out [paris]
+                *   [https://github.com/kubernetes/community/issues/4011](https://github.com/kubernetes/community/issues/4011) - help wanted to make moderators@ whole [paris]
+                *   Zoom in china [paris]
+                    *   Check on bluejeans
+                    *   Wechat
+                    *   Will we run into the case of $platform getting blocked too
+                    *   There is a zoom client that you can download in china
+                        *   Please access https://zoomcloud.cn/download.html and download the China Zoom client. After installing, users can enter the meeting ID to join a Zoom meeting.
+        *   GitHub-management:
+            *   Discussion/Update:
+                *   Had a call with Jacob Palmer from LF about easycla. Have some concerns about behaviour during transition from the current bot to the new one. Going to follow-up with them + SIG Testing later. [nikhita]
+                *   Will be replacing [fejta-bot with k8s-triage-robot](https://groups.google.com/forum/#!topic/kubernetes-dev/31oiPVzITJw) today. [nikhita]
+        *   Slack-infra:
+            *   Discussion/Update:
+                *   No updates
+        *   Contributor-documentation: second meeting is today!
+            *   Contributor Guide
+            *   Developer Guide
+                *   Need to write outreachy blurb //help wanted
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [Guin] 1.17 release cycle has started. Prepare your KEPs!
+    *   Silly Hat meetings? [Josh]
+    *   [Your name and topic here. Should this be an issue against kubernetes/community?]
+
+
+## September 12 - Mentoring
+
+Attendees
+
+
+
+*   Bob Killen
+*   Paris
+*   Dawn Foster
+*   Marky Jackson
+*   Nikhita Raghunath
+*   Naeil Ezzoueidi
+*   Jorge Alarcon
+*   Maria Ntalla
+*   Saiyam Pathak
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   Outreachy
+    *   Announcement to k-dev
+    *   Last year’s announcement - [link](https://docs.google.com/document/d/1HrirvVoH3hLnz2IZORAGqGq9Aaj_tQFdEjeesI_Jjas/edit?usp=sharing)
+    *   Possibly owners file work; will need to flesh out policies
+*   Open Mic/Discussion
+    *   [Your name and topic here. Should this be an issue against kubernetes/community?]
+    *   Script that would aggregate who is doing work in a file 
+    *   Marky to help with issue triage and getting some of the programs off the ground
+
+
+## September 12 - APAC Planning
+
+Attendees
+
+
+
+*   Yang Li
+*   Peeyush Gupta
+*   Saiyam Pathak
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   #aus-nz-dev channel created for Oceania contributors
+*   Kubernetes Summit Seoul + Sydney
+    *   CFP closed, we may see folks who are going when the schedule announced
+    *   Decide whether to have a new contributor workshop or not
+    *   how can we be part of that - if we are going to do it, we will form a team
+*   KubeCon Shanghai 2020
+    *   Contributor Summit team will be formed later
+*   CFP form/google form for APAC webinar
+    *   Contact CNCF?
+    *   Create a GitHub Issue (Saiyam) [https://github.com/kubernetes/community/issues/4086](https://github.com/kubernetes/community/issues/4086)
+    *   We talked about this [before](#bookmark=kix.3669k7ttwcf0) but forgot it
+*   How can we update the contibex community about the talks around kubernetes ecosystem (eg kubernetes workshop, kubernetes security , k3s etc) that contributors are giving at local meetups (that might not be part of cncf) 
+    *   If they are users talks, share them at [http://discuss.k8s.io](http://discuss.k8s.io/) / slack etc.
+    *   If they are contributors talks, share them at contributors channels on slack etc.
+*   How to find data around APAC contributors?
+    *   devstats is the first place to go: [https://k8s.devstats.cncf.io/d/50/countries-stats?orgId=1](https://k8s.devstats.cncf.io/d/50/countries-stats?orgId=1)
+    *   Could not find sth? Ask in #sig-contribex or open an issue at [https://github.com/cncf/devstats](https://github.com/cncf/devstats)
+
+
+## September 11 - ContribEx Meeting
+
+Attendees
+
+
+
+*   Elsie Phillips
+*   Bob Killen
+*   Marky Jackson
+*   Paris Pittman
+*   Jorge Castro
+*   Dawn Foster
+*   Guinevere Saenger
+*   Jacob Palmer
+*   Tim Pepper
+*   Christoph Blecker
+*   Jorge Alarcon Ochoa
+*   Łukasz Gryglicki
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   fine
+            *   Community Meeting [jorge]
+                *   Doesn’t have enough hosts - please volunteer
+                *   Issue open to change formatting 
+            *   Contributor Summit(s) [paris]
+                *   REG IS LIVE - TELL YOUR FRIENDS
+                    *   150 RSVPs already
+                *   Meta request - We need two sig meet and greet reps for ContribEx
+                    *   Elsie is volunteering for one slot; NEED ONE MORE; tim pepper (offered but also doing sig-release) - [Form to volunteer](https://forms.gle/hxx1qz8XtwtXEBMm8) to rep our SIG & details about who has volunteered for each SIG are [in the Issue](https://github.com/kubernetes/community/issues/3896).
+            *   Steering Committee Election [jorge]
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Need folks for October 2nd - need to send an email to k-dev and chairs
+            *   Other/Discussion [playground, gsoc, outreachy]:
+                *   Outreachy - 1: content for dev guide 2: contributor guide content
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   All contributor summit updates today; ready to roll with an email so if you have something speak now or wait until the next three 
+            *   APAC coordinator update:
+                *   See notes below for aug 29th date
+        *   GitHub-management:
+            *   Discussion/Update:
+                *   [justinsb] FYI single assignee to PRs: [https://github.com/kubernetes/test-infra/pull/14264](https://github.com/kubernetes/test-infra/pull/14264)
+        *   Slack-infra:
+            *   Discussion/Update
+                *   No update
+        *   Contributor-documentation:
+            *   We had our first meeting!!! \o/
+            *   Contributor Guide
+                *   Contributor site outreachy intern coming to help write web content 
+            *   Developer Guide
+                *   Thanks marky!! Starting to collect more content issues and build it out. Outreachy intern on the way. 
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [Demo of easyCLA tool](https://github.com/communitybridge/easycla)
+    *   FYI single assignee to PRs: [https://github.com/kubernetes/test-infra/pull/14264](https://github.com/kubernetes/test-infra/pull/14264)
+        *   Data needed:
+            *   Response times on 1 assignee vs 2 
+                *   Time to first response on a PR
+            *   We could run a 1 release trial 
+            *   
+
+
+## August 29th - APAC Planning
+
+Attendees
+
+
+
+*   Yang Li
+*   Peeyush Gupta
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+*   [idealhack] Slack channels?
+    *   #aus-nz-users may want to have a #aus-nz-dev channel? I will create one for them
+    *   [peeyush] A channel for APAC contributors? Thought about it but not sure if it’s a good idea given that we have many regional channels now. 
+*   [idealhack] Kubernetes Summit Seoul + Sydney
+    *   New contributor workshop should more useful than SIG intros
+    *   How we can staff this? Ask in SIG contribex how many folks are going
+*   [peeyush] Convert new contributors to active contributors
+    *   [idealhack] Connect your contributions with your daily work
+    *   Specific guide in community repo for them? Like the contributor cheat sheet which was translated to many languages.
+
+
+## August 28th (contributor-documentation)
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Marky Jackson
+*   Arnaud Meukam
+*   Josh Berkus
+*   Jonas Rosland
+*   Kaitlyn Barnard
+*   Kiran Oliver
+*   nzouedi
+
+Agenda:
+
+
+
+*   Contributor site
+    *   Need to do more project management; tech writers want to have punch cards, issues per pages, etc.
+    *   Project board in main org doesn’t connect to k-sigs; k-sigs doesn’t allow for project boards
+    *   Launching events, contributor guide, and a homepage
+    *   Kiran is helping with homepage content; hope to be done in 1-2 weeks for a soft launch; want some kind of project board up, too, when we launch
+*   Contributor-documentation project board triage
+    *   Cleaned up board
+    *   Assigned owners
+
+
+## August 28th
+
+Attendees:
+
+
+
+*   Bob Killen
+*   Jorge Castro
+*   Sahdev Zala (leaving early - may be not as we ended call early :-))
+*   Christoph Blecker
+*   Jason DeTiberus
+*   Elsie Phillips (cochair) 
+*   Ihor Dvoretskyi
+
+Topics:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+    *   Subprojects:
+        *   Events:
+            *   Office hours [jorge]
+                *   All good
+                *   High attendance today
+            *   Contributor Summit(s) [paris]
+                *   Registration opens next Week (September 4th)
+            *   Steering Committee Election [jorge/bob/ihor/bgrant]
+                *   Status update going out next week
+                    *   Reminder to check eligibility  
+                    *   Reminder to people that are going to run 
+                    *   Next deadline: Sept 11th
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Election stuff, see above
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   Discussion/Update:
+                *   First meeting last week
+                *   Monthly cadence
+                *   Next meeting, open to entire SIG
+        *   Slack-infra:
+            *   Discussion/Update
+            *   Moderator training w/ Sage Sharp
+                *   next training session September 16th
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+            *   First call for this subproject today at 11AM PT - if you’re interested, please attend
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic:
+    *   Kubecon planning for ContribX
+        *   Intro got same content
+        *   Need to figure out what to do for deepdive
+            *   Working Session?
+        *   Anything else we want to do?
+    *   Contributor Survey
+        *   Need to generate questions
+    *   Issue filed for declining attendance in Thur community meeting
+        *   Should we intervene?
+        *   Leave feedback in that thread
+
+
+## August 14th - ContribEx Bi-Weekly
+
+Attendees:
+
+
+
+*   Jeffrey Sica
+*   Dawn Foster
+*   Elsie Phillips
+*   Jonas Rosland
+*   Bob Killen
+*   Josh Berkus
+*   Chris Short
+*   Tim Pepper
+*   Guinevere Saenger
+*   Jorge Castro
+
+Topics:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+            *   Community Meeting [jorge]
+                *   Everyone’s confirmed for this week
+                *   Need to schedule the SIGs for the rest of the year
+                *   If there’s no KEP, add in election status instead
+            *   Contributor Summit(s) [paris]
+                *   Team is full right now for SD
+                *   Need to surface leads for next years planning (jeff is one)
+                *   Need ContribEx content - at least five sessions we should be able to pull together on sustainability and current contributor topics. Please suggest or think about leading one. 
+                    *   Look at #contribex Slack for suggestions - Elsie
+                *   We need an events team for Amsterdam’s CS before SD is finished -- by September, really
+            *   Steering Committee Election [jorge/bob/ihor/bgrant]
+                *   Email has been sent out, PRs have been made to the right repos, everything’s scheduled, elections will happen on August 21st.
+                *   Big thing this time, all of bootstrap is being retired, so it will go down to 7 steering members.
+                *   [PR in to separate steering election captains from community managers](https://github.com/kubernetes/steering/issues/120)
+                *   [https://github.com/kubernetes/steering/pull/119](https://github.com/kubernetes/steering/pull/119)
+                *   [https://github.com/kubernetes/community/pull/3991](https://github.com/kubernetes/community/pull/3991)
+                *   [https://github.com/kubernetes/steering/issues/120](https://github.com/kubernetes/steering/issues/120)
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Need a full panel for Sept; haven’t started recruitment yet
+                *   Still looking for help with building this out
+            *   Other/Discussion [playground, gsoc, outreachy]:
+                *   We had our first mentoring meeting! Will see more activity here in the next few weeks. 
+                *   Gsoc interns need to be scheduled for demos at the community meeting
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   One was sent yesterday (contrib summit, group mentoring, 
+                *   Start collecting actions in the ondeck section please
+            *   ContribEx Survey is kicking up - I’d like to see suggestions, plus ones, and other comments on the issue. [https://github.com/kubernetes/community/issues/3969](https://github.com/kubernetes/community/issues/3969)
+                *   Ihor - can you give me access to surveymonkey so I can build it out this year? [paris]
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   Discussion/Update:
+            *   Kubernetes and kubernetes-sigs org membership should be equivalent: [https://github.com/kubernetes/org/issues/966](https://github.com/kubernetes/org/issues/966)
+            *   [https://github.com/orgs/kubernetes/projects/25](https://github.com/orgs/kubernetes/projects/25)
+        *   Slack-infra:
+            *   Discussion/Update
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community? Should this be in the update section against one of the subprojects? Everything else here.]
+    *   Markdown linter for more of K8s org: [https://github.com/kubernetes/community/issues/3899](https://github.com/kubernetes/community/issues/3899)
+
+
+## August 8th - Mentoring 
+
+Attendees
+
+
+
+*   Nikhita Raghunath
+*   Paris
+*   Marky
+*   Bob
+*   Ihor
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG or subproject) like to give a brief introduction?
+*   Open Mic
+    *   Our first meeting! 
+    *   How can we break this work down? How can we recruit others?
+    *   Meet Our Contributors
+    *   Travel and KubeCon tickets for interns 
+        *   Make sure this happens 
+        *   Make sure we tell interns to fill out the forms when they are onboarded 
+    *   Outreachy
+        *   Deadline is coming up to apply for projects
+        *   Use communications from past k-dev for interest - friday; call for mentors and projects of interest 
+    *   KubeCon face to face mentoring - need to start
+        *   Marky, Paris 
+        *   Ask tim pep and others - get the word on k-dev 
+        *   Kick up convo with cncf about mentoring 
+    *   New Contributor Workshop/SIG Meet and Greet
+        *   Business as usual
+    *   Google Summer of Code 
+        *   Get a list PRed onto the gsoc page for recognition 
+        *   Scheduled to a demo at the community meeting after their assignment
+            *   Possible september 
+        *   7 students working on Kubernetes project this year (17 total for CNCF)
+    *   Community Bridge
+        *   Program that is developed by the linux foundation
+        *   Goal is to have different projects sign up with students
+        *   Organizations can donate 
+        *   CNCF Program isn’t officially launched yet
+        *   The students are from google summer of code (those who signed up for GSoC but haven’t received their slot)
+        *   Pilot deadline: plans to finish by Q4 - don’t have a defined timeline
+    *   AI for group:
+        *   Groom our project board 
+            *   Break down the issues that are already set into tasks
+        *   Make sure all issues relating to mentoring are there; triaging community
+        *   Reward and Recognition 
+        *   Written goals and objectives 
+
+
+## August 1st - APAC Planning
+
+Attendees
+
+
+
+*   Nikhita Raghunath
+*   Saiyam Pathak
+*   Peeyush Gupta
+*   Yang Li
+*   Alison Dowdney
+
+Topics
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+        *   5 attendees did introductions
+*   Kubernetes Summit Seoul + Sydney
+    *   [Official announcement](https://www.cncf.io/blog/2019/07/31/announcing-kubernetes-summits-seoul-and-sydney-expanding-cloud-native-engagement-across-the-globe/)
+    *   Contribex Intro + APAC Coordinators
+    *   Still early, but think about CFPs
+*   Webinar
+    *   Reach out to CNCF for support with APAC specific webinars
+    *   AI(alison): Create an issue for this in community repo
+*   Open Mic/Discussion
+    *   [Your name and topic here. Should this be an issue against kubernetes/community?]
+    *   [nikhita] Can we close [https://github.com/kubernetes/community/issues/3693](https://github.com/kubernetes/community/issues/3693)? 
+        *   close it, and introduce our meeting to border community
+    *   [idealhack] do we need to move this meeting notes to a new doc?
+        *   It’s ok for now, think about this later
+    *   [idelahack] update on contributor summit shanghai retro from last meeting ([July 18](#bookmark=kix.sgmcyyb8zpc2))
+        *   Retro doc: [https://docs.google.com/document/d/13aeCb6Rfy0XM2uOhEhIZJZM2ykg-j2IgxsTdNbt2_TI/edit](https://docs.google.com/document/d/13aeCb6Rfy0XM2uOhEhIZJZM2ykg-j2IgxsTdNbt2_TI/edit)
+    *   [idealhack] git.k8s.io links don’t work in China
+        *   [https://github.com/kubernetes/k8s.io/issues/325](https://github.com/kubernetes/k8s.io/issues/325)
+
+
+## July 31th - ContribEx
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Elsie Phillips
+*   Bob Killen
+*   Nikhita Raghunath
+*   Chris Short
+*   Josh Berkus
+*   Jorge Castro
+*   Ihor Dvoretskyi
+*   Christoph Blecker
+*   Tim Pepper
+*   Naeil Ezzoueidi
+*   Alison Dowdney
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   Good for the next 2 weeks
+                *   Using ‘@here’ in channel before event lead to very good engagement.
+            *   Community Meeting [jorge]
+                *   Need hosts after this week
+                *   Get ahold of Jorge if interested
+                *   Scheduling SIGS for the rest of the year
+            *   Contributor Summit(s) [jonas/josh/paris]
+                *   North America 2019
+                    *   aside from not having venue contracts, things are great
+                    *   we have a ton of volunteers, so we can have handoff next year
+                    *   session proposal form going out today or tomorrow
+                *   China 2020 is still tbd on location/date
+            *   Steering Committee Election [paris]
+                *   Coming soon in August, election committee needs decided/announced
+                *   Announcing Aug 20th
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+                *   Next week
+                *   Looking for help scaling 
+            *   Other/Discussion:
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Host guide on top  
+                *   Holding off on emails untl there's 3 action items to cut down on too much email to Leads so they read it
+                    *   That way anyone can send when there's enough stuff
+            *   APAC coordinator update:
+                *   Meeting today- 11 pm PT
+                *   Still working on format
+                *   Contact CNCF about communication channels for APAC
+        *   GitHub-management:
+            *   Discussion/Update:
+                *   Once a month public call
+                *   Rename Fejta bot 
+        *   Slack-infra:
+            *   Discussion/Update
+                *   Incident management training being planned
+                *   Almost all moderators in one of two sessions
+                *   Should we make this required for moderators
+                *   4 seats available for Aug 26th class
+                *   SIG chairs should be invited as optional (if not required) as they moderate their lists and meetings
+        *   Contributor-documentation:
+            *   Meeting cadence? 
+                *   Monthly, 30 min
+                *   Please respond to the doodle! [https://doodle.com/poll/rgcuwm35k889pfzb](https://doodle.com/poll/rgcuwm35k889pfzb)
+                *   we could also stop using github as a CMS
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+            *   Contributor site ([https://kubernetes-contributor.netlify.com/](https://kubernetes-contributor.netlify.com/))
+                *   Intend to go live (eventually) with:
+                    *   Contributor guide (missing developer guide)
+                    *   Events
+                    *   Calendar: definitely
+                    *   CoC
+                    *   Role board
+                *   Home page:  what is the key top level content to start with for a simplified landing page?  Polishing needed here especially.
+                *   Content curation plan: map this out for the next...3-6mo’s?  Action Item for next Contributor-documentation meeting
+                *   Will late in the cycle need to get the CNAME into DNS and then share that in an announcement.
+            *   Non-ContribEx people are doing community proposals in the KubeCon CFP which mesh up with our contribution documentation effort.  Tim Pepper’s reached out to Bryan Liles and got a thumbs up on contacting folks 1:1 who submitted and didn’t get accepted after the program is announced and working to bring them into our effort.  Good ideas shouldn’t get lost.  CNCF can dump a spreadsheet of Community Track proposals (eg: abstract text, contact name/email).
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [Your name and topic here. Should this be an issue against kubernetes/community?]
+    *   [ihor] Discussion regarding keeping placeholder files: [https://github.com/kubernetes/community/pull/3874#issuecomment-508844027](https://github.com/kubernetes/community/pull/3874#issuecomment-508844027) 
+        *   Do we need to remove expired placeholder files?
+        *   Ihor says that placeholder files are helpful
+    *   [jorge] contribex status at community meeting is next week. 
+    *   [jorge] Oh hey SIG Usability is a thing
+
+
+## July 18th APAC Planning
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Saiyam Pathak
+*   Peeyush Gupta
+*   Jintao Zhang
+
+Topics:
+
+
+
+*   Open Mic/Discussion
+    *   APAC friendly webinar is planned. We might do something similar to APAC friendly office hours as well.
+    *   Yang, Saiyam and others to update on the Shanghai contributor summit retro in the next meeting.
+    *   [saiyam] Need to find a place to submit all presentation and work related to end user kubernetes meetups.
+        *   [nikhita] [https://github.com/cncf/presentations](https://github.com/cncf/presentations) is a good place for that.
+
+
+## July 17th
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Elsie Phillips
+*   Bob Killen
+*   Jonas Rosland
+*   Ihor Dvoretskyi
+
+Topics:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [1-collect updates before the meeting; 2-host to read actions; 3-assign streamers to each event (if applicable)]
+        *   Events:
+            *   Office hours [jorge]
+                *   Tip of the week - updated kubernetes/test-infra readme and this one weird trick to get your job changes to merge faster [spiffxp]
+            *   Community Meeting [jorge]
+            *   Contributor Summit(s) [jonas/josh/paris]
+                *   Content proposal has gone to steering committee for approval.
+                *   General theme with more structured content.
+                *   Separate venue has been secured.
+            *   Other/Discussion: 
+        *   Mentoring:
+            *   Meet Our Contributors [paris]
+            *   Other/Discussion:
+        *   Community-management:
+            *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+                *   Community meeting
+                *   Contributor Summit
+                *   Merged code of conduct charter
+            *   APAC coordinator update:
+        *   GitHub-management:
+            *   [Looking into reconciling membership between kubernetes and kubernetes-sigs](https://github.com/kubernetes/org/issues/966)
+            *   Still looking into what dependabot.
+            *   CLABot will be open sourced soon.
+        *   Slack-infra:
+            *   no update
+        *   Contributor-documentation:
+            *   Contributor Guide
+            *   Developer Guide
+            *   Non Code Guide
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [justinsb - unable to attend] What should the github action on PR merge be - rebase, squash, merge commit etc?  We had an incompatible pairing in etcdadm, and debated for a while which the “right mode” was, but this feels like something that should be consistent across all the repos: [https://github.com/kubernetes-sigs/etcdadm/issues/112#issuecomment-509295085](https://github.com/kubernetes-sigs/etcdadm/issues/112#issuecomment-509295085) 
+        *   by default “merge” commits are used.
+        *   repo maintainers may request a change to an alternative default for their specific repo.
+    *   [https://github.com/kubernetes/community/issues/2951](https://github.com/kubernetes/community/issues/2951) -- soliciting feedback for a SIG Chair Handbook
+        *   Reverse engineer the sig-wg-lifecycle.md? [paris] 
+    *   Markdown linter for all of k org? [jonas/cblecker]
+        *   [https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/425](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/425)
+        *   [https://github.com/kubernetes/test-infra/pull/13363](https://github.com/kubernetes/test-infra/pull/13363)
+        *   Created issue here: [https://github.com/kubernetes/community/issues/3899](https://github.com/kubernetes/community/issues/3899)
+
+
+## July 4 - APAC topics
+
+Attendees:
+
+
+
+*   Yang Li
+*   Alison Dowdney
+*   Saiyam Pathak
+*   Aravind Putrevu
+*   Welcome and recurring business 
+    *   CoC
+*   KubeCon and Contributor Summit Shanghai
+    *   Had current contributor day, new contributor workshop, doc sprints, it was great
+    *   CS Retro meeting next week, ask Yang if you want to join
+    *   SIG intro has got some feedback from contributors too
+*   APAC coordinator role handbook (link [here](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/role-handbooks/apac-coordinator.md))
+    *   Discussion, anything we would like to change/add
+    *   Feel free to make a pull request if there's anything you would like to add/change
+*   Office hours, Meet our contributors, Online events
+    *   Would there be interest in an APAC stream?
+    *   Need to find contributors to interview
+    *   Survey our contributor base, See how many people would be interested
+    *   Start the Online Webinar sessions for APAC region
+*   How we can grow our team?
+    *   They are interested in helping, but we need to define tasks to take actions
+    *   Outline strategy of onboarding, and involving more people
+    *   Create a GitHub issue and share it to slack channels
+*   Community Outreach
+    *   Work on presentations, talks we can give to our local developer communities
+*   Sync better with the SIG
+    *   Try to join the SIG meetings or watch videos to get better understandings and communications
+    *   Remember the goal to bring the APAC meeting back
+
+
+## July 3
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Dawn Foster
+*   Paris Pittman
+*   Jay Pipes
+*   Nikhita Raghunath
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   [SIG Meet & Greet / SIG F2F PR](https://github.com/kubernetes/community/pull/3859) - Dawn
+    *   Issue Triage
+    *   Charter 
+
+
+## June 27 - APAC topics
+
+Canceled due to no agenda and Yang’s conflict
+
+
+## June 26
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Jeffrey Sica
+*   Nikhita Raghunath
+*   Dawn Foster
+*   Bob Killen
+*   Paris Pittman
+*   Jay Pipes
+*   Naeil Ezzoueidi
+*   Łukasz Gryglicki, CNCF
+*   Jorge Castro
+*   Jonas Rosland
+*   Aaron Crickenberger
+*   Sahdev Zala
+*   Arnaud Meukam
+*   Christoph Blecker
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+            *   Halfway through doc on how to do it
+        *   Community Meeting [jorge]
+            *   Scheduled out through July 18th, including demos
+            *   [Leads scheduling spreadsheet](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895)
+            *   Ihor running July 4th with cli and node
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/paris/josh]
+            *   Josh to provide update on (apparently awesome) summit in Shanghai
+            *   All good to go in planning on San Diego contributor summit
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Schedule for July meetings
+        *   1st and 3rd for biweekly meetings
+    *   FYI: updated docs in test-infra
+        *   [https://github.com/kubernetes/test-infra](https://github.com/kubernetes/test-infra)
+        *   [https://github.com/kubernetes/test-infra/tree/master/config/jobs](https://github.com/kubernetes/test-infra/tree/master/config/jobs)
+        *   Please provide feedback on above updated docs
+    *   DevStats dashboard for New Contributor Workshop attendees? [Jonas]
+        *   Take this as part of the [mentorship program](https://github.com/kubernetes/community/tree/master/mentoring)?
+        *   Jonas will work with Bob on getting raw data, and then go from there.
+    *   Subprojects expecting to get updates from next meeting
+        *   help :)
+    *   Discussion around the grey area/scope for slack-infra versus contrib-ex. Tooling versus policy. Who owns what? Table discussion for later
+
+
+## June 19 (recording)
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Paris Pittman
+*   Bob Killen
+*   Jeffrey Sica
+*   Chris Short
+*   Jonas Rosland
+*   Sahdev Zala
+*   Naeil Ezzoueidi
+*   Jorge Castro
+*   Vonguard
+*   Christoph Blecker
+*   Josh Berkus
+*   Imran Pochi
+*   Meukam Arnaud
+*   Saiyam Pathak
+*   Guinevere Saenger
+*   Dawn Foster
+*   Yang Li
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Need to update invite
+            *   No longer doing “west coast edition” till better time can be arranged.
+        *   Meet Our Contributors [paris]
+            *   Still working on docs for hosting
+            *   Good for July session
+        *   Community Meeting [jorge]
+            *   Good for release team retro tomorrow.
+            *   Seeking replacement for a few weeks in July (jorge on vacation).
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Reminder to sigs for community meeting sig updates
+                *   setup calendar appointments to sigs for their scheduled update?
+                    *   put on shared sig calendar?
+                *   Does not need to be a chair to give an update.
+                *   Make it clear that “no update since last update” is still an update.
+                *   Update slide template with suggested guidelines from community repo.
+                *   Update community template itself with suggested guidelines.
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Shanghai:
+                *   Had to adjust schedule due to complications with the Conference center.
+                *   Making a few changes to the NCW
+                *   “Harbor box” will be there
+                    *   For future, it must be hw there or hand carried in to avoid problems with customs.
+                *   “Current” contributor track will be more aligned to 201.
+                *   Yang will tackle the contribex intro session.
+            *   San Diego:
+                *   1st meeting kicked off this Monday.
+                *   More roles opening up in the future.
+                *   Content proposal will be coming up next week.
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   APAC Meeting [paris]
+        *   Working on recruiting for more APAC members.
+        *   Eventual goal is to have their own meeting.
+    *   Subproject meetings [paris]
+        *   Reaching out to subproject owners for scheduling other meetings.
+        *   “Documentation” could be moved to non-code contributing timeslot or do a “slack” standup.
+    *   [Review request](https://github.com/kubernetes/community/pull/3622) [sahdev]
+        *   Need to create guidelines on what defines a milestone.
+        *   Looking for more input on labels.
+        *   Going to merge and iterate.
+    *   Bloggers [paris]
+        *   Looking for more bloggers.
+        *   Need to write the rolebook.  
+    *   Travel support program - 
+        *   [https://github.com/kubernetes/community/issues/3783](https://github.com/kubernetes/community/issues/3783)
+            *   jorge going to assist
+        *   Looking to write up procedure or questions as a MVP
+            *   Discuss sharing/working with CNCF on storing data (GDPR etc)
+        *   Information gathered will help with future events and planning.
+    *   Heads up - SIG Usability is at steering
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Triage issues without assignees or milestone
+
+
+## June 13 - APAC topics (bootstrap)
+
+Attendees:
+
+
+
+*   Yang Li
+*   Alison Dowdney
+*   Aravind Putrevu
+*   Saiyam Pathak
+*   Welcome
+    *   CoC
+    *   Introduction to this meeting, Purpose
+        *   APAC contributors not very active to rest of kubernetes community
+            *   Timezones, Languages
+        *   Make specific effort to address these issues
+    *   Introduction to contributors of this effort
+*   APAC coordinator (issue: [https://github.com/kubernetes/community/issues/3693](https://github.com/kubernetes/community/issues/3693))
+    *   speaking at meetups and local events about the work that happens in contributor experience
+        *   Getting the word out there about how to contribute
+    *   writing blog posts about the same in multiple languages (coordinating translation when necessary)
+    *   Translation for the community website
+        *   A large number of contributors from China, helping extend the docs, encouraging other people to join.
+        *   More visibility on contributions/How to get involved, for APAC.
+    *   helping us with regional boards on discuss.kubernetes.io
+        *   Promote topics on discuss within slack
+    *   APAC Slack Channels
+        *   Post more help-wanted issues within apac channels to get more people involved
+    *   helping us to run the APAC Contributor Experience update meeting
+        *   We can resume the APAC version of SIG meeting after we got enough attendees
+    *   writing the role book for this role that will live under /community/sig-contributor-experience
+        *   Work on ideas together within a google doc
+*   Open Discussion
+    *   Raising visibility of what apac coordinators are doing within kubernetes at meetups
+
+
+## June 12
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Chris Short, Red Hat
+*   Jonas Rosland, VMware
+*   Paris Pittman, Google
+*   Noah Abrahams, Ticketmaster
+*   Christoph Blecker, Red Hat
+*   Niko Pen, Freelancer
+*   Jorge Castro, VMware
+*   Stephen Augustus, VMware
+*   Jeffrey Sica, University of Michigan
+*   Marko Mudrinić, Loodse
+*   Naeil Ezzoueidi
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+            *   July volunteers needed!!! 730am
+        *   Community Meeting [jorge]
+            *   Lachie is tomorrow 
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Stephen email 
+        *   Contributor Summit(s) [jonas/josh/paris]
+
+			Barcelona:
+
+
+
+            *   Getting attendance numbers this week
+            *   Venue was really good for content 
+            *   Retro is tomorrow 
+            *   Deb Giles was a great help
+
+            Shanghai:
+
+*   Almost has a schedule 
+*   Needs to do social media pushes
+*   Blog needs to be approved
+
+            San Diego: 
+
+*   Mondays @ 10am - first meeting this monday
+*   [https://github.com/kubernetes/community/tree/master/events/events-team](https://github.com/kubernetes/community/tree/master/events/events-team)
+*   Team is formed!!
+*   [https://github.com/kubernetes/community/issues/3792](https://github.com/kubernetes/community/issues/3792)
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Project-wide Triage Workflow [nikopen] [https://github.com/kubernetes/community/issues/3456](https://github.com/kubernetes/community/issues/3456) 
+*   Why do we need this: Explicitly desired by many SIG Chairs. [https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/BvGmOQ0v5f0](https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/BvGmOQ0v5f0)
+*   Triage workflow overview, new automation and labels to help with that. \
+needs-triage [https://github.com/kubernetes/test-infra/pull/11818](https://github.com/kubernetes/test-infra/pull/11818) \
+Label rework | purge ‘triage’ labels [https://github.com/kubernetes/test-infra/pull/12814](https://github.com/kubernetes/test-infra/pull/12814)  \
+Standardization of project boards **guidelines **and a template project board. \
+Each SIG should have their own board, _however_ it should **not **be mandatory. \
+Example from SIG-Windows: [https://github.com/orgs/kubernetes/projects/8](https://github.com/orgs/kubernetes/projects/8)
+*   Automation on project boards for issues to receive labels automatically while shifting through columns & shift columns automatically while changing labels on issue directly. \
+As per [Hamel Husain](https://github.com/kubernetes/community/issues/3672#issuecomment-496672458 ) from Github this is easily achievable and they’re happy to help - it just needs to be hosted somewhere. \
+Any leads on hosting a bot like this?
+*   Milestone-specific improvements: \
+1. SIGs themselves should be deciding on what Enhancements and Bugfixes they are able to handle on an upcoming release beforehand. They should be able to determine their current workforce and schedule on a proactive basis. \
+2. Auto-apply current milestone on a merged PR. This is almost ready as a GitHub Action and as a Prow Plugin: [https://github.com/kubernetes/test-infra/issues/11611](https://github.com/kubernetes/test-infra/issues/11611) \
+[https://github.com/kubernetes/test-infra/pull/12968](https://github.com/kubernetes/test-infra/pull/12968)
+*   Documentation: Given consensus is reached and changes are implemented, old documents such as [issue-triage.md](https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md ) should be updated to reflect the current state of world. \
+Docs should be short, concise and presented as guidelines to follow and utilize the mechanisms that are in place for the benefit of everyone.
+*   Release team specifics: \
+Given all above are implemented, Bug Triage role will be mostly automated and a very few responsibilities could be delegated to another role.  \
+A dashboard that combines views of all SIG boards would be ideal to have for a birds-eye view of on-going work status on a given release, but IMO not necessary as Github search / milestones are pretty much ok.
+*   Various other improvements listed at the [bottom of first post in umbrella issue](https://github.com/kubernetes/community/issues/3456) , can be looked on at a later time to optimize flows.
+*   Proposed Actions: \
+1.  Merge needs-triage & label rework \
+[https://github.com/kubernetes/test-infra/pull/11818](https://github.com/kubernetes/test-infra/pull/11818) \
+[https://github.com/kubernetes/test-infra/pull/12814](https://github.com/kubernetes/test-infra/pull/12814)  \
+Global announcement on new changes, starting on gap period until 1.16 cycle begins \
+2. Project board template, automation and renewed docs on triage \
++ announcement \
+ \
+(A KEP structure has been proposed for all this but not sure about it - it’s meta changes for upstream, not for k8s the product per se.
+
+[convo notes: potentially make scope smaller, 
+
+
+
+*   Dawn and I wanna submit a community/contributor-related CFP for kubecon, would it be ok if we all just sync on what people are submitting so we can complement each other’s sessions? (Jorge) 
+
+
+## June 5 (recording)
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Elsie Phillips, Red Hat
+*   Dawn Foster, Pivotal
+*   Nikhita Raghunath, Loodse
+*   Hamel Husain, GitHub
+*   Paris Pittman, Googs
+*   Jeffrey Sica, UMich~
+*   Bob Killen, UMich
+*   Jorge Castro, VMware
+*   Sahdev Zala, IBM
+*   Nabarun Pal, rorodata
+*   Christoph Blecker, Red Hat
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Moving west coast office hours to another time
+        *   Meet Our Contributors [paris]
+            *   Same as office hours with time moving to a later one tbd
+            *   Want to be a panelist? Get in touch with paris or #contribex slack channel
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   San Diego Summit planning has begun
+                *   Shadow roles available
+
+                    [https://github.com/kubernetes/community/issues/3445](https://github.com/kubernetes/community/issues/3445)
+
+            *   Shanghai Contrib Summit
+                *   Current and new contrib workshop 
+                *   Blogpost this week to let people know
+                *   Still need help/missing test/infra topics
+                *   
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   [Issue Label Bot](https://github.com/marketplace/issue-label-bot) Demo/Discussion [Hamel Husain - GitHub] (Issue [3672](https://github.com/kubernetes/community/issues/3672))
+    *   Custom slack loading messages [jorge]
+        *   Add helpful tips
+    *   Meeting Proposal [paris]
+    *   Roles are being created - please join us
+        *   Events team
+        *   Triage team
+        *   Marketing team 
+
+
+## May 22 ([LIVE @ KUBECON](https://youtu.be/R4AX1W18kSI))
+
+Attendees:
+
+
+
+*   Jonas Rosland
+*   Paris Pittman
+*   Elsie Phillips
+*   Dawn Foster
+*   Bob
+*   Jeff
+*   Noah
+*   Jorge
+*   Nikhita
+*   Christoph
+*   Guin
+*   Josh
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Should we have more east coast friendly times? 
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   
+        *   Contributor Summit(s) [jonas/josh/paris]
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Contributor summit retro
+        *   New contributor track
+            *   101: 
+                *   Tim Pepper Led
+                *   62 ppl registered
+            *   201:
+                *   Guin led
+                *   74 people registered
+        *   Current contributors track
+            *   SIG F2F - 13 SIGs participated
+            *   199 people registered
+        *   SIG meet and greet
+            *   Speed date SIGs
+        *   Location, communication, registration to improve for next time
+        *   Full retro later 
+*   GitHub Bots:
+    *   At the scale that k8s uses GitHub, having bots helps us scale and offload some tasks to our bot minions and frees up more time for real work.
+    *   GitHub status set to busy is now used by out GitHub bot so that people who are on vacation, away, or otherwise unable to review PRs will not be assigned new PRs. 
+    *   We developed a plugin that triggers when someone contributes their first PR to put an extra welcome message with a link to guides and other info to help people make that first contribution. This is now implemented across all k8s repos.
+    *   We have 5 orgs, 190 repos, 900+ unique members. K8s repo alone has 1000+ open PRs, 2000+ issues, which is why we need tools / bots to help us scale. 
+    *   We collaborate with SIG Testing on our infrastructure / CI tooling. 
+*   Mentoring tomorrow!!!
+    *   730am session with Paris
+    *   330pm session with Tim Pepper
+
+
+## May 15 ([recording](https://youtu.be/E8wsDVjAvjM))
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Dawn Foster
+*   Łukasz Gryglicki, CNCF
+*   Jonas Rosland
+*   Paris Pittman
+*   Jorge Castro
+*   Chris Short
+*   Elsie Phillips
+*   Christoph Blecker
+
+Agendas:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Finding a time that works with west coast folks 
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+            *   Dawns first meeting is tomorrow for hosting! \o/
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   BARCELONA IS IN A FEW DAYS!!!!!!!!!
+*   Open Mic/Discussion
+    *   [Intro for KubeCon](https://docs.google.com/presentation/d/1mlIdjFYC0ZXhKvDAyCCvVnBwWMddupu3RHVdyE1UuKQ/edit?usp=sharing)
+    *   Extend milestone
+
+
+## May 8 (Recording)
+
+Attendees:
+
+
+
+*   Paris (will be 5 mins late)
+*   Łukasz Gryglicki, CNCF
+*   Nikhita Raghunath
+*   Jeffrey Sica
+*   Jorge Castro
+*   Bob Killen
+*   Guin Saenger
+*   Sahdev Zala
+*   Tim Pepper
+*   Dawn Foster
+*   Ihor Dvoretskyi
+*   Aaron of SIG Beard
+*   Rael Garcia Arnes
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   West Coast Scheduling
+        *   Meet Our Contributors [paris]
+        *   Community meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Barcelona Contributor Summit
+                *   SIG Meet and Greet -> send people with good first issue 
+                *   Maybe clarify goals for each track 
+                *   Rooms will have preso screen - woo rah \o/ thanks to dawn and deb
+            *   nikhita : 
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   San Diego Summit planning punt until post Barcelona 
+*   Review [May Milestone](https://github.com/kubernetes/community/milestone/1)
+*   Open Mic/Discussion
+        *   [your name and topic here - should this be an issue against kubernetes/community?]
+        *   [We have an update tomorrow at the community meeting](https://github.com/kubernetes/community/issues/3661) - what should we highlight?
+            *   Mentoring, succession planning, creating roles/teams, owners files emeritus/clean up [paris]
+            *   We are trying to find better homes for things [paris]
+            *   Contributor summits [paris]
+                *   Reg still open for new contrib workshop in barcelona - spread the word
+            *   What else?
+        *   We also have an Intro that we will use mostly this same update \o/
+        *   Contrib Site [jorge]
+        *   Charter [jorge]
+
+
+## May 1 ([Recording](https://youtu.be/cLQgFGaSiqs))
+
+Attendees:
+
+
+
+*   Jonas Rosland
+*   Eduar Tua
+*   Paris Pittman
+*   Bob Killen
+*   Jeff Sica
+*   Dawn Foster
+*   Elsie Phillips
+*   Nikhita Raghunath
+*   Alex Handy
+*   Aaron Crickenberger
+*   Arnaud Meukam
+*   Sahdev Zala
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+            *   There **WILL** be one pre-kubecon.
+        *   Meet Our Contributors [paris]
+            *   Morning session went really well.
+            *   Did code-base tour for kubectl
+            *   100 people tuned in.
+        *   Community Meeting [jorge]
+            *   Need more hosts, sign up [here](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895).
+            *   GCP backing out to go under cloud provider
+            *   Lots of space freed up once cloud providers roll under sig-cloud-provider
+            *   Should working groups etc present?
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Reminder for contrib summit.
+            *   Note on docker images being removed.
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Barcelona:
+                *   finalizing comms to go out next week
+                *   248 people registered as of 4/30
+                *   current contributor track is close to capacity
+                *   harbor box as an artifact mirror is a go
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   k/k-wide triage workflow
+        *   Plan to revisit, but no traction at the moment.
+        *   moved to backlog
+    *   Umbrella issue for Reviews
+        *   moved to backlog
+    *   Umbrella issue for Community Maintenance Tasks
+        *   AI: Migrate to doc under contributor-experience directory instead of long-open task
+        *   address quarterly? annually?
+    *   Create more roles for contribex
+        *   Close to being done (everything in flight)
+        *   APAC meeting:
+            *   Low turn-out
+            *   Look for APAC coordinator to help advertise and facilitate interest in the APAC region.
+                *   Possibly reach out to sig-docs teams in APAC regions.
+            *   APAC task being spun out from ‘create more roles for contribex’
+    *   Revamp developer guide
+        *   Close to being done.
+        *   7 issues remain.
+*   Open Mic/Discussion
+        *   [your name and topic here - should this be an issue against kubernetes/community?]
+        *   Contrib Site update [jorge and b0b]
+            *   [Preview](https://kubernetes-contributor.netlify.com/)
+            *   [Code](https://github.com/kubernetes-sigs/contributor-site)
+            *   No longer being auto-generated from the community repo.
+                *   For content that will live on contributor site (e.g. contributor guide) a date will have to be picked to migrate over.
+            *   Current iteration is just various PoC content.
+            *   Look of the site is actively being improved.
+            *   AI: Send note to leads regarding formatting of calendar event names.
+            *   Content to move over before EU:
+                *   Contributor Guide
+                *   Events
+                *   Code of Conduct
+        *   Kubernetes Velocity Report? (Jonas)
+            *   [https://app.trendkite.com/report?id=70270dee-d7e1-4b1d-8948-12feec612055](https://app.trendkite.com/report?id=70270dee-d7e1-4b1d-8948-12feec612055)
+
+
+## April 24th (Recording)
+
+**APAC friendly timezone - 8pm PT!!!**
+
+**Meeting canceled @ 8:10pm PT**
+
+Attendees:
+
+	Paris Pittman
+
+	Bob Killen
+
+	Nikhita R
+
+	Christoph Blecker
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   Intro @ KubeCon and Community Meeting Update are coming up
+        *   Yay for being able to use similar decks [paris]
+        *   What do we want to highlight? 
+*   
+
+
+## April 17th ([Recording](https://youtu.be/1aQ_J0VnQOg))
+
+Attendees
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Eduar Tua
+*   Bob Killen
+*   Nikhita Raghunath
+*   Jonas Rosland
+*   Alex Handy
+*   Chris Short
+*   Dawn Foster
+*   Christoph Blecker
+*   Jeffrey Sica
+*   Sahdev Zala
+*   Aaron Crickenberger (@spiffxp), Google
+
+Agenda
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers; assign streamers to each event]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris]
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Barcelona Contributor summit
+        *   Contributor Summit(s) BCN [jonas/josh/paris]
+            *   F2F sessions confirmed and times locked in.
+            *   Invites for sched sent out to speakers.
+            *   202 current attendees approved.
+        *   Contributor Summit CN
+            *   Need additional people for current contributor sessions.
+            *   Contact jberkus if interested
+            *   WIll reach out to general speakers soon.
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Slack Infra (tempelis)
+        *   Need last sign off from leads [[PR](https://github.com/kubernetes/community/pull/3532)]
+        *   Slack[ guidelines](https://github.com/kubernetes/community/blob/master/communication/slack-guidelines.md) updated with new instructions. 
+        *   Slack management can be delegated (docs can manage docs channels)
+        *   looking into linking github ID -> slack ID for user group management
+    *   Commit msg prow plugin
+        *   waiting for consensus on ML, but should be enabled soon
+    *   enabling feja-bot org wide
+        *   waiting for consensus on ML
+    *   subproject details in sigs.yaml
+        *   need sign-off from steering on closing last issue
+            *   Aaaron will close.
+        *   2 PRs left to merge
+    *   add new roles to contribex
+        *   Needs final look over / hold release
+            *   Chirstoph will look at it
+    *   Building an issue triage team
+        *   4 person team assembled
+        *   Sahdev working on triage guidelines
+            *   Basing it off k/k triage guidelines along with release team triage guidelines.
+    *   contributor summit role book
+            *   In progress, folks are working on individual roles 
+                *   Bob working on reg role
+    *   Contributor workflow doc
+        *   Eduar should complete soon
+    *   link checker
+        *   Aaaron and Cristoph will double check on issue,, might be unblocked going forward.
+*   Open Mic/Discussion
+    *   YouTube
+        *   Karen Chu (kchu) is "taking a crack" at YouTube bumpers
+        *   Need to get time to get git good (I might reach out for help on fixing [PR 3542](https://github.com/kubernetes/community/pull/3542/); first time with a commit in this [workflow](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md))
+        *   Chris will close and reopen with new PR.
+    *   [New triage workflow](https://github.com/kubernetes/community/issues/3456)
+        *   No progress
+    *   Needs rebase will now be red like other blocking labels.
+    *   OWNERS cleanup
+        *   Need to craft language and sort out what defines emeritus inactive etc.
+    *   Charter
+        *   Jorge will follow-up with Michelle and Brandon
+
+
+## April 10th ([Recording](https://youtu.be/MS0AB0Sm6iA))
+
+Attendees:
+
+
+
+*   Elsie Phillips
+*   Paris 
+*   Eduar Tua
+*   Nikhita
+*   Jeff Sica
+*   Bob Killen
+*   Łukasz Gryglicki, CNCF
+*   Jorge Castro
+*   Alex Handy
+*   Christoph Blecker
+*   Dawn Foster
+*   Aaron Crickenberger (@spiffxp), Google
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers; assign streamers to each event]
+        *   Office hours [jorge]
+            *   Sig-windows and sig-cluster-lifecycle is doing an out of band Office Hours
+        *   Meet Our Contributors [paris]
+            *   Kubectl code base in may
+            *   Good for may - yay
+        *   Community Meeting [jorge]
+            *   All set through KubeCon EU
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Summit - full on sig f2f
+            *   Surveys - how to get access
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   working on outline for NCW content
+            *   sig f2f are booked
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   update wg sigs.yaml with more info - in progress
+        *   waiting for chairs to sign off
+    *   sub-project details in sigs.yaml
+        *   subprojects have a slack channel / mailing list / calendar 
+*   Open Mic/Discussion
+    *   OWNERs files
+    *   Charter proposal (Jorge) 
+
+
+## April 3 ([recording](https://youtu.be/09jDT6Nu9C8))
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Elsie Phillips
+*   Jorge Castro
+*   Bob Killen
+*   Jeffrey Sica
+*   Alex Handy
+*   Eduar Tua
+*   Chris Short
+*   Łukasz Gryglicki
+*   Jorge Alarcon
+*   Christoph Blecker
+*   Arnaud Meukam
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]
+        *   Community Meeting [jorge]
+        *   Meet Our Contributors [paris]
+            *   Morning session went well afternoon session is lined up
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Putting sig f2f on repeat until deadlines / space is full
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   BCN:
+                *   NCW - guin looking for someone to do code base tour
+                *   Need more room facilitators - ping jonas if interested
+            *   Shanghai:
+                *   English app done, sent off to CNCF translators
+                *   Need to sort out how to advertise contributor summit to the right audience.
+                *   Need to attract people for current contribor track 
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+
+Open Mic:
+
+
+
+*   [bob] Owners file audit
+    *   AI: open a PR against community membership to propose emeritus status to define approver/reviewer/emeritus
+*   [jorge] Would like to propose changes to our charter: [https://github.com/kubernetes/community/pull/3526](https://github.com/kubernetes/community/pull/3526)
+*   [Josh] New application form for joining the release team 
+    *   Ready for the next cycle
+*   [Alex] Requirements doc for blogs
+
+
+### March 27 (Recording)
+
+Attendees:
+
+
+
+*   Jonas Rosland
+*   Paris Pittman
+*   Chris Short
+*   Dawn Foster
+*   Bob Killen
+*   Josh Berkus
+*   Elsie Phillips
+*   Tim Pepper
+*   Jorge Castro
+*   Vonguard
+*   Łukasz Gryglicki
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]
+        *   Community Meeting [jorge]
+        *   Meet Our Contributors [paris]
+            *   Next Wednesday - have a great lineup, very excited
+            *   Will send out tweets next week
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Putting sig f2f on repeat until deadlines / space is full
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Jonas - barca - swag update from jorge: luggage tags
+                *   Reg - 115 rsvps now
+                *   Hosting local container images for workshops - possibly using Harbor; will help scale events
+                *   Sched is up but filling out as we go; four sigs signed up for f2f time
+            *   Josh - shanghai 
+                *   Reg hasn’t opened yet; working on form 
+            *   Paris - San Diego
+                *   Full steam ahead with BCN and Shanghai, not much to update here yet
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Milestone May: [https://github.com/kubernetes/community/milestone/1](https://github.com/kubernetes/community/milestone/1)
+    *   Need some help with creating process doc: [https://github.com/kubernetes/community/issues/3175](https://github.com/kubernetes/community/issues/3175)
+    *   Need some immediate help with the community site: [https://github.com/kubernetes/community/issues/3388](https://github.com/kubernetes/community/issues/3388)
+    *   Need someone to write up a blog post regarding survey results - Alex and Chris on point \
+[https://github.com/kubernetes/community/issues/2802](https://github.com/kubernetes/community/issues/2802)
+    *   Revision of community meeting invite workflow: [https://github.com/kubernetes/community/issues/1665](https://github.com/kubernetes/community/issues/1665)
+    *   Waiting on steering to resolve the working groups sigs.yaml, as the owners of the last WG is unresponsive: [https://github.com/kubernetes/community/issues/3188](https://github.com/kubernetes/community/issues/3188)
+    *   Sahdev and Nikhita - Building a team for triage handling, 3-4 people
+        *   Creating a PR to get some information around triage guidelines, triage captain responsibilities with shadow, and more: [https://github.com/kubernetes/community/issues/3364](https://github.com/kubernetes/community/issues/3364)
+    *   Create more roles for contribex (event-team, marketing-team etc): [https://github.com/kubernetes/community/issues/3076](https://github.com/kubernetes/community/issues/3076)
+        *   Adding marketing + new contrib ambassador: [https://github.com/kubernetes/community/pull/3460](https://github.com/kubernetes/community/pull/3460)
+*   Open Mic/Discussion
+    *   [spiffxp] Proposal to enable `review_acts_as_lgtm` in the kubernetes/test-infra repo. See the [slack post](https://kubernetes.slack.com/archives/C09QZ4DQB/p1553208058692200) for details
+        *   GitHub reviews approve will now act as both /lgtm and /approve
+        *   General approval, will be run by contrib-x
+        *   /lgtm cancel will still remove the lgtm label
+    *   [jorge] - Can we turn the contributor site back on?
+        *   Just need contributor/developer guide, comms folder
+        *   Josh would like it to just be a standalone hugo site with the few pages there, not generating from k/community. SGTM.
+    *   [jeefy] - Moving @Katharine’s awesome slack-ops out of test-infra into some contribex repo
+        *   Aaron will send out a message to the mailing list to get this started
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+
+
+### March 20 (Recording)
+
+Attendees:
+
+
+
+*   Parispittman
+*   Bob Killen
+*   Nikhita Raghunath
+*   Jeffrey Sica
+*   Jonas Rosland
+*   Vlad Shlosberg
+*   Łukasz Gryglicki
+*   Noah Abrahams
+*   Eduar Tua
+*   Aaron Crickenberger
+*   Jorge Castro
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge] - all set, need to move calendar to the community calendar + still need help wrt. diversity.
+        *   Meet Our Contributors [paris] 
+            *   Stream of volunteers seems to be getting better - as always - need more
+            *   
+        *   Community Meeting [jorge] - all set
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Contributor summit f2f [again] barcelona; more info about reg
+            *   Slack is open
+            *   Calendar problems/calendar guideline updates 
+            *   
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Barcelona -
+                *   Blog post is live!
+                *   [https://kubernetes.io/blog/2019/03/14/a-look-back-and-whats-in-store-for-kubernetes-contributor-summits/](https://kubernetes.io/blog/2019/03/14/a-look-back-and-whats-in-store-for-kubernetes-contributor-summits/)
+                *   Registration is live!
+                *   [https://events.linuxfoundation.org/events/contributor-summit-europe-2019/](https://events.linuxfoundation.org/events/contributor-summit-europe-2019/)
+                *   Tweets will go out tomorrow, Jonas will send out to k-dev and Discuss today.
+                *   Volunteers needed for TAs, registration desk, and SIG F2F facilitation
+            *   Shanghai - 
+                *   Have team!! \o/
+                *   Wants to do a social blitz
+                *   Be explicit about location when we are advertising so there is no confusion  
+                *   Put up registration 
+                *   NCW survey results - looking for changes to content; what goes in 101 vs 201
+            *   SD - building a team issue is live - [https://github.com/kubernetes/community/issues/3445](https://github.com/kubernetes/community/issues/3445)
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   No open mic discussion this week unless we can get through the project board
+
+
+### March 13 ([Recording](https://www.youtube.com/edit?o=U&video_id=2wcpj2oip7E))
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Jorge Castro
+*   Noah Abrahams
+*   Alex Handy 
+*   Vlad Shlosberg
+*   Tim Pepper
+*   Łukasz Gryglicki
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   W55ould any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge] - all set
+        *   Meet Our Contributors [paris] 
+        *   Community Meeting [jorge] - all set
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+*   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [nikhita] PSA: we have a new channel on slack #pr-reviews to help people find reviewers.
+        *   Tim - we should pin a summary doc in that channel. 
+    *   Slack is back \o/ - new moderator process still processing new people. 
+
+
+### March 6 (Recording)
+
+Attendees:
+
+
+
+*   Elsie Phillips- Red Hat
+*   Bob Killen - University of Michigan
+*   Dawn Foster - Pivotal
+*   Łukasz Gryglicki, CNCF
+*   Nikhita Raghunath, Loodse
+*   Jonas Rosland, Tim Pepper, Jorge Castro - VMware
+*   Vlad Shlosberg, Foqal
+*   Ihor Dvoretskyi, CNCF
+*   Eduar Tua
+*   Paris Pittman, googs
+*   Sahdev Zala - IBM
+*   Alex Handy - Red Hat
+*   Arnaud Meukam - Alter Way
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge] - set for the week
+        *   Meet Our Contributors [paris]
+            *   Updating the docs next week 
+            *   Need help figuring out transcripting 
+            *   Always need more people to volunteer for one hour (help 100!)
+        *   Community Meeting [jorge]
+            *   Moderator set for this week and next (Paris this week & Jonas next)
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Backlog grooming / issue triage doc - do you have one? If so, link it to us; we can make a template.  Example from SIG Cluster Lifecycle: [https://github.com/kubernetes/community/blob/master/sig-cluster-lifecycle/grooming.md](https://github.com/kubernetes/community/blob/master/sig-cluster-lifecycle/grooming.md) 
+            *   [API Review process](https://git.k8s.io/community/sig-architecture/api-review-process.md) - put it in your meeting notes, provide comments
+            *   Shoutouts channel on slack #shoutouts to name and recognize helpful folks’ actions
+            *   OWNERs file graduation gifts: a contributor coming into an OWNERS file as reviewer or approver can receive a contributor patch
+            *   Maybe one more?
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Jonas
+                *   [Email](https://groups.google.com/a/kubernetes.io/forum/#!topic/steering/cWBW76Fydec) went out to Steering on Monday with the content proposal
+                *   Event website will be live early next week, pending design by CNCF
+                    *   Blog post will be published to announce the BCN Summit and event website
+                *   Registration will be live shortly, targeting at the latest late March - will also have branding completed by then
+                *   Josh doing t-shirt design for Barcelona
+            *   Paris
+                *   San Diego - starting to form team of volunteers
+            *   Josh
+        *   Issue triage update
+            *   3-5 people team 
+            *   If interested, get in contact with Sahdev or add name below 
+            *   [https://github.com/kubernetes/community/issues/3364](https://github.com/kubernetes/community/issues/3364)
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Gsuite
+        *   Moderators in place \0/
+
+
+### Feb 27 (Recording)
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Eduar Tua
+*   Noah Kantrowitz
+*   Christoph Blecker
+*   Josh Berkus
+*   Yang Li
+*   Rui Chen
+*   Chris Short
+*   Ming Hsieh
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+*   Open Mic/Discussion
+    *   Slack update if people are interested [noah k]
+    *   Doing a small change to the kubernetes codebase - Tutorial [Eduar T]
+    *   Contributor Summit Shanghai work meeting in 10 hours [jberkus]
+    *   Chirstoph’s going to take a vacation next month [cblecker]
+
+
+### Feb 20 (Recording)
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Bob Killen
+*   Noah Abrahams
+*   Noah Kantrowitz
+*   Paris Pittman
+*   Dawn Foster
+*   Vlad Shlosberg
+*   Tim Pepper
+*   Arnaud Meukam
+*   Aaron Crickenberger (@spiffxp)
+*   Eduar Tua
+*   Sahdev Zala 
+*   Jonas Rosland
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]
+            *   Could always use more people 
+            *   Diversity issue -> need to figure this out
+            *   Things are going good though
+        *   Meet Our Contributors [paris]
+            *   Could always use more people
+            *   Mentors on demand!!
+        *   Community Meeting [jorge]
+            *   Contribex is up this week! What should we share? We will give our usual subproject updates. 
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [jonas/josh/paris]
+            *   Jonas: third meeting happened on Monday for Barcelona. Jorge is taking swag; Paris is taking marketing lead. Still need some more folks to help out. Paris is looking at an events landing page. Bob is looking at reg process/workflow. Dawn is working on content proposal right now. Ihor created a project board for contrib summits - yay! Photographer will be onsite.
+            *   Josh: told cncf about rooms for Shanghai. Will most likely convene first meeting next week. Core team is in place. May or may not need volunteers but will know more in the upcoming weeks. 
+            *   Paris: San Diego is almost underway. CNCF has been notified as to light space requirements. A call for a team of volunteers will be underway next week. 
+            *   EU project board:
+                *   [https://github.com/kubernetes/community/projects/4](https://github.com/kubernetes/community/projects/4)
+            *   CN project board:
+                *   [https://github.com/kubernetes/community/projects/5](https://github.com/kubernetes/community/projects/5)
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+            *   If you need something from christoph, ping him now.
+            *   Github management is working on documenting processes
+*   Open Mic/Discussion
+    *   [Deprecating Gubernator in favor of Spyglass](https://github.com/kubernetes/test-infra/pull/11302) [Katharine Berry]
+        *   Will send a note to k-dev when they are there
+    *   [SIG Roles](https://github.com/kubernetes/community/issues/3076)
+        *   volunteers:
+            *   issue triage: Arnaud, Bob, Paris, Nikhita
+            *   events: Jonas, Bob, Paris
+            *   blog: Noah A, Elsie
+            *   moderation: Jeff, Bob
+    *   Developers guide update [WIP] PR [[3245](https://github.com/kubernetes/community/pull/3245)]
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   Shutting down old WGs
+        *   [Umbrella issue](https://github.com/kubernetes/community/issues/3188)
+        *   
+
+
+### Feb 13 ([Recording](https://youtu.be/avq0R5-4lGY))
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Nikhita Raghunath
+*   Bob Killen
+*   Tim Pepper
+*   Jeffrey Sica
+*   Jonas Rosland
+*   Vlad Shlosberg
+*   Eduar Tua
+*   Jorge Castro!
+*   Noah Abrahams
+*   Rui Chen
+*   Lindsey Tulloch
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]
+        *   Meet Our Contributors [paris] - need more volunteers
+        *   Community Meeting [jorge]
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris] - need more tips
+        *   Contributor Summit(s) [paris/whoever]
+            *   1st meetings kicked off
+                *   Shanghai: Josh Berkus running
+                *   Barcelona:
+                    *   Jonas Rosland running
+                    *   [https://docs.google.com/document/d/1l9Po3kE2J7QOfflH5dPQgfHTpXmweUNEcNBDIPj8VtA/edit](https://docs.google.com/document/d/1l9Po3kE2J7QOfflH5dPQgfHTpXmweUNEcNBDIPj8VtA/edit) 
+                    *   Need Marketing & Comms lead + Swag lead - reach out to jonas on slack - @jonasrosland 
+            *   CNCF event planners are on site in Barcelona
+            *   CNCF event staff contact - Deb Giles 
+                *   slack: @Deb Giles
+                *   email: dgiles@linuxfoundation.org
+*   Slack incident follow-up
+    *   Sign-ups remain offline
+    *   Webhooks and api integrations are offline excluding a very selective few (GitHub)
+    *   No confirmation from Slack that they are fixing the notification bug
+    *   Reaching out to end-user community to discuss Slack moderation.
+        *   Goes beyond contributor experience -> end user, community, consumer experience
+        *   Use slack for contributor activity, but not end-user activity
+        *   Need more moderators, at least for the duration to help combat possible spam/trolls
+        *   Need at least 3 moderators online around the clock
+        *   CNCF will provide 1 additional moderator, but are the stance that it should be handled by the community
+    *   Many more communities in kubernetes slack beyond “just” kubernetes e.g. Helm and other projects.
+    *   Need to do a risk assessment of Slack itself and what is reasonable response/level of moderation.
+        *   Group that did the initial attack has a pattern history of repeatedly going after the same channels and groups.
+        *   Is the risk tolerable to keep things open.
+        *   Need to protect our user-base from potential harassment
+            *   Repeated targeted harassment completely negates the trust for the community. 
+    *   Moderation Tools
+        *   Slack doesn’t support an IRC Channel Moderator role
+        *   Could build something; don’t have resources
+        *   Sign-ups
+            *   block certain known “bad” domains and gateways (done)
+                *   Block list deployed to other slacks has been effective “so far”
+            *   Moderation: what questions would we ask people to prove they’re legit?  Easier for developer/community than end user/consumer?
+        *   Restrict users from joining specific channels e.g. restrict to #kubernetes-users
+            *   [single channel guests](https://get.slack.help/hc/en-us/articles/202518103-Multi-Channel-and-Single-Channel-Guests)
+        *   Discuss (discourse) has significantly better moderation tools
+        *   What are Slack’s permissions for moderators?  Moderator gets a lot of access/power on the Slack instance.  Real risk in having a bad moderator.  Today though they have to be a community member.  Risk of their login being stolen.
+        *   CNCF can potentially fund the development of tools, but it’d be contract work and would require being very spec’ed out.
+    *   Plan: 
+        *   Bring up end user group and user representation with SC
+        *   Reach out to end user community and ToC to get more moderators (currently restricted to org members)
+        *   Open up registration once we have enough moderators to cover all timezones etc
+        *   If it continues to be a problem, slack moves to contributor only and end-users are routed to discuss.
+*   Open discussion:
+    *   contribex F2F: KubeCon Barcelona
+    *   Mailing List Moderation Changes: 
+        *   Google group changes going through in May will remove new user moderation queue. Moderation will be either ON or OFF.
+        *   Paris investigating options internally at Google.
+
+
+### Feb 6 (Recording)
+
+Attendees:
+
+
+
+*   Josh Berkus
+*   Paris Pittman
+*   Tim Pepper
+*   Sahdev Zala (leaving early - 30 mins)
+*   Noah Kantrowitz
+*   Eduar Tua
+*   Noah Abrahams
+*   Jonas Rosland (only first 30 minutes)
+*   Christoph Blecker
+*   Jorge Castro
+*   Vlad Shlosberg
+*   Dawn Foster
+*   Elsie Phillips
+
+Agenda:
+
+
+
+*    Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: [collect updates before the meeting; host to read actions; collect questions/answers]
+        *   Office hours [jorge]: nothing new to report, is coming next month
+        *   Meet Our Contributors [paris]: redoing relative to public steering committee.  Need to poll k-dev for folks inputs on times that work best for community.  Add evening edition?  This morning’s had speakers need to cancel, so meeting cancelled.  Have full set of folks for today’s midday call.  As always looking for next speakers
+        *   Community Meeting [jorge]: continuing to have good stream of folks volunteering.  Demo (GitLab demo flaked, again) shifted to backup alternate demo.  No KEP for this week.
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+        *   Contributor Summit(s) [paris/whoever]
+            *   Meetings are scheduled, next week kick off
+            *   Fully staffed (~10 people) for Barcelona
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion
+    *   [your name and topic here - should this be an issue against kubernetes/community?]
+    *   SIG Networking Meeting tomorrow
+    *   Non-Code meeting at 11 today
+    *   [RETRO - SLACK INCIDENT](https://docs.google.com/document/d/1R96x3jUXQYPduJ0gsWiZ1KBFGQGizZH1_RX_CU4ueZk/edit?usp=sharing) (see that link for detailed info)
+        *   Timeline:
+            *   Late Pacific time Kubernetes users channel had an @ all of 50k people
+            *   Paris ping’d the person to check why they were @’ing channel
+            *   At same time porn started coming in too
+            *   #kubernetes-users, #helm, and multiple major open source communities were targeted, probably because they have large number of users.
+            *   Paris removed the person and pinged our moderators/admins for additional help
+            *   More griefers/bots arrived, bigger problem than typical small scale maliciousness
+            *   Set of admin’s worked to contain
+        *   Next actions:
+            *   <span style="text-decoration:underline;">Jorge has a PR</span> for moderator improvements we could do: [https://github.com/kubernetes/community/pull/3212](https://github.com/kubernetes/community/pull/3212)
+            *   Formalize ‘incident coordinator’ role to split comm’s and organizing from those who are actively squashing things in the moment
+    *   SIG Intro / Deep Dive session proposals for Barcelona? (Due Friday this week)
+        *   Elsie will submit
+
+
+### Jan 30 (Recording)
+
+Attendees:
+
+
+
+*   Paris Pittman
+*   Noah Abrahams
+*   Bob Killen
+*   Nikhita Raghunath
+*   Eduar Tua
+*   Jeffrey Sica
+*   Brian Topping
+*   Noah Kantrowitz
+*   Yang Li
+*   Christoph Blecker
+*   Benjamin Elder
+*   Aaron Crickenberger
+*   Chris Short
+
+Welcome and recurring business 
+
+
+
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates:
+        *   Office hours [jorge]
+            *   Feb 20th 
+        *   Meet Our Contributors [paris]
+            *   Feb 7th
+        *   Community Meeting [jorge]
+            *   Jeff this week
+            *   Josh next week
+        *   [Need to Know Chairs/TLs email](https://docs.google.com/document/d/1ivmV-ouim7YcTnmv21m0pP6prmj-FFZxcRBuWbT706c/edit?usp=sharing) [paris]
+            *   Mailing list moderation
+            *   SIG Roles
+            *   F2F meetings
+            *   Need more mentors
+            *   Maybe one more that is short and sweet?
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Open Mic/Discussion
+            *   Picking up operations of bi-weekly public Steering Committee meetings
+            *   Create more roles for contribex - anything I’m missing? [https://github.com/kubernetes/community/issues/3076](https://github.com/kubernetes/community/issues/3076)
+            *   Last call for review on style guide? - [https://github.com/kubernetes/community/pull/3125](https://github.com/kubernetes/community/pull/3125)
+            *   Follow-up on contribex f2f - [https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/9olx_nDmogs](https://groups.google.com/forum/#!topic/kubernetes-sig-contribex/9olx_nDmogs)
+            *   Meta APAC meeting talk:
+                *   Where do we advertise?
+
+
+### Jan 23 [(Recording)](https://youtu.be/xrgkuARpAS4)
+
+Attendees:
+
+
+
+*   Łukasz Gryglicki, CNCF
+*   Bob Killen
+*   Jeffrey Sica
+*   Paris Pittman
+*   Nikhita Raghunath
+*   Jonas Rosland, VMware
+*   Chris Short, Red Hat (because Jonas did it)
+*   Lindsey Tulloch
+*   Dawn Foster
+*   Sahdev Zala
+*   Jorge Castro (so happy to be here!)
+*   Christoph Blecker
+*   Eduar Tua
+*   Guinevere Saenger
+*   Marky Jackson (sysdig)
+*   Tim Pepper
+*   Hannes Hoerl
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Office Hours [jorge]
+            *   Needs more voices and diverse 
+            *   Ideally 3 office hours (including EMEA)
+            *   Things are pre-packaged, we could hand off scripts and whatnot. 
+            *   Do we want to try to do native-language OHs?
+        *   Meet Our Contributors [paris]
+            *   Need folks for Feb edition @ 730a PT [emea friendly]
+            *   Thinking about doing a 7pm PT - would that have impact/value?
+            *   Would we benefit from an “evening” MoC?
+                *   Evening Contribex meeting is well attended
+                *   Currently have a 7:30AM PST and 1PM PST
+        *   Community Meeting [jorge]
+            *   SIGs scheduled through August (Leads contacted)
+            *   Penciled in when (potentially) the release retros would be
+            *   Volunteers for hosts are appreciated. 
+        *   Weekly Need to Know email for chairs and TLs [what topics do we hit?]
+            *   Meet our contributors
+            *   Create roles
+            *   ?
+        *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+*   Open Mic/Discussion 
+    *   [welcome to all; add your name and topic suggestion below]
+    *   [should this be an issue against k/community?]
+    *   Bob - [Style Guide](https://github.com/kubernetes/community/pull/3125) Discussion and Review
+        *   From the contrib site work, it was realized that a lot of docs are out of date. 
+        *   For future docs, a style guide is needed before more work can happen
+        *   Based on the style guide from Kubernetes.io, but slightly more firm (with inspiration from other various high level guides)
+        *   
+      *   Timezones are hard. 
+            *   GMT over UTC? Let’s not Bikeshed
+        *   Top big things of note:
+            *   Use reference links
+            *   Preference on Line Length
+    *   Anita - OSU
+        *   [https://opensource.com/article/18/8/inclusivity-bugs-open-source-software](https://opensource.com/article/18/8/inclusivity-bugs-open-source-software)
+        *   Can the tools we use impact inclusivity? How do gender and software relate? (Gender bias bugs)
+        *   Curb cuts -- by addressing this now we help more than just the immediate biases 
+        *   GenderMag - Gender Inclusiveness Magnifier. Evaluate your tools’ inclusiveness. 5 cognitive facets identified.
+            *   Motivations
+            *   Information processing style
+            *   Computer self-efficacy
+            *   Risk averseness
+            *   Tech learning style (tinkering)
+        *   Ignoring different facets leaves behind a lot of talent.
+        *   Field study with 5 different OSS projects 
+            *   Walked through all use cases
+            *   Collected all facets
+            *   >50% # with gender bias
+    *   [spiffxp] - [https://github.com/kubernetes/test-infra/issues/10846](https://github.com/kubernetes/test-infra/issues/10846) - how should we handle tide vs staging repos [spiffxp]
+    *   [spiffxp] - [https://github.com/kubernetes/k8s.io/pull/169](https://github.com/kubernetes/k8s.io/pull/169) - added sig contribex TL’s to k8s.io root OWNERS ([k8s.io is listed as a contribex subproject](https://github.com/kubernetes/community/tree/master/sig-contributor-experience#subprojects))
+    *   [spiffxp] - I’ve heard no objections about [nikhita for github admin team](https://groups.google.com/d/msg/kubernetes-sig-contribex/Oin3mGNRwNg/2gDnVdqFFAAJ) 
+    *   [spiffxp] - [https://github.com/kubernetes/test-infra/issues/10834](https://github.com/kubernetes/test-infra/issues/10834) - enable owners-label for all
+    *   [Guin] Barcelona New Contributor workshop: who, what, when?
+        *   Jonas will gladly help out here (had to step out early)
+    *   [Eduar] Developer Guide progress.
+
+
+### Jan 16 ([Recording](https://youtu.be/QMCGb5un8Gw))
+
+Attendees:
+
+
+
+*   Paris - not attending but acting as a ghost on this doc
+*   Eduar Tua
+*   Bob Killen
+*   Hannes Hoerl
+*   Elsie Phillips
+*   Lindsey Tulloch
+*   Łukasz Gryglicki, CNCF
+*   Dawn Foster
+*   Matt Jarvis
+*   Guinevere Saenger
+*   Noah Abrahams
+*   Tim Pepper
+*   Ibrahim AshShohail
+*   Yang Li
+*   Nikhita Raghunath
+*   Christoph Blecker
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Need to know email for chairs and tls - weekly - paris
+            *   What should we share with them this week?
+            *   Maintainer track form for eu (Paris)
+            *   Meet our contributors (Paris)
+            *   Our charter was merged and read how we (contribex) communicate (Paris)
+            *   Carving out roles for your sig (Paris)
+            *   ?
+        *   Office Hours
+        *   Meet Our Contributors - Need more always - reach out to Paris
+        *   Community Meeting
+            *   [Host schedule](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895), please volunteer
+            *   Need more demos
+            *   Contributor Tip of the Week for community meeting?
+                *   Need more tips from the general community (contribex)
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+        *   Review blocked column. 
+            *   [subproject details](https://github.com/kubernetes/community/issues/2619)
+                *   debate still going on sigs.yaml and subprojects / subproject details
+                *   Looking for someone else to take on
+                *   Needs steering committee support
+        *   [update sigs.yaml with more wg info](https://github.com/kubernetes/community/issues/2176) - **no longer blocked**
+            *   progress made by nikhita
+        *   Working on a live contribex project - Do a quick standup?
+*   Open Mic/Discussion
+    *   [should this be an issue?]
+    *   [your name and topic here]
+    *   Jose Palafox, Intel - Contributor mentorship program at Intel for OSS release?
+        *   Intel built internal mentorship program
+        *   Has a good amount of material, slides etc that could be donated to Kubernetes community.
+        *   They can demo some of the material they have at the **meeting on the 30th** 
+    *   Our charter was merged as mentioned above. Please read the [how we communicate](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/charter.md#cross-cutting-and-externally-facing-processes) changes please. Charter will be revisited on July 1st. 
+    *   KubeCon EU-Intro? Deep dive?
+        *   Merged might be a problem with 80min to block out
+            *   Could become ‘face-to-face’ meeting with contributors who may not be able to often make the weekly meeting.
+        *   Turn it into a working session
+            *   work on the developer guide, wrangle other documents in the community repo.
+        *   **AI: **Discuss over the mailing list, come to a conclusion on it in 2 weeks (Jan 30th meeting)
+    *   KubeCon ShangHai - intro only
+    *   Face to face meeting?
+        *   Host during another conference? (IndexCon)
+            *   Previous one was not very productive, but little lead time.
+            *   Possibly try and attach it to one of the other kubernetes related events (non KubeCon)
+            *   Conference Ideas:
+                *   OSCon (July 15-18)
+                *   Google Next (April 9-11th)
+                *   Scale (March 7-10)
+                *   Prefer before Barcelona
+        *   **AI: **Take dates and ideas to mailing list
+    *   DevStats separate meeting has been getting less people, should be brought into main ContribEx meeting
+    *   Oops implicit self-approve got rolled out [spiffxp]
+        *   **AI: **I’m totally not sure of this timeline, suggest an issue and someone with more time than me to followup
+        *   [Sig-testing’s deploy policy](https://github.com/kubernetes/community/blob/master/sig-testing/charter.md#deploying-changes)
+        *   [Sig-contribex’s deploy policy](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/charter.md#cross-cutting-and-externally-facing-processes)
+        *   Dec 10 not sure if this is the root cause PR? [https://github.com/kubernetes/test-infra/pull/10435](https://github.com/kubernetes/test-infra/pull/10435) 
+        *   Dec 10 notify k-dev@ of k/community change [https://groups.google.com/forum/#!msg/kubernetes-dev/oWbV6uiQMIM/0ku8cvSZBgAJ](https://groups.google.com/forum/#!msg/kubernetes-dev/oWbV6uiQMIM/0ku8cvSZBgAJ) 
+        *   cblecker rolled the change into test-infra
+        *   Dec 19 last prow deploy before holiday lull [https://github.com/kubernetes/test-infra/pull/10504](https://github.com/kubernetes/test-infra/pull/10504) 
+        *   Jan 7 first prow deploy after holiday lull [https://github.com/kubernetes/test-infra/pull/10532](https://github.com/kubernetes/test-infra/pull/10532)
+        *   ??? - another change landed in test-infra that modified the default behavior to mimic the change
+        *   Jan 9 Change went in 6 days ago that pushed the new-default live
+        *   Jan 15 reports of something amiss in #sig-testing
+        *   Jan 15 Rollbackish PR (still not deployed) [https://github.com/kubernetes/test-infra/pull/10782](https://github.com/kubernetes/test-infra/pull/10782)
+        *   **AI: **No documentation on policy for rollback, how fast things should be rolled back etc
+        *   This instance was completely unintentional -- no notification / communication sent out
+        *   Long term goal to separate the prow codebase from the kubernetes prow configuration.
+            *   contribex could become the long term owners of the kubernetes prow config.
+            *   Discussion should be taken to the #prow channel.
+
+	
+
+
+
+    *   Eduar Tua -  Cleaning the /devel folder
+        *   Could we add a line that says `**Owner: SIG-name** `to docs that are not part of a SIG folder?
+            *   Move to design proposal layout so that they may have rights assigned via owners files.
+
+
+### Jan 9 ([Recording](https://youtu.be/KWbNnmxJ3Xg))
+
+Attendees:
+
+
+
+*   Josh Berkus
+*   Łukasz Gryglicki, CNCF
+*   Tim Pepper - VMware
+*   Bob Killen
+*   Jeffrey Sica
+*   Paris Pittman
+*   Dawn Foster
+*   Aaron Crickenberger
+*   Chris Short
+*   Nikhita Raghunath
+*   Jorge Castro
+*   Sahdev Zala 
+*   Matt Jarvis
+*   Christoph Blecker
+*   Yang Li
+*   Noah Abrahams
+*   Arnaud Meukam
+*   Ibrahim AshShohail
+*   Eduar Tua
+*   Guinevere Saenger
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Office Hours 
+            *   All set for next week
+        *   Meet Our Contributors - Need more always - reach out to Paris
+        *   Community Meeting
+            *   [Host schedule](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k/edit#gid=1543199895), please volunteer
+            *   Need more demos
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+        *   Ping Aaron today re: periobols
+
+Open Mic/Discussion
+
+
+
+*   Staffing Contributor Summits for Barcelona and Shanghai
+    *   Barcelona: lots of contribex folks intending to go
+    *   Shanghai: few contribex folks intending to go..Josh Berkus & Chris Short & Yang Li & ??
+*   Contributor Summit Feedback status
+*   Team management via Peribolos [Christoph]
+    *   [https://groups.google.com/d/topic/kubernetes-dev/dwHkzW6QyTU/discussion](https://groups.google.com/d/topic/kubernetes-dev/dwHkzW6QyTU/discussion) 
+*   Non-Code call at 11am PST
+*   Clarity of purpose for Contributor Playground: [https://github.com/kubernetes-sigs/contributor-playground/pull/216](https://github.com/kubernetes-sigs/contributor-playground/pull/216) - is this potentially a Chinese workaround? Not sure how to proceed
+
+
+### Jan 2
+
+Attendees:
+
+
+
+*   Nikhita Raghunath
+*   Łukasz Gryglicki, CNCF
+*   Matt Jarvis
+*   Sahdev Zala
+*   Dawn Foster 
+*   Noah Abrahams
+*   John Harris
+*   Eduar Tua
+
+Agenda:
+
+
+
+*   Welcome and recurring business 
+    *   CoC
+    *   Would any new contributors (or new to this SIG) like to give a brief introduction?
+    *   Regular program updates: 
+        *   Office Hours 
+        *   Meet Our Contributors - I need someone for 9pm UTC TODAY!
+            *   Just kidding - both of the livestreamers are ill and I’m canceling [paris]
+            *   But I do need more mentors for upcoming sessions!! 1 hour of your time for 1 year - not bad!! [paris]
+        *   Community Meeting - paris checking since Jorge is out
+            *   [ihor] this is on, and SIG UI, SIG Apps, and SIG VMWare will be updating us.
+    *   Review [project board](https://github.com/orgs/kubernetes/projects/1)
+    *   Open Mic / Discussion
+        *   [noah] Non-code contributor’s guide is going to ramp up efforts again after conferences/end-of-year hiatus

--- a/sig-contributor-experience/meeting-notes-archive/README.md
+++ b/sig-contributor-experience/meeting-notes-archive/README.md
@@ -1,0 +1,12 @@
+# Archiving meeting notes
+
+At the beginning of each year, archive the old Google docs into this repo to improve the performance of the current doc.
+
+### Convert meeting notes into markdown:
+
+1. Make sure you have a document (new or exisiting) with exactly the content you wish to store.
+2. Install [Docs2Markdown](https://github.com/evbacher/gd2md-html/wiki#using-docs-to-markdown)
+3. Open up Google Doc > Add-ons > Docs2Markdown > Convert [Markdown] (taking the unselected defaults)
+4. Select the output and paste into a document
+5. Clean up any reported errors (usually from embedded images)
+6. Add the new document to this repository


### PR DESCRIPTION
The meeting notes google doc is around 200 pages and getting pretty slow. This archives off the 2018 and 2019 notes.
Fixes #4737 
/assign @cblecker @nikhita @castrojo 

