### PR TITLE
docs: fix typo

### DIFF
--- a/contributors/devel/sig-api-machinery/strategic-merge-patch.md
+++ b/contributors/devel/sig-api-machinery/strategic-merge-patch.md
@@ -52,7 +52,7 @@ There are multiple directives:
 - delete
 - delete from primitive list
 
-`replace`, `merge` and `delete` are mutual exclusive.
+`replace`, `merge` and `delete` are mutually exclusive.
 
 ## `replace` Directive
 


### PR DESCRIPTION
mutual exclusive -> mutually exclusive

**Which issue(s) this PR fixes**: #4764