### PR TITLE
Add new slack channel: seccomp-operator

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -272,6 +272,7 @@ channels:
   - name: schemahero
   - name: se-users
   - name: sealed-secrets
+  - name: seccomp-operator
   - name: shippable
   - name: shipper
   - name: shoutouts


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Request for creating a new slack channel `seccomp-operator`.

This is a off-tree project to develop an operator to help users managing clusters that use custom seccomp profiles.

Topic: Seccomp operator - for easier management of seccomp profiles in Kubernetes.

**Which issue(s) this PR fixes**:
N/A