### PR TITLE
Add slack #jp-mentoring channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -113,6 +113,7 @@ channels:
   - name: jenkins-x-user
   - name: jp-dev
   - name: jp-events
+  - name: jp-mentoring
   - name: jp-users
   - name: jp-users-novice
   - name: jsonnet


### PR DESCRIPTION
This PR adds slack #jp-mentoring channel.
This channel is used for discussion and Q&A about mentoring in Japanese.
And also used for Q&A at Japan local upstream training.

**Which issue(s) this PR fixes**:

NONE