### PR TITLE
Add a slack group for Velero maintainers

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -39,6 +39,18 @@ usergroups:
   - name: test-infra-oncall
     external: true
 
+  - name: velero-maintainers
+    long_name: Velero Maintainers
+    description: Velero Maintainers group.
+    channels:
+      - velero 
+    members:
+      - ashish-amarnath
+      - carlisia
+      - nrb
+      - skriss
+      - stephbman
+
   - name: youtube-admins
     long_name: YouTube Admins
     description: YouTube Admin group. Ping for a YouTube-specific issue

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -49,7 +49,6 @@ usergroups:
       - carlisia
       - nrb
       - skriss
-      - stephbman
 
   - name: youtube-admins
     long_name: YouTube Admins

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -5,8 +5,10 @@ users:
   aleksandra-malinowska: U357LUPHS
   alisondy: U9CBCBLCV
   aravindputrevu: U1G27SDU6
+  ashish-amarnath: U65JLLS0J
   bubblemelon: U7K9C643G
   calebamiles: U1ZDD4CUR
+  carlisia: UBDSF40G2
   castrojo: U1W1Q6PRQ
   chrisshort: U2YGXSD9B
   cpanato: U8DFY4TTK
@@ -29,6 +31,7 @@ users:
   mbbroberg: U18JTHMDY
   mrbobbytables: U511ZSKHD
   nikhita: U2PQHGMLN
+  nrb: U7S597E00
   nzoueidi: UBU72MWP2
   onlydole: U1DD4AZND
   palnabarun: UBH9NTMBM
@@ -38,6 +41,8 @@ users:
   sammy: U8NJFL023
   saschagrunert: U53SUDBD4
   simplytunde: UAY1NBYHE
+  skriss: U43B14TNX
+  stephbman: U01283LTN93
   Sujay Pillai: UBW3N1VGW
   sumitranr: UCQN13L9H
   TaoBeier: UCLDV6MN1

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -42,7 +42,6 @@ users:
   saschagrunert: U53SUDBD4
   simplytunde: UAY1NBYHE
   skriss: U43B14TNX
-  stephbman: U01283LTN93
   Sujay Pillai: UBW3N1VGW
   sumitranr: UCQN13L9H
   TaoBeier: UCLDV6MN1


### PR DESCRIPTION
Please add a slack group for the [Velero](https://velero.io) maintainers.