### PR TITLE
feat(communication/slack-config): adding slack channels for Falco

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -73,6 +73,10 @@ channels:
   - name: events
   - name: external-dns
   - name: falco
+  - name: falco-projects
+  - name: falco-maintainers
+  - name: falco-drivers
+  - name: falco-maintainers-pvt
   - name: fiaas
   - name: fi-users
   - name: flink-operator


### PR DESCRIPTION


This PR adds new slack channels for [Falco](https://github.com/falcosecurity) CNCF project.

The initial and main channel was added by [4038](https://github.com/kubernetes/community/pull/4038).

After a [very long discussion](https://github.com/falcosecurity/falco/issues/983) with CNCF, we finally decided to move the Slack community over the Kubernetes slack (as per Chris A. 's suggestion [here](https://github.com/falcosecurity/falco/issues/983#issuecomment-625901549)).

We are going to [officially announce the cutoff](https://github.com/falcosecurity/falco/issues/983#issuecomment-630980624) during today community call! 🙂 

And we already started putting documentation about the new channels (and the new slack) in place for the community to read (see [here](https://github.com/falcosecurity/community/pull/95/files)).

cc @kris-nova @fntlnz @leogr

---

A question.

The `falco-maintainers-pvt` channel is intended for core maintainers private discussions about vulns/security things, github management and similar topics.

Is it feasible to have it as per [guidelines](https://github.com/kubernetes/community/blob/master/communication/slack-guidelines.md#requesting-a-channel)?


