### PR TITLE
Add Fury slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -78,6 +78,7 @@ channels:
   - name: flink-operator
   - name: fr-events
   - name: fr-users
+  - name: fury
   - name: garden
   - name: garden-dev
   - name: gardener


### PR DESCRIPTION
From SIGHUP.io we want to include a new channel in the Kubernetes slack group.

The channel will be used to share experiences between Fury Distribution users.

Fury is a CNCF certified Kubernetes distribution crafted by SIGHUP -> https://landscape.cncf.io/selected=fury-distribution

In addition to the Distribution, the team is building OSS tools around Kubernetes.

https://github.com/sighupio

Thanks!