### PR TITLE
sig-cluster-lifecycle: remove references to kube-deploy

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -148,6 +148,7 @@ channels:
   - name: krex
   - name: kube-aws
   - name: kube-deploy
+    archived: true
   - name: kube-monkey
   - name: kube-oidc-proxy
   - name: kube-router

--- a/incubator.md
+++ b/incubator.md
@@ -129,13 +129,11 @@ These are grandfathered in as full projects:
 These projects are young but have significant user facing docs pointing at their current github.com/kubernetes location. Lets put them through incubation process but leave them at github.com/kubernetes.
 
 - github.com/kubernetes/charts
- 
+
 **Projects to Move to Incubator**
 
 - github.com/kubernetes/kube2consul
 - github.com/kubernetes/frakti
-- github.com/kubernetes/kube-deploy
-- github.com/kubernetes/kubernetes-anywhere
 - github.com/kubernetes/application-images
 - github.com/kubernetes/rktlet
 - github.com/kubernetes/horizontal-self-scaler

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -135,11 +135,6 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
   - https://raw.githubusercontent.com/kubernetes-incubator/kube-aws/master/OWNERS
 - **Contact:**
   - Slack: [#kube-aws](https://kubernetes.slack.com/messages/kube-aws)
-### kube-deploy
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kube-deploy/master/OWNERS
-- **Contact:**
-  - Slack: [#kube-deploy](https://kubernetes.slack.com/messages/kube-deploy)
 ### kube-up
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1019,11 +1019,6 @@ sigs:
       slack: kube-aws
     owners:
     - https://raw.githubusercontent.com/kubernetes-incubator/kube-aws/master/OWNERS
-  - name: kube-deploy
-    contact:
-      slack: kube-deploy
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/kube-deploy/master/OWNERS
   - name: kube-up
     owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS


### PR DESCRIPTION
the repository is being archived. please see:
https://github.com/kubernetes/org/issues/1888

/kind cleanup
/priority backlog
/sig cluster-lifecycle

sig-cluster-lifecycle: remove kube-deploy from the list of projects

Remove:
- The sub-project from sigs.yaml
- The reference in incubator.md (also remove kubernetes-anywhere)

Mark the slack channel #kube-deploy as archived.

Leave the mentions and links in these outdated design documents:
- /contributors/design-proposals/cluster-lifecycle/local-cluster-ux.md
- /contributors/design-proposals/multi-platform.md
- /sig-cluster-lifecycle/migrated-from-wiki/roadmap-cluster-deployment.md
