### PR TITLE
slack: add channels for projects devspace and kiosk

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -195,7 +195,6 @@ channels:
     archived: true
   - name: linode
   - name: litmus
-  - name: loft
   - name: lokomotive
   - name: malaysia-users
   - name: malta-users

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -55,6 +55,7 @@ channels:
   - name: csi-secrets-store #this channel is for secrets-store-csi-driver which is a subproject of sig-auth
   - name: de-events
   - name: de-users
+  - name: devspace
   - name: devstats
   - name: dexidp
   - name: digitalocean-k8s
@@ -130,6 +131,7 @@ channels:
   - name: keel
   - name: kiam
   - name: kind
+  - name: kiosk
   - name: kcli
   - name: klog
   - name: knative
@@ -193,6 +195,7 @@ channels:
     archived: true
   - name: linode
   - name: litmus
+  - name: loft
   - name: lokomotive
   - name: malaysia-users
   - name: malta-users


### PR DESCRIPTION
We have channels for these projects in our internal slack and allowed users to join after they asked for slack access. I got asked by several users if we could move the discussions to the k8s slack which makes a lot of sense, I think. 

About the projects:
- devspace: development tool for kubernetes, on GitHub: https://github.com/devspace-cloud/devspace
- kiosk: multi-tenancy extension for kubernetes, on GitHub: https://github.com/kiosk-sh/kiosk

The purpose of these channels will be to prioritize features together, answer questions about the projects, help users resolve issues quicker, and to provide a way to share experiences with these tools.

Thanks for reviewing this PR! Let me know if you need me to make any changes.