### PR TITLE
sig-api-machinery: add controller-manager repo

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -105,7 +105,9 @@ The following [subprojects][subproject-definition] are owned by sig-api-machiner
 ### server-frameworks
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/apiserver/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/controller-manager/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/controller-manager/OWNERS
 ### server-sdk
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/apiserver-builder-alpha/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -113,7 +113,9 @@ sigs:
   - name: server-frameworks
     owners:
     - https://raw.githubusercontent.com/kubernetes/apiserver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/controller-manager/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/controller-manager/OWNERS
   - name: server-sdk
     contact:
       mailing_list: https://groups.google.com/forum/#!forum/kubebuilder


### PR DESCRIPTION
For kubernetes/org#1895 (PR to add staging dir at kubernetes/kubernetes#91354)

/assign @deads2k @fedebongio @lavalamp 
cc @cheftako @andrewsykim 

/hold
for lgtm from sig-api-machinery leads