### PR TITLE
Clean up formatting and links for marketing team docs

### DIFF
--- a/communication/marketing-team/CHARTER.md
+++ b/communication/marketing-team/CHARTER.md
@@ -1,12 +1,12 @@
 # Kubernetes Upstream Marketing Team Charter
 
-## Summary 
+## Summary
 
 The mission of the Kubernetes Upstream Marketing Team is to elevate the hard work being done throughout the Kubernetes community by its contributors. Promoting the work and helping fill the needs of the Kubernetes community is the driving force behind the Kubernetes Upstream Marketing Team. The goal of this work is to improve the overall sustainability of the project by giving or elevating information to contributors so they stay well informed.
 
 ## Ethos/Vision
 
-This group's work is in support of the upstream Kubernetes community (the open source project). As such it will adhere to the [Kubernetes Community Values](https://github.com/kubernetes/community/blob/master/values.md#kubernetes-community-values). The core value we feel strongest about is [Community over product or company](https://github.com/kubernetes/community/blob/master/values.md#community-over-product-or-company). The makeup of this team will be from all walks of life including vendors. The work of the Kubernetes community should always be prioritized over vendor created works. Kubernetes Upstream Marketing Team members are expected to act in the interest of the community and not their employers.
+This group's work is in support of the upstream Kubernetes community (the open source project). As such it will adhere to the [Kubernetes Community Values](/values.md#kubernetes-community-values). The core value we feel strongest about is [Community over product or company](/values.md#community-over-product-or-company). The makeup of this team will be from all walks of life including vendors. The work of the Kubernetes community should always be prioritized over vendor created works. Kubernetes Upstream Marketing Team members are expected to act in the interest of the community and not their employers.
 
 ## Goals
 

--- a/communication/marketing-team/README.md
+++ b/communication/marketing-team/README.md
@@ -1,46 +1,51 @@
-# Contributor Marketing  
+# Contributor Marketing
+
 The Contributor Marketing Team is part of the community-management subproject in
 [Contributor Experience] view our [charter] to learn more about us
 
-## Purpose  
+## Purpose
+
 to better inform the Kubernetes contributor community and highlight their work to
 the broader ecosystem
 
 | Area & Handbook Link | Lead | Team | Notes |
 | --- | --- | --- | --- |
 | [Editorial] | editor: @parispittman (to bootstrap)| assoc editor: @mbbroberg |  |
-| [Internal Communications] | @jonasrosland | @simplytunde |  |
+| [Internal Communications] | @jonasrosland | @rajula96reddy |  |
 | [Social Media] | @chris-short | @kaslin (paris to help bootstrap) | |
 | [Storytellers] | liaison to sig-docs-blog team @onlydole |  @celanthe, @vonguard, @boluisa, @kaslin, and [Could be you!] |  |
 | [Designer] | [Could be you!] |  | help us with digital assets, infographics, contributor site |  
 
-
 ## Contact Us!
-Reach out to an individual above via slack  
-Whole group - @contributor-comms in #sig-contribex on slack    
-Tag us in an issue in `kubernetes/community` with the label `area/contributor-comms`
 
-## Focus Areas  
-1.  inter-community group comms/project-wide contributor communications,   
-2.  contributor twitter/social and web (contributor site),   
-3.  blogging (work happening in SIGs, stories about contributors, recaps),  
-4.  program and event promotion (community meeting, meet our contributors, steering
-  election, et al)  
+- Reach out to an individual above via slack
+- Whole group - @contributor-comms in #sig-contribex on slack
+- Tag us in an issue in [kubernetes/community] with the label [area/contributor-comms]
+
+## Focus Areas
+
+1. inter-community group comms/project-wide contributor communications,
+2. contributor twitter/social and web (contributor site),
+3. blogging (work happening in SIGs, stories about contributors, recaps),
+4. program and event promotion (community meeting, meet our contributors, steering
+  election, et al)
 
 ## Could be you!
+
 We still have many roles available!  
 
 Come to one of our [meetings] (join kubernetes-sig-contribex@googlegroups.com for the invite)
 or reach out to us on the #sig-contribex channel on the Kubernetes slack (slack.k8s.io for invite)
 Let us know you are interested and if you have any questions.
 
-
 [meetings]: /sig-contributor-experience#community-management
 [charter]: ./CHARTER.md
-[Could be you!]: (#Could-be-you!)
+[Could be you!]: #Could-be-you!
 [Contributor Experience]: /sig-contributor-experience
-[Editorial]: /role-handbooks/editor.md
-[Internal Communications]: /role-handbooks/internal-marketing.md
-[Social Media]: /role-handbooks/social-media.md
-[Storytellers]: /role-handbooks/storytellers.md
-[Designer]: /role-handboos/wip-roles.md
+[Editorial]: ./role-handbooks/editor.md
+[Internal Communications]: ./role-handbooks/internal-marketing.md
+[Social Media]: ./role-handbooks/social-media.md
+[Storytellers]: ./role-handbooks/storytellers.md
+[Designer]: ./role-handbooks/wip-roles.md
+[kubernetes/community]: https://github.com/kubernetes/community/issues
+[area/contributor-comms]: https://github.com/kubernetes/community/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Fcontributor-comms

--- a/communication/marketing-team/blog-guidelines.md
+++ b/communication/marketing-team/blog-guidelines.md
@@ -6,30 +6,30 @@ We are looking for Kubernetes-curious community members who are **interested in 
 
 ## Requested Content
 
-We are looking for: 
+We are looking for:
 
 * TODO << Request specific types of content
 
-Other types of content, like Kubernetes capabilities and tutorials, are better suited for the [SIG-Docs blogging initiative](https://github.com/kubernetes/community/blob/77aa44ba8a506b2d8a7110ff96f545c36db906f3/sig-docs/blog-subproject/README.md).
+Other types of content, like Kubernetes capabilities and tutorials, are better suited for the [SIG-Docs blogging initiative](/sig-docs/blog-subproject/README.md).
 
 ## Submit a Post
 
 The quickest way to get involved is to let the team in [#sig-contribex](https://kubernetes.slack.com/archives/C1TU9EB9S) know that you have an idea for an article.
 
-For now, our official process is to use [SIG-Doc's system](https://github.com/kubernetes/community/blob/77aa44ba8a506b2d8a7110ff96f545c36db906f3/sig-docs/blog-subproject/README.md).
+For now, our official process is to use [SIG-Doc's system](/sig-docs/blog-subproject/README.md).
 
 ## Blogger Expectations, Responsibilities, and Info
 
-Anyone is welcome to contribute when they have time. 
+Anyone is welcome to contribute when they have time.
 
 If you would like to be listed as a member of the team, here are the expectations:
 
 1. Be prepared to write one blog a quarter and participate in edits to other articles. The time commitment is typically 5-10 hours per quarter depending on the number of blog posts in the review queue.
-2. Bloggers are expected to attend at least one upstream marketing team meeting a month or check-in to remain active. 
+2. Bloggers are expected to attend at least one upstream marketing team meeting a month or check-in to remain active.
 3. Remain non-partial: if you receive a request to write about a project, an individual, or a group of people from your employer, you should ask an impartial blogger to write it.
 4. As with all contribution to Kubernetes, adhere to the [code of conduct](/code-of-conduct.md), values, and principles of the project.
 
-## How to Write an Effective Blog: 
+## How to Write an Effective Blog
 
 Keep the following points in mind as you write in order to speed up the review process:
 
@@ -49,19 +49,17 @@ Keep the following points in mind as you write in order to speed up the review p
   * Find images on sites like [Creative Commons](https://search.creativecommons.org/), [Pexels](https://www.pexels.com/public-domain-images/), and [Unsplash](https://unsplash.com/images/stock/public-domain))
 * Be accountable and honest as an author
   * Remove anything that lacks adequate evidence
-  * Avoid interjecting personal reactions 
+  * Avoid interjecting personal reactions
   * Ensure that the blog post is reviewed by the anyone being mentioned in the piece
   * As the author, never talk about your employer, sell, promote, or pitch; this is about upstream community endeavours and the individuals and groups that create it
 
-## Further Recommendations 
+## Further Recommendations
 
-The following are helpful resources for authoring articles: 
+The following are helpful resources for authoring articles:
 
-- [Creating Quality Content (For Search Engines and People)](https://moz.com/blog/quality-blog-content)
-- [How to write effective documentation for your open source project](https://opensource.com/article/20/3/documentation)
-
+* [Creating Quality Content (For Search Engines and People)](https://moz.com/blog/quality-blog-content)
+* [How to write effective documentation for your open source project](https://opensource.com/article/20/3/documentation)
 
 ## Review Process
 
-This process is bootstrapped from the sig-docs blog [subproject](https://github.com/kubernetes/community/blob/77aa44ba8a506b2d8a7110ff96f545c36db906f3/sig-docs/blog-subproject/README.md). Please ask for review from community liaisons on the sig-docs-blog team or let the team in [#sig-contribex](https://kubernetes.slack.com/archives/C1TU9EB9S) know you need help. 
-
+This process is bootstrapped from the sig-docs blog [subproject](/sig-docs/blog-subproject/README.md). Please ask for review from community liaisons on the sig-docs-blog team or let the team in [#sig-contribex](https://kubernetes.slack.com/archives/C1TU9EB9S) know you need help.

--- a/communication/marketing-team/role-handbooks/editor.md
+++ b/communication/marketing-team/role-handbooks/editor.md
@@ -23,22 +23,23 @@ appeals to our mission
 between the groups
 - Helping to recruit other members of the team, ensuring onboarding but delegating to proper lead; fall back when no lead present is the Editor
 - Has the ability to modify the team charter and seeks consensus with Contributor Experience communication [OWNERS] when considering any major changes.
-- If time allows, market the team; blog about the team and it's progress, encourage team to blog about their work   
+- If time allows, market the team; blog about the team and it's progress, encourage team to blog about their work
 
 ### Minimum Skills and Requirements
 
 Skills:
+
 - Be comfortable with general GitHub workflows. We can teach you ours but a foundation for this role is necessary. You'll be working inside of multiple repositories with different experiences and helping others on the team with troubleshooting.
 - Strong written and verbal skills
 - Be ok with saying no, but with a reason to back it up; be empathetic.
 - Have existing relationships with the contributor community either through other work or as an Associate Editor
 - Patience
 
-Requirements:  
+Requirements:
+
 - Member of the [Kubernetes GitHub Org]
 - [Reviewer] in the marketing team folder
 - Shadowed under a lead in any role on the team for 6 months total (could be a combination of roles during that time period
-
 
 #### Expected Time Investment
 
@@ -50,7 +51,7 @@ Here is a checklist of items we will work to get access when you accept the role
 
 - Access to send and respond to email from community@kubernetes.io
 - Access to community and website repositories, all relevant calendars, and project boards
-- Other items listed in [team-resources.md]
+- Other items listed in [team-resources]
 
 ### Duration  
 
@@ -65,17 +66,13 @@ The Associate Editor should be able to achieve the above list of skills by the t
 
 Collaborate closely with the lead Editor toward the responsibilities outlined above. Be ready to backfill for them when they are unable to attend a meeting or represent the working group.
 
-
-
 TODO  
-
-
 
 [editorial calendar]: https://github.com/orgs/kubernetes/projects/41
 [marketing project]: https://github.com/orgs/kubernetes/projects/39
-[team resources]: /team-resources.md
+[team-resources]: ../team-resources.md
 [Kubernetes GitHub Org]: https://git.k8s.io/community/community-membership.md
-[Reviewer]: ./OWNERS
+[Reviewer]: ../OWNERS
 [OWNERS]: /communication/OWNERS
-[blogging]: /blog-guidelines.md
-[ethos]: /CHARTER.md#ethos/vision
+[blogging]: ../blog-guidelines.md
+[ethos]: ../CHARTER.md#ethosvision

--- a/communication/marketing-team/role-handbooks/internal-marketing.md
+++ b/communication/marketing-team/role-handbooks/internal-marketing.md
@@ -2,41 +2,46 @@
 
 ## Overview
 
-TODO
+The Internal communications role is responsible for handling communications out to the broader Kubernetes contributor community. The types of communications are outlined in our [multichannel communications doc].
 
 ## Responsibilities
+
 - Working towards a more streamlined communication process within the project for different use cases
 - Create and maintain a one stop shop intake form/issue template/etc for contributors to get comms and marketing support
-- identifying communication milestones and deadlines
-- map out communication pipelines
-- promoting contributor events
-Events
-- in the events folder or one off contributor events like SIG onboarding sessions
-KEPs
-- to follow the same process as [social guidelines]
-- no promotion unless there is an explicit documented request
+- Identifying communication milestones and deadlines
+- Map out communication pipelines
+- Promoting contributor events
+  - In the events folder or one off contributor events like SIG onboarding sessions
+- KEPs
+  - To follow the same process as [social guidelines]
+  - No promotion unless there is an explicit documented request
 
+## Minimum Skills and Requirements
 
-## Minimum Skills and Requirements  
 - Are a member of the [Kubernetes GitHub Org]
 - Shadowed in this role or another role on the marketing team for at least 3 months
 
-
 ### Expected Time Investment
 
-TODO  
-3-5 hours a week?
+3-5 hours a week
 
 ### Platforms, Tools, and Access
 
 - Needs access to send and respond to mail on community@kubernetes.io
-- contributor calendar
-- and everything listed in [team-resources.md]
+- Contributor calendar
+- and everything listed in [team-resources]
 
 ## Associates Overview (Shadow)
 
+The Internal Communicaitons Shadow should be able to achieve the above list of skills by the time they will be eligible to become the lead.
 
 ## Out of scope
+
 - release; there is a communications coordinator (can help where needed, be an advisor, or help with reach)
 - contributor summit; there is a role that will assume a communications function (can help where needed, be an advisor, or help with reach)
-- TODO
+- community meetings; there is already a well-defined process in place where each month's lead manage communications out to the community
+
+[multichannel communications doc]: ../multichannel-communications.md
+[social guidelines]: ../social-guidelines.md
+[team-resources]: ../team-resources.md
+[Kubernetes GitHub Org]: https://git.k8s.io/community/community-membership.md

--- a/communication/marketing-team/role-handbooks/social-media.md
+++ b/communication/marketing-team/role-handbooks/social-media.md
@@ -20,7 +20,6 @@ TODO
 - Most of this information can be found in our [social guidelines]
 - Be welcoming, be yourself
 
-
 ## Associates Overview (Shadow)
 
 TODO  

--- a/communication/marketing-team/role-handbooks/storytellers.md
+++ b/communication/marketing-team/role-handbooks/storytellers.md
@@ -17,11 +17,13 @@ collaborative doc tool and the sig-docs-liaison or Editor will start the PR
 process
 
 ## Minimum Skills and Experience
+
 - Have a passion for telling stories, technical writing, journalism, and painting pictures with words
 - Desire to be a Kubernetes Org Member and if not already, work your way towards membership
 - Comfortable with working with GitHub workflows or working in a collaborative doc tool with the Editor  
 
 ## Expectations
+
 Anyone is welcome to contribute when they have time. The core expectation of storytelling is taking responsibility for getting the story from inception to published.
 
 If you would like to be listed as a member of the team, here are the expectations:

--- a/communication/marketing-team/role-handbooks/wip-roles.md
+++ b/communication/marketing-team/role-handbooks/wip-roles.md
@@ -1,10 +1,11 @@
 # Work In Progress Roles
 
-## Purpose  
+## Purpose
+
 Capture roles that we would like to have but don't have them filled for Reasons.
 
-
 ## Roles
+
 1. Designer
 someone to help with youtube thumbnails, logos, social clips/gifs  
 help us manage digital assets  

--- a/communication/marketing-team/social-guidelines.md
+++ b/communication/marketing-team/social-guidelines.md
@@ -4,7 +4,7 @@
 
 ## General guidelines
 
-All messaging must be consistent with the values and principles of the project and the [ethos/vision of the team](https://github.com/kubernetes/community/blob/master/communication/marketing-team/CHARTER.md#ethosvision). Messaging should be positive and uplifting. Be aware that sarcasm and/or jokes are generally hard to read over a medium such as social media.
+All messaging must be consistent with the values and principles of the project and the [ethos/vision of the team](./CHARTER.md#ethosvision). Messaging should be positive and uplifting. Be aware that sarcasm and/or jokes are generally hard to read over a medium such as social media.
 
 Original messages should come out of this teams' accounts at least twice a week (if not more). However, there should be no more than three tweets per hour (including retweets). Retweets, likes, and responses are unlimited, but they should be used thoughtfully to encourage inclusive and kind participation. Use scheduling software as needed to space out messages. All messages should serve a purpose: have an action and/or thumbnail image ("click link for details," "register today," etc. are example actions). Never include photos, user handles, or other personally identifiable information without explicit permission.
 
@@ -17,6 +17,7 @@ Ideally, no individuals outside of the contributor community, with the possible 
 Other CNCF projects, unless there is a common contributor cause, are out of scope for coverage by this team's social media accounts.
 
 Kubernetes Organization Members with access to account are:
+
 - @parispittman
 - @mrbobbytables
 - @chris-short
@@ -32,13 +33,14 @@ Kubernetes Organization Members with access to account are:
 - Steering Committee Announcements
 
 ## KEPs
+
 ([Kubernetes Enhancement Proposals])
 
 ### Ground Rules  
+
 - The social media team cannot tweet KEPs at this time.
 - This may change if we can get a few owner(s)/group who can approve them
 - This guideline can only change with Steering, SIG-Arch, and SIG-Release approval  
-
 
 ### Frequently Asked Questions (FAQ)
 
@@ -48,10 +50,8 @@ A: TODO (Y/N). The account is designed for information dissemination, so we will
 
 Q: Do we engage with hostile messages?  
 
-A: No. Don't feed the trolls. Mute them is the correct response. Block them as a last resort and only after discussing with team members. Reasons to block include verbal abuse, violating the platform's terms, or violating the [Code of Conduct](https://github.com/kubernetes/community/blob/master/code-of-conduct.md). The community is focused on openness and our accounts should be too, but there are times when we should reduce harmful people's visibility through blocking.
+A: No. Don't feed the trolls. Mute them is the correct response. Block them as a last resort and only after discussing with team members. Reasons to block include verbal abuse, violating the platform's terms, or violating the [Code of Conduct](/code-of-conduct.md). The community is focused on openness and our accounts should be too, but there are times when we should reduce harmful people's visibility through blocking.
 
 Credit: [Fedora Community](https://fedoraproject.org/wiki/Marketing)
 
-
-[#KEPs]: (#KEPs)
 [Kubernetes Enhancement Proposals]: https://github.com/kubernetes/enhancements/tree/master/keps

--- a/communication/marketing-team/team-resources.md
+++ b/communication/marketing-team/team-resources.md
@@ -1,4 +1,5 @@
 # Resources for the team
+
 [Entire community repo]  - tons of contributor documentation and how we operate  
 [contributor site]  (future home)  
 [project board] for contributor site  
@@ -10,10 +11,8 @@
 [Community Groups List] - main list of SIGs, WGs, and Committees  
 [Values] and [principles]
 
-
-
 [contributor site]: https://sigs.k8s.io/contributor-site
-[project board]: https://github.com/orgs/kubernetes-sigs/projects
+[project board]: https://github.com/orgs/kubernetes-sigs/projects/3
 [surveys]: /sig-contributor-experience/surveys
 [Communication]: /communication/README.md
 [style guide]: /contributors/guide/style-guide.md


### PR DESCRIPTION
This PR cleans up some of the Markdown formatting and links for the Contributor Marketing Team docs, and also adds @rajula96reddy as shadow for the internal comms role.

Signed-off-by: jonasrosland <jrosland@vmware.com>