### PR TITLE
add missing channels of sig-release subprojects

### DIFF
--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -1,7 +1,9 @@
 channels:
   - name: sig-release
+  - name: release-bug-triage  
   - name: release-ci-signal
   - name: release-comms
+  - name: release-docs
   - name: release-management
     id: CJH2GBF7Y
   - name: release-notes


### PR DESCRIPTION
This PR adds the missing slack channels of the sig-release's subprojects:

- release-bug-triage
- release-docs
- release-emeritus

/cc @kubernetes/release-managers @justaugustus 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>