### PR TITLE
Revert "Add fury slack channel"

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -78,7 +78,6 @@ channels:
   - name: flink-operator
   - name: fr-events
   - name: fr-users
-  - name: fury
   - name: garden
   - name: garden-dev
   - name: gardener


### PR DESCRIPTION
Reverts https://github.com/kubernetes/community/pull/4794
The fury slack channel name clashes with a user of the same name. Channels and usernames share the same namespace and cannot co-exist. =/

ref: https://github.com/kubernetes/community/pull/3852