### PR TITLE
Removed outdated CSI limitation

### DIFF
--- a/sig-storage/volume-plugin-faq.md
+++ b/sig-storage/volume-plugin-faq.md
@@ -66,9 +66,6 @@ For more information about CSI, see:
 *   [Kubernetes CSI Beta Announcement Blog Post](https://kubernetes.io/blog/2018/04/10/container-storage-interface-beta/)
 *   [Kubernetes CSI GA Announcement Blog Post](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/)
 
-**What are the limitations of CSI?**
-*   CSI implementation in Kubernetes is not yet stable/GA (currently in alpha).
-
 **How do I write a CSI Driver?**
 
 For more information on how to write and deploy a CSI Driver on Kubernetes, see https://kubernetes-csi.github.io/docs/developing.html


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Conflicting statement since the CSI implementation is now GA.

Please correct me if I'm wrong 😅