### PR TITLE
Add a slack channel for kpt

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -143,6 +143,7 @@ channels:
   - name: kops-users
   - name: kots
     id: CFFKXV0JZ
+  - name: kpt
   - name: kr-dev
   - name: kr-users
   - name: kraken


### PR DESCRIPTION
We want to add a slack channel in the kubernetes slack group for kpt. 

Kpt is an OSS tool for packaging, configuration and management of KRM resources: https://github.com/GoogleContainerTools/kpt

We currently get some questions about kpt in the kustomize channel, so it would be better to have a dedicated channel.