### PR TITLE
slack/sig-release: Update usergroups

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -27,3 +27,24 @@ usergroups:
       - tpepper # subproject owner / Release Manager
       - Verolop # Release Manager Associate
       - xmudrii # Release Manager Associate
+
+  # Should match the Release Team Leads of the current cycle and SIG Chairs at all times
+  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.19/release_team.md
+  - name: release-team-leads
+    long_name: Release Team Leads
+    description: Release Team Leads. Ping for questions on the current Kubernetes release cycle.
+    channels:
+      - release-bug-triage
+      - release-ci-signal
+      - release-comms
+      - release-docs
+      - release-management
+      - release-notes
+      - sig-release
+    members:
+      - calebamiles # SIG Chair
+      - jeremyrickard # 1.19 Release Team Lead Shadow
+      - justaugustus # SIG Chair
+      - mrbobbytables # 1.19 Release Team Lead Shadow
+      - onlydole # 1.19 Release Team Lead
+      - tpepper # SIG Chair

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -1,6 +1,9 @@
 # This file contains a list of all Slack User Groups that are managed by SIG Release.
 
 usergroups:
+  # Should match the membership of the following teams at all times:
+  # - https://git.k8s.io/sig-release/release-managers.md#release-managers
+  # - https://git.k8s.io/sig-release/release-managers.md#associates
   - name: release-managers
     long_name: Release Managers
     description: Release Managers. Ping for questions on branch cuts and building/packaging Kubernetes.
@@ -10,12 +13,17 @@ usergroups:
       - sig-release
     members:
       - calebamiles # subproject owner
-      - cpanato # Branch Manager
-      - dougm # Patch Release Team
-      - feiskyer # Patch Release Team
-      - hasheddan # Branch Manager
-      - hoegaarden # Patch Release Team
-      - idealhack # Patch Release Team
-      - justaugustus # subproject owner / Patch Release Team
-      - saschagrunert # Branch Manager
-      - tpepper # subproject owner / Patch Release Team
+      - cpanato # Release Manager
+      - dougm # Release Manager
+      - feiskyer # Release Manager
+      - hasheddan # Release Manager
+      - hoegaarden # Release Manager
+      - idealhack # Release Manager
+      - jimangel # Release Manager Associate
+      - justaugustus # subproject owner / Release Manager
+      - markyjackson-taulia # Release Manager Associate
+      - saschagrunert # Release Manager
+      - sethmccombs # Release Manager Associate
+      - tpepper # subproject owner / Release Manager
+      - Verolop # Release Manager Associate
+      - xmudrii # Release Manager Associate

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -1,4 +1,4 @@
-# This file contains an alpahbetically sorted mapping of lowercase GitHub
+# This file contains an alphabetically sorted mapping of lowercase GitHub
 # usernames to Kubernetes Slack user IDs.
 users:
   alejandrox1: U6AS37R50
@@ -21,6 +21,7 @@ users:
   jdumars: U0YJS6LHL
   jeefy: U5MCFK468
   jeremyrickard: U72ESU398
+  jimangel: U4HSVFA5U
   johnbelamaric: U246A1A0N
   jonasrosland: U0A4G34S2
   justaugustus: U0E0E78AK
@@ -40,6 +41,7 @@ users:
   Rin Oliver: USF4LMDCN
   sammy: U8NJFL023
   saschagrunert: U53SUDBD4
+  sethmccombs: U92LLUZ8A
   simplytunde: UAY1NBYHE
   skriss: U43B14TNX
   Sujay Pillai: UBW3N1VGW
@@ -47,3 +49,5 @@ users:
   TaoBeier: UCLDV6MN1
   tpepper: U6UB5V4TX
   Tunde: UAY977ENN
+  Verolop: U7NNE57PU
+  xmudrii: U4Q2TNGVD


### PR DESCRIPTION
- Update `release-managers` usergroup
  - Reference existing members as Release Managers (ref: https://github.com/kubernetes/sig-release/pull/1106)
  - Include [Release Manager Associates](https://git.k8s.io/sig-release/release-managers.md#associates)
- Add `release-team-leads` usergroup
 Includes:
   - Current (1.19) Release Team Lead and Lead Shadows
   - SIG Chairs

/assign @tpepper @onlydole @mrbobbytables @jeremyrickard 
cc: @kubernetes/release-engineering @kubernetes/release-team-leads 
/sig release
/area release-eng