### PR TITLE
Update formatting to community meeting doc

### DIFF
--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -1,32 +1,54 @@
+---
+title: Monthly Community Meeting
+weight: 1
+description: |
+  The Kubernetes community meeting is intended to provide a holistic overview of
+  community activities, critical release information, and governance updates. It
+  also provides a forum for discussion of project-level concerns that might need
+  a wider audience than a single special interest group (SIG).
+---
+
 # Kubernetes Monthly Community Meeting
 
-We have PUBLIC and RECORDED [monthly meeting](https://zoom.us/my/kubernetescommunity) the third Thursday of the month at [10am PT](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29)
-a). There will be no community meeting in the month of December, or in a week that conflicts with KubeCon + CloudNativeCon.
+We have PUBLIC and RECORDED [monthly meeting][community-meeting] the third
+Thursday of the month at [10am PT]; with the exception of December, or in the
+event it clashes with KubeCon + CloudNativeCon.
  
-See it on the web at [calendar.google.com](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles) , or paste this [iCal url](https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics) into any [iCal client](https://en.wikipedia.org/wiki/ICalendar). Do NOT copy the meetings over to your personal calendar, you will miss meeting updates. Instead use your client's calendaring feature to say you are attending the meeting so that any changes made to meetings will be reflected on your personal calendar. 
+See it on the web at [calendar.google.com], or paste this [iCal url] into any
+[iCal client]. Do NOT copy the meetings over to your personal calendar, you will
+miss meeting updates. Instead use your client's calendaring feature to say you
+are attending the meeting so that any changes made to meetings will be reflected
+on your personal calendar. 
 
-All meetings are archived on the [YouTube Channel](https://www.youtube.com/playlist?list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ).
+All meetings are archived on the [YouTube Channel].
 
 Quick links:
 
-- [Agenda document](http://bit.ly/k8scommunity)
-- [Zoom meeting link](https://zoom.us/my/kubernetescommunity)
+- [Agenda document][agenda]
+- [Zoom meeting link][community-meeting]
+
 
 ## Purpose
 
-The Kubernetes community meeting is intended to provide a holistic overview of community activities, critical release information, and governance updates. 
-It also provides a forum for discussion of project-level concerns that might need a wider audience than a single special interest group (SIG).
+The Kubernetes community meeting is intended to provide a holistic overview of
+community activities, critical release information, and governance updates. It
+also provides a forum for discussion of project-level concerns that might need a
+wider audience than a single special interest group (SIG).
+
 
 ## Notetaker(s)
 
-Notes from the meeting are published to [this forum thread](https://discuss.kubernetes.io/t/kubernetes-weekly-community-meeting-notes/35/53) for wider distribution. 
-A good notetaker is important to help get the information out to people who cannot attend. 
-Volunteers are always welcome to either add their notes directly to the document, or inform the host that they would like to help take notes at the beginning of the call.
+Notes from the meeting are published to [this forum thread] for wider distribution.
+A good notetaker is important to help get the information out to people who
+cannot attend. Volunteers are always welcome to either add their notes directly
+to the document, or inform the host that they would like to help take notes at
+the beginning of the call.
+
 
 ## Meeting Agenda
 
 If you have a topic you'd like to present or would like to see discussed,
-please propose a specific date on the [Kubernetes Community Meeting Agenda](http://bit.ly/k8scommunity).
+please propose a specific date on the [Kubernetes Community Meeting Agenda][agenda].
 
 General speaking the meeting is structured as follows:
 
@@ -37,58 +59,104 @@ General speaking the meeting is structured as follows:
   - Stable Release and point releases
   - Older stable releases and point releases
 - Contributor Tip of the Week (~2 minutes, Optional)
-  - These can be a variety of topics, including [devstats graphs](https://k8s.devstats.cncf.io/)
+  - These can be a variety of topics, including [devstats graphs]
 - SIG Updates
   - Three SIGs per meeting, 10 minutes per SIG, if time allows 4 SIGs may present 
 - Announcements (~5 minutes)
   - Any other community announcements should go here
-  - Shoutouts, an aggregation of thanks from community members to other contributors via the #shoutouts channel 
+  - Shoutouts, an aggregation of thanks from community members to other
+    contributors via the `#shoutouts` channel 
+
 
 ## Demos
 
-The first 10 minutes of a meeting is dedicated to demonstrations from the community. 
-These demos are noted at the top of the community document. 
-There is a hard stop of the demo at 10 minutes, with up to 5 more minutes for questions.
-Feel free to add your demo request to the bottom of the list, then one of the organizers will get back to you to schedule an exact date. 
-Demo submissions MUST follow the requirements listed below: 
+The first 10 minutes of a meeting is dedicated to demonstrations from the
+community. These demos are noted at the top of the community document. There is
+a hard stop of the demo at 10 minutes, with up to 5 more minutes for questions.
+Feel free to add your demo request to the bottom of the list, then one of the
+organizers will get back to you to schedule an exact date. Demo submissions MUST 
+follow the requirements listed below: 
+
 
 ### Requirements
 
-This meeting has a large number of attendees. 
-Out of respect for their time, we ask that you be fully prepared for your demo. Make sure slides are clear if applicable, and the link to them is posted in the meeting agenda. 
-Also, if you are doing a live coding demo, please make sure it has a reasonable chance of completing within the allotted time box.
+This meeting has a large number of attendees. Out of respect for their time, we
+ask that you be fully prepared for your demo. Make sure slides are clear if
+applicable, and the link to them is posted in the meeting agenda. Also, if you 
+are doing a live coding demo, please make sure it has a reasonable chance of
+completing within the allotted time box.
 
-- Demos must be about a core component of Kubernetes or a related project that is owned by a SIG. For projects in the Kubernetes ecosystem, you can sign up for a [CNCF Webinar](https://www.cncf.io/webinars/).
-- You are required to show up 10 minutes before the meeting to verify your audio and screensharing capabilities with the hosts. If you cannot make and keep this commitment, you will not be allowed to proceed with your demo until such time you can.
-- You also required to commit to being available the week before your demo date in case there is an issue with that week's demo.
-- The use of a headset or other high-quality audio equipment is strongly encouraged. Typing on a laptop while using the system microphone is distracting, so please insulate your microphone from key noises.
+- Demos must be about a core component of Kubernetes or a related project that
+  is owned by a SIG. For projects in the Kubernetes ecosystem, you can sign up
+  for a [CNCF Webinar].
+- You are required to show up 10 minutes before the meeting to verify your audio
+  and screensharing capabilities with the hosts. If you cannot make and keep this
+  commitment, you will not be allowed to proceed with your demo until such time
+  you can.
+- You also required to commit to being available the week before your demo date
+  in case there is an issue with that week's demo.
+- The use of a headset or other high-quality audio equipment is strongly
+  encouraged. Typing on a laptop while using the system microphone is distracting,
+  so please insulate your microphone from key noises.
 - Ensure you are presenting from a quiet environment.
-- If you run out of time while performing your demo, you may ask the audience if they would like a follow-up at a subsequent meeting. If there is enthusiastic support, the community team will help schedule a continuation.
+- If you run out of time while performing your demo, you may ask the audience
+  if they would like a follow-up at a subsequent meeting. If there is
+  enthusiastic support, the community team will help schedule a continuation.
+
 
 ## SIG Updates
 
-SIGs will give a community update at least once per release cycle per the [schedule](https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k).
+SIGs will give a community update at least once per release cycle per the [schedule].
 The SIG Update should mention:
 
 - Topics where input is being sought from other SIGs
 - Topics that could affect other SIGs
 - Currently active themes and goals in the SIG
   - Broad description of future themes and goals if possible
-- Status of any notable features that are transitioning across the spectrum of incubation, alpha, beta, stable/GA, or are being deprecated
+- Status of any notable features that are transitioning across the spectrum of
+  incubation, alpha, beta, stable/GA, or are being deprecated
 - New or deprecated subprojects
 - Leadership position changes or updates
 - Charter status and updates, if any
 - How people can contribute, areas where help is needed
-- Any pending Kubernetes Enhancement Proposals (KEPs) or general big ideas that might warrant outside input
+- Any pending Kubernetes Enhancement Proposals (KEPs) or general big ideas that
+  might warrant outside input
 - Prior 1.X.Y release patches in flight status
 - Current 1.X release targeted feature status
-- Rescheduling an update can happen, but is strongly discouraged as the schedule is done with as much lead time as possible to allow SIGs time to plan ahead
-  - SIGs should consider asking someone who is not a chair or lead to give this update as a mentorship/growth opportunity to newer members
-  - There is a [pregenerated slide template](https://docs.google.com/presentation/d/1-nTvKCiqu9UvFYUeM6p6RIqHS5-H-u3_x-V4xj_eIWo/edit#slide=id.g401c104a3c_0_0) that you can use for your status
-  - The update belongs entirely to the SIG, there will be periods when "boring" work happens and the SIG might want to not give a status update, instead consider a shorter update that at least lets the community know if you're in a quiet period. Informing the community that you've been clearing out the backlog in a 1 minute status is much better than not having a status report because you're concerned about not filling out the template in full. Just cut out what doesn't apply to you. 
+- Rescheduling an update can happen, but is strongly discouraged as the schedule
+  is done with as much lead time as possible to allow SIGs time to plan ahead
+  - SIGs should consider asking someone who is not a chair or lead to give this
+    update as a mentorship/growth opportunity to newer members
+  - There is a [pregenerated slide template] that you can use for your status
+  - The update belongs entirely to the SIG, there will be periods when "boring"
+    work happens and the SIG might want to not give a status update, instead
+    consider a shorter update that at least lets the community know if you're in
+    a quiet period. Informing the community that you've been clearing out the
+    backlog in a 1 minute status is much better than not having a status report
+    because you're concerned about not filling out the template in full. Just
+    cut out what doesn't apply to you. 
 
-Since you only usually have ~10 minutes generally speaking if something is internal only to your SIG and doesn't affect others it doesn't need to be mentioned, people can always attend your SIG meeting for the details.
+Since you only usually have ~10 minutes generally speaking if something is
+internal only to your SIG and doesn't affect others it doesn't need to be
+mentioned, people can always attend your SIG meeting for the details.
+
 
 ## Archives
 
-The document gets slow as we add notes, so it is archived regularly into the [Meeting Notes Archive](https://git.kubernetes.io/community/communication/meeting-notes-archive).
+The document gets slow as we add notes, so it is archived regularly into the
+[Meeting Notes Archive].
+
+
+[community-meeting]: https://zoom.us/my/kubernetescommunity
+[10am PT]: http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29
+[calendar.google.com]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles
+[iCal url]: https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics
+[iCal client]: https://en.wikipedia.org/wiki/ICalendar
+[YouTube Channel]: https://www.youtube.com/playlist?list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ
+[agenda]: http://bit.ly/k8scommunity
+[this forum thread]: https://discuss.kubernetes.io/t/kubernetes-weekly-community-meeting-notes/35/53
+[devstats graphs]: https://k8s.devstats.cncf.io/
+[CNCF Webinar]: https://www.cncf.io/webinars/
+[schedule]: https://docs.google.com/spreadsheets/d/1adztrJ05mQ_cjatYSnvyiy85KjuI6-GuXsRsP-T2R3k
+[pregenerated slide template]: https://docs.google.com/presentation/d/1-nTvKCiqu9UvFYUeM6p6RIqHS5-H-u3_x-V4xj_eIWo/edit#slide=id.g401c104a3c_0_0
+[Meeting Notes Archive]: https://git.kubernetes.io/community/communication/meeting-notes-archive


### PR DESCRIPTION
For the most part this is a no-op and just applies the style guide suggestions to the doc. The one content change is this part in the beginning:

We have PUBLIC and RECORDED monthly meeting the third Thursday of the month at 10am PT a). There will be no community meeting in the month of December, or in a week that conflicts with KubeCon + CloudNativeCon.

to

We have PUBLIC and RECORDED monthly meeting the third Thursday of the month at 10am PT; with the exception of December, or in the event it clashes with KubeCon + CloudNativeCon.
