### PR TITLE
Update formatting of meet our contributors doc

### DIFF
--- a/mentoring/programs/meet-our-contributors.md
+++ b/mentoring/programs/meet-our-contributors.md
@@ -1,3 +1,12 @@
+---
+title: Meet our Contributors
+weight: 4
+description: |
+  Meet Our Contributors gives you a monthly one-hour opportunity to ask questions
+  about our upstream community, watch interviews with our contributors, and
+  participate in peer code reviews.
+---
+
 # Meet Our Contributors - Ask Us Anything!
 
 When Slack seems like it’s going too fast, and you just need a quick answer from
@@ -8,57 +17,62 @@ about our upstream community, watch interviews with our contributors, and
 participate in peer code reviews.
 
 ## When:
-Every first Wednesday of the month at the following times. Grab a copy of the
-calendar to yours from [kubernetes.io/community]
-* 03:30pm UTC [Convert to your timezone].
 
-## Where:  
-Follow along live:  
-[Kubernetes YouTube Channel]
+Every first Wednesday of the month at the following times:
+- 03:30pm UTC [Convert to your timezone].
 
-Ask questions:
-#meet-our-contributors slack channel  
-To ask anonymously, direct message the host on slack. They will ID at the start
-of the show.  
+## Where:
 
-Watch past recordings:  
+Follow along live: [Kubernetes YouTube Channel]
+
+Ask questions: [#meet-our-contributors] Slack channel
+
+
+To ask anonymously, direct message the host on Slack. They will ID at the start
+of the show.
+
+Watch past recordings:
 Playlist of [previous Meet-Our-Contributors monthly meetings]
 
 
 ## What You'll Gain By Participating:
 
-* An opportunity to learn more about how to get started contributing to K8s
-* A chance to get your PRs reviewed by members of the community
-* Peer code review that can help you get more eyes on your code, or learn more
+- An opportunity to learn more about how to get started contributing to K8s
+- A chance to get your PRs reviewed by members of the community
+- Peer code review that can help you get more eyes on your code, or learn more
 about a part of the Kubernetes code that may have you struggling
-* A deeper understanding of the unique role that our contributors occupy in the
+- A deeper understanding of the unique role that our contributors occupy in the
 Kubernetes ecosystem as a whole
-* Practical advice and hands-on tips for how you can get started as a Kubernetes
+- Practical advice and hands-on tips for how you can get started as a Kubernetes
 contributor, become a member, or otherwise contribute to the project
 
 ## What’s on-topic:
-* How our contributors got started with k8s
-* Advice for getting attention on your PR
-* GitHub tooling and automation
-* Your first commit
-* kubernetes/community
-* Testing
+
+- How our contributors got started with k8s
+- Advice for getting attention on your PR
+- GitHub tooling and automation
+- Your first commit
+- kubernetes/community
+- Testing
 
 ## What’s off-topic:
-* End-user questions (Check out [#office-hours] on Slack and details [here])
+
+- End-user questions (Check out [#office-hours] on Slack and details [here])
 
 ## Submitting questions and/or code for review/walk through:
+
 ### Questions:
-* Day of on Twitter - use the hashtag [#k8smoc] after your question   
-* Slack - Ask your question in #meet-our-contributors
+
+- Day of on Twitter - use the hashtag [#k8smoc] after your question
+- Slack - Ask your question in [#meet-our-contributors]
 
 Questions will be on a first-come, first-served basis. The first half of the
 discussion will be dedicated to questions for contributors and in the second
 half, we will pick a problem (in advance) for peer code review.
 
-### Code snip / PR for peer code review / Suggestion for part of codebase walk
-through:
-* At least 24 hours before the session to Slack channel (#meet-our-contributors)
+### Code snip / PR for peer code review / Suggestion for part of codebase walk through:
+
+- At least 24 hours before the session to Slack channel ([#meet-our-contributors])
 
 Problems will be chosen based on time commitment needed, the skills of the reviewer,
 and if a large amount are submitted, need for the project.
@@ -66,22 +80,22 @@ and if a large amount are submitted, need for the project.
 ## Call for Mentor Panelists!
 
 Expectations of mentors:
-* Be online 5 minutes early. You can look at questions in the queue by joining
+- Be online 5 minutes early. You can look at questions in the queue by joining
 the #meet-our-contributors Slack channel to give yourself some time to prepare.
-* Expect questions about the contribution process, membership, navigating the
+- Expect questions about the contribution process, membership, navigating the
 Kubernetes seas, testing, and general questions about you and your path to open
 source/Kubernetes. It's okay if you don't know the answer!
-* We will be using video chat (Zoom, but livestreaming through YouTube) but
+- We will be using video chat (Zoom, but livestreaming through YouTube) but
 voice-only is fine if you are more comfortable with that.
-* Be willing to provide suggestions and feedback to make this process & experience
+- Be willing to provide suggestions and feedback to make this process & experience
 better!
 
 
 
-[kubernetes.io/community]: https://kubernetes.io/community/
 [#meet-our-contributors]: https://kubernetes.slack.com/messages/meet-our-contributors
 [Convert to your timezone]: https://www.thetimezoneconverter.com/?t=03%3A30%20pm&tz=UTC&
-[Kubernetes YouTube Channel]: (https://www.youtube.com/c/KubernetesCommunity/live
+[#meet-our-contributors]: https://kubernetes.slack.com/messages/meet-our-contributors
+[Kubernetes YouTube Channel]: https://www.youtube.com/c/KubernetesCommunity/live
 [previous Meet-Our-Contributors monthly meetings]: https://www.youtube.com/playlist?list=PL69nYSiGNLP3QpQrhZq_sLYo77BVKv09F
 [#office-hours]: https://kubernetes.slack.com/messages/office-hours
 [#k8smoc]: https://twitter.com/hashtag/k8smoc


### PR DESCRIPTION
For the most part this is a no-op and just adds the metadata  header and a few other small formatting fixes.

The only content change is the removal of this sentence:
```
Grab a copy of the calendar to yours from [kubernetes.io/community]
```
The link it references does not container a calendar event. ¯\\_(ツ)_/¯

Fixes #4790
