### PR TITLE
Update 2020 Events w/ covid cancellations and event leads

### DIFF
--- a/events/2020/03-contributor-summit/README.md
+++ b/events/2020/03-contributor-summit/README.md
@@ -1,6 +1,6 @@
 # 2020 Kubernetes Contributor Summit EU
 
-**This event is still in the planning stages. Please check back here for updates!**
+## This event was cancelled due to the COVID-19 global pandemic
 
 ## What
 
@@ -9,31 +9,6 @@ It is an opportunity for existing contributors to help shape the future of the p
 space for new community members to learn, explore, and put the contributor workflow to practice. The summit 
 is held in the two days before KubeCon + CloudNativeCon with an optional social event in the evening of 
 Sunday, March 29th along with the main full-day event on Monday, March 30th.
-
-## Registration
-
-Registration is not yet open. We will announce the opening of registration on the 
-[kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) mailing list or check this page for updates.
-
-## When and Where
-
-The Contributor Summit takes place in the days leading up to 
-[KubeCon + CloudNativeCon EU](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2020), 
-so make sure you plan travel accordingly.
-
-- Sunday, March 29th, 2020 ~5PM - 9PM  
-  Social event (optional)
-- Monday, March 30th, 2020 ~8AM - 6PM   
-  Full day event
-- Amsterdam, The Netherlands
-- Event website with more information:   
-  https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2020
-
-### Transparency
-
-- Recording: Sessions will be video recorded and uploaded to YouTube.
-- Transcription: Transcriptions will be uploaded with the video.
-- Content Sharing: All presentations will be uploaded.
 
 ## Team
 
@@ -49,15 +24,3 @@ so make sure you plan travel accordingly.
 | New Contributor Workshop 201 | Alison [@alisondy](https://github.com/alisondy) | Benjamin Elder [@BenTheElder](https://github.com/BenTheElder) <br /> James Munnelly [@munnerz](https://github.com/munnerz) <br /> Vineeth Pothulapati [@VineethReddy02](https://github.com/VineethReddy02) | Tim Pepper [@tpepper](https://github.com/tpepper) Emeritus |
 | SIG Meet & Greet | Jason DeTiberus [@detiber](https://github.com/detiber) | Jonas Rosland [@jonasrosland](https://github.com/jonasrosland) | |
 | Accessibility, Inclusiveness, and Diversity | Marky Jackson [@markyjackson](https://github.com/markyjackson-taulia) | Kim McMahon [@kim.mcMahon](https://github.com/KimMcMahon) | |
-
-## Code of Conduct
-
-This event, like all Kubernetes events, has a [Code of Conduct](/code-of-conduct.md). We will have an onsite rep with contact information to be provided here and posted during the event.
-
-## Misc
-
-We want to remove as many barriers as possible for you to attend this event. Please contact community@kubernetes.io to see if we can accommodate a request.
-
-For general info and questions, please join and direct questions to the [#contributor-summit](https://kubernetes.slack.com/messages/C7J893413/) slack channel. To speak directly to the staff, please join the [#summit-staff](https://kubernetes.slack.com/messages/CEMM39SKG/) slack channel.
-
-As stated above, this doc will be updated with further details. Please check back for additional information.

--- a/events/2020/07-contributor-summit/README.md
+++ b/events/2020/07-contributor-summit/README.md
@@ -1,6 +1,6 @@
 # 2020 Kubernetes Contributor Summit CN
 
-**This event is still in the planning stages. Please check back here for updates!**
+## This event was cancelled due to the COVID-19 global pandemic
 
 ## What
 
@@ -9,43 +9,8 @@ It is an opportunity for existing contributors to help shape the future of the p
 space for new community members to learn, explore, and put the contributor workflow to practice. The summit 
 is held the day before KubeCon + CloudNativeCon + Open Source Summit on Tuesday, July 28th.
 
-## Registration
-
-Registration is not yet open. We will announce the opening of registration on the 
-[kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) mailing list or check this page for updates.
-
-## When and Where
-
-The Contributor Summit takes place the day before
-[KubeCon + CloudNativeCon + Open Source Summit China](https://events.linuxfoundation.cn/kubecon-cloudnativecon-open-source-summit-china/),
-so make sure you plan travel accordingly.
-
-- Tuesday, July 28th, 2020 ~8AM - 6PM   
-  Full day event
-- Shanghai, China 
-- Event website with more information:   
-  https://events.linuxfoundation.cn/kubecon-cloudnativecon-open-source-summit-china/
-
-### Transparency
-
-- Recording: Sessions will be video recorded and uploaded to YouTube.
-- Transcription: Transcriptions will be uploaded with the video.
-- Content Sharing: All presentations will be uploaded.
-
 ## Team
 
 | Role | Lead | Shadow | Notes |
 |---|---|---|---|
-| Roles| TBD | | |
-
-## Code of Conduct
-
-This event, like all Kubernetes events, has a [Code of Conduct](/code-of-conduct.md). We will have an onsite rep with contact information to be provided here and posted during the event.
-
-## Misc
-
-We want to remove as many barriers as possible for you to attend this event. Please contact community@kubernetes.io to see if we can accommodate a request.
-
-For general info and questions, please join and direct questions to the [#contributor-summit](https://kubernetes.slack.com/messages/C7J893413/) slack channel. To speak directly to the staff, please join the [#summit-staff](https://kubernetes.slack.com/messages/CEMM39SKG/) slack channel.
-
-As stated above, this doc will be updated with further details. Please check back for additional information.
+| Event Lead | Yang Li [@idealhack](https://github.com/idealhack) | | |

--- a/events/2020/11-contributor-summit/README.md
+++ b/events/2020/11-contributor-summit/README.md
@@ -39,7 +39,7 @@ so make sure you plan travel accordingly.
 
 | Role | Lead | Shadow | Notes |
 |---|---|---|---|
-| Roles| TBD | | |
+| Event Lead | Bob [@mrbobbytables](https://github.com/mrbobbytables) | | |
 
 ## Code of Conduct
 


### PR DESCRIPTION
Finally closing this loop for EU2020.

While doing this, noticed @idealhack and @mrbobbytables weren't set as leads for their respective events and tossed that in as well. 

/assign @mrbobbytables @idealhack 