### PR TITLE
Add packet cluster-api-provider

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -110,6 +110,9 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
 ### cluster-api-provider-openstack
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
+### cluster-api-provider-packet
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-packet/master/OWNERS
 ### cluster-api-provider-vsphere
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-vsphere/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -991,6 +991,9 @@ sigs:
   - name: cluster-api-provider-openstack
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
+  - name: cluster-api-provider-packet
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-packet/master/OWNERS
   - name: cluster-api-provider-vsphere
     contact:
       slack: cluster-api-vsphere


### PR DESCRIPTION
[Packet](https://www.packet.com/) would like to move the cluster-api-provider repository to kubernetes-sig.
Here you can find the request https://github.com/kubernetes/org/issues/1934