### PR TITLE
sig-release: Add Jorge Alarcon Ochoa and Sascha Grunert as TLs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -61,8 +61,10 @@ aliases:
     - dchen1107
     - derekwaynecarr
   sig-release-leads:
+    - alejandrox1
     - calebamiles
     - justaugustus
+    - saschagrunert
     - tpepper
   sig-scalability-leads:
     - mm4tt

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -26,6 +26,13 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**), VMware
 * Tim Pepper (**[@tpepper](https://github.com/tpepper)**), VMware
 
+### Technical Leads
+The Technical Leads of the SIG establish new subprojects, decommission existing
+subprojects, and resolve cross-subproject technical issues and decisions.
+
+* Jorge Alarcon Ochoa (**[@alejandrox1](https://github.com/alejandrox1)**), Searchable AI
+* Sascha Grunert (**[@saschagrunert](https://github.com/saschagrunert)**), SUSE
+
 ## Emeritus Leads
 
 * Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1675,6 +1675,13 @@ sigs:
     - github: tpepper
       name: Tim Pepper
       company: VMware
+    tech_leads:
+    - github: alejandrox1
+      name: Jorge Alarcon Ochoa
+      company: Searchable AI
+    - github: saschagrunert
+      name: Sascha Grunert
+      company: SUSE
     emeritus_leads:
     - github: jdumars
       name: Jaice Singer DuMars


### PR DESCRIPTION
Discussed on the SIG Release [mailing list](https://groups.google.com/d/topic/kubernetes-sig-release/2VZndEcjPTo/discussion) and in today's SIG Release [meeting](https://docs.google.com/document/d/1Fu6HxXQu8wl6TwloGUEOXVzZ1rwZ72IAhglnaAMCPqA/edit#heading=h.6hgnu9qtrd4o).

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @calebamiles @alejandrox1 @saschagrunert 
cc: @kubernetes/sig-release 
/hold for lazy consensus (timeout: Thursday, June 18 at 4pm US Eastern)