### PR TITLE
release docs: update 9 months to 1 year patch support

### DIFF
--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -166,13 +166,20 @@ cherry pick.
 
 ## Cherry Picks for Unsupported Releases
 
-The release team only supports & patches `n-3` releases (`n` being the latest
-release of Kubernetes). In January of 2019 the community discovered a
-regression, that was introduced in a post-release patch, but was currently no
-longer supported.
+The community supports & patches releases for approximately 1 year
+for releases 1.19 and newer.  For releases 1.18 and older the patch
+support extended for approximately 9 months, which was derived from
+keeping `n-3` releases (`n` being the latest -release of Kubernetes)
+in support and a quarterly release cycle.
 
-As discussed in a SIG Release meeting on 2019-01-15, a fix was backported to
-the non supported version.
+The community makes no guarantees, but in the event of a high
+severity issue with a patch that is backportable and can be proved
+with CI signal, this extra support may occasionally be given.
+
+For example, in January of 2019 the community discovered a regression, that was
+introduced in a post-release patch, but was currently no longer
+supported.  As discussed in a SIG Release meeting on 2019-01-15, a
+fix was backported to the non supported version.
 
 Reference PR: [#72860](https://github.com/kubernetes/kubernetes/pull/72860)
 

--- a/contributors/devel/sig-release/release.md
+++ b/contributors/devel/sig-release/release.md
@@ -119,6 +119,9 @@ The general labeling process should be consistent across artifact types.
   Created at the time of the `vX.Y-rc.0` release and maintained after the
   release for approximately 12 months with `vX.Y.Z` patch releases.
 
+  Note: releases 1.19 and newer receive 1 year of patch release support, and
+  releases 1.18 and earlier received 9 months of patch release support.
+
 ## The Release Cycle
 
 ![Image of one Kubernetes release cycle](release-cycle.png)


### PR DESCRIPTION
As of the KEP
https://git.k8s.io/enhancements/keps/sig-release/1498-kubernetes-yearly-support-period
becoming implementable for 1.19, we should note this change in the
developer guide description of the release process and lifecycle.

Signed-off-by: Tim Pepper <tpepper@vmware.com>
