### PR TITLE
Fix some broken links

### DIFF
--- a/contributors/design-proposals/README.md
+++ b/contributors/design-proposals/README.md
@@ -13,4 +13,4 @@ Note that a number of these documents are historical and may be out of date or u
 TODO: Add the current status to each document and clearly indicate which are up to date.
 
 
-[keps]: http://git.k8s.io/enhancements/keps/0001a-meta-kep-implementation.md#meta-kep-implementation
+[keps]: http://git.k8s.io/enhancements/keps/

--- a/contributors/design-proposals/api-machinery/controller-ref.md
+++ b/contributors/design-proposals/api-machinery/controller-ref.md
@@ -64,7 +64,7 @@ Approvers:
   Deployment rollout state and history, and possibly also corruption or loss of
   StatefulSet application data.
 
-* ControllerRef is not intended to replace [selector generation](selector-generation.md),
+* ControllerRef is not intended to replace [selector generation](/contributors/design-proposals/apps/selector-generation.md),
   used by some controllers like Job to ensure all selectors are unique
   and prevent overlapping selectors from occurring in the first place.
 


### PR DESCRIPTION
I found some broken links during reading design proposals.
This fixes the following links.
- https://github.com/kubernetes/community/tree/master/contributors/design-proposals/api-machinery/controller-ref.md -> "selector generation"
- https://github.com/kubernetes/community/tree/master/contributors/design-proposals -> "Kubernetes Enhancement Proposals (KEP)"

