### PR TITLE
Add a slack channel for chartcenter

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -27,8 +27,9 @@ channels:
   - name: cert-manager
   - name: cert-manager-dev
   - name: chairs-and-techleads
+  - name: chartcenter
   - name: chartmuseum
-  - name: charts
+  - name: charts 
   - name: cka-exam-prep
   - name: ckad-exam-prep
   - name: client-go-docs


### PR DESCRIPTION
We want to add a slack channel in the kubernetes slack group for ChartCenter.

ChartCenter is a free central repository for Helm charts:
https://chartcenter.io
https://github.com/jfrog/chartcenter
