### PR TITLE
Add kubevirt-dev slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -192,6 +192,7 @@ channels:
   - name: kubernetes-users
   - name: kubespray
   - name: kubespray-dev
+  - name: kubevirt-dev
   - name: kubicorn
   - name: kudo
   - name: kurl


### PR DESCRIPTION
Most communication regarding to the CNCF sandbox project KubeVirt is
happening inside #virtualization. We are spending a lot of time also on
development and keeping our e2e tests stable. This creates a lot of
traffic which we don't think is good to have in #virtualization. We
therefore want to have a dedicated channel to discuss and reports issues
around code and CI.