### PR TITLE
Update docs to suggest creating PRs in k/org for kubernetes members

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -71,8 +71,10 @@ We are currently working on automation that would transfer membership in the
 Kubernetes organization to any related orgs automatically, but such is not the
 case currently. If you are a Kubernetes org member, you are implicitly eligible
 for membership in related orgs, and can request membership when it becomes
-relevant, by [opening an issue][membership request] against the kubernetes/org
-repo, as above. However, if you are a member of any of the related
+relevant, by creating a PR directly or [opening an issue][membership request]
+against the kubernetes/org repo, as above.
+
+However, if you are a member of any of the related
 [Kubernetes GitHub organizations] but not of the [Kubernetes org],
 you will need explicit sponsorship for your membership request.
 


### PR DESCRIPTION
We've had many issues opened in k/org where existing `kubernetes` org
members request membership to `kubernetes-sigs`. Under our current
policy, all members of `kubernetes` are implicitly eligible for
membership to `kubernetes-sigs` and don't require sponsorship.

In such cases, we usually ask them to create a PR directly or we create
one ourselves and let the requester lgtm it. To ease the often
unnecessary two step process, this commit updates community membership
guidelines to suggest creating PRs directly if they are existing
`kubernetes` members.

/area github-management
/assign @mrbobbytables @cblecker @spiffxp 

/hold 
for review