### PR TITLE
Move sig-docs channels to sig-docs/ subdirectory

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -303,14 +303,7 @@ channels:
     archived: true
   - name: sig-contribex
   - name: sig-contribex-triage
-  - name: sig-docs
-  - name: sig-docs-blog
-  - name: sig-docs-maintainers
-  - name: sig-docs-modeling
-  - name: sig-docs-release
-  - name: sig-docs-security
-    archived: true
-  - name: sig-docs-tools
+  # sig-docs* channels are defined in sig-docs/
   - name: sig-high-availability
     archived: true
   - name: sig-instrumentation

--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -22,6 +22,8 @@ restrictions:
   - path: "sig-docs/*.yaml"
     channels:
       - "^kubernetes-docs-[a-z]{2}(-maintainers)?$"
+      - "^sig-docs$"
+      - "^sig-docs-.*$"
   - path: "sig-release/*.yaml"
     channels:
       - "^sig-release$"

--- a/communication/slack-config/sig-docs/docs-channels.yaml
+++ b/communication/slack-config/sig-docs/docs-channels.yaml
@@ -16,3 +16,11 @@ channels:
   - name: kubernetes-docs-be
   - name: kubernetes-docs-pl
   - name: kubernetes-docs-uk
+  - name: sig-docs
+  - name: sig-docs-blog
+  - name: sig-docs-maintainers
+  - name: sig-docs-modeling
+  - name: sig-docs-release
+  - name: sig-docs-security
+    archived: true
+  - name: sig-docs-tools


### PR DESCRIPTION
After the following question on Slack I noticed the `sig-docs*` channels were still in the channels.yml even though sig-docs has its own subdirectory already.

https://kubernetes.slack.com/archives/CA1MMM1HU/p1594016729218100

/cc @sftim @zacharysarah @mrbobbytables 