### PR TITLE
add sig docs ja maintainers

### DIFF
--- a/communication/slack-config/sig-docs/docs-channels.yaml
+++ b/communication/slack-config/sig-docs/docs-channels.yaml
@@ -7,6 +7,7 @@ channels:
   - name: kubernetes-docs-id
   - name: kubernetes-docs-it
   - name: kubernetes-docs-ja
+  - name: kubernetes-docs-ja-maintainers
   - name: kubernetes-docs-ko
   - name: kubernetes-docs-pt
   - name: kubernetes-docs-ru


### PR DESCRIPTION
This PR adds slack #kubernetes-docs-ja-maintainers channel.
This channel is used for discussion and communication about localization of Japanese language, but specifically for its maintaining.

**Which issue(s) this PR fixes**:

NONE