### PR TITLE
Update sig-docs channel restriction to allow maintainers channels

### DIFF
--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -21,7 +21,7 @@ restrictions:
       - "^enhancements-owners$"
   - path: "sig-docs/*.yaml"
     channels:
-      - "^kubernetes-docs-[a-z]{2}$"
+      - "^kubernetes-docs-[a-z]{2}(-maintainers)?$"
   - path: "sig-release/*.yaml"
     channels:
       - "^sig-release$"


### PR DESCRIPTION
This allows localization channels to create an additional maintainers channel.

Ref #4918 

/cc @sftim @zacharysarah @jimangel @inductor