### PR TITLE
Auto add a label for sig-docs changes

### DIFF
--- a/communication/slack-config/sig-docs/OWNERS
+++ b/communication/slack-config/sig-docs/OWNERS
@@ -2,3 +2,5 @@
 
 approvers:
   - sig-docs-leads
+labels:
+  - sig/docs


### PR DESCRIPTION
This auto adds the `sig/docs` label for changes in the [sig-docs/](https://github.com/kubernetes/community/tree/master/communication/slack-config/sig-docs) subdirectory.

/assign @sftim 