### PR TITLE
Add reddit-mods Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -277,6 +277,7 @@ channels:
   - name: rancher
   - name: random
     archived: true
+  - name: reddit-mods
   - name: rktnetes
   - name: ro-users
   - name: ru-users


### PR DESCRIPTION
The r/kubernetes subreddit has grown to over 45k subscribers and is loosely maintained by a small set of moderators that largely overlap with the Kubernetes Slack org.

This channel is being created to get our mod team organized about policies and enforcement, and to work towards sufficient quality and Code of Conduct enforcement to eventually become an "official" subreddit (should the community will it).

Signed-off-by: Greg Taylor <greg@gctaylor.com>