### PR TITLE
sig-cluster-lifecycle: remove outdated postmortems owners file

### DIFF
--- a/sig-cluster-lifecycle/postmortems/OWNERS
+++ b/sig-cluster-lifecycle/postmortems/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-reviewers:
-  - pipejakob
-approvers:
-  - pipejakob


### PR DESCRIPTION
The single owner in this file has been [inactive](https://github.com/kubernetes/community/blob/master/community-membership.md#inactive-members) for some time (over 18 months with no devstats recorded activity) and is slated for removal (ref: https://github.com/kubernetes/org/issues/2013).

I don't think a new owner for this specific directory needs to be established, but if so I can leave it in place and amend it instead.