### PR TITLE
Adding a folder with example resources for storytelling.

### DIFF
--- a/communication/marketing-team/storytelling-resources/example-interview-qs-sig-windows.md
+++ b/communication/marketing-team/storytelling-resources/example-interview-qs-sig-windows.md
@@ -1,0 +1,20 @@
+*Note this is an example specific to SIG-Windows. If reusing, replace SIG-Windows specific text."*
+
+Q: A lot of folks are familiar with Kubernetes on Linux, but SIG-Windows focuses on the experience of using Kubernetes on Windows. Could you tell us a little about what SIG-Windows does?
+
+Q: When Windows containers first came out 4 or 5 years ago, there was a lot of confusion over what they were. Could you just run the same Linux containers on Windows? And also a lot of excitement over what this might mean for the future of multi-OS systems. Can you give a brief introduction to Windows containers?
+
+Q: What are the biggest differences between using Kubernetes on Linux and Kubernetes on Windows?
+
+Q: Kubernetes 1.18 just released on April 23rd. What’s new for Windows in 1.18?
+
+Q: What are users excited about with Kubernetes on Windows? What are you getting positive feedback on, and what’s coming up next for SIG-Windows?
+
+Q: Why should new [or existing] contributors consider joining SIG-Windows?
+
+Q: What do you do to help new contributors get started?
+
+Q: Are there any particular skills you’d like to recruit for? What skills are
+contributors to SIG-Windows likely to learn?
+
+Q: Any closing thoughts/resources you’d like to share?

--- a/communication/marketing-team/storytelling-resources/example-topics.md
+++ b/communication/marketing-team/storytelling-resources/example-topics.md
@@ -1,0 +1,21 @@
+# SIG Profiles/Stories
+## Kubernetes Blog Series
+
+### Starter Topics
+
+- How did your SIG or working group form?
+- What problem(s) are you trying to solve today?
+- What are some of the key challenges you face?
+- What do you consider to be a success, resulting from this group?
+- What do you look for in new contributors
+- What are you doing to help make your WG more welcoming to new contributors?
+- What are some things that can people do to help this WG if they come from a background that isn’t directly linked to programming? 
+- Are there any issues you would like to recommend to people that are just getting started contributing to Docs/WGs/OSS? 
+- What do you think helps keep people in this group?
+- Are there any funny / cool / TIL anecdotes that you could tell us?
+- Would you like to shout out to any individuals or profile folks doing work within this SIG/WG?
+- What’s a SIG or WG related accomplishment that you are really proud of?
+- What’s the biggest misconception people have about the SIG or WG?
+- What are some guidelines that influence the decisions made in your SIG or WG? Where can we find them?
+- Who should people contact if they want to get started helping out/contributing to this WG? 
+


### PR DESCRIPTION
Adding a folder with resources for storytellers within /kubernetes/community/communication/marketing-team/. Adding two md files - one with suggested topics when interviewing a SIG for a SIG profile blog post. One with an example set of questions used in the SIG-Windows profile blog post.

Fixes #4798
