### PR TITLE
Add channel for external-secrets

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -74,6 +74,7 @@ channels:
   - name: etcdadm
   - name: events
   - name: external-dns
+  - name: external-secrets
   - name: falco
   - name: fiaas
   - name: fi-users


### PR DESCRIPTION
Adding a channel for users of GoDaddy's [Kubernetes External Secrets](https://github.com/godaddy/kubernetes-external-secrets) as discussed in the linked issue.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes godaddy/kubernetes-external-secrets#388.
