### PR TITLE
Add description to contributor guide readme

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -1,3 +1,11 @@
+title: "Getting Started"
+weight: 1
+description:
+  A small list of things that you should read and be familiar with before you
+  get started with contributing. This includes such things as signing the
+  Contributor License Agreement, familiarizing yourself with our Code of Conduct
+  and more.
+
 # Welcome
 
 Have you ever wanted to contribute to the coolest cloud technology?


### PR DESCRIPTION
As the readme is now the entrypoint for the contributor guide on the contributor site, it needed some metadata to go along with it \o/

/assign @castrojo 

EDIT: Forgot to reference the issue where they were consolidated: https://github.com/kubernetes/community/pull/4876