### PR TITLE
Add Unconscious Bias Training requirement for all leads

### DIFF
--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -150,6 +150,8 @@ curation from other SIG participants
 - *MAY* build new functionality for subprojects
 - *MAY* participate in decision making for the subprojects they hold roles in
 - Includes all reviewers and approvers in [OWNERS] files for subprojects
+- *MUST* take an [inclusive speaker training course] in support of our community values
+within 30 days from the date of their appointment.
 
 ### Security Contact
 
@@ -241,3 +243,4 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
 [Google group]: https://groups.google.com/forum/#!forum/kubernetes-sig-config
 [dashboard]: https://testgrid.k8s.io/
 [monthly community meeting]: /events/community-meeting.md
+[inclusive speaker training course]: https://training.linuxfoundation.org/training/inclusive-speaker-orientation/


### PR DESCRIPTION
As discussed in the last [public steering committee meeting on July 6th](https://docs.google.com/document/d/1qazwMIHGeF3iUh5xMJIJ6PDr-S3bNkT8tNLRkSiOkOU/edit), this PR adds an Unconscious Bias Training requirement for all leads to be completed 30 days within the date of their appointment.

An email will be sent with more details soon.

/assign @cblecker 
/cc @kubernetes/steering-committee 

/hold
for reviews