### PR TITLE
sig-node: add seccomp-operator repo

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -66,6 +66,11 @@ The following [subprojects][subproject-definition] are owned by sig-node:
   - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
 - **Contact:**
   - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
+### seccomp-operator
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/seccomp-operator/master/OWNERS
+- **Contact:**
+  - Slack: [#seccomp-operator](https://kubernetes.slack.com/messages/seccomp-operator)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1671,6 +1671,11 @@ sigs:
       slack: node-problem-detector
     owners:
     - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
+  - name: seccomp-operator
+    contact:
+      slack: seccomp-operator
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/seccomp-operator/master/OWNERS
 - dir: sig-release
   name: Release
   mission_statement: >


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1873

/assign @derekwaynecarr @dchen1107 
cc @saschagrunert 

/hold
for lgtm by sig node leads

