### PR TITLE
Archive sig-docs-security

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -309,6 +309,7 @@ channels:
   - name: sig-docs-modeling
   - name: sig-docs-release
   - name: sig-docs-security
+    archived: true
   - name: sig-docs-tools
   - name: sig-high-availability
     archived: true


### PR DESCRIPTION
This PR archives the #sig-docs-security channel on Kubernetes Slack.

/assign @mrbobbytables 
/sig docs