### PR TITLE
Setting up a slack channel for sig-storage subproject kubernetes-cosi

### DIFF
--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -34,6 +34,7 @@ restrictions:
   - path: "sig-storage/*.yaml"
     channels:
       - "^sig-storage$"
+      - "^sig-storage-"
       - "^csi$"
       - "^csi-"
   - path: "sig-cloud-provider/*.yaml"

--- a/communication/slack-config/sig-storage/config.yaml
+++ b/communication/slack-config/sig-storage/config.yaml
@@ -5,3 +5,4 @@ channels:
     id: CG04EL876
   - name: csi-windows
   - name: sig-storage
+  - name: sig-storage-cosi


### PR DESCRIPTION
This PR adds a slack channel for the kubernetes-cosi subproject under sig-storage. We are having weekly design meetings and working on prototyping. We'd like to have a slack channel for communication.

https://github.com/kubernetes/community/tree/master/sig-storage#kubernetes-cosi

CC @saad-ali @msau42 @jsafrane @jeffvance 
