### PR TITLE
Adding litmus-dev channel to kubernetes slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -203,6 +203,7 @@ channels:
     archived: true
   - name: linode
   - name: litmus
+  - name: litmus-dev
   - name: lokomotive
   - name: malaysia-users
   - name: malta-users


### PR DESCRIPTION
Signed-off-by: Raj Babu Das <raj.das@mayadata.io>

This channel is to go alongside the existing #litmus and should be managed the same way.

The intent with #litmus-dev is to provide separation of development-related discussions and other notification mechanisms to track changes from user queries and feature requests.