### PR TITLE
Rename secret-sync-rotation to k8s-gsm-tools

### DIFF
--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -47,6 +47,10 @@ Boskos is a resource manager service that handles different kinds of resources a
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/boskos/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
+### k8s-gsm-tools
+Controllers to sync and rotate kubernetes secrets with google cloud secret manager
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/k8s-gsm-tools/master/OWNERS
 ### kind
 Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
 - **Owners:**
@@ -73,10 +77,6 @@ Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action 
 ### repo-infra
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
-### secret-sync-rotation
-Controllers to sync and rotate kubernetes secrets with google cloud secret manager
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/secret-sync-rotation/master/OWNERS
 ### test-infra
 Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2161,6 +2161,11 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/boskos/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
+  - name: k8s-gsm-tools
+    description: |
+      Controllers to sync and rotate kubernetes secrets with google cloud secret manager
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/k8s-gsm-tools/master/OWNERS
   - name: kind
     description: |
       Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
@@ -2195,11 +2200,6 @@ sigs:
   - name: repo-infra
     owners:
     - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
-  - name: secret-sync-rotation
-    description: |
-      Controllers to sync and rotate kubernetes secrets with google cloud secret manager
-    owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/secret-sync-rotation/master/OWNERS
   - name: test-infra
     description: |
       Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project


### PR DESCRIPTION
Naming is hard. This makes the resulting staging gcr.io repo project
hit the 30 character limit

ref: https://github.com/kubernetes-sigs/secret-sync-rotation/issues/3