### PR TITLE
Add olm-dev and operator-sdk-dev channels to slack config

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -254,6 +254,7 @@ channels:
   - name: octant
   - name: office-hours
   - name: okteto
+  - name: olm-dev
   - name: opencontainers
   - name: openebs
   - name: openebs-dev
@@ -261,6 +262,7 @@ channels:
   - name: openshift-users
   - name: openstack-helm
   - name: openstack-kolla
+  - name: operator-sdk-dev
   - name: ops-status
     archived: true
   - name: osbkit


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

This PR adds new Kubernetes Slack channels `olm-dev` and `operator-sdk-dev`.

[Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager) and [Operator SDK](https://github.com/operator-framework/operator-sdk) were recently accepted into CNCF as Incubating projects under Operator Framework.

We would like to encourage the community to participate more in the development activities of these projects, so we are moving our communication to open slack channels.

Many of our user questions are raised in the existing `kubernetes-operators` channel, so we do not currently see a need for any new user channels.

