### PR TITLE
Remove repo-infra subproject from sig-contribex, keep in sig-testing

### DIFF
--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -123,10 +123,6 @@ Oversees and develops programs for helping contributors ascend the contributor l
   - sig-contribex mentoring subproject meeting (EU/NA Friendly Time): [Tuesdays at 08:30 PT](https://zoom.us/j/98162537924) (2nd and 4th Tuesday of each month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=08:30&tz=PT).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/edit#heading=h.o9thwxp2o68r).
     - [Meeting recordings](https://www.youtube.com/watch?v=Cqf9dIiS6Ig&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr).
-### repo-infra
-Creates and maintains tools and templates for kubernetes-namespace repositories.
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
 ### slack-infra
 Creates and maintains tools and automation for Kubernetes Slack.
 - **Owners:**

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -75,6 +75,7 @@ Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action 
 - **Contact:**
   - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
 ### repo-infra
+Creates and maintains tools and templates for kubernetes-namespace repositories.
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
 ### test-infra

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1235,11 +1235,6 @@ sigs:
       url: https://zoom.us/j/98162537924
       archive_url: https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/edit#heading=h.o9thwxp2o68r
       recordings_url: https://www.youtube.com/watch?v=Cqf9dIiS6Ig&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr
-  - name: repo-infra
-    description: Creates and maintains tools and templates for kubernetes-namespace
-      repositories.
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
   - name: slack-infra
     description: Creates and maintains tools and automation for Kubernetes Slack.
     contact:
@@ -2203,6 +2198,8 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
   - name: repo-infra
+    description: Creates and maintains tools and templates for kubernetes-namespace
+      repositories.
     owners:
     - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
   - name: test-infra


### PR DESCRIPTION
The `repo-infra` repo exists as a subproject both in SIG Contribex and
SIG Testing. Given that the repo is more appropriate under SIG Testing,
removing it from SIG Contribex's list of subprojects.

contribex -> https://github.com/kubernetes/community/tree/master/sig-contributor-experience#repo-infra
testing -> https://github.com/kubernetes/community/tree/master/sig-testing#repo-infra

/hold
for ack from sig-testing leads and other sig-contribex leads

/assign @cblecker @mrbobbytables @castrojo 
contribex leads

/assign @spiffxp @BenTheElder @stevekuznetsov 
testing leads
