### PR TITLE
Add governance.md to WG Naming

### DIFF
--- a/wg-naming/governance.md
+++ b/wg-naming/governance.md
@@ -1,0 +1,85 @@
+# WG Naming governance
+
+## Uphold project values
+
+WG Naming upholds the Kubernetes project's [core values](/values.md).
+
+### Inclusive is better than exclusive
+
+> Broadly successful and useful technology requires different perspectives and skill sets which can only be heard in a welcoming and respectful environment.
+
+This document covers some specific ways in which WG Naming offers respect and welcome.
+
+> Our community shows respect for the time and effort put into a discussion regardless of where a contributor is on their growth path.
+
+Like other SIGs and working groups, WG Naming has prerequisite skills, training, and experience that are necessary for meaningful contribution. For example:
+
+  - Education or professional experience in dismantling systemic discrimination
+  - Demonstrable familiarity with current antidiscrimination resources
+  - A track record of supporting inclusion in the Kubernetes project
+
+WG Naming has many stakeholders, with many people eager to add their voices. WG Naming invites folks who are new to antiracism or inclusive language, and folks less experienced with frameworks of discrimination to participate by observing and learning. WG Naming invites contributors who meet prerequisites to contribute within the scope of WG Naming’s goals.
+
+### Resources for antidiscrimination
+
+- https://developers.google.com/style/inclusive-documentation
+- https://www.antiracismresources.info/#online-resources
+- _How to Be An Antiracist_, Ibrahim X. Kendi
+- _So You Want to Talk About Race_, Ijeoma Oluo
+
+### Scope of discussion
+
+WG Naming actively moderates discussion for speech that affirms the humanity of underrepresented minorities and affirms their ongoing experience of discrimination. For example: specific suggestions for replacement terms are welcome. Disagreement over the presence and impact of racism is not welcome.
+
+## Follow the community code of conduct
+
+Like all WGs and SIGs, WG Naming expects contributors to follow the [Kubernetes Code of Conduct (CoC)]. 
+
+We raise this section’s topics as potential blockers to the work of WG Naming, since experience has shown they are a common and detrimental response.
+
+From the CoC:
+
+> Examples of unacceptable behavior by participants include:
+>
+>   - Personal attacks
+>   - Trolling or insulting/derogatory comments
+
+**Note:** the CoC governs conduct, not intent. WG Naming leads may refer unacceptable conduct to the Code of Conduct Committee regardless of professed intent.
+
+[Kubernetes Code of Conduct (CoC)]: /code-of-conduct.md
+
+### Personal attacks
+
+Personal attacks include denying or questioning the lived experience of underrepresented minorities. For example: arguing that problematic terms "aren't racist", or any statements reducible or equivalent to "all lives matter".
+
+### Trolling
+
+Trolling includes:
+
+- [Concern trolling](https://en.wiktionary.org/wiki/concern_troll)
+
+- Derailing behavior
+
+    Behavior that distracts from WG Naming's purpose or attempts to redirect participants' energy into minutiae or unrelated topics or goals.
+
+    For example: 
+      - insisting that previous decisions be re-argued
+      - insisting that WG Naming can take no action until all possible inequities are addressed
+
+- [Sea lioning](https://www.forbes.com/sites/marshallshepherd/2019/03/07/sealioning-is-a-common-trolling-tactic-on-social-media-what-is-it/)
+
+  Endless demands for evidence; refusing to accept or acknowledge peer-reviewed scientific research; insisting that one's ignorance, whether real or feigned, be satisfied by the WG group to an individual's satisfaction.
+
+  See the original Wondermark comic: [sea lions](http://wondermark.com/1k62/)
+
+- [Brigading](https://en.wikipedia.org/wiki/Vote_brigading)
+
+  Attempting to overrepresent a viewpoint through participation bias
+
+## Deviations from [sig-governance]
+
+WG Naming leads may close or end meetings at their discretion to shut down trolling or protect the safety of community members.
+
+WG Naming [restricts the scope of discussion](#scope-of-discussion).
+
+[sig-governance]: /committee-steering/governance/sig-governance.md


### PR DESCRIPTION
This PR adds a governance document to WG Naming, described in #4968.

/wg naming
/assign @celestehorgan @jdumars @justaugustus 
