### PR TITLE
add group / alias entry for current google build admin oncall

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -39,6 +39,9 @@ usergroups:
   - name: test-infra-oncall
     external: true
 
+  - name: google-build-admin
+    external: true
+
   - name: velero-maintainers
     long_name: Velero Maintainers
     description: Velero Maintainers group.


### PR DESCRIPTION
see:
- go.k8s.io/oncall
- https://github.com/kubernetes/sig-release/issues/1150
