### PR TITLE
Update calendar guidelines & links

### DIFF
--- a/.github/ISSUE_TEMPLATE/marketing-request.md
+++ b/.github/ISSUE_TEMPLATE/marketing-request.md
@@ -44,7 +44,7 @@ Blog and Social Media Guidelines: https://git.k8s.io/community/communication/mar
 - [ ] Twitter (via [@k8scontributors](https://twitter.com/k8scontributors))
 - [ ] YouTube ([Kubernetes](https://www.youtube.com/channel/UCZ2bu0qutTOM0tHYa_jkIwg))
 - [ ] Slack (assumes `#kubernetes-dev` unless otherwise mentioned)
-- [ ] Contributor Calendar event entry (available [here](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America%2FLos_Angeles))
+- [ ] Contributor Calendar event entry (available [here](https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io))
 - [ ] Other (fill this out)
 
 **Where is your first draft available?**

--- a/communication/README.md
+++ b/communication/README.md
@@ -173,7 +173,7 @@ place!
 
 
 [Kubernetes Blog]: https://kubernetes.io/blog/
-[shared calendar]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles
+[shared calendar]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [Kubernetes code of conduct]: /code-of-conduct.md
 [events]: https://www.cncf.io/events/
 [file an issue]: https://github.com/kubernetes/kubernetes/issues/new

--- a/communication/calendar-guidelines.md
+++ b/communication/calendar-guidelines.md
@@ -55,8 +55,6 @@ addition of [gsuite], this practice may change soon.
     will need to be set to "public".
   - In the calendar invite body - include your meeting notes, zoom information,
     and any other pertinent information that you want your group to know.
-  - Invite your SIG/WG mailing list and the Kubernetes Community Public
-    Calendar address: `cgnt364vd8s86hr2phapfjc6uk@group.calendar.google.com`
 
 
 ### Testing Permissions
@@ -122,5 +120,5 @@ to refresh invites sent to the group.
 [new shared calendar]: https://support.google.com/calendar/answer/37095?hl=en
 [configure access permissions and sharing:]: https://support.google.com/calendar/answer/37082?hl=en
 [SIG/WG list]: /sig-list.md
-[Public Community Calendar]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America%2FLos_Angeles
+[Public Community Calendar]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io&ctz=America%2FLos_Angeles
 [contributor mailing list]: https://groups.google.com/forum/#!forum/kubernetes-dev

--- a/contributors/guide/contributor-cheatsheet/README-de.md
+++ b/contributors/guide/contributor-cheatsheet/README-de.md
@@ -354,7 +354,7 @@ anderer Beitragenden zu überlassen, die als Reviewer und Approver für den PR z
 [GitHub Labels]: https://go.k8s.io/github-labels
 [Kubernetes Code Search]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[Kalender]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[Kalender]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [Slack Channels]: http://slack.k8s.io/
 [Stack-Overflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README-fr.md
+++ b/contributors/guide/contributor-cheatsheet/README-fr.md
@@ -294,7 +294,7 @@ Si vous ne savez pas si vous devez faire un squash de vos commits, il est pr√©f√
 [gitHub labels]: https://go.k8s.io/github-labels
 [Kubernetes Code Search]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[calendar]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[calendar]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [slack channels]: http://slack.k8s.io/
 [stackOverflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README-hi.md
+++ b/contributors/guide/contributor-cheatsheet/README-hi.md
@@ -285,7 +285,7 @@ PR संशोधन का चरण। यदि आप अनिश्चि
 [Github लेबल]: https://go.k8s.io/github-labels
 [कुबरनेट्स Code Search]: https://cs.kubs.io/
 [@dims]: https://github.com/dims
-[कैलेंडर]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[कैलेंडर]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [Slack चैनल]: http://slack.k8s.io/
 [stackOverflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README-id.md
+++ b/contributors/guide/contributor-cheatsheet/README-id.md
@@ -355,7 +355,7 @@ _squashing_ perlu dilakukan atau tidak.
 [Label GitHub]: https://go.k8s.io/github-labels
 [Pencarian Kode Kubernetes]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[kalender]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[kalender]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [slack _channels_]: http://slack.k8s.io/
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README-it.md
+++ b/contributors/guide/contributor-cheatsheet/README-it.md
@@ -362,7 +362,7 @@ git push --force
 [gitHub labels]: https://go.k8s.io/github-labels
 [Kubernetes Code Search]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[calendar]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[calendar]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [slack channels]: http://slack.k8s.io/
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README-ja.md
+++ b/contributors/guide/contributor-cheatsheet/README-ja.md
@@ -302,7 +302,7 @@ git checkout -b myfeature
 [GitHubラベル]: https://go.k8s.io/github-labels
 [Kubernetes Code Search]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[カレンダー]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[カレンダー]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [slackチャンネル]: http://slack.k8s.io/
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README-ko.md
+++ b/contributors/guide/contributor-cheatsheet/README-ko.md
@@ -360,7 +360,7 @@ PR을 검토하고 승인하도록 지정된 다른 참여자의 판단에 맡�
 [gitHub 레이블]: https://go.k8s.io/github-labels
 [쿠버네티스 코드 검색]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[달력]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[달력]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [Slack 채널]: http://slack.k8s.io/
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README-pt.md
+++ b/contributors/guide/contributor-cheatsheet/README-pt.md
@@ -341,7 +341,7 @@ fase de uma revisão do PR. Se você não tem certeza se deve efetuar o squashin
 [gitHub labels]: https://go.k8s.io/github-labels
 [Pesquisa no código do Kubernetes]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[Calendário]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[Calendário]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [slack]: http://slack.k8s.io/
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README-uk.md
+++ b/contributors/guide/contributor-cheatsheet/README-uk.md
@@ -287,7 +287,7 @@ git checkout -b myfeature
 [GitHub мітки]: https://go.k8s.io/github-labels
 [Пошук у коді Kubernetes]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[Календар]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[Календар]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [Канали Slack]: http://slack.k8s.io/
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README-zh.md
+++ b/contributors/guide/contributor-cheatsheet/README-zh.md
@@ -292,7 +292,7 @@ git checkout -b myfeature
 [GitHub 标签]: https://go.k8s.io/github-labels
 [Kubernetes 代码搜索]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[日历]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[日历]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [Slack 频道]: http://slack.k8s.io/
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -386,7 +386,7 @@ git push --force
 [gitHub labels]: https://go.k8s.io/github-labels
 [Kubernetes Code Search]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
-[calendar]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com
+[calendar]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
 [kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
 [slack channels]: http://slack.k8s.io/
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/kubernetes

--- a/events/community-meeting.md
+++ b/events/community-meeting.md
@@ -149,8 +149,8 @@ The document gets slow as we add notes, so it is archived regularly into the
 
 [community-meeting]: https://zoom.us/my/kubernetescommunity
 [10am PT]: http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29
-[calendar.google.com]: https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America/Los_Angeles
-[iCal url]: https://calendar.google.com/calendar/ical/cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com/public/basic.ics
+[calendar.google.com]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
+[iCal url]: https://calendar.google.com/calendar/ical/calendar%40kubernetes.io/public/basic.ics
 [iCal client]: https://en.wikipedia.org/wiki/ICalendar
 [YouTube Channel]: https://www.youtube.com/playlist?list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ
 [agenda]: http://bit.ly/k8scommunity

--- a/mentoring/programs/README.md
+++ b/mentoring/programs/README.md
@@ -5,4 +5,4 @@
 APAC friendly time is, Monday at 20:30, every second and fourth week of the month
 EU/NA friendly time is, Tuesdays at 08:30, every second and fourth week of the month
 
-Details can be found on the Contribex community calendar [here](https://calendar.google.com/calendar/embed?src=cgnt364vd8s86hr2phapfjc6uk%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+Details can be found on the Contribex community calendar [here](https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io)


### PR DESCRIPTION
This updates the process and all links referencing the community calendar.

The community calendar no longer needs to be manually added as a guest for meetings. It has been replaced by a named account (calendar@kubernetes.io) that has joined each community group mailing list and will auto-aggregate the events.

fixes #3467 
fixes #4903 

Resolves some items for annual maintenance - ref: #3717
