### PR TITLE
Update New Membership Coordinators

### DIFF
--- a/github-management/README.md
+++ b/github-management/README.md
@@ -56,9 +56,9 @@ GitHub organization.
 They also have approval privileges for adding new members to the GitHub config.
 
 Our current coordinators are:
-* Naeil Ezzoueidi (**[@nzoueidi](https://github.com/nzoueidi)**, Central European)
-* Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**, US Eastern)
-* Yang Li (**[@idealhack](https://github.com/idealhack)**, Japan Standard Time)
+* Arnaud Meukam (**[@ameukam](https://github.com/ameukam)**, Central European)
+* Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**, Indian Standard Time)
+* Savitha Raghunathan (**[@savitharaghunathan](https://github.com/savitharaghunathan)**, US Eastern)
 
 ## Project Owned Organizations
 


### PR DESCRIPTION
The GitHub Admin already confirmed with the old NMCs about stepping down due to lack of bandwidth and confirmed with the new NMCs that they'd like to take on this role.

@justaugustus @idealhack @nzoueidi this is a lot of chopping wood and carry water, thank you SO MUCH for all your work!

Congrats to @ameukam @palnabarun @savitharaghunathan! :tada: I'll reach out to y'all later about next steps. :)

/assign @cblecker @mrbobbytables 
/hold

@ameukam @palnabarun @savitharaghunathan For the record,  can you please confirm here that you'd like to take this role?