### PR TITLE
Fix metadata header in contributor guide readme

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -1,3 +1,4 @@
+---
 title: "Getting Started"
 weight: 1
 description:
@@ -5,6 +6,7 @@ description:
   get started with contributing. This includes such things as signing the
   Contributor License Agreement, familiarizing yourself with our Code of Conduct
   and more.
+---
 
 # Welcome
 


### PR DESCRIPTION
I left the leading and trailing `---` to signify the top section is a metadata header in #4935 🤦  This fixes it.