### PR TITLE
sig-service-catalog: add mcs-api repo

### DIFF
--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -51,6 +51,9 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-service-catalog:
+### mcs-api
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/master/OWNERS
 ### minibroker
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/minibroker/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1989,6 +1989,9 @@ sigs:
     - name: sig-service-catalog-test-failures
       description: Test Failures and Triage
   subprojects:
+  - name: mcs-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/master/OWNERS
   - name: minibroker
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/minibroker/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1970

/assign @jberkhahn @mszostok 
for lgtm

/hold
for lgtm from sig-service-catalog leads

cc @JeremyOT 