### PR TITLE
Move kubernetes-template-project from steering to contribex

### DIFF
--- a/committee-steering/README.md
+++ b/committee-steering/README.md
@@ -41,10 +41,6 @@ The following [subprojects][subproject-definition] are owned by the Steering Com
 Funding requests for project infrastructure, events, and consulting
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/funding/master/OWNERS
-### kubernetes-template-project
-Template for starting new projects in the GitHub organizations owned by Kubernetes.
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
 ### steering
 Steering Committee policy and documentation
 - **Owners:**

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -97,6 +97,7 @@ Creates and runs contributor-focused events, such as the Contributor Summit.  Ev
 Manages and controls Github permissions, repos, and groups, including Org Membership.
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
 - **Contact:**
   - Slack: [#github-management](https://kubernetes.slack.com/messages/github-management)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1189,6 +1189,7 @@ sigs:
       slack: github-management
     owners:
     - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
     meetings:
     - description: GitHub Administration Subproject
@@ -2964,11 +2965,6 @@ committees:
     description: Funding requests for project infrastructure, events, and consulting
     owners:
     - https://raw.githubusercontent.com/kubernetes/funding/master/OWNERS
-  - name: kubernetes-template-project
-    description: Template for starting new projects in the GitHub organizations owned
-      by Kubernetes.
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
   - name: steering
     description: Steering Committee policy and documentation
     owners:


### PR DESCRIPTION
Ref: https://groups.google.com/a/kubernetes.io/g/steering/c/Ph7j8r0L0rA

/assign @mrbobbytables @castrojo @cblecker 

/hold
to ensure lgtm from another contribex lead