### PR TITLE
sig-storage: remove kubernetes-incubator repos

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -54,7 +54,6 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 The following [subprojects][subproject-definition] are owned by sig-storage:
 ### external-storage
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-lib-external-provisioner/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/OWNERS
 ### git-sync
@@ -107,7 +106,6 @@ The following [subprojects][subproject-definition] are owned by sig-storage:
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/mount-utils/OWNERS
 ### nfs-provisioner
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-incubator/nfs-provisioner/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-sigs/nfs-subdir-external-provisioner/master/OWNERS
 ### volumes

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2058,7 +2058,6 @@ sigs:
   subprojects:
   - name: external-storage
     owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-lib-external-provisioner/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/OWNERS
   - name: git-sync
@@ -2111,7 +2110,6 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/mount-utils/OWNERS
   - name: nfs-provisioner
     owners:
-    - https://raw.githubusercontent.com/kubernetes-incubator/nfs-provisioner/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/nfs-subdir-external-provisioner/master/OWNERS
   - name: volumes


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1563

external-storage has now been retired - https://github.com/kubernetes-retired/external-storage

/assign @xing-yang 
for lgtm

/hold
for lgtm from sig-storage lead