### PR TITLE
Update cherry-pick docs for cloud provider-specific changes

### DIFF
--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -61,7 +61,15 @@ If the change is in cloud provider-specific platform code (which is in the
 process of being moved out of core Kubernetes), describe the customer impact,
 how the issue escaped initial testing, remediation taken to prevent similar
 future escapes, and why the change cannot be carried in your downstream fork of
-the Kubernetes project branches.
+the Kubernetes project branches. The changes are only allowable when:
+
+- No new features are introduced (e.g. changing Kubernetes API or supporting new
+  Kubernetes features)
+- Serious bugs or broken scenarios (because of cloud platform changes) are fixed, e.g.
+  - new machine types are added
+  - new properties are required from Cloud API, which break existing features
+- If new annotations are added, they should be limited to cloud provider only,
+  and shouldn't be exposed explicitly in Kubernetes API
 
 It is critical that our full community is actively engaged on enhancements in
 the project. If a released feature was not enabled on a particular provider's


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Since out-of-tree cloud providers are not GA yet, to ensure all active Kubernetes versions running well on in-tree cloud providers, we should allow cherry-picks for cloud provider-specific changes (e.g. cloud API version upgrading or small features limited to one single cloud provider).

cc @tpepper @justaugustus