### PR TITLE
Adding @kaslin as social lead + grammar

### DIFF
--- a/communication/marketing-team/README.md
+++ b/communication/marketing-team/README.md
@@ -12,8 +12,7 @@ the broader ecosystem.
 | --- | --- | --- | --- |
 | [Editorial] | editor: @mbbroberg | assoc editor: [Could be you!] | advisor: @parispittman |
 | [Internal Communications] | @rajula96reddy | [Could be you!] |  |
-| [Social Media] | @kaslin | [Could be you!] | advisors: @parispittman,
-@chris-short |
+| [Social Media] | @kaslin | [Could be you!] | advisors: @parispittman,@chris-short |
 | [Storytellers] | liaison to sig-docs-blog team @onlydole |  @celanthe, @vonguard, @boluisa, @kaslin, @divya-mohan0209, and [Could be you!] |  |
 | [Designer] | [Could be you!] |  | help us with digital assets, infographics, contributor site | 
 | APAC Liaison | @pensu91 | [Could be you!] | | 

--- a/communication/marketing-team/README.md
+++ b/communication/marketing-team/README.md
@@ -1,18 +1,19 @@
 # Contributor Marketing
 
 The Contributor Marketing Team is part of the community-management subproject in
-[Contributor Experience] view our [charter] to learn more about us
+[Contributor Experience]. View our [charter] to learn more about us.
 
 ## Purpose
 
-to better inform the Kubernetes contributor community and highlight their work to
-the broader ecosystem
+To better inform the Kubernetes contributor community and highlight their work to
+the broader ecosystem.
 
 | Area & Handbook Link | Lead | Team | Notes |
 | --- | --- | --- | --- |
 | [Editorial] | editor: @mbbroberg | assoc editor: [Could be you!] | advisor: @parispittman |
 | [Internal Communications] | @rajula96reddy | [Could be you!] |  |
-| [Social Media] | @chris-short @kaslin | n/a | |
+| [Social Media] | @kaslin | [Could be you!] | advisors: @parispittman,
+@chris-short |
 | [Storytellers] | liaison to sig-docs-blog team @onlydole |  @celanthe, @vonguard, @boluisa, @kaslin, @divya-mohan0209, and [Could be you!] |  |
 | [Designer] | [Could be you!] |  | help us with digital assets, infographics, contributor site | 
 | APAC Liaison | @pensu91 | [Could be you!] | | 
@@ -22,15 +23,15 @@ the broader ecosystem
 - Reach out to an individual above via slack
 - Whole group - @contributor-comms in #sig-contribex on slack
 - Tag us in an issue in [kubernetes/community] with the label [area/contributor-comms]
-- Set a marketing issue template in [kubernets/community]
+- Set a marketing issue template in [kubernetes/community]
 - Follow us on @K8sContributors on Twitter
 
 ## Focus Areas
 
-1. inter-community group comms/project-wide contributor communications,
-2. contributor twitter/social and web (contributor site),
-3. blogging (work happening in SIGs, stories about contributors, recaps),
-4. program and event promotion (community meeting, meet our contributors, steering
+1. Inter-community group comms/project-wide contributor communications
+2. Contributor twitter/social and web (contributor site)
+3. Blogging (work happening in SIGs, stories about contributors, recaps)
+4. Program and event promotion (community meeting, meet our contributors, steering
   election, et al)
 
 ## Could be you!
@@ -38,7 +39,7 @@ the broader ecosystem
 We still have many roles available!  
 
 Come to one of our [meetings] (join kubernetes-sig-contribex@googlegroups.com for the invite)
-or reach out to us on the #sig-contribex channel on the Kubernetes slack (slack.k8s.io for invite)
+or reach out to us on the #sig-contribex channel on the Kubernetes slack (slack.k8s.io for invite).
 Let us know you are interested and if you have any questions.
 
 [meetings]: /sig-contributor-experience#community-management


### PR DESCRIPTION
Updating the README of the marketing team. Switching @kaslin to social media lead, indicating @chris-short and @parispittman as advisors. Fixing various grammar.
