### PR TITLE
[CoCC] Add section on emeritus members, link to elections.md

### DIFF
--- a/committee-code-of-conduct/README.md
+++ b/committee-code-of-conduct/README.md
@@ -32,16 +32,27 @@ The [charter](charter.md) defines the scope and governance of the Code of Conduc
 
 The members and their terms are as follows:
 
-### Term ends on August 7, 2020
-- Jaice Singer Dumars (Google)
-- Jennifer Rondeau (Stripe)
-- Carolyn Van Slyck (Microsoft)
-
 ### Term ends on August 7, 2021
+
 - Aeva van der Veen (Microsoft)
 - Tasha Drew (VMWare)
 
+### Term ends on August 7, 2022
+
+- Karen Chu (Microsoft)
+- Celeste Horgan (CNCF)
+- Tim Pepper (VMWare)
+
 Please see the [bootstrapping document](./bootstrapping-process.md) for more information on how members are picked, their responsibilities, and how the committee will initially function.
+
+## Emeritus Committee Members
+
+The Code of Conduct Committee sincerely thanks our emeritus committee members for their contributions.
+
+- Jaice Singer Dumars (Google)
+- Jennifer Rondeau (Stripe)
+- Carolyn Van Slyck (Microsoft)
+- Paris Pittman (Apple)
 
 _More information on conflict resolution process to come in the near future. For now, any Code of Conduct or Code of Conduct Committee concerns can be directed to <conduct@kubernetes.io>_.
 <!-- END CUSTOM CONTENT -->

--- a/committee-code-of-conduct/charter.md
+++ b/committee-code-of-conduct/charter.md
@@ -65,7 +65,8 @@ authority and enforcement to this committee. The committee can, at its
 discretion, delegate some authority to those tasked with enforcement.*
 
 ## Election
-TODO: Our election processes will be outlined in a separate document, coming soon.
+
+See [elections](https://github.com/kubernetes/community/blob/master/committee-code-of-conduct/election.md)
 
 ## Committee Operation
 The committee strives to respond quickly to reports, as well as initiate


### PR DESCRIPTION
Signed-off-by: Celeste Horgan <celeste@cncf.io>

This PR:
- Adds a section to the Code of Conduct Committee's `README.md` file for emeritus members. We thank @jdumars, @Bradamant3, and @carolynvs for their service to the community! It also adds @parispittman to this list, so that the information in `sigs.yaml` and listed on `README.md` match. Thanks to you too, Paris!
- Adds members with a term ending August 7, 2022 to the team: @celestehorgan, @karenhchu and @tpepper 
- Links the `elections.md` document from `charter.md`, and removes the TODO in the charter, because cleanup.