### PR TITLE
contributor guide: Add site aliases

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Getting Started"
 weight: 1
+aliases: [ "/guide" ]
 description:
   A small list of things that you should read and be familiar with before you
   get started with contributing. This includes such things as signing the

--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -1,6 +1,7 @@
 ---
 title: Contributor Cheatsheet
 weight: 2
+aliases: [ "/cheatsheet" ]
 description: |
   A list of common resources when contributing to Kubernetes, tips, tricks, and
   common best practices used within the Kubernetes project. It is a "TL;DR" or


### PR DESCRIPTION
Adds aliases to the contributor guide and cheatsheet for use on the contributor website.

https://k8s.dev/guide -> contributor guide
https://k8s.dev/cheatsheet -> contributor cheatsheet

