### PR TITLE
Update to go1.15, fix local make verify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/community
 
-go 1.12
+go 1.15
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -21,7 +21,6 @@ set -o pipefail
 CRT_DIR=$(pwd)
 VERIFY_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t k8s-community.XXXXXX)
 WORKING_DIR="${VERIFY_TEMP}/src/testgendocs"
-GOPATH="${VERIFY_TEMP}"
 mkdir -p "${WORKING_DIR}"
 
 function cleanup {


### PR DESCRIPTION
`make verify` was failing locally as follows
```
+ cleanup
+ rm -rf /var/folders/8g/47qms67d0_1361dcyx3cpt3h00jp2t/T/tmp.yiOM5On7
rm: /var/folders/8g/47qms67d0_1361dcyx3cpt3h00jp2t/T/tmp.yiOM5On7/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20190409140830-cdc409dda467/decode_test.go: Permission denied
rm: /var/folders/8g/47qms67d0_1361dcyx3cpt3h00jp2t/T/tmp.yiOM5On7/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20190409140830-cdc409dda467/emitterc.go: Permission denied
# ... etc
rm: /var/folders/8g/47qms67d0_1361dcyx3cpt3h00jp2t/T/tmp.yiOM5On7: Directory not empty
FAILED   verify-generated-docs.sh	4s
```

I was originally going to solve this by setting `GOFLAGS="-modcacherw"` to allow `cleanup`'s `rm -rf` to work.  That flag isn't available until go1.14, so I decided let's go ahead and upgrade to go1.15.

But on further reflection, why does this script need its own GOPATH?  So I dropped that line, but left the go1.15 commit, since that puts this repo in sync with kubernetes/kubernetes