### PR TITLE
Add channel for Grafana-Operator

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -93,6 +93,7 @@ channels:
   - name: gitops
   - name: gke
   - name: gloo
+  - name: grafana-operator
   - name: helm-chart-testing
   - name: helm-deprecated
     archived: true


### PR DESCRIPTION
Hi, We'd like to create a channel for our [Grafana-Operator](https://github.com/integr8ly/grafana-operator) to have a centralized place for discussion, we think this is the most suitable place for it seeing as prometheus-operator is also housed here, this will help out the community a lot and speed up our response time with more urgent issues since currently we lack a place to do so. Thanks!

pinging: 
- @david-martin
- @pb82
- @grdryn