### PR TITLE
Fix broken link in contrib guide contributing doc

### DIFF
--- a/contributors/guide/contributing.md
+++ b/contributors/guide/contributing.md
@@ -25,7 +25,7 @@ If you find that this is not the case, please complain loudly.
 As a potential contributor, your changes and ideas are welcome at any hour of the day or night, weekdays, weekends, and holidays.
 Please do not ever hesitate to ask a question or send a pull request.
 
-Check out our [community guiding principles](/contributors/guide/collab.md) on how to create great code as a big group.
+Check out our [community guiding principles](/contributors/guide/expectations.md#code-review) on how to create great code as a big group.
 
 Beginner focused information can be found below in [Open a Pull Request](#open-a-pull-request) and [Code Review](#code-review).
 


### PR DESCRIPTION
collab.md was removed in https://github.com/kubernetes/community/pull/4866 This updates it to the link we've been using in its place.