### PR TITLE
Add channel for public service binding conversations

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -289,8 +289,8 @@ channels:
   - name: schemahero
   - name: se-users
   - name: sealed-secrets
-  - name: service-binding-operator
   - name: seccomp-operator
+  - name: service-binding-operator
   - name: shippable
   - name: shipper
   - name: shoutouts

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -289,6 +289,7 @@ channels:
   - name: schemahero
   - name: se-users
   - name: sealed-secrets
+  - name: service-binding-operator
   - name: seccomp-operator
   - name: shippable
   - name: shipper


### PR DESCRIPTION
The service binding project aims to be a community-driven project to define and implement a Service Binding API for binding kubernetes workloads with services.

It would be moved to a neutral org shortly.

https://github.com/redhat-developer/service-binding-operator

