### PR TITLE
slack: add cluster-api-packet channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -29,7 +29,7 @@ channels:
   - name: chairs-and-techleads
   - name: chartcenter
   - name: chartmuseum
-  - name: charts 
+  - name: charts
   - name: cka-exam-prep
   - name: ckad-exam-prep
   - name: client-go-docs
@@ -42,6 +42,7 @@ channels:
   - name: cluster-api-docker
     archived: true
   - name: cluster-api-openstack
+  - name: cluster-api-packet
   - name: cluster-api-vsphere
   - name: cn-dev
   - name: cn-events


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Request the slack channel for the `cluster-api-packet` similar that aws, azure, DigitalOcean have, to discuss subjects related to the CAPP


/cc @detiber 