### PR TITLE
Add a slack channel for cluster-api-aws-alerts

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -37,6 +37,7 @@ channels:
   - name: cluster-addons
   - name: cluster-api
   - name: cluster-api-aws
+  - name: cluster-api-aws-alerts
   - name: cluster-api-azure
   - name: cluster-api-baremetal
   - name: cluster-api-digitalocean


### PR DESCRIPTION
This channel is intended to be used for routing of alerts that
affect tests running for the cluster-api-provider-aws subproject.

These alerts are currently routed to test-infra-oncall, and this will
allow for the alerts to be routed to the community members that are
more likely able to take action on the alerts.