### PR TITLE
Add Slack Channel for k8satl meetup

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -211,6 +211,7 @@ channels:
   - name: malta-users
   - name: meet-our-contributors
   - name: meetup-athens
+  - name: meetup-atlanta
   - name: meetup-austin
   - name: meetup-bayarea
   - name: meetup-bordeaux

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -84,3 +84,12 @@ usergroups:
       - nzoueidi
       - onlydole
       - paris
+
+  - name: k8satl-hosts
+    long_name: Kubernetes Atlanta Meetup Hosts
+    description: Kubernetes Atlanta Meetup Hosts group
+    channels:
+      - meetup-atlanta
+    members:
+      - phenixblue
+      - AlexB138

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -3,6 +3,7 @@
 users:
   alejandrox1: U6AS37R50
   aleksandra-malinowska: U357LUPHS
+  AlexB138: U3JA3MDGV
   alisondy: U9CBCBLCV
   aravindputrevu: U1G27SDU6
   ashish-amarnath: U65JLLS0J
@@ -38,6 +39,7 @@ users:
   palnabarun: UBH9NTMBM
   paris: U5SB22BBQ
   pensu91: U44FHF81G
+  phenixblue: UB4UVLEAK
   Rin Oliver: USF4LMDCN
   sammy: U8NJFL023
   saschagrunert: U53SUDBD4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

This PR is to add a dedicated Slack Channel (`meetup-atlanta`) for the Kubernetes Atlanta Meetup group. This will help facilitate general communication with Meetup members, speakers, etc. and foster a more robust community. This also adds a Slack Usergroup (`k8satl-hosts`) to make it easy for users to address the Meetup hosts to recommend speakers, topics, and other related items.

**Relevant Links**

- Meetup Group: https://www.meetup.com/Kubernetes-Atlanta-Meetup/
- Meetup Youtube Channel: https://meetups.k8satl.io/videos/
- Meetup Notes: http://github.com/k8satl/meetups/


