### PR TITLE
Fixing broken link for KEP

### DIFF
--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -226,7 +226,7 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
 [forums provided]: /communication/README.md
 [lazy-consensus]: http://en.osswiki.info/concepts/lazy_consensus
 [super-majority]: https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote
-[KEP]: https://git.k8s.io/enhancements/keps/YYYYMMDD-kep-template.md
+[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/NNNN-kep-template/README.md
 [sigs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml
 [OWNERS]: contributors/devel/owners.md
 [SIG Charter process]: https://git.k8s.io/community/committee-steering/governance/README.md


### PR DESCRIPTION
The KEP link was broken - it led to a 404 Not Found on GitHub.  I'm proposing to replace it with the KEP template link taken from the kubernetes/enhancements/ document found at https://github.com/kubernetes/enhancements/tree/master/keps.  The new link is https://github.com/kubernetes/enhancements/tree/master/keps/NNNN-kep-template/README.md.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
