### PR TITLE
Rename slack channel seccomp-operator to security-operator

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -294,7 +294,8 @@ channels:
   - name: schemahero
   - name: se-users
   - name: sealed-secrets
-  - name: seccomp-operator
+  - name: security-operator
+    id: C013FQNB0A2
   - name: service-binding-operator
   - name: shippable
   - name: shipper


### PR DESCRIPTION
This is part of rebranding of seccomp-operator to security-operator.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to # https://github.com/kubernetes-sigs/seccomp-operator/issues/127
