### PR TITLE
Adding Elasticsearch channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -69,6 +69,7 @@ channels:
   - name: draft-users
   - name: eks
   - name: elastickube
+  - name: elasticsearch
   - name: elk-charts
   - name: emea-dev
   - name: emea-users


### PR DESCRIPTION
Request Reason: Elasticsearch is a popular search engine project. There are many use cases in this ecosystem that people use k8s. 
- Running Elasticsearch, Kibana, APM on Kubernetes via k8s operator
- Using Elasticsearch for Kubernetes monitoring.

I could see a channel as `#elk-charts` but they are helm charts specific. They are k8s community members who want to talk about other (Search, Observability) aspects around the k8s & ES. 

Please let me know if you need any details further.