### PR TITLE
sig-release: add zeitgeist

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -61,6 +61,7 @@ The Release Engineering subproject is responsible for the [process/procedures](h
   - https://raw.githubusercontent.com/kubernetes-sigs/k8s-container-image-promoter/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-sigs/mdtoc/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-sigs/release-notes/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/zeitgeist/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1755,6 +1755,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/k8s-container-image-promoter/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/mdtoc/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/release-notes/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/zeitgeist/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2172

/assign @justaugustus 

/hold
for lgtm from sig-release leads