### PR TITLE
communication/slack-config/channels.yaml: Add prometheus-operator-dev

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -281,6 +281,7 @@ channels:
   - name: pr-reviews
   - name: prometheus
   - name: prometheus-operator
+  - name: prometheus-operator-dev
   - name: prow
   - name: prow-alerts
   - name: pt_br-users


### PR DESCRIPTION
This allows developers and maintainers of https://github.com/prometheus-operator to communicate in an open channel, and the current prometheus-operator channel is left for user questions and support.

If I understood the docs this is all I need to do to create a new channel. Let me know if I missed something, thanks! :)