### PR TITLE
Request pinniped Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -277,6 +277,7 @@ channels:
   - name: outreachy-apps
     id: CDH610735
   - name: pharmer
+  - name: pinniped
   - name: pl-users
   - name: pr-reviews
   - name: prometheus


### PR DESCRIPTION
Hi there -

We (@cfryanr and @mattmoyer) would like to create a Kubernetes Slack channel for our project, Pinniped.
* Pinniped is an new project that will be open sourced in the coming weeks.
* Pinniped provides identity services to Kubernetes.
* We realize that we don't have any links to our project to share right now, but our hope is that we can go ahead and start the process of creating a Kubernetes Slack channel so that we can have a Slack channel as close to release as possible.
* Pinniped development is sponsored by VMware, Inc.

**Which issue(s) this PR fixes**:

None.
