### PR TITLE
Add onboarding and offboarding procedures for cocc members

### DIFF
--- a/committee-code-of-conduct/governance/onboarding-offboarding.md
+++ b/committee-code-of-conduct/governance/onboarding-offboarding.md
@@ -1,0 +1,43 @@
+# Onboarding and offboarding new Code of Conduct Committee members
+
+Different actions on this list must be carried out by different members: 
+
+- **Outgoing members:** members who are ending their term
+- **Incoming members:** members beginning their term
+- **Carryover members:** members mid-way through their term
+
+## Permissions 
+
+### Slack
+
+**Who executes:** When offboarding, outgoing members must remove themselves from Slack channels. When onboarding, carryover members must add incoming members.
+
+- [ ] Code of conduct committee Slack channel on `kubernetes.slack.com`
+- [ ] Code of conduct sync Slack channel on `cloud-native.slack.com`
+
+### Kubernetes/community permissions and google permissions
+
+**Who executes:** Carryover members should ensure that outgoing members are removed and incoming members are invited. 
+
+- [ ] Update `kubernetes/community` [`sigs.yaml`](https://github.com/kubernetes/community/blob/master/sigs.yaml) 
+- [ ] Update `kubernetes/k8s.io` [`groups.yaml`](https://github.com/kubernetes/k8s.io/blob/master/groups/groups.yaml)
+
+    > **Note:** This file controls access to the mailing list and Google Drive! If you do not update this file, adding people manually (via the UIs) continually revert until this file is updated.
+
+    - [ ] `conduct@kubernetes.io` mailing list
+    - [ ] Google drive
+
+## Communications 
+
+**Who executes:** Anyone but outgoing members!
+
+- [ ] Give an update at the monthly Community meeting
+- [ ] Send an email to the `kubernetes/dev` mailing list
+
+## Knowledge transfer and group procedures
+
+**Who executes:** Carryover members should lead
+
+- [ ] Introduce new members to relevant contacts
+- [ ] Re-evaluate weekly meeting time
+- [ ] Schedule training and knowledge management sessions for new members


### PR DESCRIPTION
Signed-off-by: Celeste Horgan <celeste@cncf.io>

Document the (known) onboarding and offboarding procedures for Code of Conduct Committee members

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/community/issues/3954


cc: @tpepper @karenhchu @AevaOnline @tashimi – please check this for completion!