### PR TITLE
Correcting mistake: accidentally kept Joel as a chair during WG-SIG transition

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1962,9 +1962,6 @@ sigs:
     - github: jaybeale
       name: Jay Beale
       company: InGuardians
-    - github: joelsmith
-      name: Joel Smith
-      company: Red Hat
   meetings:
   - description: Regular SIG Meeting
     day: Monday


### PR DESCRIPTION
Joel, a lead on wg-security-audit did not want to lead on sig-security.  His comment referenced below.  I mistakenly kept Joel on the chair list.  This corrects that mistake.

https://github.com/kubernetes/community/pull/4962#issuecomment-675606204