### PR TITLE
Archive sig-docs-release channel in favor of release-docs channel

### DIFF
--- a/communication/slack-config/sig-docs/docs-channels.yaml
+++ b/communication/slack-config/sig-docs/docs-channels.yaml
@@ -23,6 +23,7 @@ channels:
   - name: sig-docs-maintainers
   - name: sig-docs-modeling
   - name: sig-docs-release
+    archived: true
   - name: sig-docs-security
     archived: true
   - name: sig-docs-tools


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

During the Sig Docs meeting today (20200915), the team decided to archive this channel in favor of #release-docs channel. 

#release-docs channel will be used by the release docs team to communicate with each other and Sig Release on ongoing efforts related to the current release.
#sig-docs channel will be used to communicate with Sig Docs team as intended which includes asking for reviews/help related to the release.

This decision was made to reduce duplicate channels that exist currently and to add clear purpose to the channels used by the release docs team.

cc @kubernetes/sig-docs-leads 