### PR TITLE
slack-config/sig-release: Update teams

### DIFF
--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -29,6 +29,7 @@ restrictions:
       - "^sig-release$"
       - "^release-"
     usergroups:
+      - "^sig-release-"
       - "^release-"
   - path: "sig-network/*.yaml"
     channels:

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -15,20 +15,23 @@ usergroups:
       - cpanato # Release Manager
       - dougm # Release Manager
       - feiskyer # Release Manager
+      - gianarb # Release Manager Associate
       - hasheddan # Release Manager
       - hoegaarden # Release Manager
       - idealhack # Release Manager
       - jimangel # Release Manager Associate
       - justaugustus # subproject owner / Release Manager
-      - markyjackson-taulia # Release Manager Associate
-      - saschagrunert # Release Manager
+      - mkorbi # Release Manager Associate
+      - onlydole # Release Manager Associate
+      - puerco # Release Manager Associate
+      - saschagrunert # subproject owner / Release Manager
       - sethmccombs # Release Manager Associate
       - tpepper # subproject owner / Release Manager
       - Verolop # Release Manager Associate
-      - xmudrii # Release Manager Associate
+      - xmudrii # Release Manager
 
   # Should match the Release Team Leads of the current cycle and SIG Chairs at all times
-  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.19/release_team.md
+  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.20/release_team.md
   - name: release-team-leads
     long_name: Release Team Leads
     description: Release Team Leads. Ping for questions on the current Kubernetes release cycle.
@@ -41,10 +44,28 @@ usergroups:
       - release-notes
       - sig-release
     members:
-      - alejandrox1 # SIG Technical Lead
-      - jeremyrickard # 1.19 Release Team Lead Shadow
-      - justaugustus # SIG Chair
-      - mrbobbytables # 1.19 Release Team Lead Shadow
-      - onlydole # 1.19 Release Team Lead
-      - saschagrunert # SIG Technical Lead
-      - tpepper # SIG Chair
+      - alejandrox1 # SIG Release Technical Lead
+      - hasheddan # 1.20 Release Team Lead Shadow
+      - jeremyrickard # 1.20 Release Team Lead
+      - justaugustus # SIG Release Chair
+      - LappleApple # SIG Release Program Manager
+      - palnabarun # 1.20 Release Team Lead Shadow
+      - saschagrunert # SIG Release Technical Lead
+      - savitharaghunathan # 1.20 Release Team Lead Shadow
+      - tpepper # SIG Release Chair
+
+  # Should match SIG Release Leads at all times:
+  # https://git.k8s.io/community/sig-release/README.md#leadership
+  - name: sig-release-leads
+    long_name: SIG Release Leads
+    description: SIG Release Leads. Ping for questions on SIG Release process and escalations.
+    channels:
+      - release-ci-signal
+      - release-management
+      - sig-release
+    members:
+      - alejandrox1 # SIG Release Technical Lead
+      - justaugustus # SIG Release Chair
+      - LappleApple # SIG Release Program Manager
+      - saschagrunert # SIG Release Technical Lead
+      - tpepper # SIG Release Chair

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -15,6 +15,7 @@ users:
   cpanato: U8DFY4TTK
   dougm: U8GG20UE9
   feiskyer: U0ASA4398
+  gianarb: U0FSCELCR
   hasheddan: ULLQEF30C
   hoegaarden: U7VA4RZS9
   idealhack: U5NJ3DQM9
@@ -28,9 +29,11 @@ users:
   justaugustus: U0E0E78AK
   kaslin: U5ENKU0AE
   katharine: UBTBNJ6GL
+  LappleApple: U011C07244F
   listx: UFCU8S8P3
   markyjackson-taulia: U19TKJ64E
   mbbroberg: U18JTHMDY
+  mkorbi: UEBLUUA0P
   mrbobbytables: U511ZSKHD
   nikhita: U2PQHGMLN
   nrb: U7S597E00
@@ -40,10 +43,12 @@ users:
   paris: U5SB22BBQ
   pensu91: U44FHF81G
   phenixblue: UB4UVLEAK
+  puerco: ULGHLJ7TP
   rajula96reddy: U7K9EK1HC
   Rin Oliver: USF4LMDCN
   sammy: U8NJFL023
   saschagrunert: U53SUDBD4
+  savitharaghunathan: UC8U2V3BM
   sethmccombs: U92LLUZ8A
   simplytunde: UAY1NBYHE
   Sujay Pillai: UBW3N1VGW


### PR DESCRIPTION
- Add Lauri to teams
- Update Release Manager membership (ref: https://github.com/kubernetes/sig-release/issues/1226, https://github.com/kubernetes/sig-release/issues/1227)
- Rotate Release Team Leads (ref: https://kubernetes.slack.com/archives/C2C40FMNF/p1600212320332200?thread_ts=1600212056.329700&cid=C2C40FMNF)
- Add sig-release-leads group

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @alejandrox1 @saschagrunert @LappleApple @mrbobbytables 
cc: @kubernetes/release-team-leads @kubernetes/release-engineering 