### PR TITLE
sig-arch: add component-helpers repo

### DIFF
--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -63,7 +63,9 @@ The following [subprojects][subproject-definition] are owned by sig-architecture
 ### code-organization
 [Described below](#code-organization)
 - **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/component-helpers/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-helpers/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/vendor/OWNERS
   - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -323,7 +323,9 @@ sigs:
     contact:
       slack: k8s-code-organization
     owners:
+    - https://raw.githubusercontent.com/kubernetes/component-helpers/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-helpers/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/vendor/OWNERS
     - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2231

/hold
for sig-arch leads to lgtm

/assign @dims 