### PR TITLE
Document slack channel creation for other projects

### DIFF
--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -120,7 +120,7 @@ determining if you should request a channel:
 - The channel MUST be Kubernetes related in some way.
   - Related cloud native projects might be more appropriate on the [CNCF Slack].
 - The project MUST be open source. 
-  - If you are open sourcing a project DO THAT FIRST, we cannot accomodate every
+  - If you are open sourcing a project DO THAT FIRST, we cannot accommodate every
     organization's open sourcing launch plans.
   - The purpose of Slack is to organize an existing community, not seed new ones.
   - Moderators look at contributor activity, adoption and community concensus

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -3,7 +3,7 @@
 Slack serves as the main communication platform for the Kubernetes community
 outside of the mailing lists. It’s important that conversations stays on topic
 in each channel, and that everyone abides by the [Code of Conduct][coc]. There
-are over 50,000 members who should all expect to have a positive experience.
+are over 100,000 members who should all expect to have a positive experience.
 
 Chat is searchable and public. Do not make comments that you would not say on a
 video recording or in another public space. Please be courteous to others.
@@ -55,7 +55,6 @@ The Kubernetes Slack Workspace is archived and made available when the
 administrators have time. There is no explicit interval.
 
 [Slack Archive Download]
-
 
 ### DM (Direct Message) Conversations
 
@@ -110,6 +109,32 @@ a [code of conduct][coc] issue, please send an email to <conduct@kubernetes.io>
 and describe the situation.
 
 ---
+
+## Should you have a channel on the Kubernetes Slack?
+
+The primary purpose of the Kubernetes slack is for the coordination of the
+Kubernentes project. However it is useful for developers and users to have a
+strong ecosystem of channels for related things. Here are some guidelines for
+determining if you should request a channel:
+
+- The channel MUST be Kubernetes related in some way
+  - Related cloud native projects might be more appropriate on the [CNCF Slack]
+- The project MUST be open source 
+  - If you are open sourcing a project DO THAT first, we cannot accomodate every
+    organization's open sourcing launch plans
+  - The purpose of our to organize an existing community, not seed new ones
+  - Moderators look at contributor activity, adoption and community concensus
+    around a project, otherwise Slack becomes a vehicle for promotion instead of
+    promulgation
+  - Establishing and maintaining a Slack channel should be an inflection point
+    in a project's adoption
+  - Requesting a channel means maintaining it on behalf of the project filing
+    the issue, you will be expected to participate and foster a healthy
+    discourse
+- Channels around commercial services built on OSS projects are allowed
+  - Users love the value of being able to collaborate around various services
+  - Keep it classy, on the Kubernetes Slack we're all on the same team
+- Ask in #slack-admins if you're unsure, it never hurts to ask 
 
 ## Requesting a Channel
 
@@ -376,3 +401,4 @@ Report any actions taken to the other slack admins, and if needed the
 [default message pinned]: ./slack-config/template.yaml
 [Slack’s policy on inactivated accounts]: https://get.Slack.help/hc/en-us/articles/204475027-Deactivate-a-member-s-account
 [moderation guidelines]: ./moderation.md
+[CNCF Slack](https://slack.cncf.io/)

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -123,7 +123,7 @@ determining if you should request a channel:
   - If you are open sourcing a project DO THAT FIRST, we cannot accommodate every
     organization's open sourcing launch plans.
   - The purpose of Slack is to organize an existing community, not seed new ones.
-  - Moderators look at contributor activity, adoption and community concensus
+  - Moderators look at contributor activity, adoption and community consensus
     around a project, otherwise Slack becomes a vehicle for promotion instead of
     promulgation.
   - Establishing and maintaining a Slack channel should be an inflection point

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -401,4 +401,4 @@ Report any actions taken to the other slack admins, and if needed the
 [default message pinned]: ./slack-config/template.yaml
 [Slack’s policy on inactivated accounts]: https://get.Slack.help/hc/en-us/articles/204475027-Deactivate-a-member-s-account
 [moderation guidelines]: ./moderation.md
-[CNCF Slack](https://slack.cncf.io/)
+[CNCF Slack]: (https://slack.cncf.io/)

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -117,24 +117,24 @@ Kubernentes project. However it is useful for developers and users to have a
 strong ecosystem of channels for related things. Here are some guidelines for
 determining if you should request a channel:
 
-- The channel MUST be Kubernetes related in some way
-  - Related cloud native projects might be more appropriate on the [CNCF Slack]
-- The project MUST be open source 
-  - If you are open sourcing a project DO THAT first, we cannot accomodate every
-    organization's open sourcing launch plans
-  - The purpose of our to organize an existing community, not seed new ones
+- The channel MUST be Kubernetes related in some way.
+  - Related cloud native projects might be more appropriate on the [CNCF Slack].
+- The project MUST be open source. 
+  - If you are open sourcing a project DO THAT FIRST, we cannot accomodate every
+    organization's open sourcing launch plans.
+  - The purpose of Slack is to organize an existing community, not seed new ones.
   - Moderators look at contributor activity, adoption and community concensus
     around a project, otherwise Slack becomes a vehicle for promotion instead of
-    promulgation
+    promulgation.
   - Establishing and maintaining a Slack channel should be an inflection point
-    in a project's adoption
+    in a project's adoption.
   - Requesting a channel means maintaining it on behalf of the project filing
     the issue, you will be expected to participate and foster a healthy
-    discourse
-- Channels around commercial services built on OSS projects are allowed
-  - Users love the value of being able to collaborate around various services
-  - Keep it classy, on the Kubernetes Slack we're all on the same team
-- Ask in #slack-admins if you're unsure, it never hurts to ask 
+    discourse.
+- Channels around commercial services built on OSS projects are allowed.
+  - Users love the value of being able to collaborate around various services.
+  - Keep it classy, on the Kubernetes Slack we're all on the same team.
+- Ask in #slack-admins or file an issue if you're unsure, it never hurts to ask.
 
 ## Requesting a Channel
 

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -134,6 +134,13 @@ determining if you should request a channel:
 - Channels around commercial services built on OSS projects are allowed.
   - Users love the value of being able to collaborate around various services.
   - Keep it classy, on the Kubernetes Slack we're all on the same team.
+- The channel MUST be public.
+  - In order to ensure all channels adhere to our Code of Conduct, we heavily
+    restrict private channels.
+  - We do allow `#...-dev` channels for established projects where a single
+    project channel is too noisy, but please don't create both at the start.
+  - If you need private discussion areas for security-sensitive topics, a
+    project-specific Slack or the [CNCF Slack] may be a better fit.
 - Ask in #slack-admins or file an issue if you're unsure, it never hurts to ask.
 
 ## Requesting a Channel

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -401,4 +401,4 @@ Report any actions taken to the other slack admins, and if needed the
 [default message pinned]: ./slack-config/template.yaml
 [Slack’s policy on inactivated accounts]: https://get.Slack.help/hc/en-us/articles/204475027-Deactivate-a-member-s-account
 [moderation guidelines]: ./moderation.md
-[CNCF Slack]: (https://slack.cncf.io/)
+[CNCF Slack]: https://slack.cncf.io/


### PR DESCRIPTION
Sometimes there's some confusion as to when/how/if a project should ask for a slack channel on the K8s slack. We never really wrote that down so I took some of the excellent recommendations from @jdumars from this issue and wrote them down: https://github.com/kubernetes/community/pull/5107

I'm adding a hold since I'm sure I've missed some of the other things we look for in channel creation to give other people a chance to weigh in. 

/hold
/cc @jdumars 
/sig contributor-experience
