### PR TITLE
Update triage/support label references to kind/support

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,7 +1,7 @@
 ---
 name: Support Request
 about: Support request or question relating to Kubernetes
-labels: triage/support
+labels: kind/support
 
 ---
 

--- a/contributors/guide/issue-triage.md
+++ b/contributors/guide/issue-triage.md
@@ -153,7 +153,7 @@ Use [these labels](https://github.com/kubernetes/kubernetes/labels?utf8=%E2%9C%9
 Depending on your permissions, either close or comment on any issues that are identified as support requests, duplicates, or not-reproducible bugs, or that lack enough information from the reporter.
  
 ### Support Requests
-Some people mistakenly use GitHub issues to file support requests. Usually they're asking for help configuring some aspect of Kubernetes. To handle such an issue, direct the author to use our [support request channels](#support-requests-channels). Then apply the `triage/support` label, which is directed to our support structures, and apply the `close` label.
+Some people mistakenly use GitHub issues to file support requests. Usually they're asking for help configuring some aspect of Kubernetes. To handle such an issue, direct the author to use our [support request channels](#support-requests-channels). Then apply the `kind/support` label, which is directed to our support structures, and apply the `close` label.
 
 Please find more detailed information about Support Requests in the [Footnotes section](#footnotes).
 


### PR DESCRIPTION
The label triage/support has been reclassified as kind/support. The
kind/* family of labels makes more logical sense, as they describe the
"kind" of thing an issue or PR is.

For more information, see the announcement email:
https://groups.google.com/g/kubernetes-dev/c/YcaJpsjjLKw/m/i15cLLx5CAAJ
