### PR TITLE
Remove references to velodrome

### DIFF
--- a/contributors/devel/sig-testing/flaky-tests.md
+++ b/contributors/devel/sig-testing/flaky-tests.md
@@ -77,14 +77,10 @@ We offer the following tools to aid in finding or troubleshooting flakes
   - https://testgrid.k8s.io/presubmits-kubernetes-blocking - all merge-blocking jobs
   - https://testgrid.k8s.io/presubmits-kubernetes-blocking#pull-kubernetes-e2e-gce&exclude-filter-by-regex=BeforeSuite&sort-by-flakiness= - results for the pull-kubernetes-e2e-gce job sorted by flakiness
   - https://testgrid.k8s.io/sig-release-master-informing#gce-cos-master-default&sort-by-flakiness=&width=10 - results for the equivalent CI job
-- [velodrome.k8s.io] - dashboards driven by the results of queries run against test results using bigquery
-  - http://velodrome.k8s.io/dashboard/db/job-health-merge-blocking?orgId=1 - includes flake rate and top flakes for merge-blocking jobs for kubernetes/kubernetes
-  - http://velodrome.k8s.io/dashboard/db/job-health-release-blocking?orgId=1 - includes flake rate and top flakes for release-blocking jobs for kubernetes/kubernetes
 - [`kind/flake` github query][flake] - open issues or PRs related to flaky jobs or tests for kubernetes/kubernetes
 
 [go.k8s.io/triage]: https://go.k8s.io/triage
 [testgrid.k8s.io]: https://testgrid.k8s.io
-[velodrome.k8s.io]: http://velodrome.k8s.io
 
 # GitHub Issues for Known Flakes
 

--- a/contributors/guide/contributing.md
+++ b/contributors/guide/contributing.md
@@ -62,7 +62,7 @@ Common new contributor PR issues are:
 
 * not having correctly signed the CLA ahead of your first PR. See the [CLA page](/CLA.md) for troubleshooting help, in some cases you might need to file a ticket with the CNCF to resolve a CLA problem.  
 * finding the right SIG or reviewer(s) for the PR (see [Code Review](#code-review) section) and following any SIG or repository specific contributing guidelines (see [Learn about SIGs](#learn-about-sigs) section)
-* dealing with test cases which fail on your PR, unrelated to the changes you introduce (see [Test Flakes](http://velodrome.k8s.io/dashboard/db/bigquery-metrics?orgId=1))
+* dealing with test cases which fail on your PR, unrelated to the changes you introduce (see [Test Flakes](/contributors/devel/sig-testing/flaky-tests.md))
 * Not following [scalability good practices](scalability-good-practices.md)
 * Include mentions (like @person) and [keywords](https://help.github.com/en/articles/closing-issues-using-keywords) which could close the issue (like fixes #xxxx) in commit messages.
 

--- a/contributors/guide/contributor-cheatsheet/README-de.md
+++ b/contributors/guide/contributor-cheatsheet/README-de.md
@@ -75,7 +75,6 @@ nützlicher Informationen gedacht, um deine Beitragserfahrung auf GitHub besser 
 - [Prow] - Kubernetes CI/CD-System.
 - [Test Grid] - Ansicht historischer Tests und den zugehörigen Informationen.
 - [Triage Dashboard] - Aggregiert ähnliche Fehler zur besseren Fehlerbehandlung.
-- [Velodrome] - Dashboard zur Überwachung der Job- und Testgesundheit.
 
 
 ### Wichtige Email-Adressen
@@ -361,7 +360,6 @@ anderer Beitragenden zu überlassen, die als Reviewer und Approver für den PR z
 [Youtube Channel]: https://www.youtube.com/c/KubernetesCommunity/
 [Triage Dashboard]: https://go.k8s.io/triage
 [Test Grid]: https://testgrid.k8s.io
-[Velodrome]: https://go.k8s.io/test-health
 [Developer Statistiken]: https://k8s.devstats.cncf.io
 [Code of Conduct]: /code-of-conduct.md
 [user support requests]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README-fr.md
+++ b/contributors/guide/contributor-cheatsheet/README-fr.md
@@ -70,7 +70,6 @@ C'est un "TL;DR" ou une référence rapide d'informations utiles pour améliorer
 - [Prow] - Kubernetes CI/CD System.
 - [Test Grid] - Afficher les tests historiques et leurs informations associées.
 - [Triage Dashboard] - Regroupe les défaillances similaires pour un meilleur dépannage.
-- [Velodrome] - Tableau de bord pour suivre le travail et tester la santé.
 
 ### Alias de messagerie importants
 
@@ -301,7 +300,6 @@ Si vous ne savez pas si vous devez faire un squash de vos commits, il est préf�
 [youtube channel]: https://www.youtube.com/c/KubernetesCommunity/
 [triage dashboard]: https://go.k8s.io/triage
 [test grid]: https://testgrid.k8s.io
-[velodrome]: https://go.k8s.io/test-health
 [statistiques de développeur]: https://k8s.devstats.cncf.io
 [code of conduct]: /code-of-conduct.md
 [user support request]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README-hi.md
+++ b/contributors/guide/contributor-cheatsheet/README-hi.md
@@ -69,7 +69,6 @@
 - [Prow] - कुबेरनेट्स CI / CD सिस्टम।
 - [परीक्षण ग्रिड] - ऐतिहासिक परीक्षण और उनसे जुड़ी जानकारी देखें।
 - [triage डैशबोर्ड] - बेहतरलिए समान विफलताओं को एक साथ समस्या निवारण केरखता है।
-- [veldrome] - नौकरी और परीक्षण स्वास्थ्य को ट्रैक करने के लिए डैशबोर्ड।
 
 ### महत्वपूर्ण ईमेल उपनाम
 
@@ -292,7 +291,6 @@ PR संशोधन का चरण। यदि आप अनिश्चि
 [youtube चैनल]: https://www.youtube.com/c/KubernetesCommunity/
 [triage डैशबोर्ड]: https://go.k8s.io/triage
 [परीक्षण ग्रिड]: https://testgrid.k8s.io
-[veldrome]: https://go.k8s.io/test-health
 [डेवलपर आँकड़े]: https://k8s.devstats.cncf.io
 [आचार संहिता]: /code-of-conduct.md
 [उपयोगकर्ता समर्थन अनुरोध]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README-id.md
+++ b/contributors/guide/contributor-cheatsheet/README-id.md
@@ -76,7 +76,6 @@ di GitHub menjadi lebih baik.
 - [Prow] - Mekanisme CI/CD Kubernetes.
 - [Test Grid] - Melihat data _historical testing_ beserta informasi terkait.
 - [Dasbor Triase] - Melakukan agregasi _failure_ untuk mekanisme _troubleshoot_ yang lebih baik.
-- [Velodrome] - Dasbor untuk melacak _job_ dan _testing_ kesehatan.
 
 
 ### Alamat Email Penting
@@ -362,7 +361,6 @@ _squashing_ perlu dilakukan atau tidak.
 [youtube _channel_]: https://www.youtube.com/c/KubernetesCommunity/
 [dasbor triase]: https://go.k8s.io/triage
 [test grid]: https://testgrid.k8s.io
-[velodrome]: https://go.k8s.io/test-health
 [Statistik Pengembang]: https://k8s.devstats.cncf.io
 [code of conduct]: /code-of-conduct.md
 [_user support request_]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README-it.md
+++ b/contributors/guide/contributor-cheatsheet/README-it.md
@@ -76,7 +76,6 @@ condensato di informazioni utili per rendere migliore la tua esperienza di GitHu
 - [Prow] - Kubernetes CI/CD System.
 - [Test Grid] - Visualizzo lo storico dei test e tutte le informazioni associate.
 - [Triage Dashboard] - Aggrega problematiche simili per semplificare il troubleshooting.
-- [Velodrome] - Dashboard per monitorare lo storico dei job e dei test.
 
 ### Important Email Aliases
 
@@ -369,7 +368,6 @@ git push --force
 [youtube channel]: https://www.youtube.com/c/KubernetesCommunity/
 [triage dashboard]: https://go.k8s.io/triage
 [test grid]: https://testgrid.k8s.io
-[velodrome]: https://go.k8s.io/test-health
 [developer statistics]: https://k8s.devstats.cncf.io
 [code of conduct]: /code-of-conduct.md
 [user support requests]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README-ja.md
+++ b/contributors/guide/contributor-cheatsheet/README-ja.md
@@ -70,7 +70,6 @@ Kubernetesにコントリビュートする際のtipsや、Kubernetesプロジ�
 - [Prow] - KubernetesのCI/CDシステム
 - [Test Grid] - 歴史的なテストや関連した情報を見る
 - [Triageダッシュボード] - よりよくトラブルシューティングをするために、似たような失敗をまとめる
-- [Velodrome] - ジョブやテスト結果を追跡するためのダッシュボード
 
 
 ### 重要なEメールエイリアス
@@ -309,7 +308,6 @@ git checkout -b myfeature
 [youtubeチャンネル]: https://www.youtube.com/c/KubernetesCommunity/
 [triageダッシュボード]: https://go.k8s.io/triage
 [test grid]: https://testgrid.k8s.io
-[velodrome]: https://go.k8s.io/test-health
 [開発者統計]: https://k8s.devstats.cncf.io
 [code of conduct]: /code-of-conduct.md
 [ユーザーによるサポート要求]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README-ko.md
+++ b/contributors/guide/contributor-cheatsheet/README-ko.md
@@ -79,7 +79,6 @@
 - [테스트 그리드] - 테스트 기록과 관련된 정보 확인
 - [Triage 대시보드] - 더 나은 문제 해결을 위해 유사한 오류를
   수집
-- [Velodrome] - 작업과 테스트 상태를 추적하는 대시보드
 
 
 ### 중요한 이메일 별칭
@@ -367,7 +366,6 @@ PR을 검토하고 승인하도록 지정된 다른 참여자의 판단에 맡�
 [YouTube 채널]: https://www.youtube.com/c/KubernetesCommunity/
 [triage 대시보드]: https://go.k8s.io/triage
 [테스트 그리드]: https://testgrid.k8s.io
-[velodrome]: https://go.k8s.io/test-health
 [개발자 통계]: https://k8s.devstats.cncf.io
 [행동 강령]: /code-of-conduct.md
 [사용자 지원 요청]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README-pt.md
+++ b/contributors/guide/contributor-cheatsheet/README-pt.md
@@ -73,7 +73,6 @@ Melhor.
 - [Prow] - Kubernetes CI/CD System.
 - [Test Grid] - Veja o histórico de testes e suas informações associadas.
 - [Dashboard de Triagem] - Junta falhas semelhantes para melhor solução de problemas.
-- [Velodrome] - Dashboard para rastrear jobs e testar a estabilidade.
 
 
 ### E-mails-Importantes
@@ -348,7 +347,6 @@ fase de uma revisão do PR. Se você não tem certeza se deve efetuar o squashin
 [youtube]: https://www.youtube.com/c/KubernetesCommunity/
 [Dashboard de Triagem]: https://go.k8s.io/triage
 [test grid]: https://testgrid.k8s.io
-[velodrome]: https://go.k8s.io/test-health
 [Estatísticas do Desenvolvedor]: https://k8s.devstats.cncf.io
 [Código de Conduta]: /code-of-conduct.md
 [solicitações de suporte ao usuário]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README-uk.md
+++ b/contributors/guide/contributor-cheatsheet/README-uk.md
@@ -70,7 +70,6 @@
 - [Prow] - Kubernetes CI/CD система.
 - [Test Grid] - Перегляд історії тестів та дотичної до них інформації.
 - [Triage Dashboard] - Агрегування схожих помилок для їх кращого виправлення.
-- [Velodrome] - Дашборд для відстеження статусу виконання задач і тестів.
 
 ### Важливі поштові адреси
 
@@ -294,7 +293,6 @@ git checkout -b myfeature
 [youtube канал]: https://www.youtube.com/c/KubernetesCommunity/
 [triage dashboard]: https://go.k8s.io/triage
 [test grid]: https://testgrid.k8s.io
-[velodrome]: https://go.k8s.io/test-health
 [developer statistics]: https://k8s.devstats.cncf.io
 [Кодексом поведінки Спільноти]: /code-of-conduct.md
 [підтримки користувачів]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README-zh.md
+++ b/contributors/guide/contributor-cheatsheet/README-zh.md
@@ -70,7 +70,6 @@
 - [Prow] - Kubernetes CI/CD 系统
 - [Test Grid] - 查看过往的测试以及相关信息
 - [Triage 仪表盘] - 把相似的失败聚合在一起以便排除故障
-- [Velodrome] - 追踪任务和测试健康度的仪表盘
 
 
 ### 重要的 Email 地址
@@ -299,7 +298,6 @@ git checkout -b myfeature
 [YouTube 频道]: https://www.youtube.com/c/KubernetesCommunity/
 [triage 仪表盘]: https://go.k8s.io/triage
 [test grid]: https://testgrid.k8s.io
-[velodrome]: https://go.k8s.io/test-health
 [开发者统计]: https://k8s.devstats.cncf.io
 [行为守则]: /code-of-conduct.md
 [用户支持请求]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -93,7 +93,6 @@ better.
 - [Test Grid] - View historical tests and their associated information.
 - [Triage Dashboard] - Aggregates similar failures together for better
   troubleshooting. 
-- [Velodrome] - Dashboard to track job and test health.
 
 
 ### Important Email Aliases
@@ -394,7 +393,6 @@ git push --force
 [youtube channel]: https://www.youtube.com/c/KubernetesCommunity/
 [triage dashboard]: https://go.k8s.io/triage
 [test grid]: https://testgrid.k8s.io
-[velodrome]: https://go.k8s.io/test-health
 [developer statistics]: https://k8s.devstats.cncf.io
 [code of conduct]: /code-of-conduct.md
 [user support requests]: /contributors/guide/issue-triage.md#determine-if-its-a-support-request

--- a/sig-testing/charter.md
+++ b/sig-testing/charter.md
@@ -27,7 +27,7 @@ health of the project.
   contributors who wish to provide additional test results not generated
   by the project's CI
 - Extraction, display and analysis of test artifacts via tools like
-  [gubernator], [kettle], [testgrid], [triage] and [velodrome]
+  [gubernator], [kettle], [testgrid], and [triage]
 - Configuration management of jobs and ensuring they use a consistent
   process via tools such as [job configs], [kubetest]
 - Tools that facilitate configuration management of github such as
@@ -131,7 +131,6 @@ Subprojects are created by Tech Leads following the process defined in [sig-gove
 [testgrid]: https://testgrid.k8s.io
 [tide]: https://prow.k8s.io/tide
 [triage]: https://go.k8s.io/triage
-[velodrome]: https://velodrome.k8s.io
 
 [Release Team test-infra role]: https://git.k8s.io/sig-release/release-team/role-handbooks/test-infra
 [kubernetes-dev@]: https://groups.google.com/forum/#!forum/kubernetes-dev


### PR DESCRIPTION
Velodrome no longer exists [[1]](https://github.com/kubernetes/test-infra/pull/18404) [[2]](https://github.com/kubernetes/test-infra/issues/16836)

I was looking at the [flaky tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/flaky-tests.md) page that @k8s-ci-robot links to and saw that we are still linking to it for assistance in triaging flaky tests.