### PR TITLE
Rename seccomp-operator to security-profiles-operator

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -160,7 +160,7 @@ channels:
   - name: krane
   - name: krew
   - name: krex
-  - name: krustlet  
+  - name: krustlet
   - name: kube-aws
   - name: kube-deploy
     archived: true
@@ -301,7 +301,8 @@ channels:
   - name: schemahero
   - name: se-users
   - name: sealed-secrets
-  - name: seccomp-operator
+  - name: security-profiles-operator
+    id: C013FQNB0A2
   - name: service-binding-operator
   - name: shippable
   - name: shipper

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -66,11 +66,11 @@ The following [subprojects][subproject-definition] are owned by sig-node:
   - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
 - **Contact:**
   - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
-### seccomp-operator
+### security-profiles-operator
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/seccomp-operator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/master/OWNERS
 - **Contact:**
-  - Slack: [#seccomp-operator](https://kubernetes.slack.com/messages/seccomp-operator)
+  - Slack: [#security-profiles-operator](https://kubernetes.slack.com/messages/security-profiles-operator)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1694,11 +1694,11 @@ sigs:
       slack: node-problem-detector
     owners:
     - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
-  - name: seccomp-operator
+  - name: security-profiles-operator
     contact:
-      slack: seccomp-operator
+      slack: security-profiles-operator
     owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/seccomp-operator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/master/OWNERS
 - dir: sig-release
   name: Release
   mission_statement: >


### PR DESCRIPTION
Renaming the operator to it's new proposed name.

Refers to https://github.com/kubernetes/org/issues/2177