### PR TITLE
Add sig-network-policy-api slack channel

### DIFF
--- a/communication/slack-config/sig-network/config.yaml
+++ b/communication/slack-config/sig-network/config.yaml
@@ -1,2 +1,3 @@
 channels:
   - name: sig-network-service-apis
+  - name: sig-network-policy-api


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

Adds the sig-network-policy-api slack channel for the sig-network network policy evolution subproject.

