### PR TITLE
Add cluster-api-nested Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -43,6 +43,7 @@ channels:
   - name: cluster-api-digitalocean
   - name: cluster-api-docker
     archived: true
+  - name: cluster-api-nested
   - name: cluster-api-openstack
   - name: cluster-api-packet
   - name: cluster-api-vsphere


### PR DESCRIPTION
`cluster-api-provider-nested` was approved in https://github.com/kubernetes/org/issues/2247

Signed-off-by: Chris Hein <me@chrishein.com>

/cc @parispittman @Fei-Guo