### PR TITLE
Slack channel for TGIK community

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -356,6 +356,7 @@ channels:
   - name: test-failures
   - name: testing-commons
   - name: testing-ops
+  - name: tgik
   - name: tilt
   - name: tn-users
   - name: topology-aware-scheduling


### PR DESCRIPTION
Channel purpose:
Channel will be a dedicated community gathered around [TGIK](https://github.com/vmware-tanzu/tgik). The main purpose of the channel will be discussing topics related to Kubernetes and extend knowledge on the subject mentioned in TGIK streams.