### PR TITLE
Adding sig-security-tooling slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -333,6 +333,7 @@ channels:
   - name: sig-scalability
   - name: sig-scheduling
   - name: sig-security
+  - name: sig-security-tooling
   - name: sig-service-catalog
   - name: sig-testing
   - name: sig-ui


### PR DESCRIPTION
New slack channel for discussions for the tooling working group in sig-security.