### PR TITLE
Add a #odo channel on the Kubernetes Slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -264,6 +264,7 @@ channels:
   - name: node-problem-detector
   - name: norw-users
   - name: octant
+  - name: odo
   - name: office-hours
   - name: okteto
   - name: olm-dev


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
N/A

First of all! Hi!

We're a project called `odo` located here:

https://github.com/openshift/odo

**Information about us:**

We're an open source project that focuses on specifically on Kubernetes.
We also add support for other Kubernetes-based platforms, but our main
focus in k8s.

In a nutshell, odo is a tool that abstracts specific Kubernetes concepts
for an easier deployment of applications.

Our site is located here: https://odo.dev/ if you'd like to try it out!

**Purpose of the channel:**

For the past.. about a year. We've been using our own public slack channel
located here: http://openshiftdo.slack.com/

We have 100+ members and we're constantly chatting. Our motivation to
join kubernetes.slack.com is because well.. most of us are already on
the Kubernetes slack! That and the fact that we're a dedicated and
Kubernetes-focused project.

**Criteria:**

I believe we fit all the criteria, we're:

- An open source project
- Kubernetes-specific
- Not product focused / proprietary

**Chatroom name requested:**

`odo`

**About the team:**

Charlie Drage (cdrage on GitHub):

- Maintainer / core contributor of: http://github.com/kubernetes/kompose
which already has a Kubernetes #kompose channel

Tomas Kral (kadel on GitHub):

- Past maintainer / contributor of: http://github.com/kubernetes/kompose

Girish Ramnani (girishramnani on GitHub):

- Golang meetup organizer and open source contributor to HashiCorp,
OpenShift and Terraform projects.

Dharmit Shah (dharmit on GitHub):

- Open source contributor to OpenShift, CentOS, MiniShift and Che
projects.

Many thanks and let us know if you need anything else!

We will most likely do another PR requesting updates to usergroups.yaml
so we can ping (for example: odo-devs) or something similar to that.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>