### PR TITLE
slack: add cluster-api-gcp channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -44,6 +44,7 @@ channels:
   - name: cluster-api-digitalocean
   - name: cluster-api-docker
     archived: true
+  - name: cluster-api-gcp
   - name: cluster-api-nested
   - name: cluster-api-openstack
   - name: cluster-api-packet


### PR DESCRIPTION
Request the slack channel for the `cluster-api-gcp` similar that aws, azure, DigitalOcean have, to discuss subjects related to the CAPG and trying to back that project back on track 👍 

/assign @mrbobbytables @castrojo @nikhita 

@rsmitty FYI as we discussed in slack



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes n/a
