### PR TITLE
Add odo-devs user group

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -132,3 +132,18 @@ usergroups:
       - varshaprasad96
       - rashmigottipati
       - jberkhahn
+
+  - name: odo-devs
+    long_name: Odo Development Team
+    description: Active developers of odo on #odo
+    channels:
+      - odo
+    members:
+      - adisky
+      - cdrage
+      - dharmit
+      - girishramnani
+      - mohammedzee1000
+      - mik-dass
+      - prietyc123
+      - kadel

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -1,6 +1,7 @@
 # This file contains an alphabetically sorted mapping of lowercase GitHub
 # usernames to Kubernetes Slack user IDs.
 users:
+  adisky: U9YRVLTEH
   alejandrox1: U6AS37R50
   aleksandra-malinowska: U357LUPHS
   AlexB138: U3JA3MDGV
@@ -14,13 +15,16 @@ users:
   camilamacedo86: UJDM393EH
   carlisia: UBDSF40G2
   castrojo: U1W1Q6PRQ
+  cdrage: U2TU9NPH9
   chrisshort: U2YGXSD9B
   cpanato: U8DFY4TTK
+  dharmit: U0APPPEKE
   dougm: U8GG20UE9
   estroz: UKSEANEC9
   fabianvf: UAJ3UH29F
   feiskyer: U0ASA4398
   gianarb: U0FSCELCR
+  girishramnani: U9M4K75EU
   gsquared94: U0131C0PJBU
   hasheddan: ULLQEF30C
   hoegaarden: U7VA4RZS9
@@ -39,6 +43,7 @@ users:
   johnbelamaric: U246A1A0N
   jonasrosland: U0A4G34S2
   justaugustus: U0E0E78AK
+  kadel: U0DE6E8JY
   kaslin: U5ENKU0AE
   katharine: UBTBNJ6GL
   LappleApple: U011C07244F
@@ -47,7 +52,9 @@ users:
   markyjackson-taulia: U19TKJ64E
   MarlonGamez: U016N1XK06R
   mbbroberg: U18JTHMDY
+  mik-dass: U3PFFE8CD
   mkorbi: UEBLUUA0P
+  mohammedzee1000: U3PFFE8CD
   mrbobbytables: U511ZSKHD
   nikhita: U2PQHGMLN
   nkubala: UA90QL2BE
@@ -58,6 +65,7 @@ users:
   paris: U5SB22BBQ
   pensu91: U44FHF81G
   phenixblue: UB4UVLEAK
+  prietyc123: U01D4MBLM52
   puerco: ULGHLJ7TP
   rajula96reddy: U7K9EK1HC
   rashmigottipati: U013T1DD3PW


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

N/A

**Channel:**

`#odo`

**Request:**

We'd like to be able to have the ability for users to ping `odo-devs` in
the channel in order to contact maintainers.

I have gone through each user's GitHub / Slack ID and added it to
`users.yaml` and created a new users group.

Many thanks!

Signed-off-by: Charlie Drage <charlie@charliedrage.com>