### PR TITLE
Adding sig-security-docs slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -336,6 +336,7 @@ channels:
   - name: sig-scalability
   - name: sig-scheduling
   - name: sig-security
+  - name: sig-security-docs
   - name: sig-security-tooling
   - name: sig-service-catalog
   - name: sig-testing


### PR DESCRIPTION
New slack channel for discussions for the security docs sub-project in sig-security 🎉 

cc: @IanColdwater @tabbysable 