### PR TITLE
Link technical lead role description in sig-governance

### DIFF
--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -127,6 +127,7 @@ curation from other SIG participants
   - Resolve X-Subproject technical issues and decisions
   - Number: 2-3
   - Membership tracked in [sigs.yaml]
+  - Role description in [technical-lead.md]
 
 ### Subproject Owner
 
@@ -244,3 +245,4 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
 [dashboard]: https://testgrid.k8s.io/
 [monthly community meeting]: /events/community-meeting.md
 [inclusive speaker training course]: https://training.linuxfoundation.org/training/inclusive-speaker-orientation/
+[technical-lead.md]: /contributors/chairs-and-techleads/technical-lead.md

--- a/contributors/chairs-and-techleads/technical-lead.md
+++ b/contributors/chairs-and-techleads/technical-lead.md
@@ -5,9 +5,11 @@
 ### About
 
 Target of this document is to define and outline the Technical Lead role within
-the Kubernetes community. The document can be used as guidance for Special
-Interest Groups (SIGs) to onboard new Technical Leads as well as clarifying the
-expectations associated with this role.
+the Kubernetes community in correspondence with the existing [description of SIG
+Governance](/committee-steering/governance/sig-governance.md#tech-lead). The
+document can be used as guidance for Special Interest Groups (SIGs) to onboard
+new Technical Leads as well as clarifying the expectations associated with this
+role.
 
 ### Abstract
 


### PR DESCRIPTION
This links both documents together to enhance their visibility.

**Which issue(s) this PR fixes**:

None
Follow-up of https://github.com/kubernetes/community/pull/5179