### PR TITLE
Add haproxy-ingress as a new Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -101,6 +101,7 @@ channels:
   - name: gke
   - name: gloo
   - name: grafana-operator
+  - name: haproxy-ingress
   - name: helm-chart-testing
   - name: helm-deprecated
     archived: true


### PR DESCRIPTION
This adds HAProxy Ingress, [link](https://haproxy-ingress.github.io/), as a new channel at Kubernetes' Slack workspace. HAProxy Ingress is a community driven ingress controller for HAProxy loadbalancer.