### PR TITLE
slack: archive elk-charts channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -74,6 +74,7 @@ channels:
   - name: eks
   - name: elastickube
   - name: elk-charts
+    archived: true
   - name: emea-dev
   - name: emea-users
   - name: es-users


### PR DESCRIPTION
The channel was dedicated to the development of the ELK helm chart. The
original maintainers have discussion back to the main charts channel.

For more info see this: https://kubernetes.slack.com/archives/C4M06S5HS/p1578279465008900