### PR TITLE
[WG Naming] Add OWNERS

### DIFF
--- a/wg-naming/OWNERS
+++ b/wg-naming/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - wg-naming-leads
+approvers:
+  - wg-naming-leads
+labels:
+  - wg/naming


### PR DESCRIPTION
I noticed in https://github.com/kubernetes/community/pull/5211 that @kubernetes/wg-naming-leads don't have approval powers over our directory, so let's fix that!

/assign @jdumars 