### PR TITLE
slack: add #crossplane slack channel for crossplane.io

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -60,6 +60,7 @@ channels:
   - name: crash-diagnostics
   - name: crd-installation
   - name: crio
+  - name: crossplane
   - name: csi-secrets-store #this channel is for secrets-store-csi-driver which is a subproject of sig-auth
   - name: de-events
   - name: de-users


### PR DESCRIPTION
This PR contains a new Slack channel request for Crossplane (https://crossplane.io/), a [CNCF Sandbox project](https://www.cncf.io/sandbox-projects/) that allows you to manage any infrastructure your applications need directly from Kubernetes.

The channel will be used for general discussion about the project, answering questions from Kubernetes community users that are interested in Crossplane, and supporting/troubleshooting issues from adopters.

The proposed channel name is #crossplane.