### PR TITLE
Update location of SIG Contribex meeting notes

### DIFF
--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -14,7 +14,7 @@ The [charter](charter.md) defines the scope and governance of the Contributor Ex
 
 ## Meetings
 * Regular SIG Meeting: [Wednesdays at 9:30 PT (Pacific Time)](https://zoom.us/j/397264241?pwd=bHNnZVArNFdPaWVJMmttdko0Sktudz09) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1CBz8qV_mD6rbDmTsMuosTOQGRXGhN3d8UrcULUI6Vkw/edit).
   * [Meeting recordings](https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr).
 
 ## Leadership

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1123,7 +1123,7 @@ sigs:
     tz: PT (Pacific Time)
     frequency: weekly
     url: https://zoom.us/j/397264241?pwd=bHNnZVArNFdPaWVJMmttdko0Sktudz09
-    archive_url: https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/
+    archive_url: https://docs.google.com/document/d/1CBz8qV_mD6rbDmTsMuosTOQGRXGhN3d8UrcULUI6Vkw/edit
     recordings_url: https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr
   contact:
     slack: sig-contribex


### PR DESCRIPTION
Moving to a new google document, the old one had google-only permissions, this new one is owned by contributors@kubernetes.io so we're all set

Signed-off-by: Jorge O. Castro <jorgec@vmware.com>

/cc @mrbobbytables @cblecker 