### PR TITLE
github-management: add rule for template files for donated repos

### DIFF
--- a/github-management/kubernetes-repositories.md
+++ b/github-management/kubernetes-repositories.md
@@ -101,6 +101,8 @@ the developers who could not be reached
    * Additions of [the standard Kubernetes header](https://git.k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt)
      to code created by the contributors can occur post-transfer, but should
      ideally occur shortly thereafter.
+   * Should contain template files as per the
+     [kubernetes-template-project](https://github.com/kubernetes/kubernetes-template-project).
 
 Note that copyright notices should only be modified or removed by the people or
 organizations named in the notice. See [the FAQ below](#faq) for more information


### PR DESCRIPTION
I'm not sure if we need additional approvals for adding a new rule here (steering sign off?)...this PR is retroactively adding a rule which we follow today anyway.

To be clear, template files like `OWNERS`, etc can be added post-migration but it's usually easier to migrate repos when everything has been setup. It also signals that the repo donor is opting into the Kubernetes Code of Conduct.

/hold
for approval from GitHub admins

/assign @cblecker @mrbobbytables @spiffxp 
/cc @kubernetes/owners 