### PR TITLE
Add website guidelines

### DIFF
--- a/communication/README.md
+++ b/communication/README.md
@@ -108,6 +108,10 @@ We use Zoom for all of our community group meetings and contributor programs. -
 We keep a [shared calendar] with all of our community group meetings. If you'd
 like a contributor event published, please reach out to [#sig-contribex] on slack.
 
+### Website
+
+Documentation is published at https://kubernetes.io - [website guidelines]
+
 ### Social Media & Blogs
 
 #### Twitter
@@ -185,6 +189,7 @@ place!
 [10am US Pacific Time]: https://www.google.com/search?q=1000+am+in+pst
 [troubleshooting guide]: https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/
 [@kubernetesio]: https://twitter.com/kubernetesio
+[website guidelines]: ./website-guidelines.md
 [Josh Berkus]: https://github.com/jberkus
 [zoom]: https://zoom.us/my/kubernetescommunity
 [k-dev moderators]: ./moderators.md#kubernetes-dev

--- a/communication/website-guidelines.md
+++ b/communication/website-guidelines.md
@@ -1,0 +1,33 @@
+# Website guidelines
+
+## General content
+
+The SIG-Docs [website subproject] maintains the kubernetes.io website,
+including site content, documentation, and generated reference documentation.
+SIG-Docs maintains guides for website contributors, including a [content guide]
+detailing the types of content allowed, and a [style guide].
+
+[Contribute to Kubernetes docs]
+
+## Blog 
+
+The [Kubernetes Blog] is a subproject of SIG-Docs and operated by the [blog team].
+
+[Submit a blog post]
+
+## Community statements
+
+Prominent notices on Kubernetes web sites (such as site-wide or front-page banners)
+may be used occasionally to publish statements on behalf of the Kubernetes community.
+The content of those statements must be approved by the [Kubernetes Steering Committee].
+Statements may remain up to 3 weeks, after which they automatically expire
+and are removed unless renewed by the steering committee for additional 3 week periods.
+
+[website subproject]: https://github.com/kubernetes/community/tree/master/sig-docs#website
+[content guide]: https://kubernetes.io/docs/contribute/style/content-guide/
+[style guide]: https://kubernetes.io/docs/contribute/style/style-guide/
+[Contribute to Kubernetes docs]: https://kubernetes.io/docs/contribute/
+[Kubernetes Blog]: https://kubernetes.io/blog/
+[blog team]: /sig-docs/blog-subproject
+[Submit a blog post]: https://kubernetes.io/docs/contribute/#other-ways-to-contribute
+[Kubernetes Steering Committee]: https://github.com/kubernetes/steering#steering-committee

--- a/communication/website-guidelines.md
+++ b/communication/website-guidelines.md
@@ -18,9 +18,9 @@ The [Kubernetes Blog] is a subproject of SIG-Docs and operated by the [blog team
 ## Community statements
 
 Prominent notices on Kubernetes web sites (such as site-wide or front-page banners)
-may be used occasionally to publish statements on behalf of the Kubernetes community.
-The content of those statements must be approved by the [Kubernetes Steering Committee].
-Statements may remain up to 3 weeks, after which they automatically expire
+may be used occasionally to publish information on behalf of the Kubernetes community.
+The content of those notices must be approved by the [Kubernetes Steering Committee].
+Notices may remain up to 3 weeks, after which they automatically expire
 and are removed unless renewed by the steering committee for additional 3 week periods.
 
 [website subproject]: https://github.com/kubernetes/community/tree/master/sig-docs#website


### PR DESCRIPTION
Added a brief policy on use/duration of the website banner for community statements as discussed in steering. I wasn't quite sure where this belonged, but under "communication", peer to mailing list / slack / discuss / social media guidelines seemed reasonable. All suggestions on location and phrasing welcome.

Also linked to existing sig-docs website content/style guides, and the blog subproject / contribution page.

/cc @cblecker @derekwaynecarr @dims @mrbobbytables @nikhita @parispittman

steering:
- [ ] @cblecker
- [x] @derekwaynecarr
- [x] @dims
- [x] @liggitt
- [x] @mrbobbytables
- [x] @nikhita
- [ ] @parispittman

sig-docs chairs:
- [x] @irvifa
- [x] @jimangel
- [ ] @kbarnard10

sig-docs tech leads:
- [x] @kbhawkey
- [x] @onlydole
- [x] @sftim