### PR TITLE
sig-node: add noderesourcetopology-api repo

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -66,6 +66,9 @@ The following [subprojects][subproject-definition] are owned by sig-node:
   - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
 - **Contact:**
   - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
+### noderesourcetopology-api
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/noderesourcetopology-api/master/OWNERS
 ### security-profiles-operator
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1710,6 +1710,9 @@ sigs:
       slack: node-problem-detector
     owners:
     - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
+  - name: noderesourcetopology-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/noderesourcetopology-api/master/OWNERS
   - name: security-profiles-operator
     contact:
       slack: security-profiles-operator


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2302

/assign @derekwaynecarr @dchen1107 
fyi @swatisehgal

/hold
for lgtm from sig-node leads