### PR TITLE
Add kubeinit channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -184,6 +184,7 @@ channels:
   - name: kubecon
   - name: kubectl-trace
   - name: kubedb
+  - name: kubeinit
   - name: kubekhan
     archived: true
   - name: kubeless


### PR DESCRIPTION
This requests a new channel for kubeinit, which is an Ansible collection
designed to deploy multiple Kubernetes distributions on top of multiple
infrastructure platforms.

The tool also allows to easily create kubernetes clusters either using
kubeadm, openshift/okd, rancher or canonical kubernetes with the idea to
extend it to other kubernetes distributions and deployment tools,
hence the request to host it here.

Also this Ansible collection helps potential new users to understand
the different components required to deploy production ready clusters.

The project's repository is hosted at https://github.com/kubeinit/kubeinit

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
