### PR TITLE
Archive client-go-docs channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -35,6 +35,7 @@ channels:
   - name: ckad-exam-prep
   - name: cks-exam-prep
   - name: client-go-docs
+    archived: true
   - name: cluster-addons
   - name: cluster-api
   - name: cluster-api-aws


### PR DESCRIPTION
The channel used to be used for coordination on client-go documentation improvement. It has not been used in quite a while and can be archived. (See [relevant Slack discussion](https://kubernetes.slack.com/archives/C86T1T737/p1605167908017000).)

/cc @sttts 