### PR TITLE
Add Hetzner to channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -114,6 +114,7 @@ channels:
     id: C67TNP3FF
   - name: hephy-users
     id: C678BMZ89
+  - name: hetzner
   - name: homelab
   - name: id-events
   - name: id-users


### PR DESCRIPTION
Adds a dedicated channel for Hetzner (https://www.hetzner.com/cloud).
This is a popular cloud provider with attractive prices.

Currently no managed Kubernetes service, it's in the work.
But they do provide:
https://github.com/hetznercloud/hcloud-cloud-controller-manager
https://github.com/hetznercloud/csi-driver

to support K8S on their cloud.

I came across Hetzner multiple times in other channels, so I think it could use a dedicated channel.