### PR TITLE
Initialize 2021 Steering Committee Election docs

### DIFF
--- a/events/elections/2021/OWNERS
+++ b/events/elections/2021/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# replace with election officers once election starts
+approvers:
+  - committee-steering
+labels:
+  - committee/steering

--- a/events/elections/2021/README.md
+++ b/events/elections/2021/README.md
@@ -1,0 +1,204 @@
+# 2021 VOTERS GUIDE - KUBERNETES STEERING COMMITTEE ELECTION
+
+## Purpose
+
+The role of this election is to fill out the four (4) seats due for
+reelection this year on the [Kubernetes Steering Committee]. Each elected
+member will serve a two (2) year term.
+
+## Background
+
+This election will shape the future of Kubernetes as a community and project.
+While SIGs and WGs help shape the technical direction of the project, the
+[Steering Committee Charter] covers the health of the project and community
+as a whole. Some direct responsibilities of steering members to consider as
+you are deciding whether to run or who to vote for:
+
+* Through the chartering review process, delegate ownership of, responsibility
+  for and authority over areas of the project to specific entities
+* Define, evolve, and defend the non-technical vision / mission and the values
+  of the project
+* Charter and refine policy for defining new community groups and establish
+  transparency and accountability policies for such groups
+* Define and evolve project and group governance
+  structures and policies
+* Act as a final non-technical escalation point for any Kubernetes repository
+* Request funds and other support from the CNCF (e.g. marketing, press, etc.)
+* Define and enforce requirements for community groups to be in good standing
+  such as having an approved charter
+
+For more context, please see the [current steering committee backlog] or a
+previous [governance meeting video] which led to this whole process.
+
+## Eligibility
+
+Please refer to the [Steering Committee Election Charter] for [Eligibility for candidacy]
+
+Eligibility for voting in 2021 is defined as:
+
+* People who had at least 50 contributions to the Kubernetes project over
+  the past year, according to a snapshot taken 2021-MM-DD of the data driving
+  the [devstats developer activity counts dashboard][devstats-dashboard],
+  who are also [Org Members].
+  Contributions include GitHub events like creating issues, creating PRs,
+  reviewing PRs, commenting on issues, etc. For full details see
+  [the SQL query used by devstats for developer activity counts][devstats-sql].
+
+* People who have submitted the [voter exemption form] and are accepted by
+  the election committee. We *explicitly* believe the above heuristic will be
+  inaccurate and not represent the entire community. Thus we provide the form
+  for those who have contributed to the project but may not meet the above
+  criteria.  Acceptance of a form submission will be defined by a simple
+  majority vote, and the criteria used during this process will be used to
+  help refine further elections.
+
+If you otherwise qualify to vote but have not yet applied for Org Membership,
+then please [request an exception][voter exemption form] (and please apply for
+Org Membership as well).
+
+Corporate affiliation is applied after the election. If an organization finds
+itself with too many representatives it is up to those individuals to come
+to a consensus on who should serve on the committee.
+
+### Schedule
+
+| Date         | Event                    |
+| ------------ | ------------------------ |
+| August XX    | Announcement of Election and publication of Voters.md |
+| August XX    | Steering Committee Meeting with Q+A with the candidates and community |
+| September XX | All candidate bios and voting exception forms due by 0000 UTC (5pm PST) |
+| ~1 week      | Election prep week (voters.md validation and CIVS setup and testing)
+| September XX | Election Begins via email ballots |
+| October XX   | Deadline to request a replacement ballot |
+| October XX   | Election Closes by 0000 UTC (5pm PST) |
+| October XX   | Announcement of Results at Public Steering Committee meeting |
+
+## Candidacy Process
+
+**Nomination**
+
+If you want to stand for election, send an email to kubernetes-dev@googlegroups.com
+with the subject line "Steering Committee Nomination: Your Name (@yourgithub)".
+
+If you want to nominate someone else, you may do so, but PLEASE talk to them
+first.
+
+If you wish to accept a nomination from someone else, reply to the nomination
+email saying something like "I accept the nomination".
+
+**Endorsement**
+
+Once nominated, you must get the endorsement of three (3) different eligible
+voters from three (3) different employers.  If you are eligible to vote
+yourself, you count as one of the three. Endorsements from non-voting members
+does not count towards the final count.
+
+[Eligible voters] may endorse candidates of their choosing by replying to the
+candidate's nomination email saying something like "I endorse this nominee,
+and I work for <COMPANY>" or "+1". Please specify your github ID, state that
+you are in voters.md, and include your employer's name so that we see can
+which candidates have sufficient endorsements.
+
+When a candidate has reached the necessary three endorsements, one of the
+Election Officers will announce that on the email thread.  After that,
+please do not endorse the candidate further.
+
+**Running**
+
+Eligible candidates can submit a pull request with a biography in this
+directory with their platform and intent to run. This statement is
+**limited to 300 words** and must follow the format of `firstnamelastname.md`.
+Please refer to the [2020 candidate bios] for examples. Biography statements are optional.
+
+Missed deadlines by the candidates will be addressed by steering on a per case basis to determine eligibility.
+
+**Campaigning**
+
+Please refer to the [Steering Committee Election Charter] and understand
+that we care deeply about [limiting corporate campaigning]. The election
+officers and members of the steering committee [pledge to recuse] themselves
+from any form of electioneering.
+
+You should be running as a "brand free" individual, based on your contribution
+to the project as a member of this community, outside of whatever corporate
+roles you may hold.
+
+## Voting Process
+
+Kubernetes members in [voters.md] will receive a ballot via email. If you are
+not on that list and feel you have worked on Kubernetes in a way that is NOT
+reflected in GitHub contributions, you can use the [voter exemption form] to ask
+to participate in the election.
+
+Elections will be held using time-limited [Condorcet] ranking on [CIVS]
+using the [IRV method]. The top vote getters will be elected to the open
+seats.
+
+Employer diversity is encouraged, and thus maximal representation will be
+enforced as spelled out in the [Steering Committee Election Charter].
+
+You will be ranking your choices of the candidates with an option for
+"no opinion". In the event of a tie, a coin will be flipped.
+
+The election will open for voting starting September XX via email and
+end three weeks after on October XX, 2021 at 00:00am UTC. You will receive
+an email to the address on file at the start of the election from "Kubernetes
+(CIVS Poll Supervisor) `<civs@cs.cornell.edu>`, please add to the list of addresses
+you don't spam filter. Detailed voting instructions will be addressed in email
+and the CIVS polling page. Please note that email ballots might be unreliable,
+so you are encouraged to contact the election officials if you do not receive a
+ballot by September XX.
+
+If you do not receive your ballot, request a new one via the [Ballot Replacement Form].
+
+### Officers
+
+The Steering Committee has selected the following people as [election officers]:
+- Name, GitHub handle, Affiliation
+
+Please direct any questions via email to <election@k8s.io>.
+
+### Decision
+
+The newly elected body will be announced in the monthly [Kubernetes Community Meeting]
+on October XX, 2021.
+
+Following the meeting, the raw voting results and winners will be published on the
+[Kubernetes Blog].
+
+For more information, definitions, and/or detailed election process, please refer to
+the [Steering Committee Election Charter]
+
+## Nominees
+
+|                    Name                    | Organization/Company |                        GitHub                        |
+|:------------------------------------------:|:--------------------:|:----------------------------------------------------:|
+| [Jane Containerface](./biotemplate.md)     |      ExampleCo       | [@github](https://github.com)                        |
+
+[Kubernetes Steering Committee]: https://github.com/kubernetes/steering
+[Steering Committee Charter]: https://github.com/kubernetes/steering/blob/master/charter.md
+[current steering committee backlog]: https://github.com/kubernetes/steering/projects/1
+[governance meeting video]: https://www.youtube.com/watch?v=ltRKXLl0RaE&list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ&index=23
+
+[Steering Committee Election Charter]: https://git.k8s.io/steering/elections.md
+[Eligibility for voting]: https://github.com/kubernetes/steering/blob/master/elections.md#eligibility-for-voting
+[Eligibility for candidacy]: https://github.com/kubernetes/steering/blob/master/elections.md#eligibility-for-candidacy
+[limiting corporate campaigning]: https://github.com/kubernetes/steering/blob/master/elections.md#limiting-corporate-campaigning
+[pledge to recuse]: https://github.com/kubernetes/steering/blob/master/elections.md#steering-committee-and-election-officer-recusal
+
+[Condorcet]: https://en.wikipedia.org/wiki/Condorcet_method
+[CIVS]: http://civs.cs.cornell.edu/
+[IRV method]: https://www.daneckam.com/?p=374
+
+[2021 candidate bios]: https://github.com/kubernetes/community/tree/master/events/elections/2021
+[election officers]: https://github.com/kubernetes/community/tree/master/events/elections#election-officers
+[Kubernetes Community Meeting]: https://github.com/kubernetes/community/blob/master/events/community-meeting.md
+[Kubernetes Blog]: https://kubernetes.io/blog/
+[eligible voters]: ./voters.md
+[voter exemption form]: https://www.surveymonkey.com/r/k8s-sc-election-2021
+[voters.md]: ./voters.md
+
+[devstats-sql]: https://github.com/cncf/devstats/blob/master/metrics/shared/project_developer_stats.sql
+[devstats-dashboard]: https://k8s.devstats.cncf.io/d/13/developer-activity-counts-by-repository-group?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All
+[Org Member]: https://github.com/kubernetes/community/blob/master/community-membership.md
+[Ballot Replacement Form]: https://www.surveymonkey.com/r/kubernetes-sc-2021-ballot

--- a/events/elections/2021/README.md
+++ b/events/elections/2021/README.md
@@ -45,46 +45,79 @@ Eligibility for voting in 2021 is defined as:
   [the SQL query used by devstats for developer activity counts][devstats-sql].
 
 * People who have submitted the [voter exemption form] and are accepted by
-  the election committee. We *explicitly* believe the above heuristic will be
-  inaccurate and not represent the entire community. Thus we provide the form
-  for those who have contributed to the project but may not meet the above
-  criteria.  Acceptance of a form submission will be defined by a simple
-  majority vote, and the criteria used during this process will be used to
-  help refine further elections.
-
-If you otherwise qualify to vote but have not yet applied for Org Membership,
-then please [request an exception][voter exemption form] (and please apply for
-Org Membership as well).
+  the election committee.
 
 Corporate affiliation is applied after the election. If an organization finds
 itself with too many representatives it is up to those individuals to come
 to a consensus on who should serve on the committee.
 
+### Voter Exemption
+
+We *explicitly* believe that the above heuristic will be inaccurate
+and not represent the entire community. Thus we provide the form
+for those who have contributed to the project but may not meet the above
+criteria. Acceptance of a form submission will be defined by a simple
+majority vote, and the criteria used during this process will be used to
+help refine further elections.
+
+If you otherwise qualify to vote but have not yet applied for Org Membership,
+then please [request an exception][voter exemption form] (and please apply for
+Org Membership as well).
+
+Only contributions to projects and artifacts that fall under Steering
+Committee's governance will be considered for voter exemption.
+
+Examples of contributions that would be considered:
+* Slack admins who are not active in GitHub
+* Code of Conduct Committee members whose actions are private by default
+
+Examples of contributions that would NOT be considered:
+* Contributions to ecosystem projects and products
+* Organizing meetups or podcasts
+
 ### Schedule
+
+<!-- While finalizing the dates in the schedule, ensure that:
+- The Steering Committee and candidate Q+A occurs at a public SC meeting
+  (usually a Monday).
+- Dealine to submit voter exception forms and request a
+  replacement ballot is ~3 days before voting closes.
+- Private announcement of results to SC members is at least ~2 days
+  before private announcement to all candidates.
+- The interval between private announcement to all candidates and the
+  public announcement is a weekend.
+-->
 
 | Date         | Event                    |
 | ------------ | ------------------------ |
-| August XX    | Announcement of Election and publication of Voters.md |
+| July 1       | Steering Committee selects Election Committee |
+| August XX    | Announcement of Election and publication of voters.md |
 | August XX    | Steering Committee Meeting with Q+A with the candidates and community |
-| September XX | All candidate bios and voting exception forms due by 0000 UTC (5pm PST) |
+| September XX | All candidate bios due by 0000 UTC (5pm PST) |
 | ~1 week      | Election prep week (voters.md validation and CIVS setup and testing)
 | September XX | Election Begins via email ballots |
-| October XX   | Deadline to request a replacement ballot |
+| October XX   | Deadline to submit voter exception forms and request a replacement ballot |
 | October XX   | Election Closes by 0000 UTC (5pm PST) |
-| October XX   | Announcement of Results at Public Steering Committee meeting |
+| October XX   | Private announcement of Results to SC members not up for election |
+| October XX   | Private announcement of Results to all candidates |
+| October XX   | Public announcement of Results at Public Steering Committee Meeting |
+| October XX   | Election Retro |
 
 ## Candidacy Process
 
 **Nomination**
 
-If you want to stand for election, send an email to kubernetes-dev@googlegroups.com
-with the subject line "Steering Committee Nomination: Your Name (@yourgithub)".
+If you want to stand for the election, create an issue in this GitHub repo
+(kubernetes/community) with the title `Steering Committee Nomination: Your Name (@yourgithub)`.
+After creating the issue, send an email to kubernetes-dev@googlegroups.com
+with a link to the issue. The subject line of the email should be same as
+the title of the issue.
 
 If you want to nominate someone else, you may do so, but PLEASE talk to them
 first.
 
 If you wish to accept a nomination from someone else, reply to the nomination
-email saying something like "I accept the nomination".
+**issue** saying something like "I accept the nomination".
 
 **Endorsement**
 
@@ -94,20 +127,25 @@ yourself, you count as one of the three. Endorsements from non-voting members
 does not count towards the final count.
 
 [Eligible voters] may endorse candidates of their choosing by replying to the
-candidate's nomination email saying something like "I endorse this nominee,
-and I work for <COMPANY>" or "+1". Please specify your github ID, state that
-you are in voters.md, and include your employer's name so that we see can
-which candidates have sufficient endorsements.
+candidate's nomination **issue** saying something like "I endorse this nominee,
+and I work for <COMPANY>" or "+1". Please state that you are in voters.md,
+and include your employer's name so that we see can which candidates have
+sufficient endorsements.
+
+Note that **only endorsements on the GitHub issue will be considered**.
+Endorsements on the nomination email will NOT be considered.
 
 When a candidate has reached the necessary three endorsements, one of the
-Election Officers will announce that on the email thread.  After that,
-please do not endorse the candidate further.
+Election Officers will announce that on the GitHub issue.
 
 **Running**
 
 Eligible candidates can submit a pull request with a biography in this
 directory with their platform and intent to run. This statement is
 **limited to 300 words** and must follow the format of `firstnamelastname.md`.
+The word limit applies to the source markdown file and the [`hack/verify-steering-election.sh`]
+script can be used to check the word count.
+
 Please refer to the [2020 candidate bios] for examples. Biography statements are optional.
 
 Missed deadlines by the candidates will be addressed by steering on a per case basis to determine eligibility.
@@ -160,16 +198,23 @@ Please direct any questions via email to <election@k8s.io>.
 
 ### Decision
 
-The newly elected body will be announced in the monthly [Kubernetes Community Meeting]
-on October XX, 2021.
+- First, the results are privately announced to the incumbent Steering Committee
+members (who are not up for election) and all the candidates.
 
-Following the meeting, the raw voting results and winners will be published on the
+- The newly elected body will be publicly announced in the monthly
+[public Steering Committee Meeting] on October XX, 2021.
+
+- Following the meeting, the raw voting results and winners will be published on the
 [Kubernetes Blog].
 
 For more information, definitions, and/or detailed election process, please refer to
 the [Steering Committee Election Charter]
 
 ## Nominees
+
+The nominee list is filled in by the Election Officers after all bios have been
+submitted. Please do not edit the following table.
+
 
 |                    Name                    | Organization/Company |                        GitHub                        |
 |:------------------------------------------:|:--------------------:|:----------------------------------------------------:|
@@ -190,7 +235,8 @@ the [Steering Committee Election Charter]
 [CIVS]: http://civs.cs.cornell.edu/
 [IRV method]: https://www.daneckam.com/?p=374
 
-[2021 candidate bios]: https://github.com/kubernetes/community/tree/master/events/elections/2021
+[`hack/verify-steering-election.sh`]: https://git.k8s.io/community/hack/verify-steering-election.sh
+[2020 candidate bios]: https://github.com/kubernetes/community/tree/master/events/elections/2021
 [election officers]: https://github.com/kubernetes/community/tree/master/events/elections#election-officers
 [Kubernetes Community Meeting]: https://github.com/kubernetes/community/blob/master/events/community-meeting.md
 [Kubernetes Blog]: https://kubernetes.io/blog/
@@ -200,5 +246,5 @@ the [Steering Committee Election Charter]
 
 [devstats-sql]: https://github.com/cncf/devstats/blob/master/metrics/shared/project_developer_stats.sql
 [devstats-dashboard]: https://k8s.devstats.cncf.io/d/13/developer-activity-counts-by-repository-group?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All
-[Org Member]: https://github.com/kubernetes/community/blob/master/community-membership.md
+[Org Members]: https://github.com/kubernetes/community/blob/master/community-membership.md
 [Ballot Replacement Form]: https://www.surveymonkey.com/r/kubernetes-sc-2021-ballot

--- a/events/elections/2021/README.md
+++ b/events/elections/2021/README.md
@@ -44,14 +44,14 @@ Eligibility for voting in 2021 is defined as:
   reviewing PRs, commenting on issues, etc. For full details see
   [the SQL query used by devstats for developer activity counts][devstats-sql].
 
-* People who have submitted the [voter exemption form] and are accepted by
+* People who have submitted the [voter exception form] and are accepted by
   the election committee.
 
 Corporate affiliation is applied after the election. If an organization finds
 itself with too many representatives it is up to those individuals to come
 to a consensus on who should serve on the committee.
 
-### Voter Exemption
+### Voter exception
 
 We *explicitly* believe that the above heuristic will be inaccurate
 and not represent the entire community. Thus we provide the form
@@ -61,11 +61,11 @@ majority vote, and the criteria used during this process will be used to
 help refine further elections.
 
 If you otherwise qualify to vote but have not yet applied for Org Membership,
-then please [request an exception][voter exemption form] (and please apply for
+then please [request an exception][voter exception form] (and please apply for
 Org Membership as well).
 
 Only contributions to projects and artifacts that fall under Steering
-Committee's governance will be considered for voter exemption.
+Committee's governance will be considered for voter exception.
 
 Examples of contributions that would be considered:
 * Slack admins who are not active in GitHub
@@ -80,7 +80,7 @@ Examples of contributions that would NOT be considered:
 <!-- While finalizing the dates in the schedule, ensure that:
 - The Steering Committee and candidate Q+A occurs at a public SC meeting
   (usually a Monday).
-- Dealine to submit voter exception forms and request a
+- Deadline to submit voter exception forms and request a
   replacement ballot is ~3 days before voting closes.
 - Private announcement of results to SC members is at least ~2 days
   before private announcement to all candidates.
@@ -107,17 +107,28 @@ Examples of contributions that would NOT be considered:
 
 **Nomination**
 
-If you want to stand for the election, create an issue in this GitHub repo
+1. If you want to stand for the election, create an issue in this GitHub repo
 (kubernetes/community) with the title `Steering Committee Nomination: Your Name (@yourgithub)`.
-After creating the issue, send an email to kubernetes-dev@googlegroups.com
-with a link to the issue. The subject line of the email should be same as
-the title of the issue.
-
 If you want to nominate someone else, you may do so, but PLEASE talk to them
 first.
 
-If you wish to accept a nomination from someone else, reply to the nomination
+2. After creating the issue, send an email to kubernetes-dev@googlegroups.com
+with a link to the issue. The subject line of the email should be same as
+the title of the issue. This email should encourage people to second your
+nomination on GitHub, as +1s via email will not count. Here's an example email:
+
+    Hi! I'm nominating _candidate_ for steering committee this year.
+    If you are an eligible voter and think they should run, please add your +1 as
+    a comment on the issue _link_ and mention the organization you work for.
+    While supportive replies are very nice, only comments on the issue will count
+    towards their eligibility.
+
+3. If you wish to accept a nomination from someone else, reply to the nomination
 **issue** saying something like "I accept the nomination".
+
+4. Finally, the candidate closes the **issue** (`#NNN`) by opening a Pull Request
+to add their bio. The PR body must contain the text `Fixes #NNN` to automatically
+close the issue once the PR is merged.
 
 **Endorsement**
 
@@ -128,7 +139,7 @@ does not count towards the final count.
 
 [Eligible voters] may endorse candidates of their choosing by replying to the
 candidate's nomination **issue** saying something like "I endorse this nominee,
-and I work for <COMPANY>" or "+1". Please state that you are in voters.md,
+and I work for <COMPANY>" or "+1". Please state that you an eligible voter,
 and include your employer's name so that we see can which candidates have
 sufficient endorsements.
 
@@ -163,9 +174,9 @@ roles you may hold.
 
 ## Voting Process
 
-Kubernetes members in [voters.md] will receive a ballot via email. If you are
+Eligible voters will receive a ballot via email. If you are
 not on that list and feel you have worked on Kubernetes in a way that is NOT
-reflected in GitHub contributions, you can use the [voter exemption form] to ask
+reflected in GitHub contributions, you can use the [voter exception form] to ask
 to participate in the election.
 
 Elections will be held using time-limited [Condorcet] ranking on [CIVS]
@@ -236,12 +247,12 @@ submitted. Please do not edit the following table.
 [IRV method]: https://www.daneckam.com/?p=374
 
 [`hack/verify-steering-election.sh`]: https://git.k8s.io/community/hack/verify-steering-election.sh
-[2020 candidate bios]: https://github.com/kubernetes/community/tree/master/events/elections/2021
+[2020 candidate bios]: https://github.com/kubernetes/community/tree/master/events/elections/2020
 [election officers]: https://github.com/kubernetes/community/tree/master/events/elections#election-officers
 [Kubernetes Community Meeting]: https://github.com/kubernetes/community/blob/master/events/community-meeting.md
 [Kubernetes Blog]: https://kubernetes.io/blog/
 [eligible voters]: ./voters.md
-[voter exemption form]: https://www.surveymonkey.com/r/k8s-sc-election-2021
+[voter exception form]: https://www.surveymonkey.com/r/k8s-sc-election-2021
 [voters.md]: ./voters.md
 
 [devstats-sql]: https://github.com/cncf/devstats/blob/master/metrics/shared/project_developer_stats.sql

--- a/events/elections/2021/biotemplate.md
+++ b/events/elections/2021/biotemplate.md
@@ -1,0 +1,18 @@
+# Your Name
+
+- GitHub: https://github.com/
+- Affiliation: Where you work or independent
+- Slack: @you
+- Twitter/Other: Add lines as appropriate
+
+## SIGS
+
+- SIGS/WG/UGs you're a member of
+
+## What I have done
+
+## What I'll do
+
+## Resources About Me
+
+- Links to KubeCon or other conference talks or other related material 

--- a/events/elections/2021/templates/election-templates.md
+++ b/events/elections/2021/templates/election-templates.md
@@ -12,7 +12,7 @@ If you’d like to vote or run for a seat, all details and next steps are outlin
 
 As mentioned in the process doc, eligibility for voting will be determined by 50 contributions to a Kubernetes project over the past year and Kubernetes Org membership[5], which will result in you getting a ballot emailed to you when the election starts. All contributors who will receive a ballot are listed in voters.md[6]; if your name is not there, you will need an exception to vote.
 
-For those of you doing work within the Kubernetes project/community that is NOT measured in GitHub, or if you have 50 contributions but not Org Membership, you can apply for participation via the voter exemption form[7]. This is to ensure that non-code contributors can participate, so please don’t hesitate to use the form.
+For those of you doing work within the Kubernetes project/community that is NOT measured in GitHub, or if you have 50 contributions but not Org Membership, you can apply for participation via the voter exception form[7]. This is to ensure that non-code contributors can participate, so please don’t hesitate to use the form.
 
 Resources:
 
@@ -23,7 +23,7 @@ Resources:
 [4] Voters Guide: https://github.com/kubernetes/community/tree/master/events/elections/2021 - Updated on a rolling basis. This guide will always have the latest information throughout the election cycle. The complete schedule of events and candidate bios will be housed here.
 [5] Contributor Ladder: https://github.com/kubernetes/community/blob/master/community-membership.md -  explains Org Membership as well as all of the higher levels
 [6] Voters.md: https://github.com/kubernetes/community/blob/master/events/elections/2021/voters.md -  list of contributors who will automatically receive a ballot
-[7] Exemption Form: https://www.surveymonkey.com/r/k8s-sc-election-2021
+[7] exception Form: https://www.surveymonkey.com/r/k8s-sc-election-2021
 
 
 On behalf of the election officers,

--- a/events/elections/2021/templates/election-templates.md
+++ b/events/elections/2021/templates/election-templates.md
@@ -58,10 +58,11 @@ The candidates and links to their bios are all available here: https://git.k8s.i
 
 The next deadline is XXX , you have until then to complete your ballot. If you have any questions, let us know.
 
-| September XX | All candidate bios and voting exception forms due by 0000 UTC (5pm PST) |
+| September XX | All candidate bios due by 0000 UTC (5pm PST) |
 | September XX | Election Begins via email ballots |
-| October XX    | Election Closes by 0000 UTC (5pm PST) |
-| October XX    | Announcement of Results at Community Meeting |
+| October XX   | Deadline to submit voter exception forms and request a replacement ballot |
+| October XX   | Election Closes by 0000 UTC (5pm PST) |
+| October XX   | Announcement of Results at Community Meeting |
 
 
 // Resources

--- a/events/elections/2021/templates/election-templates.md
+++ b/events/elections/2021/templates/election-templates.md
@@ -1,0 +1,126 @@
+Adjust this template as necessary:
+
+## Election Announcement
+
+It’s that time of year again!
+
+As is now customary, this fall is election season for Kubernetes. Three(3) elected members (bobkillen, dims, liggitt) will stay on for the remaining year of their terms, and there will be four(4) positions open for election. Every election term will be 2 years. We will be posting regular updates to kubernetes-dev with deadlines and instructions as well as providing quick updates during the regular Thursday community meetings until completion of the election.
+
+If you’d like to vote or run for a seat, all details and next steps are outlined in the election process doc[3] and voters guide.[4] The voters guide will be the single source of truth of information for this cycle. It will be updated live as new bios of candidates flow through over the next four weeks. Please pay attention to the scheduled dates:
+
+| schedule here |
+
+As mentioned in the process doc, eligibility for voting will be determined by 50 contributions to a Kubernetes project over the past year and Kubernetes Org membership[5], which will result in you getting a ballot emailed to you when the election starts. All contributors who will receive a ballot are listed in voters.md[6]; if your name is not there, you will need an exception to vote.
+
+For those of you doing work within the Kubernetes project/community that is NOT measured in GitHub, or if you have 50 contributions but not Org Membership, you can apply for participation via the voter exemption form[7]. This is to ensure that non-code contributors can participate, so please don’t hesitate to use the form.
+
+Resources:
+
+
+[1] Steering Committee:  https://github.com/kubernetes/steering - who sits on the committee and terms, their projects and meeting info
+[2] Steering Committee Charter: https://github.com/kubernetes/steering/blob/master/charter.md  - this is a great read if you’re interested in running (or assessing for the best candidates!)
+[3] Election Process: https://git.k8s.io/steering/elections.md 
+[4] Voters Guide: https://github.com/kubernetes/community/tree/master/events/elections/2021 - Updated on a rolling basis. This guide will always have the latest information throughout the election cycle. The complete schedule of events and candidate bios will be housed here.
+[5] Contributor Ladder: https://github.com/kubernetes/community/blob/master/community-membership.md -  explains Org Membership as well as all of the higher levels
+[6] Voters.md: https://github.com/kubernetes/community/blob/master/events/elections/2021/voters.md -  list of contributors who will automatically receive a ballot
+[7] Exemption Form: https://www.surveymonkey.com/r/k8s-sc-election-2021
+
+
+On behalf of the election officers,
+
+Name (github), Name (github), etc
+
+If you have questions, please feel free to ask on the list; otherwise, you can reach the Election Officials at election@kubernetes.io.
+
+## Election Status Updates
+
+Post these weekly to kubernetes-dev
+
+$greeting,
+
+The Kubernetes Steering Committee Election begins today/is underway! Here's what you need to know as we begin prep to send out the ballots.
+
+    Ballots are going out today via email. Expect a mail from "Kubernetes Election Officers (CIVS poll supervisor) <ci...@cs.cornell.edu>" with a subject like "Poll: Kubernetes Steering Committee Election 2021"
+        Email can be unreliable, so generally expect them this morning, if you haven't received one by the end of the day let us know, sending you a new ballot is easy for us.
+
+The candidates and links to their bios are all available here: https://git.k8s.io/community/events/elections/2021
+
+// Voting
+
+- You should check to see if you are in voters.md. Your github handle MUST BE IN THIS DOCUMENT to vote: https://github.com/kubernetes/community/blob/master/events/elections/2021/voters.md
+
+- If you feel you have made enough contributions to be able to vote but you are NOT in voters.md, you need to fill out this form by XXX: https://www.surveymonkey.com/r/k8s-sc-election-2021
+
+- If you are planning on running for Steering Committee please see this section of the documentation, you need to PR your biography into the repo by XXX: https://github.com/kubernetes/community/tree/master/events/elections/2021#candidacy-process
+
+
+// Schedule
+
+The next deadline is XXX , you have until then to complete your ballot. If you have any questions, let us know.
+
+| September XX | All candidate bios and voting exception forms due by 0000 UTC (5pm PST) |
+| September XX | Election Begins via email ballots |
+| October XX    | Election Closes by 0000 UTC (5pm PST) |
+| October XX    | Announcement of Results at Community Meeting |
+
+
+// Resources
+
+Voters Guide - https://git.k8s.io/community/events/elections/2021
+Steering Committee -  https://git.k8s.io/steering
+Steering Committee Charter - https://git.k8s.io/steering/charter.md
+Election Process - https://git.k8s.io/steering/elections.md
+
+On behalf of the election officers,
+Name (github), Name (github), etc
+
+If you have questions, please feel free to ask on the list; otherwise, you can reach the Election Officials at election@kubernetes.io
+
+## Election Poll Header
+
+Welcome to the 2021 annual Kubernetes Steering Committee election.  More information, including candidates, links to candidate bios, deadlines and procedures, can be found <a href="https://github.com/kubernetes/community/tree/master/events/elections/2021">on the 2021 election page.</a>
+<br /><br />
+All eligible <a href="https://github.com/kubernetes/community/blob/master/events/elections/2021/voters.md">voters</a> for this election should have received individual ballots by email.  Please do not use a ballot that was forwarded to you by another contributor, as that will invalidate your vote.
+<br /><br />
+The Steering Committee Election is a preference election.  Please arrange the candidates in the order you would prefer them.  Three members of the committee will be elected this year.  PLEASE NOTE: "No opinion" is also a voting option if you do not feel comfortable ranking every single candidate.
+<br /><br />
+To report issues with this election, need a replacement ballot, or ask questions, email <a href="mailto:election@kubernetes.io">the Election Officials.</a>
+
+## Election Results
+
+This mail only goes to the incumbent members of steering who are NOT running that year!
+
+$greeting,
+
+Please keep this information private!
+
+An incumbent steering member announces the results. At least one of you please come to the community meeting tomorrow to make the announcement. Let us know if you cannot.
+
+After the community meeting, we'll publish this blog post (feedback encouraged).
+
+A note on the results, as per previous elections we plan on announcing/celebrating the winners and only publishing their names, GitHub handles, and affiliations. We purposely don't mention rankings or the results of the rest of the field.
+
+We will quietly check in the full election results (with anonymized ballots) into the community repo in the next few weeks. This will satisfy transparency requirements while being respectful to the other candidates.
+
+Results and data from the 2021 Steering Committee election:
+
+- XXX eligible voters as determined by:
+    - XXX org members with 50+ DevStats recorded contributions between
+    Aug 1 2020 and Aug 1 2021.
+    - XX additional exception voters comprising XX% of exception requests
+    - Of the XXX eligible voters, no useful address could be initially
+    determined for XX of them, XX members submitted corrected email addresses,
+    and X were denied due to ineligibility
+
+Emails were obtained from the CNCF's gitdm along with some manual
+reconciliation and comparison with last year's email list.
+
+XXX total votes cast as of the close on October XX at 5pm PT (XX%)
+
+Last Year's data: XXX eligible voters with XXX votes cast (XX%)
+
+
+Final Results:
+
+(paste these from CIVS)
+1. Jane Containerface (@github)  (Condorcet winner: wins contests with all other choices)

--- a/events/elections/README.md
+++ b/events/elections/README.md
@@ -17,9 +17,9 @@ eligibility for voting, eligibility for candidacy, maximal representation, etc.
 - Recommend the month of October to not collide with a release or end of a quarter.
 - Nomination and Voter Registration period start
 - Nomination period end (At least a two week period)
-- Voter Registration Deadline
 - Election period start
   - It takes time to create the poll in CIVS, so don’t give a specific hour, instead say “Morning of the 10th” or something vague.
+- Voter Registration Deadline
 - Election period stop
   - CIVS needs to be manually stopped, so an actual person needs to click for the poll to stop, so this needs to be a human friendly time
 - Results announcement date


### PR DESCRIPTION
This is a follow-up from the 2020 election [retro](https://docs.google.com/document/d/1xLs1PLoPDXHZAgImNHTiepn_f7-k5HjsCZqaozgFLzI/edit?usp=sharing). This PR only updates the election policy. It does NOT update the Election Committee guide. I have created an issue for updating the guide - https://github.com/kubernetes/steering/issues/190.

The first commit initializes the docs based on the 2020 docs. The second commit has updates based on the retro. Mainly:

- Move nomination and endorsement process to GitHub issues
- Clarify criteria for voter exemption forms
- Clarify word limit restriction for candidate bios
- Clarify that the EC updates the candidate index list in the README
- Update schedule to include:
  - Selection of EC by the SC
  - Move deadline for voter exemptions few days before voting closes
  - Private announcement of results to SC members who are not up for election
  - Private announcement to all candidates
  - Election retro

/hold
for steering review

cc @kubernetes/steering-committee @jberkus @jdumars @idvoretskyi 