### PR TITLE
Add munnerz as a primary admin/approver

### DIFF
--- a/communication/slack-config/OWNERS
+++ b/communication/slack-config/OWNERS
@@ -13,5 +13,6 @@ approvers:
   - idvoretskyi
   - rlenferink
   - idealhack
+  - munnerz
 labels:
   - area/slack-management

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -56,6 +56,7 @@ users:
   mkorbi: UEBLUUA0P
   mohammedzee1000: U3PFFE8CD
   mrbobbytables: U511ZSKHD
+  munnerz: U0EC03FTN
   nikhita: U2PQHGMLN
   nkubala: UA90QL2BE
   nrb: U7S597E00


### PR DESCRIPTION
A while back at the last Slack admins meet, we discussed moving some non-primary admins to be 'primary' admins. I don't think this was ever put into effect though, so thought I'd open up a PR to add myself as an approver so I can help within this repo too 😄

There's also a Google Sheet that lists all the admins that'll need updating too, which I'll go take a look for after this has been reviewed/accepted 🙂