### PR TITLE
Update LF course for inclusive training

### DIFF
--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -151,7 +151,7 @@ curation from other SIG participants
 - *MAY* build new functionality for subprojects
 - *MAY* participate in decision making for the subprojects they hold roles in
 - Includes all reviewers and approvers in [OWNERS] files for subprojects
-- *MUST* take an [inclusive speaker training course] in support of our community values
+- *MUST* take an [Inclusive Open Source Community Orientation course] in support of our community values
 within 30 days from the date of their appointment.
 
 ### Security Contact
@@ -244,5 +244,5 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
 [Google group]: https://groups.google.com/forum/#!forum/kubernetes-sig-config
 [dashboard]: https://testgrid.k8s.io/
 [monthly community meeting]: /events/community-meeting.md
-[inclusive speaker training course]: https://training.linuxfoundation.org/training/inclusive-speaker-orientation/
+[Inclusive Open Source Community Orientation course]: https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/
 [technical-lead.md]: /contributors/chairs-and-techleads/technical-lead.md

--- a/contributors/chairs-and-techleads/leadership-changes.md
+++ b/contributors/chairs-and-techleads/leadership-changes.md
@@ -16,7 +16,7 @@ mailing list. At a minimum, the email should contain:
 
 - [ ] If nominating another lead, ensure that they
   - [ ] are a Kubernetes GitHub org [member]
-  - [ ] have completed the [Inclusive Leadership Training]
+  - [ ] have completed the [Inclusive Open Source Community Orientation course]
 
 - [ ] Once lazy consensus has been achieved, update the following
       files in the respective repos:
@@ -44,5 +44,5 @@ administration of the election.
 [kubernetes/enhancements]: https://github.com/kubernetes/enhancements
 [milestone-maintainers team]: https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml
 [team configs]: https://git.k8s.io/org/config
-[Inclusive Leadership Training]: https://training.linuxfoundation.org/training/inclusive-speaker-orientation/
+[Inclusive Open Source Community Orientation course]: https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/
 [sig-wg-lifecycle.md]: /sig-wg-lifecycle.md


### PR DESCRIPTION
Ref: https://lists.cncf.io/g/cncf-toc/topic/78231677#5503, https://github.com/cncf/toc/pull/570

LF has launched a new course for inclusive training in an open source
context - https://training.linuxfoundation.org/announcements/linux-foundation-and-ncwit-release-free-training-course-on-diversity-in-open-source/

All CNCF maintainers are also required to take this course.

/hold
steering review

cc @kubernetes/steering-committee 