### PR TITLE
slack-config: Update SIG usergroups + add PSC groups

### DIFF
--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -31,6 +31,7 @@ restrictions:
     usergroups:
       - "^sig-release-"
       - "^release-"
+      - "^security-release-team$"
   - path: "sig-network/*.yaml"
     channels:
       - "^sig-network-.*$"

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -6,28 +6,28 @@ usergroups:
   # - https://git.k8s.io/sig-release/release-managers.md#associates
   - name: release-managers
     long_name: Release Managers
-    description: Release Managers. Ping for questions on branch cuts and building/packaging Kubernetes.
+    description: |-
+      Release Managers. Ping for questions on branch cuts and building/packaging
+      Kubernetes.
     channels:
       - release-ci-signal
       - release-management
       - sig-release
     members:
+      - ameukam # Release Manager Associate
       - cpanato # Release Manager
-      - dougm # Release Manager
       - feiskyer # Release Manager
       - gianarb # Release Manager Associate
-      - hasheddan # Release Manager
-      - hoegaarden # Release Manager
+      - hasheddan # subproject owner / Release Manager
       - idealhack # Release Manager
       - jimangel # Release Manager Associate
       - justaugustus # subproject owner / Release Manager
       - markyjackson-taulia # Release Manager Associate
       - mkorbi # Release Manager Associate
       - onlydole # Release Manager Associate
-      - puerco # Release Manager Associate
+      - puerco # Release Manager
       - saschagrunert # subproject owner / Release Manager
       - sethmccombs # Release Manager Associate
-      - tpepper # subproject owner / Release Manager
       - Verolop # Release Manager Associate
       - xmudrii # Release Manager
 
@@ -35,7 +35,9 @@ usergroups:
   # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.20/release_team.md
   - name: release-team-leads
     long_name: Release Team Leads
-    description: Release Team Leads. Ping for questions on the current Kubernetes release cycle.
+    description: |-
+      Release Team Leads. Ping for questions on the current Kubernetes release
+      cycle.
     channels:
       - release-bug-triage
       - release-ci-signal
@@ -46,27 +48,27 @@ usergroups:
       - sig-release
     members:
       - alejandrox1 # SIG Release Technical Lead
-      - hasheddan # 1.20 Release Team Lead Shadow
+      - hasheddan # SIG Release Technical Lead / 1.20 Release Team Lead Shadow
       - jeremyrickard # 1.20 Release Team Lead
       - justaugustus # SIG Release Chair
       - LappleApple # SIG Release Program Manager
       - palnabarun # 1.20 Release Team Lead Shadow
-      - saschagrunert # SIG Release Technical Lead
-      - savitharaghunathan # 1.20 Release Team Lead Shadow
-      - tpepper # SIG Release Chair
+      - saschagrunert # SIG Release Chair
+      - savitharaghunathan # 1.20 Release Team Lead Shadows
 
   # Should match SIG Release Leads at all times:
   # https://git.k8s.io/community/sig-release/README.md#leadership
   - name: sig-release-leads
     long_name: SIG Release Leads
-    description: SIG Release Leads. Ping for questions on SIG Release process and escalations.
+    description: |-
+      SIG Release Leads. Ping for questions on SIG Release process and escalations.
     channels:
       - release-ci-signal
       - release-management
       - sig-release
     members:
       - alejandrox1 # SIG Release Technical Lead
+      - hasheddan # SIG Release Technical Lead
       - justaugustus # SIG Release Chair
       - LappleApple # SIG Release Program Manager
-      - saschagrunert # SIG Release Technical Lead
-      - tpepper # SIG Release Chair
+      - saschagrunert # SIG Release Chair

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -72,3 +72,32 @@ usergroups:
       - justaugustus # SIG Release Chair
       - LappleApple # SIG Release Program Manager
       - saschagrunert # SIG Release Chair
+
+  # Should match the membership of the following teams at all times:
+  # - https://git.k8s.io/security/#product-security-committee-psc
+  # - https://git.k8s.io/sig-release/release-managers.md#release-managers
+  - name: security-release-team
+    long_name: Security Release Team
+    description: |-
+      Security Release Team is the composite of full-fledged Product Security
+      Committee members and Release Managers. Ping for questions on Kubernetes
+      security releases.
+    channels:
+      - release-management
+      - sig-release
+    members:
+      - cjcullen # Product Security Committee
+      - cji # Product Security Committee
+      - cpanato # Release Manager
+      - feiskyer # Release Manager
+      - hasheddan # subproject owner / Release Manager
+      - idealhack # Release Manager
+      - joelsmith # Product Security Committee
+      - justaugustus # subproject owner / Release Manager
+      - lukehinds # Product Security Committee
+      - micahhausler # Product Security Committee
+      - puerco # Release Manager
+      - saschagrunert # subproject owner / Release Manager
+      - swamymsft # Product Security Committee
+      - tallclair # Product Security Committee
+      - xmudrii # Release Manager

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -43,6 +43,25 @@ usergroups:
   - name: google-build-admin
     external: true
 
+  # Should match the membership of the following teams at all times:
+  # - https://git.k8s.io/security/#product-security-committee-psc
+  - name: product-security-committee
+    long_name: Product Security Committee
+    description: |-
+      The Product Security Committee (PSC) is responsible for triaging and
+      handling the security issues for Kubernetes.
+    channels:
+      - release-management
+      - sig-release
+    members:
+      - cjcullen
+      - cji
+      - joelsmith
+      - lukehinds
+      - micahhausler
+      - swamymsft
+      - tallclair
+
   - name: velero-maintainers
     long_name: Velero Maintainers
     description: Velero Maintainers group.

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -6,6 +6,7 @@ users:
   aleksandra-malinowska: U357LUPHS
   AlexB138: U3JA3MDGV
   alisondy: U9CBCBLCV
+  ameukam: U68KPQ448
   aravindputrevu: U1G27SDU6
   ashish-amarnath: U65JLLS0J
   asmacdo: UNVH7RY9J

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -18,6 +18,8 @@ users:
   castrojo: U1W1Q6PRQ
   cdrage: U2TU9NPH9
   chrisshort: U2YGXSD9B
+  cjcullen: U0ALJAVMF
+  cji: U5YSRC21J
   cpanato: U8DFY4TTK
   Dave Smith-Uchida: UDZDED8G2
   dharmit: U0APPPEKE
@@ -43,6 +45,7 @@ users:
   jmccormick2001: UMPLV0G0H
   jmrodri: U4KATPQ48
   johnbelamaric: U246A1A0N
+  joelsmith: U5SLG8T8F
   jonasrosland: U0A4G34S2
   justaugustus: U0E0E78AK
   kadel: U0DE6E8JY
@@ -50,10 +53,12 @@ users:
   katharine: UBTBNJ6GL
   LappleApple: U011C07244F
   listx: UFCU8S8P3
+  lukehinds: UN2P2M4F4
   marc-obrien: UL51BRL9Y
   markyjackson-taulia: U19TKJ64E
   MarlonGamez: U016N1XK06R
   mbbroberg: U18JTHMDY
+  micahhausler: U1WJ1BZA5
   mik-dass: U3PFFE8CD
   mkorbi: UEBLUUA0P
   mohammedzee1000: U3PFFE8CD
@@ -79,6 +84,8 @@ users:
   simplytunde: UAY1NBYHE
   Sujay Pillai: UBW3N1VGW
   sumitranr: UCQN13L9H
+  swamymsft: UHU7ZNXH8
+  tallclair: U64VCBURE
   TaoBeier: UCLDV6MN1
   tejal29: UACD7R316
   theishshah: U01891A4TRS


### PR DESCRIPTION
SIG Release updates as described in https://github.com/kubernetes/sig-release/pull/1331.

Also adds two new usergroups:
- `security-release-team`: @kubernetes/release-managers + @kubernetes/product-security-committee 
- `product-security-committee`: https://github.com/kubernetes/security/#product-security-committee-psc

as requested by @tallclair. 
PSC Associates were purposely left off these groups, but can be added at a later time.

/assign @hasheddan @saschagrunert
cc: @kubernetes/sig-release-leads 