### PR TITLE
sig-api-machinery: add kubectl-check-ownerreferences repo

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -58,6 +58,7 @@ The following [subprojects][subproject-definition] are owned by sig-api-machiner
 ### control-plane-features
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes-sigs/kubectl-check-ownerreferences/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/resourcequota/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -66,6 +66,7 @@ sigs:
   - name: control-plane-features
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/kubectl-check-ownerreferences/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/resourcequota/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2350

/assign @lavalamp @deads2k @fedebongio 
sig-api-machinery leads

/hold
for lgtm by apimachinery leads