### PR TITLE
Updating meeting details

### DIFF
--- a/communication/marketing-team/README.md
+++ b/communication/marketing-team/README.md
@@ -37,9 +37,8 @@ the broader ecosystem.
 
 We still have many roles available!  
 
-* Come to one of our [meetings] (Every Friday at 8am PT), see the [calendar] to add it to your own calendar.
-* Join our [mailing-list],
-* Reach out to us on the #sig-contribex channel on the Kubernetes slack (slack.k8s.io for invite).
+* Come to one of our [meetings] (Every Friday at 8am PT). See the [calendar] to add it to your own calendar.
+* Join our [mailing-list], and/or reach out to us on the #sig-contribex channel on the Kubernetes slack ([slack.k8s.io](http://slack.k8s.io)).
 
 Let us know you are interested and if you have any questions.
 

--- a/communication/marketing-team/README.md
+++ b/communication/marketing-team/README.md
@@ -37,11 +37,15 @@ the broader ecosystem.
 
 We still have many roles available!  
 
-Come to one of our [meetings] (join kubernetes-sig-contribex@googlegroups.com for the invite)
-or reach out to us on the #sig-contribex channel on the Kubernetes slack (slack.k8s.io for invite).
+* Come to one of our [meetings] (Every Friday at 8am PT), see the [calendar] to add it to your own calendar.
+* Join our [mailing-list],
+* Reach out to us on the #sig-contribex channel on the Kubernetes slack (slack.k8s.io for invite).
+
 Let us know you are interested and if you have any questions.
 
-[meetings]: /sig-contributor-experience#community-management
+[meetings]: /sig-contributor-experience#contributor-comms
+[calendar]: https://calendar.google.com/calendar/u/0/r/customday?eid=NmU5MjFnYWwwMzIwNjVwamFvNmszZHBuYzhfMjAyMDEyMDRUMTYwMDAwWiBjYWxlbmRhckBrdWJlcm5ldGVzLmlv&ctz=America/Los_Angeles&sf=true
+[mailing-list]: https://groups.google.com/g/kubernetes-sig-contribex
 [charter]: ./CHARTER.md
 [Could be you!]: #could-be-you
 [Contributor Experience]: /sig-contributor-experience


### PR DESCRIPTION
I was struggling to find the right meeting, I eventually found it at the big [kubernetes calendar](https://calendar.google.com/calendar/u/0/embed?src=calendar@kubernetes.io) after Matt Broberg gave me the time for it.  This update should make it easier to find. 

I believe the meetings link should have been to the `#contributor-comms anchor`, so I updated that too, let me know if I'm wrong.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

