### PR TITLE
sig-storage: remove k-csi/csi-driver-flex repo

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -75,7 +75,6 @@ The following [subprojects][subproject-definition] are owned by sig-storage:
 ### kubernetes-csi
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2175,7 +2175,6 @@ sigs:
   - name: kubernetes-csi
     owners:
     - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-flex/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2371

kubernetes-csi/csi-driver-fibre-channel was surprisingly not in sigs.yaml in the first place...

/assign @msau42 @xing-yang 

/hold
until repos are actually archived