### PR TITLE
Correct list api examples and add link to field selector documentation

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -123,11 +123,10 @@ defaults) and may not have lists.
 
    In addition, all lists that return objects with labels should support label
 filtering (see [the labels documentation](https://kubernetes.io/docs/user-guide/labels/)), and most
-lists should support filtering by fields.
+lists should support filtering by fields (see 
+[the fields documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/)).
 
-   Examples: `PodLists`, `ServiceLists`, `NodeLists`.
-
-   TODO: Describe field filtering below or in a separate doc.
+   Examples: `PodList`, `ServiceList`, `NodeList`.
 
 3. **Simple** kinds are used for specific actions on objects and for
 non-persistent entities.


### PR DESCRIPTION
Updates the examples for `List` types to be de-pluralized since I think they are meant to be directly referencing the actual API objects of [PodList](https://github.com/kubernetes/api/blob/4a626d306b987a4096cf0784ec01af1be2f6d67f/core/v1/types.go#L3688), [ServiceList](https://github.com/kubernetes/api/blob/4a626d306b987a4096cf0784ec01af1be2f6d67f/core/v1/types.go#L4344), and [NodeList](https://github.com/kubernetes/api/blob/4a626d306b987a4096cf0784ec01af1be2f6d67f/core/v1/types.go#L4933).  

Also add a link to the existing field selector documentation as done for label filtering to satisfy the TODO.