### PR TITLE
New slack channel for open-cluster-management

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -278,6 +278,7 @@ channels:
   - name: office-hours
   - name: okteto
   - name: olm-dev
+  - name: open-cluster-mgmt
   - name: opencontainers
   - name: openebs
   - name: openebs-dev


### PR DESCRIPTION
open-cluster-management is a project focused on enabling end-to-end visibility and control across Kubernetes clusters.

https://github.com/open-cluster-management/community

The open-cluster-management architecture uses a hub - agent model. The hub centralizes control of all the managed clusters. An agent, which we call the klusterlet, resides on each managed cluster to manage registration to the hub and run instructions from the hub.

It is available under the Apache 2.0 license.

The channel name `open-cluster-mgmt` is chosen due to the character limit.