### PR TITLE
Add exception for metric component prefixes for object metrics

### DIFF
--- a/contributors/devel/sig-instrumentation/instrumentation.md
+++ b/contributors/devel/sig-instrumentation/instrumentation.md
@@ -138,6 +138,12 @@ group.  Metrics take the form:
 kube_[<group>](https://kubernetes.io/docs/reference/using-api/#api-groups)_<kind>_metric
 ```
 
+The [Kube-State-Metrics](https://github.com/kubernetes/kube-state-metrics) 
+project introduced the original kube_* prefixed metrics.  For examples of
+kube_* prefixed metrics, refer to the list of 
+[Exposed Metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/docs#exposed-metrics)
+in the Kube-State-Metrics documentation.
+
 ## Dimensionality & Cardinality
 
 Metrics can often replace more expensive logging as they are time-aggregated

--- a/contributors/devel/sig-instrumentation/instrumentation.md
+++ b/contributors/devel/sig-instrumentation/instrumentation.md
@@ -118,14 +118,14 @@ in kubectl, i.e. daemon sets are `daemonset` rather than `daemon_set`.
 
 ### Exception for object state metrics
 
-One exception to the component prefix rule is for metrics collected about
-the state of kubernetes objects.  From users' perspective, controllers are an
+One exception to the component prefix rule is for metrics derived from
+the state of Kubernetes objects.  From the users' perspective, controllers are an
 implementation detail of object reconciliation.  The collection of controllers
-which comprise a working kuberntes cluster is viewed as a single system which
+which comprise a working Kubernetes cluster is viewed as a single system which
 drives objects towards their specified desired state.  Metrics concerning a
-given object should be easily discoverable and compareable even when they are
+given object should be easily discoverable and comparable even when they are
 produced by different controllers.  Metrics describing the state of a built-in
-kubernetes object take the form:
+Kubernetes object take the form:
 
 ```
 kube_<kind>_<metric>
@@ -235,4 +235,3 @@ metric could look as follows:
 ```
 kube_pod_restarts and on(namespace, pod) kube_pod_info{uuid=”ABC”}
 ```
-

--- a/contributors/devel/sig-instrumentation/instrumentation.md
+++ b/contributors/devel/sig-instrumentation/instrumentation.md
@@ -116,6 +116,28 @@ requests.
 Resource objects that occur in names should inherit the spelling that is used
 in kubectl, i.e. daemon sets are `daemonset` rather than `daemon_set`.
 
+### Exception for object state metrics
+
+One exception to the component prefix rule is for metrics collected about
+the state of kubernetes objects.  From users' perspective, controllers are an
+implementation detail of object reconciliation.  The collection of controllers
+which comprise a working kuberntes cluster is viewed as a single system which
+drives objects towards their specified desired state.  Metrics concerning a
+given object should be easily discoverable and compareable even when they are
+produced by different controllers.  Metrics describing the state of a built-in
+kubernetes object take the form:
+
+```
+kube_<kind>_<metric>
+```
+
+Metrics describing the state of a custom resource avoids collisions by adding a
+group.  Metrics take the form:
+
+```
+kube_[<group>](https://kubernetes.io/docs/reference/using-api/#api-groups)_<kind>_metric
+```
+
 ## Dimensionality & Cardinality
 
 Metrics can often replace more expensive logging as they are time-aggregated


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
This is a follow-up to https://github.com/kubernetes/enhancements/pull/1916, which added kube_* prefixed metrics to the scheduler.  The kube_* prefix was first used in Kube-state-metrics, and the linked KEP expanded the use of the prefix beyond a single component.

My primary motivation is to capture the discussions that have been had over the past few months, and make sure that we keep metrics in-line with our naming guidelines.

Some of the related discussion threads: 
https://github.com/kubernetes/kubernetes/pull/94866#discussion_r520884815
https://github.com/kubernetes/kubernetes/pull/95839#issuecomment-724197407
https://github.com/kubernetes/enhancements/pull/1916#discussion_r498559514

I realized there can be naming collisions if there are controllers for CRDs with the same name, so I added <group> to the prefix of non-built-in resources.  Feel free to suggest alternatives.

@kubernetes/sig-instrumentation-api-reviews @smarterclayton 