### PR TITLE
cleanup pr-review team for cluster-lifecycle

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -45,7 +45,6 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fcluster-lifecycle)
 - GitHub Teams:
     - [@kubernetes/sig-cluster-lifecycle](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle) - Notify group
-    - [@kubernetes/sig-cluster-lifecycle-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle-pr-reviews) - PR Reviews
 
 ## Subprojects
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -904,8 +904,6 @@ sigs:
     teams:
     - name: sig-cluster-lifecycle
       description: Notify group
-    - name: sig-cluster-lifecycle-pr-reviews
-      description: PR Reviews
   subprojects:
   - name: bootkube
     contact:


### PR DESCRIPTION
https://groups.google.com/g/kubernetes-sig-cluster-lifecycle/c/OZPzQ5Niofc/m/oWHWDp7iBQAJ

```
The above PR also removed "sig-cluster-lifecycle-pr-reviews" as it was
matching the main "sig-cluster-lifecycle" team and updated the list of
active contributors in it.
```

@kubernetes/sig-cluster-lifecycle-pr-reviews - PR Reviews 
this is removed.
