### PR TITLE
Add note about calendar invites to templates

### DIFF
--- a/committee-steering/README.md
+++ b/committee-steering/README.md
@@ -13,6 +13,7 @@ The Kubernetes Steering Committee is the governing body of the Kubernetes projec
 The [charter](https://git.k8s.io/steering/charter.md) defines the scope and governance of the Steering Committee.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/a/kubernetes.io/forum/#!forum/steering) for the group will typically add invites for the following meetings to your calendar.*
 * Private Steering Committee Meeting: [third Mondays at 9:30 PT (Pacific Time)](https://bit.ly/k8s-steering-wd) (monthly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29).
   * [Meeting recordings](https://www.youtube.com/watch?v=YAzgJRQxsdc&list=PL69nYSiGNLP1yP1B_nd9-drjoxp0Q14qM).
 * Public Steering Committee Meeting: [first Mondays at 9:30 PT (Pacific Time)](https://bit.ly/k8s-steering-wd) (monthly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29).

--- a/generator/committee_readme.tmpl
+++ b/generator/committee_readme.tmpl
@@ -8,6 +8,11 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{- if .Meetings }}
 
 ## Meetings
+
+{{- if .Contact.MailingList }}
+*Joining the [mailing list]({{.Contact.MailingList}}) for the group will typically add invites for the following meetings to your calendar.*
+{{- end }}
+
 {{- range .Meetings }}
 * {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
 {{- if .ArchiveURL }}

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -7,6 +7,11 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{ end }}
 {{ if .Meetings -}}
 ## Meetings
+
+{{- if .Contact.MailingList }}
+*Joining the [mailing list]({{.Contact.MailingList}}) for the group will typically add invites for the following meetings to your calendar.*
+{{- end }}
+
 {{- range .Meetings }}
 * {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
 {{- if .ArchiveURL }}

--- a/generator/ug_readme.tmpl
+++ b/generator/ug_readme.tmpl
@@ -7,6 +7,11 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{ end }}
 {{ if .Meetings -}}
 ## Meetings
+
+{{- if .Contact.MailingList }}
+*Joining the [mailing list]({{.Contact.MailingList}}) for the group will typically add invites for the following meetings to your calendar.*
+{{- end }}
+
 {{- range .Meetings }}
 * {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
 {{- if .ArchiveURL }}

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -13,6 +13,11 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{ end }}
 {{ if .Meetings -}}
 ## Meetings
+
+{{- if .Contact.MailingList }}
+*Joining the [mailing list]({{.Contact.MailingList}}) for the group will typically add invites for the following meetings to your calendar.*
+{{- end }}
+
 {{- range .Meetings }}
 * {{.Description}}: [{{.Day}}s at {{.Time}} {{.TZ}}]({{.URL}}) ({{.Frequency}}). [Convert to your timezone](http://www.thetimezoneconverter.com/?t={{.Time}}&tz={{.TZ | tzUrlEncode}}).
 {{- if .ArchiveURL }}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -13,6 +13,7 @@ Covers all aspects of API server, API registration and discovery, generic API CR
 The [charter](charter.md) defines the scope and governance of the API Machinery Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery) for the group will typically add invites for the following meetings to your calendar.*
 * Kubebuilder and Controller Runtime Meeting: [Thursdays at 09:00 PT (Pacific Time)]() (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1Ih-2cgg1bUrLwLVTB9tADlPcVdgnuMNBGbUl4D-0TIk/edit?usp=sharing).
 * Regular SIG Meeting: [Wednesdays at 11:00 PT (Pacific Time)](https://zoom.us/my/apimachinery) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -13,6 +13,7 @@ Covers deploying and operating applications in Kubernetes. We focus on the devel
 The [charter](charter.md) defines the scope and governance of the Apps Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-apps) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Mondays at 9:00 PT (Pacific Time)](https://zoom.us/j/739385290?pwd=ekVmNGRjT214MGJkY1JUUUpPMVlJUT09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2LMq7vznITnpd2Fk1YIZF3).

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -13,6 +13,7 @@ The Architecture SIG maintains and evolves the design principles of Kubernetes, 
 The [charter](charter.md) defines the scope and governance of the Architecture Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture) for the group will typically add invites for the following meetings to your calendar.*
 * Enhancements Subproject Meeting: [Thursdays at 10:00 PT (Pacific Time)](https://zoom.us/j/95357819945) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://bit.ly/k8s-enhancements-agenda).
   * [Meeting recordings](TBD).

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -15,6 +15,7 @@ Covers improvements to Kubernetes authorization, authentication, and cluster sec
 The [charter](charter.md) defines the scope and governance of the Auth Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-auth) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Wednesdays at 11:00 PT (Pacific Time)](https://zoom.us/j/264572674) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1woLGRoONE3EBVx-wTb4pvp4CI7tmLZ6lS26VTbosLKM/edit#).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0VMOZ-V7-5AchXTHAQFzJw).

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -13,6 +13,7 @@ Covers development and maintenance of components for automated scaling in Kubern
 The [charter](charter.md) defines the scope and governance of the Autoscaling Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Mondays at 16:00 Poland](https://zoom.us/j/944410904) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=Poland).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1RvhQAEIrVLHbyNnuaT99-6u9ZUMp7BfkPupT2LAZK7w/edit).
 

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -13,6 +13,7 @@ Covers kubectl and related tools. We focus on the development and standardizatio
 The [charter](charter.md) defines the scope and governance of the CLI Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cli) for the group will typically add invites for the following meetings to your calendar.*
 * Bug Scrub: [Wednesdays at 09:00 PT (Pacific Time)](https://zoom.us/j/288426795?pwd=UDdoYnFyNjBiS1RHcXRxS1BCNy9wUT09) (monthly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF).

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -13,6 +13,7 @@ Ensures that the Kubernetes ecosystem is evolving in a way that is neutral to al
 The [charter](CHARTER.md) defines the scope and governance of the Cloud Provider Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cloud-provider) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Wednesdays at 13:00 PT (Pacific Time)](https://zoom.us/j/508079177?pwd=ZmEvMksxdTFTc0N1eXFLRm91QUlyUT09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1OZE-ub-v6B8y-GuaWejL-vU_f9jsjBbrim4LtTfxssw/edit#heading=h.w7i4ksrweimp).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3dXLcYbRKCbpPCN-8CDFAB).

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -13,6 +13,7 @@ The Cluster Lifecycle SIG examines how we should change Kubernetes to make it ea
 The [charter](charter.md) defines the scope and governance of the Cluster Lifecycle Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Tuesdays at 09:00 PT (Pacific Time)](https://zoom.us/j/916523531?pwd=eVhPNU5IQWtBYWhmT1N4T0V6bHZFZz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1Gmc7LyCIL_148a9Tft7pdhdee0NBHdOfHS1SAF0duI4/edit).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -13,6 +13,7 @@ Developing and sustaining a healthy community of contributors is critical to sca
 The [charter](charter.md) defines the scope and governance of the Contributor Experience Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-contribex) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Wednesdays at 9:00 PT (Pacific Time)](https://zoom.us/j/397264241?pwd=bHNnZVArNFdPaWVJMmttdko0Sktudz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1CBz8qV_mD6rbDmTsMuosTOQGRXGhN3d8UrcULUI6Vkw/edit).
   * [Meeting recordings](https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr).

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -13,6 +13,7 @@ Covers documentation, doc processes, and doc publishing for Kubernetes.
 The [charter](charter.md) defines the scope and governance of the Docs Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs) for the group will typically add invites for the following meetings to your calendar.*
 * APAC SIG Meeting: [Wednesdays at 01:00 UTC](https://docs.google.com/document/d/1emuO4nmaQq3K8JZ9-MQeIygtrCPO9kWv7U7RzTaW4F8/edit) (monthly - Wednesday, after the fourth Tuesday, every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=01:00&tz=UTC).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1ddHwLK3kUMX1wVFIwlksjTk0MsqitBnWPe1LRa1Rx5A/edit).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8).

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -13,6 +13,7 @@ Covers best practices for cluster observability through metrics, logging, and ev
 The [charter](charter.md) defines the scope and governance of the Instrumentation Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Thursdays at 9:30 PT (Pacific Time)](https://zoom.us/j/5342565819?pwd=RlVsK21NVnR1dmE3SWZQSXhveHZPdz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1FE4AQ8B49fYbKhfg4Tx0cui1V0eI4o3PxoqQPUwNEiU/edit?usp=sharing).
 * Regular Triage Meeting: [Thursdays at 9:30 PT (Pacific Time)](https://zoom.us/j/5342565819?pwd=RlVsK21NVnR1dmE3SWZQSXhveHZPdz09) (biweekly - alternating with regular meeting). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29).

--- a/sig-k8s-infra/README.md
+++ b/sig-k8s-infra/README.md
@@ -14,6 +14,7 @@ In other words, we seek to eradicate usage of the phrase "oh that's something th
 The [charter](charter.md) defines the scope and governance of the K8s Infra Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-k8s-infra) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Wednesdays at 20:00 UTC](https://zoom.us/j/93109963352?pwd=SHJTcFR2bVg1akYxSDREUWQzaldrQT09) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=20:00&tz=UTC).
   * [Meeting notes and Agenda](http://bit.ly/sig-k8s-infra-notes).
   * [Meeting recordings](http://bit.ly/sig-k8s-infra-playlist).

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -13,6 +13,7 @@ A Special Interest Group focused on solving common challenges related to the man
 The [charter](charter.md) defines the scope and governance of the Multicluster Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Tuesdays at 9:30 PT (Pacific Time)](https://zoom.us/my/k8s.mc) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://tinyurl.com/sig-multicluster-notes).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0HqgyqTby6HlDEz7i1mb0-).

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -13,6 +13,7 @@ Covers networking in Kubernetes.
 The [charter](charter.md) defines the scope and governance of the Network Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-network) for the group will typically add invites for the following meetings to your calendar.*
 * Gateway API Meeting: [Mondays at 15:00 PT (Pacific Time)](https://zoom.us/j/441530404) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit).
 * Network Policy API Meeting: [Mondays at 13:00 PT (Pacific Time)](https://zoom.us/j/96264742248) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=PT%20%28Pacific%20Time%29).

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -13,6 +13,7 @@ SIG Node is responsible for the components that support the controlled interacti
 The [charter](charter.md) defines the scope and governance of the Node Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node) for the group will typically add invites for the following meetings to your calendar.*
 * Main SIG Meeting: [Tuesdays at 10:00 PT (Pacific Time)](https://zoom.us/j/4799874685) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG).

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -13,6 +13,7 @@ Ensure quality Kubernetes releases
 The [charter](charter.md) defines the scope and governance of the Release Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-release) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Tuesdays at 14:30 UTC](https://zoom.us/j/327142148?pwd=RE9aZWtCc0hhOWs4ZTdXZ0hBM0ROdz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:30&tz=UTC).
   * [Meeting notes and Agenda](https://bit.ly/k8s-sig-release-meeting).
   * [Meeting recordings](https://bit.ly/k8s-sig-release-videos).

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -13,6 +13,7 @@ SIG Scalability is responsible for defining and driving scalability goals for Ku
 The [charter](charter.md) defines the scope and governance of the Scalability Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scale) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Thursdays at 10:30 PT (Pacific Time)](https://zoom.us/j/94252896018?pwd=cTlMMlBoTHZqUEdjRm9VY2NWNUg5dz09) (bi-weekly ([upcoming meeting dates](#upcoming-meeting-dates))). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:30&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/a/bobsplanet.com/document/d/1hEpf25qifVWztaeZPFmjNiJvPo-5JX1z0LSvvVY5G2g/edit?usp=drive_web).
   * [Meeting recordings](https://www.youtube.com/watch?v=NDP1uYyom28&list=PL69nYSiGNLP2X-hzNTqyELU6jYS3p10uL).

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -13,6 +13,7 @@ SIG Scheduling is responsible for the components that make Pod placement decisio
 The [charter](charter.md) defines the scope and governance of the Scheduling Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling) for the group will typically add invites for the following meetings to your calendar.*
 * 10AM PT Meeting: [Thursdays at 17:00 UTC](https://zoom.us/j/841218129) (biweekly starting Thursday June 7, 2018). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=17:00&tz=UTC).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/13mwye7nvrmV11q9_Eg77z-1w3X7Q1GTbslpml4J7F3A/edit).
   * [Meeting recordings](https://www.youtube.com/watch?v=PweKj6SU7UA&list=PL69nYSiGNLP2vwzcCOhxrL3JVBc-eaJWI).

--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -13,6 +13,7 @@ Covers horizontal security initiatives for the Kubernetes project, including reg
 The [charter](charter.md) defines the scope and governance of the Security Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-security) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Thursdays at 9:00 PT (Pacific Time)](https://zoom.us/j/9934z1184192?pwd=L25Tc0ZOL3FqU09KNERlTU12dFhTQT09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1GgmmNYN88IZ2v2NBiO3gdU8Riomm0upge_XNVxEYXp0/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP1mXOLAc9ti0oX8s_ookQCi).

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -13,6 +13,7 @@ Service Catalog is a Kubernetes extension project that implements the [Open Serv
 The [charter](charter.md) defines the scope and governance of the Service Catalog Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Mondays at 10:00 PT (Pacific Time)](https://zoom.us/j/7201225346) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/17xlpkoEbPR5M6P5VDzNx17q6-IPFxKyebEekCGYiIKM/edit).
   * [Meeting recordings](https://www.youtube.com/watch?v=ukPj1sFFkr0&list=PL69nYSiGNLP2k9ZXx9E1MvRSotFDoHUWs).

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -13,6 +13,7 @@ SIG Storage is responsible for ensuring that different types of file and block s
 The [charter](charter.md) defines the scope and governance of the Storage Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-storage) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Thursdays at 9:00 PT (Pacific Time)](https://zoom.us/j/614261834) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1-8KEG8AjAgKznS9NFm3qWqkGyCHmvU6HVl0sk5hwoAE/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/watch?v=Eh7Qa7KOL8o&list=PL69nYSiGNLP02-BMqJdfFgGxYQ4Nb-2Qq).

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -13,6 +13,7 @@ Interested in how we can most effectively test Kubernetes. We're interested spec
 The [charter](charter.md) defines the scope and governance of the Testing Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-testing) for the group will typically add invites for the following meetings to your calendar.*
 * SIG Testing Bi-Weekly Meeting: [Tuesdays at 10:00 PT (Pacific Time)](https://zoom.us/j/135450138?pwd=WGJyaVZzekJCWFBTMGJGTXVjUFJaUT09) (bi-weekly starting Tuesday August 13, 2019). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://bit.ly/k8s-sig-testing-notes).
   * [Meeting recordings](https://bit.ly/k8s-sig-testing-videos).

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -13,6 +13,7 @@ Covers all things UI related. Efforts are centered around Kubernetes Dashboard: 
 The [charter](charter.md) defines the scope and governance of the UI Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Thursdays at 09:00 PT (Pacific Time)](https://groups.google.com/forum/#!forum/kubernetes-sig-ui) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1PwHFvqiShLIq8ZpoXvE3dSUnOv1ts5BTtZ7aATuKd-E/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/watch?v=r3pL8i3wPhk&list=PL69nYSiGNLP35H5MZbg9OU6pqpfWgtbLm).

--- a/sig-usability/README.md
+++ b/sig-usability/README.md
@@ -13,6 +13,7 @@ The scope of SIG usability is the core end-user usability of the Kubernetes proj
 The [charter](charter.md) defines the scope and governance of the Usability Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-usability) for the group will typically add invites for the following meetings to your calendar.*
 * Regular SIG Meeting: [Tuesdays at 9:00 PT (Pacific Time)](https://zoom.us/j/3832562240) (every third week). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1gJHgt8RpH4TvqPuC8NtR31-CMqtTYkHy_loxubHq8lg/).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0eY-U8DVJWHBwKvMDEtOxx).

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -13,6 +13,7 @@ Focuses on supporting Windows Node and scheduling Windows containers on Kubernet
 The [charter](charter.md) defines the scope and governance of the Windows Special Interest Group.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-windows) for the group will typically add invites for the following meetings to your calendar.*
 * Backlog Refinement  / Bug Triage Meeting: [Thursdays at 12:30 Eastern Time (ET)](https://zoom.us/j/94389601840?pwd=MCs2SEJQWG0zUWpBS3Nod0ZNMmVXQT09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:30&tz=Eastern%20Time%20%28ET%29).
 * Regular SIG Meeting: [Tuesdays at 12:30 Eastern Time (ET)](https://zoom.us/j/96892680257?pwd=TVNyMzB4VVMwRGZnUkgzT1dnb2szZz09) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:30&tz=Eastern%20Time%20%28ET%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431).

--- a/ug-big-data/README.md
+++ b/ug-big-data/README.md
@@ -11,6 +11,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 Serve as a community resource for advising big data and data science related software projects on techniques and best practices for integrating with Kubernetes. Represents the concerns of users from big data communities to Kubernetes for the purposes of driving new features and other enhancements, based on big data use cases.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-ug-big-data) for the group will typically add invites for the following meetings to your calendar.*
 * Regular User Group Meeting: [Wednesdays at 18:00 UTC](https://zoom.us/my/ug.big.data) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:00&tz=UTC).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit).
   * [Meeting recordings](https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit).

--- a/ug-vmware-users/README.md
+++ b/ug-vmware-users/README.md
@@ -11,6 +11,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 The VMware User Group facilitates communication among Kubernetes users and contributors on topics pertaining to running all conformant forms of Kubernetes on VMware infrastructure.
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-ug-vmware) for the group will typically add invites for the following meetings to your calendar.*
 * Regular User Group Meeting: [Thursdays at 11:00 PT (Pacific Time)](https://docs.google.com/document/d/1ujpqj4hhcIBrSCK2qn6J1r--3QyD96rfDjXTZQ7n7Mw/edit) (monthly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
 
 ## Organizers

--- a/wg-api-expression/README.md
+++ b/wg-api-expression/README.md
@@ -16,6 +16,7 @@ Enable API authors to better serve API consumers, by improving and documenting a
 * SIG Architecture
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-api-expression) for the group will typically add invites for the following meetings to your calendar.*
 * Regular WG Meeting: [Tuesdays at 9:30 PT (Pacific Time)](https://zoom.us/j/94238112084) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:30&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1CSpNaicbEqKJoW306qaQEBIkwC1mGIcKl3yiB_C0HZk).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0CU9g6-yb1NgZXGAhMxfFE&jct=9Leh8O_yrRTB0Kcv3rMKZHncZq8POg).

--- a/wg-data-protection/README.md
+++ b/wg-data-protection/README.md
@@ -18,6 +18,7 @@ The [charter](charter.md) defines the scope and governance of the Data Protectio
 * SIG Storage
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-data-protection) for the group will typically add invites for the following meetings to your calendar.*
 * Regular WG Meeting: [Wednesdays at 9:00 PT (Pacific Time)](https://zoom.us/j/6933410772) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/15tLCV3csvjHbKb16DVk-mfUmFry_Rlwo-2uG6KNGsfw/edit).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP336DulLgPdlWJ_gzRz1iL5).

--- a/wg-iot-edge/README.md
+++ b/wg-iot-edge/README.md
@@ -15,6 +15,7 @@ A Working Group dedicated to discussing, designing and documenting using Kuberne
 * SIG Network
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge) for the group will typically add invites for the following meetings to your calendar.*
 * APAC WG Meeting: [Wednesdays at 5:00 UTC](https://zoom.us/j/91251176046?pwd=cmdqclovM3R3eDB1VlpuL1ZGU1hnZz09) (every four weeks). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=5:00&tz=UTC).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1Yuwy9IO4X6XKq2wLW0pVZn5yHQxlyK7wdYBZBXRWiKI/edit?usp=sharing).
 * Regular WG Meeting (Pacific Time): [Wednesdays at 09:00 PT](https://zoom.us/j/92778512626?pwd=MXhlemwvYnhkQmkxeXllQ0Z5VGs4Zz09) (every four weeks). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT).

--- a/wg-multitenancy/README.md
+++ b/wg-multitenancy/README.md
@@ -19,6 +19,7 @@ Define the models of multitenancy that Kubernetes will support. Discuss and exec
 * SIG Storage
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy) for the group will typically add invites for the following meetings to your calendar.*
 * Regular WG Meeting: [Tuesdays at 11:00 PT (Pacific Time)](https://zoom.us/my/k8s.sig.auth) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1fj3yzmeU2eU8ZNBCUJG97dk_wC7228-e_MmdcmTNrZY/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP1tBA0W8zEe6UwPsabGQk-j).

--- a/wg-policy/README.md
+++ b/wg-policy/README.md
@@ -20,6 +20,7 @@ Provide an overall architecture that describes both the current policy related i
 * SIG Storage
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-policy) for the group will typically add invites for the following meetings to your calendar.*
 * Regular WG Meeting: [Wednesdays at 8:00 PT (Pacific Time)](https://zoom.us/j/7375677271) (semimonthly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=8:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1ihFfEfgViKlUMbY2NKxaJzBkgHh-Phk5hqKTzK-NEEs/edit?usp=sharing).
 

--- a/wg-reliability/README.md
+++ b/wg-reliability/README.md
@@ -20,6 +20,7 @@ The [charter](charter.md) defines the scope and governance of the Reliability Wo
 * SIG Testing
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-reliability) for the group will typically add invites for the following meetings to your calendar.*
 * Regular WG Meeting: [Mondays at 11:00 PT (Pacific Time)](https://zoom.us/j/97964505804?pwd=R3hzSnArQWJHYmdWUnpSUDh3aXhFUT09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1KF_kof3rBWzis87wMkwXicetREuutxlPI6dFDSqdWbo/edit).
   * [Meeting recordings](TODO).

--- a/wg-structured-logging/README.md
+++ b/wg-structured-logging/README.md
@@ -23,6 +23,7 @@ The [charter](charter.md) defines the scope and governance of the Structured Log
 * SIG Storage
 
 ## Meetings
+*Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-structured-logging) for the group will typically add invites for the following meetings to your calendar.*
 * Regular Meeting: [Thursdays at 14:30 UTC](https://zoom.us/j/96716142646?pwd=VmgrN29sbmhDREp3R0NtZlpGSlZ4Zz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:30&tz=UTC).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1R9bZ34L9vR1ftH0dFeOp-j50lLh5ijKVwwXJ3LDrY4I/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2GY3so1z2Cnkvkt5A_x1Aw).


### PR DESCRIPTION
This PR adds a note to all org templates about receiving calendar invites by joining the mailing list.

I've encountered many folks in the community (both new and old) that didn't know this was a thing. I think it makes sense to explicitly call it out.

Happy to change the wording.