### PR TITLE
Remove lingering references for test-infra kubetest2

### DIFF
--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -67,7 +67,6 @@ It is the next significant iteration of kubetest. We will be deprecating kubetes
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/kubetest2/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/test-infra/master/kubetest/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/test-infra/master/kubetest2/OWNERS
 ### prow
 Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2289,7 +2289,6 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kubetest2/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/kubetest/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/kubetest2/OWNERS
   - name: prow
     description: |
       Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project


### PR DESCRIPTION
kubetest2 was moved out of test-infra in https://github.com/kubernetes/test-infra/pull/18567

/cc @spiffxp @BenTheElder 