### PR TITLE
slack-config: add 1.21 RT Leads to the release-team-lead usergroup

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -48,13 +48,15 @@ usergroups:
       - sig-release
     members:
       - alejandrox1 # SIG Release Technical Lead
-      - hasheddan # SIG Release Technical Lead / 1.20 Release Team Lead Shadow
+      - bai # 1.21 Release Team Lead Shadow
+      - hasheddan # SIG Release Technical Lead
       - jeremyrickard # 1.20 Release Team Lead
       - justaugustus # SIG Release Chair
+      - kikisdeliveryservice # 1.21 Release Team Lead Shadow
       - LappleApple # SIG Release Program Manager
-      - palnabarun # 1.20 Release Team Lead Shadow
+      - palnabarun # 1.21 Release Team Lead
       - saschagrunert # SIG Release Chair
-      - savitharaghunathan # 1.20 Release Team Lead Shadows
+      - savitharaghunathan # 1.21 Release Team Lead Shadow
 
   # Should match SIG Release Leads at all times:
   # https://git.k8s.io/community/sig-release/README.md#leadership

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -10,6 +10,7 @@ users:
   aravindputrevu: U1G27SDU6
   ashish-amarnath: U65JLLS0J
   asmacdo: UNVH7RY9J
+  bai: U4XAULHL3
   briandealwis: UAZKM38JV
   bubblemelon: U7K9C643G
   calebamiles: U1ZDD4CUR
@@ -52,6 +53,7 @@ users:
   kadel: U0DE6E8JY
   kaslin: U5ENKU0AE
   katharine: UBTBNJ6GL
+  kikisdeliveryservice: U9HFFRFT2
   LappleApple: U011C07244F
   listx: UFCU8S8P3
   lukehinds: UN2P2M4F4


### PR DESCRIPTION
Add 1.21 RT Leads to `release-team-leads` Slack usergroup.

Thank you @jeremyrickard for your service as the 1.20 Release Team Lead. ❤️ 

**Which issue(s) this PR fixes**:

ref: https://github.com/kubernetes/sig-release/issues/1404

/assign
/sig release
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @hasheddan @alejandrox1
/cc @kikisdeliveryservice @savitharaghunathan @bai