### PR TITLE
Remove licensing subproject, move doc to vendor.md

### DIFF
--- a/contributors/devel/sig-architecture/vendor.md
+++ b/contributors/devel/sig-architecture/vendor.md
@@ -164,10 +164,14 @@ Additionally:
 - If this is all good, approve, but don't LGTM, unless you also do code review
   or unless it is trivial (e.g. moving from k/k/pkg/utils -> k/utils).
 
+Licenses for dependencies are specified by the CNCF [Allowlist Policy].
 All new dependency licenses should be reviewed by @kubernetes/dep-approvers to ensure that they
 are compatible with the Kubernetes project license. It is also important to note
 and flag if a license has changed when updating a dependency, so that these can
 also be reviewed.
 
-For reference, whitelisted licenses as per the CNCF Whitelist Policy are
-mentioned [here](https://git.k8s.io/sig-release/licensing/README.md#licenses-for-dependencies).
+In case of questions or concerns regarding the allowlist policy, please create
+an issue or send an email to the [SIG Architecture] mailing list.
+
+[Allowlist Policy]: https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md
+[SIG Architecture]: https://groups.google.com/forum/#!forum/kubernetes-sig-architecture

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -51,10 +51,6 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-release:
-### Licensing
-The Licensing subproject is responsible for analyzing/reporting/remediating licensing concerns within the Kubernetes project orgs.
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/sig-release/master/licensing/OWNERS
 ### Release Engineering
 The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1792,11 +1792,6 @@ sigs:
     - name: sig-release-admins
       description: Admins for SIG Release repositories
   subprojects:
-  - name: Licensing
-    description: |
-      The Licensing subproject is responsible for analyzing/reporting/remediating licensing concerns within the Kubernetes project orgs.
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/sig-release/master/licensing/OWNERS
   - name: Release Engineering
     description: |
       The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.


### PR DESCRIPTION
Ref: https://github.com/kubernetes/sig-release/pull/1412#discussion_r556191521

/cc @dims @justaugustus @saschagrunert @hasheddan @alejandrox1 