### PR TITLE
Adding a #keda-dev channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -150,6 +150,7 @@ channels:
   - name: k8spin
   - name: kapitan
   - name: keda
+  - name: keda-dev
   - name: keel
   - name: kiam
   - name: kind


### PR DESCRIPTION
This patch adds a `#keda-dev` channel to the Slack channel list. @tomkerkhove, myself and others have discussed adding this channel on the `#keda` channel. The purpose of it is to facilitate discussion about development of the KEDA core project and ancillary projects (such as the [HTTP add on](https://github.com/kedacore/http-add-on)), separate from other discussion on the current `#keda` channel, which is generally about troubleshooting, higher-level features, and so forth.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A
