### PR TITLE
slack: add loft channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -224,6 +224,7 @@ channels:
   - name: linode
   - name: litmus
   - name: litmus-dev
+  - name: loft
   - name: lokomotive
   - name: malaysia-users
   - name: malta-users


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

I would like to open a #loft slack channel for users of [Loft](https://loft.sh/): Virtual clusters and multi-tenancy extension for Kubernetes

The channel would also be used to discuss the open-source projects around Loft located in the [loft-sh](https://github.com/loft-sh) organization on GitHub. So far, discussions have mostly been 1:1 between users and Loft maintainers or users have used other slack channels to ask questions about Loft and surrounding projects, so I think it would make sense to have a separate channel for everyone to ask questions, share thoughts and discuss the roadmap.