### PR TITLE
Archive SIG Storage meeting notes

### DIFF
--- a/sig-storage/archive/README.md
+++ b/sig-storage/archive/README.md
@@ -2,7 +2,7 @@
 
 This contains the historical archives from the SIG Storage meetings.
 
-Current active meeting notes can be found in the working documented used by the
+Current active meeting notes can be found in the working document used by the
 SIG. For links to this document, and for current meeting details, please refer
 to the [SIG Storage README](../README.md) for details.
 

--- a/sig-storage/archive/README.md
+++ b/sig-storage/archive/README.md
@@ -1,0 +1,14 @@
+# SIG Storage Historical Meeting Notes
+
+This contains the historical archives from the SIG Storage meetings.
+
+Current active meeting notes can be found in the working documented used by the
+SIG. For links to this document, and for current meeting details, please refer
+to the [SIG Storage README](../README.md) for details.
+
+## Meeting Archives
+
+* [2019](meeting-notes-2019.md)
+* [2018](meeting-notes-2018.md)
+* [2017](meeting-notes-2017.md)
+* [2016](meeting-notes-2016.md)

--- a/sig-storage/archive/meeting-notes-2016.md
+++ b/sig-storage/archive/meeting-notes-2016.md
@@ -1,0 +1,738 @@
+# Kubernetes Storage SIG Meeting Notes (2016)
+
+The Kubernetes Storage Special-Interest-Group (SIG) is a working group within the Kubernetes contributor community interested in storage and volume plugins. This document contains historical meeting notes from past meeting.
+
+## December 22, 2016
+
+Recording: [https://youtu.be/pMMAM6SNeeY](https://youtu.be/pMMAM6SNeeY)
+
+Agenda/Notes:
+
+* [Radoslaw Zarzynski] Provide a quick status update on the rbd-nbd integration.
+  * Another way to access Ceph RBD volume
+  * Original plugin only allowed access via kernel client which is less featureful than LibRBD client
+  * Radoslaw created a few pull requests:
+    * rbd-nbd zero-copy
+      * [https://github.com/ceph/ceph/pull/12609](https://github.com/ceph/ceph/pull/12609),
+      * Optimizing memory perf, comparable to krbd driver
+    * [https://github.com/ceph/ceph/pull/11878](https://github.com/ceph/ceph/pull/11878)
+    * rbd-nbd fencing improvement
+      * [https://github.com/ceph/ceph/pull/11438](https://github.com/ceph/ceph/pull/11438)
+      * Making the fencing easier, just need to set one more option
+    * rbd-nbd integration with K8S
+      * [https://github.com/kubernetes/kubernetes/pull/38936](https://github.com/kubernetes/kubernetes/pull/38936)
+      * Support for RBD-NBD backend
+    * Code reviewers:
+      * [rootfs](http://github.com/rootfs)
+
+## December 8, 2016
+
+Recording: [https://youtu.be/1GYAulB4mdM](https://youtu.be/1GYAulB4mdM)
+
+Agenda/Notes:
+
+* Status Update:
+  * Jing’s containerized mounter changes went into 1.5 and are backported to 1.4.7
+* Storage Wish List (Brainstorming) for 2017 and 1.6 (Starter)
+  * (AI) Create a separate doc to let people think it over and track thi
+  * [Matt De Lio] Some ideas:
+    * Only schedule pods on nodes that support a given volume type
+    * Containerized Mounts/Out-of-tree Volume Driver
+    * Stabilizing AWS support for EBS
+    * Snapshot
+      * Need a consensus on what this really need
+    * Data Replication?
+    * Local Storage Support
+    * Mount Option Passthrough
+* Quarterly face to face meeting for Q1 2017
+  * Dell EMC is willing to host in our office in Santa Clara
+    * Potential for this to be at KubeCon EU too? [CML]
+  * Timing: Late Q1 early Q2?
+  * Should have an agenda set before the meeting to make discussion more focused.
+* [from last meeting] [rootfs] Metrics in volume controller
+  * [https://github.com/kubernetes/kubernetes/issues/36818](https://github.com/kubernetes/kubernetes/issues/36818)
+* [jsafrane] Safer mount manager that does not accidentally delete user data
+  * [https://github.com/kubernetes/kubernetes/pull/37698](https://github.com/kubernetes/kubernetes/pull/37698)
+* [jsafrane] Configurable ReclaimPolicy in StorageCla
+  * [https://github.com/kubernetes/kubernetes/issues/38192](https://github.com/kubernetes/kubernetes/issues/38192)
+
+## November 23, 2016
+
+Since Thursday, November 24, 2016 is a holiday in the United States, we are moving this occurrence of the Storage SIG meeting one day early to Wednesday, November 23, 2016.
+
+Recording: [https://youtu.be/fhtaR0rsLBA](https://youtu.be/fhtaR0rsLBA)
+
+Agenda/Notes:
+
+* [Steve Watt] In-Tree/Out-of-Tree question
+  * [Michael Rubin] Plugin Freedom
+  * [Scott Creeley] Enhanced error resolution hint
+  * Flex v.next
+    * Let’s separate future of Out-of-tree and Flex v.next
+* [Saad Ali] Hung volumes can wedge the kubelet
+  * [https://github.com/kubernetes/kubernetes/issues/31272](https://github.com/kubernetes/kubernetes/issues/31272)
+* [rootfs] Mount option
+  * [https://github.com/kubernetes/kubernetes/issues/31613](https://github.com/kubernetes/kubernetes/issues/31613)
+* Did not get to: [rootfs] Metrics in volume controller
+  * <https://github.com/kubernetes/kubernetes/issues/36818>
+
+## November 10, 2016
+
+Recording: [https://youtu.be/k1JRpMd051M](https://youtu.be/k1JRpMd051M)
+
+Agenda/Note
+
+* Feature complete date
+  * (saad-ali) Now in code freeze for 1.5
+* Status updates on pending work
+  * (jingxu97) NFS Gluster Containerization
+  * (rkouj) Better Messaging for missing Binarie
+* Work that missed 1.5
+  * (rootfs) RBD attached
+  * (jsafrane) Default provisioner
+* [Steve Wong] KubeCon Storage SIG F2F Recap:
+  * Agenda: [https://docs.google.com/document/d/1drdxPkZEiGA06-jnsbSqywzQ6z0bT8uMpJdnIzkRoPo/edit?ts=57ed5df2#heading=h.hs60nbsyz2jk](https://docs.google.com/document/d/1drdxPkZEiGA06-jnsbSqywzQ6z0bT8uMpJdnIzkRoPo/edit?ts=57ed5df2#heading=h.hs60nbsyz2jk)
+  * Meeting minutes/notes: [https://docs.google.com/document/d/10AJzJvJcEA5w1wW6wMgS7aOfiH0FTZhszt_P6VNRxLk/edit?usp=sharing](https://docs.google.com/document/d/10AJzJvJcEA5w1wW6wMgS7aOfiH0FTZhszt_P6VNRxLk/edit?usp=sharing)
+
+## November 7, 2016
+
+F2F meeting in Seattle, WA
+
+* Logistics/Agenda: [https://docs.google.com/document/d/1drdxPkZEiGA06-jnsbSqywzQ6z0bT8uMpJdnIzkRoPo/edit?ts=57ed5df2](https://docs.google.com/document/d/1drdxPkZEiGA06-jnsbSqywzQ6z0bT8uMpJdnIzkRoPo/edit?ts=57ed5df2)
+* [Minutes:](https://docs.google.com/document/d/1drdxPkZEiGA06-jnsbSqywzQ6z0bT8uMpJdnIzkRoPo/edit?ts=57ed5df2)[https://docs.google.com/document/d/10AJzJvJcEA5w1wW6wMgS7aOfiH0FTZhszt_P6VNRxLk/edit](https://docs.google.com/document/d/10AJzJvJcEA5w1wW6wMgS7aOfiH0FTZhszt_P6VNRxLk/edit)
+
+## October 27, 2016
+
+Recording: [https://youtu.be/gjb2X1QiKG0](https://youtu.be/gjb2X1QiKG0)
+
+Agenda/Note
+
+* Reminder meeting is now held on Zoom
+  * This meeting will be held on Zoom (<https://zoom.us/j/614261834>) NOT Hangouts!
+  * Meetings will be recorded and published.
+* [Saad Ali] Update on NFS/Gluster in GCI (GCE/GKE)
+* [Michael Rubin] On Containerization and the future of volume plugins and deployment (Flex, etc.)
+* [Hayley Swimelar (Linbit)] Adding support for DRBD Volumes. issue #[32739](https://github.com/kubernetes/kubernetes/pull/32739)
+* [Saad Ali] We have less than two weeks left until code freeze. Please list the outstanding PRs that really need attention:
+  * PR #[30285](https://github.com/kubernetes/kubernetes/pull/30285) - Proposal for external dynamic provisioner
+  * PR #[30091](https://github.com/kubernetes/kubernetes/pull/30091) - support Azure disk dynamic provisioning
+  * PR #[33660](https://github.com/kubernetes/kubernetes/pull/33660) - rbd attach/detach refactoring
+  * PR #[35284](https://github.com/kubernetes/kubernetes/pull/35284) - Add test for provisioning with storage cla
+  * PR #[35675](https://github.com/kubernetes/kubernetes/pull/35675) - Require PV provisioner secrets to match type
+* [Erin Boyd] Status update on Testing
+  * [bchilds] - update on AWS E2E test
+* [bchilds] External NFS Provisioner incubator proposal
+* [Simon Croome] StorageOS introduction / plans for Kubernetes integration
+* [bchilds] External Storage Provisioner - [https://github.com/kubernetes/kubernetes/pull/30285](https://github.com/kubernetes/kubernetes/pull/30285)
+* [Steve Wong] Storage SIG face to face Nov 7 logistic
+  * Agenda: [https://docs.google.com/document/d/1drdxPkZEiGA06-jnsbSqywzQ6z0bT8uMpJdnIzkRoPo/edit?ts=57ed5df2#](https://docs.google.com/document/d/1drdxPkZEiGA06-jnsbSqywzQ6z0bT8uMpJdnIzkRoPo/edit?ts=57ed5df2#)
+  * 505 1st Ave S. Ste 600, Seattle, WA 98104 - Elliott Bay Conference Room - Floor 2Doors open 7:30, get badge from receptionistPlease RSVP using entry in meeting doc by Oct 31.
+
+## October 13, 2016
+
+Agenda/Note
+
+* Switching to Zoom
+  * This meeting will be held on Zoom ([https://zoom.us/j/614261834](https://zoom.us/j/614261834)) NOT Hangouts!
+  * Future meetings will be recorded and published.
+* Updates on librbd and rbd-nbd integration with Kubernetes.
+  * Radoslaw Zarzynski - Looking at TCMU in addition to rbd-nbd.  Interested in building a bridge between.  Plugin needs to address both and doing so is possible since they are so similar.  Taking requirements on CEPH side, have people from mirantis to do the development.  Looking at in-tree instead of flex and plans to start development next week. Could support V2 vs V1 [https://github.com/kubernetes/kubernetes/issues/32266](https://github.com/kubernetes/kubernetes/issues/32266)
+  * Love to see PoC and implementations coming. Please ensure krbd is not broken when introducing user space rbd.
+* Reminder: Please review the external storage provisioning PR [https://github.com/kubernetes/kubernetes/pull/30285](https://github.com/kubernetes/kubernetes/pull/30285)
+* Flex in 1.5 - Will not make 1.5, but will discuss in November F2F.  Working with Docker to come to consensus about the API such that its the same between Flex and Docker.  Should see updates on proposal next week.  Trending towards socket model instead of exec.  Proposals will be updated to reflect it.
+* November F2F Agenda: [https://docs.google.com/document/d/1drdxPkZEiGA06-jnsbSqywzQ6z0bT8uMpJdnIzkRoPo/edit?ts=57ed5df2#](https://docs.google.com/document/d/1drdxPkZEiGA06-jnsbSqywzQ6z0bT8uMpJdnIzkRoPo/edit?ts=57ed5df2#)
+* provisioning/deleting secrets on storage class
+  * Passing via annotations on a PV from provisioning to deleting is not secure
+  * Issue: [https://github.com/kubernetes/kubernetes/issues/34822](https://github.com/kubernetes/kubernetes/issues/34822)
+* AWS Storage E2E Tests Update - Need an XFS filesystem on the host images.
+* DAS - (local) storage - may be designed in F2F. no target release.
+
+## September 29, 2016
+
+Agenda/Note
+
+* Status Update
+  * v1.4 Work Completed
+    * Dynamic Provisioning
+      * <http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html>
+    * Bug fixes/stabilization
+  * v1.5 Coding begin
+    * Increasing test coverage
+    * Critical bug fixe
+      * E.g. <https://github.com/kubernetes/kubernetes/issues/29324>
+    * Dynamic Volume Provisioning
+      * Default provisioner
+        * Need to get this in for v1.5. We want pre-installed provisioners, only open question is if they should be marked default or not.
+      * External Provisioner
+        * Design Proposal: [https://github.com/kubernetes/kubernetes/pull/30285](https://github.com/kubernetes/kubernetes/pull/30285)
+        * NFS Provisioner: [https://github.com/wongma7/nfs-provisioner#deployment](https://github.com/wongma7/nfs-provisioner#deployment)
+        * Proposal, proof of concept NFS provisioner. Can demo it, and use it to ratify proposal and start implementing out-of-tree.
+        * When do we want it to land?
+        * Probably a peer to kubernetes repo.
+    * GCI Storage Utilitie
+      * NFS Testing
+        * Humain? Can you help us out with this. [https://github.com/kubernetes/kubernetes/issues/33447#issuecomment-250396321](https://github.com/kubernetes/kubernetes/issues/33447#issuecomment-250396321)
+    * Flex Volumes <https://github.com/kubernetes/kubernetes/issues/32543>
+      * Maybe we should ratify proposal at F2F for v1.5 and then focus on implementation for v1.6
+    * Snapshot
+      * Design only
+      * Jing Xu working on this, please reach out to her.
+      * AI (Jing Xu): beginning to middle of November send out a 2nd iteration of design
+    * Mount option support (move to F2F), [https://github.com/kubernetes/kubernetes/issues/31613](https://github.com/kubernetes/kubernetes/issues/31613)
+      * Work on proposal, discuss at F2F
+    * LibStorage PR needs to be looked at
+* Adding support for Ceph rbd-nbd client[https://github.com/kubernetes/kubernetes/issues/32266](https://github.com/kubernetes/kubernetes/issues/32266)
+  * Proposal for new driver for RBD, RBD-NBD,
+  * At the moment, ceph rbd, very unusual compare to vmware lib-rbd, as a result big feature gap compared to openstack
+  * Using kernel driver could affect the reliability of nodes.
+  * Maybe taking another approach?
+  * One feature we get out of the box is lack of feature gap, like object map, etc, these are being implemented in lib rbd.
+  * Move conversation to issue.
+* Update on: Chakri has a PR with the first cut of the API and if anyone has comments please add them to the PR: [https://github.com/kubernetes/kubernetes/issues/32543](https://github.com/kubernetes/kubernetes/issues/32543)
+* Switching to Zoom
+
+## September 15, 2016
+
+Agenda/Note
+
+* v1.4 Status
+  * AWS Attaches issue: Wrong AWS volume can be mounted
+    * <https://github.com/kubernetes/kubernetes/pull/31090>
+    * <https://github.com/kubernetes/kubernetes/pull/32242>
+    * <https://github.com/kubernetes/kubernetes/pull/32636>
+  * NFS Volume Hanging
+    * Delayed to next release
+  * 1.4.1 should be open next week
+* (Huamin) Attach/detach interface feature request: [https://drive.google.com/file/d/0B0YiMoOYtt_sYld6ZUE1YkMxem8/view?usp=sharing](https://drive.google.com/file/d/0B0YiMoOYtt_sYld6ZUE1YkMxem8/view?usp=sharing)
+  * Saad: Volume Spec should be fine
+  * Saad: Device path should be picked up from WaitForAttach and used down the pipeline
+* Brief overview of nfs provisioner work in progress - bchilds / Matthew Wong
+  * Questions around capacity on NFS provisioner
+* (Jan) Passwords in StorageCla
+  * [https://github.com/kubernetes/kubernetes/pull/31869](https://github.com/kubernetes/kubernetes/pull/31869)
+  * Did not progress since last SIG meeting
+  * AI: Put it on the next meeting Agenda, ping Tim to join
+* Hangout hit limit more people can no longer join call
+  * AI: Saad will look in to Zoom/see if we can increase hangout limit.
+* Vlad: Progress on LibStorage
+  * Attach and dynamic provisioners: implemented
+* Gopal: for external APIs flex volume. Chakri has a PR with the first cut of the API and if anyone has comments please add them to the PR: [https://github.com/kubernetes/kubernetes/issues/32543](https://github.com/kubernetes/kubernetes/issues/32543)
+* Vlad: Unable to modify agenda
+  * Use [this link](https://docs.google.com/document/d/1-8KEG8AjAgKznS9NFm3qWqkGyCHmvU6HVl0sk5hwoAE/edit?usp=sharing), it should give you ability to suggest change
+
+## September 1, 2016
+
+Agenda/Note
+
+* v1.4 Statu
+  * API object move from extension
+  * Bug
+    * NFS mounts can wedge
+      * Pmorie working on it
+      * [https://github.com/kubernetes/kubernetes/issues/31272](https://github.com/kubernetes/kubernetes/issues/31272)
+    * Node “attach/detach” control, ensure field is always updated.
+    * AWS Attaches issue: Wrong AWS volume can be mounted
+      * [https://github.com/kubernetes/kubernetes/issues/29324](https://github.com/kubernetes/kubernetes/issues/29324)
+    * Some flaky test
+* v1.5 Prioritie
+  * Testing
+  * Debuggability
+  * Code hardening
+  * Dynamic Provisioning:
+    * Direction for “secrets” and endpoints on PV
+      * Jan: we need to close on this.
+      * Concern about backwards compat
+      * Tim: 1.4 too late, hard to justify.
+      * MRubin/PMorie: might be something we want to bring up at community SIG--other SIGs are touching on and interested in this area
+      * Erin, Eric Paris, and Jan will help with this.
+    * External provisioner
+      * Tim may be able to look at it for 1.5 (about 3 weeks)
+  * Flex Volume
+    * Resolve open issues.
+  * Local Storage
+    * Beep and Clayton are driving, SIG should keep an eye on it
+  * Snapshotting
+    * Jing is driving
+  * There is a kubernetes features repo, where issues are created and tracked (in v1.4 we did this last minute), for 1.5 we should do this early.
+    * [https://github.com/kubernetes/features](https://github.com/kubernetes/features)
+* Switch to from Hangouts to something else
+  * Zoom?
+    * Others use thi
+    * Requires an external binary
+    * Seems to work fine
+    * You need a Mac or Linux, no ChromeBook
+    * Paid service--need an Admin account for SIG
+  * Current limit is 30 on Hangouts.
+  * Saad: We’ll keep hangouts until we hit the limit. If we start to have issues, I’ll look into switching us to Zoom
+* Discuss dates for next F2F
+  * Nov 7, 2016 before KubeCon (Nov 8 to Nov 9) work for everyone?
+    * Steve Wong has tentatively arranged for a conference room for 25 people at the [EMC Seattle office](https://www.google.nl/maps/place/EMC+Corporation/@47.6009484,-122.3377655,16z/data=!4m8!1m2!2m1!1semc+seattle!3m4!1s0x54906aa489f54c35:0xc91e3386db767a1c!8m2!3d47.5977856!4d-122.3345112?hl=en) near Pioneer Square. This includes lunch and hosting of a dinner at some nearby location TBD
+      * Patrick from Samsung can help with organizing.
+
+## August 18, 2016
+
+Agenda/Note
+
+* Update from F2F for Community
+  * [https://groups.google.com/forum/#!topic/kubernetes-sig-storage/tsKYK6rdjy0](https://groups.google.com/forum/#!topic/kubernetes-sig-storage/tsKYK6rdjy0)
+  * Steve Watt volunteered to follow up
+* v1.4 Code Freeze this week
+  * Status of in-flight PR
+    * Flex Volume
+      * In review
+      * Very large but well factored
+      * Should be able to get it in before code freeze
+      * Some open questions around attacher
+    * Azure
+      * Verifying functionality
+      * Questions about performance
+    * Quobyte
+      * In review, no major issues.
+    * Event
+      * LGTM’d
+* Storage community test strawman - bchilds [https://docs.google.com/document/d/17j5ofzOOhWUVBOJ3Uop-MUay2k1iJomBJuVCGxMZcMA/edit?usp=sharing](https://docs.google.com/document/d/17j5ofzOOhWUVBOJ3Uop-MUay2k1iJomBJuVCGxMZcMA/edit?usp=sharing)
+  * Can’t test all plugin
+    * Non-GCE cloud storage plugins can’t run in GCE need federated testing
+* Jan: StorageClass/PV security - jsafrane
+  * Is it safe to store credentials to Gluster server on non-namespaced objects?
+    * 1.4 storage classes with .
+    * GlusterFS needs to store user/name password etc in blob.
+    * Problem with secrets is we don’t have cross namespace/using a secret from non-namespaced context. Should get BrianGrant’s opinion.
+    * Parameters are a map of strings.
+    * Need to handle this for more than Gluster. File on FS.
+    * Will go forward with password in blob, and
+* Mark: 1.5 features question
+  * Snapshots: would like to participate in design
+    * Sync up with Jing
+
+## August 11, 2016
+
+F2F meeting in San Jose
+
+* Intro Slide
+  * [https://docs.google.com/presentation/d/1wLUYKABzj1gUrn-JUlSo0QXKeKValy9EBgrwHuyJC6E/edit](https://docs.google.com/presentation/d/1wLUYKABzj1gUrn-JUlSo0QXKeKValy9EBgrwHuyJC6E/edit)
+* Agenda
+  * [https://docs.google.com/document/d/1qVL7UE7TtZ_D3P4F7BeRK4mDOvYskUjlULXmRJ4z-oE/edit](https://docs.google.com/document/d/1qVL7UE7TtZ_D3P4F7BeRK4mDOvYskUjlULXmRJ4z-oE/edit)
+* Note
+  * [https://docs.google.com/document/d/1vA5ul3Wy4GD98x3GZfRYEElfV4OE8dBblSK4rnmrE_M/edit?ts=57ab5b83](https://docs.google.com/document/d/1vA5ul3Wy4GD98x3GZfRYEElfV4OE8dBblSK4rnmrE_M/edit?ts=57ab5b83)
+
+## August 4, 2016
+
+Agenda/Note
+
+* Status Updates:
+  * v1.3.4 went out on Monday
+    * Lots of storage fixe
+* Face to face meeting - Everyone welcome - Logistics info -&gt; [https://docs.google.com/document/d/1qVL7UE7TtZ_D3P4F7BeRK4mDOvYskUjlULXmRJ4z-oE/edit](https://docs.google.com/document/d/1qVL7UE7TtZ_D3P4F7BeRK4mDOvYskUjlULXmRJ4z-oE/edit)
+* Tim: Internal/external plugins discussion
+  * Probably want to save it for the face-to-face meeting. It’s big.
+* Tim: Storage volumes read-write once multiple pods can use it at once. This is inconsistent, if pod happens to land on the same machine it will work if not it will not.
+  * Two separate conversations if that is correct or not.
+  * Share if on same machine AND bias scheduler to put on same machine.
+  * Use case: people want to do rolling updates without down time
+  * Concern: is this something that is unsafe. We can’t guarantee it will always work for applications.
+  * AI: would love to define the correct semantic document it
+  * Eric Paris: this is a bad idea.
+  * Eric Paris: biasing scheduler could be a good idea. but two mounting at same time bad idea.
+  * AI: make attacher/detacher smarter--don’t detach if volume is already attached
+    * Saad: may already do that.
+  * Tim: What about a new Read-Write-Node access mode?
+  * Steve Watt: maybe k8s should fail Read-Write-Only if it is used by multiple pod
+  * Agreement, using Read-Write-Only in multiple pods is an anti-pattern
+  * AI: Tim will follow up on the various conversations.
+  * AI: Saad will check if Attach/Detach is already optimal for waiting pod. If not file low-pri bug.
+
+## July 21, 2016
+
+Agenda/Note
+
+* Diamanti Demo
+  * Action item: would like snapshotting support in flex
+* Discuss support for Cinder volumes without cloud-provider (cf hypernetes)
+  * Enable Cinder volumes to attach to any VM or bare metal
+  * Action Item: WIP will be sent out by Quentin
+* Dynamic Provisioning V2 [https://github.com/kubernetes/kubernetes/pull/29006](https://github.com/kubernetes/kubernetes/pull/29006)
+  * Action item: need reviewers for PR
+* Face to face meeting
+  * Decided on dates: Aug 10 and 11 with optional break out sessions on Aug 12
+* Post-mortems:
+  * Google has a format.
+  * Brad work on it with Michael?
+* Lots of storage improvements in v1.3.4
+  * If anyone has spare cycles to help debug issues, please volunteer
+* Flex volume/pluggable volume discussion
+  * Blocked on Tim Hockin
+  * Would be great to discuss at F2F
+* Portworks welcome!
+
+## July 7, 2016
+
+Agenda/Notes:
+
+* EMC{code} team proposal on external persistent volume mounts for container
+  * 10 minute presentation followed by Q &amp; A by [steven.wong@emc.com](mailto:steven.wong@emc.com) and [vladimir.vivien@emc.com](mailto:vladimir.vivien@emc.com)
+  * [https://github.com/kubernetes/kubernetes/pull/28599](https://github.com/kubernetes/kubernetes/pull/28599)
+* Bug Scrub (bchilds@redhat.com)
+  * Propose that we target issues the following way:
+    * Milestone v1.3 - All issues that are targeted for some 1.3.x release
+    * Milestone v1.4 - All issues for v1.4
+    * “Unassign” All subsequent than v1.4.
+* Post Mortem ([mrubin@google.com](mailto:mrubin@google.com), [eboyd@redhat.com](mailto:eboyd@redhat.com), [bchilds@redhat.com](mailto:bchilds@redhat.com), [saadali@google.com](mailto:saadali@google.com))
+  * We need to do a post mortem on the storage events at the tail of v1.3.
+  * We should figure out how to get that started.
+* Making our testing and code paths more robust (eboyd@redhat.com)
+  * What makes sense to make the Kubernetes test suite more robust and
+  * easier to find bugs over all?
+* Face to Face SIG Meeting ([swatt@redhat.com](mailto:stevewatt@redhat.com), gopal@datawisesystems.com, mrubin, nelcyguy@gmail.com)
+  * When is a good time for a storage sig face to face?
+* v1.4 feature
+  * Dynamic Provisioning/Storage Classes V2 Proposal (thockin@google.com,Tom? [nelcyguy@gmail.com](mailto:nelcyguy@gmail.com), [pmorie@redhat.com](mailto:pmorie@redhat.com), tg@convergeio.com)
+    * (Jan Šafránek &amp; Paul Morie)  [https://github.com/kubernetes/kubernetes/pull/26908](https://github.com/kubernetes/kubernetes/pull/26908)
+    * Want proposal submitted by eod 7/8
+  * GID feature for PV
+    * <https://github.com/kubernetes/kubernetes/issues/27197>
+    * Want early in 1.4
+  * Flex Volume
+    * New Volume plugin
+    * Discussion on Flex Volumes or built in storage (See
+    * <https://groups.google.com/forum/#!topic/kubernetes-sig-storage/9o1vA4jFwqk>)
+  * Local storage
+    * Start on the design, maybe have some alpha level code
+    * Action item: open a bug for people to start contributing to
+* Run down testing (eparis@redhat.com) [https://github.com/kubernetes/kubernetes/issues/28367](https://github.com/kubernetes/kubernetes/issues/28367)
+
+## June 23, 2016
+
+Agenda/Notes:
+
+* v1.3 status update
+  * Kubelet Mount/Unmount Redesign [merged](https://github.com/kubernetes/kubernetes/pull/26801)
+  * Bugs Squashed
+  * Open, potentially 1.3 blocking bugs:
+    * [Flakiness of read-only PD test](https://github.com/kubernetes/kubernetes/issues/27477)/[#27691](https://github.com/kubernetes/kubernetes/issues/27691)
+  * Flex Volume Plugin changes punted from 1.3
+    * [https://github.com/kubernetes/kubernetes/pull/26926](https://github.com/kubernetes/kubernetes/pull/26926)
+  * Testing
+    * Erin:
+      * NFS Gluster Cep
+        * Should be done by today
+    * Humin:
+      * Cinder
+        * Should be done by today
+    * Justin SB
+      * AWS
+        * Looks good
+* v1.4 prioritie
+  * Want early in 1.4 (1.3.x release):
+    * 1) Dynamic Provisioning/Storage Classes V2 Proposal (Jan Šafránek)
+      * [https://github.com/kubernetes/kubernetes/pull/26908](https://github.com/kubernetes/kubernetes/pull/26908)
+      * What’s missing to get merged?
+    * 2) GID feature for PV
+      * Shared File/Read Write Many
+      * [https://github.com/kubernetes/kubernetes/issues/27197](https://github.com/kubernetes/kubernetes/issues/27197)
+    * 3) Make volume manager more robust across restart
+      * [https://github.com/kubernetes/kubernetes/issues/27653](https://github.com/kubernetes/kubernetes/issues/27653)
+    * 4) Finish of changes to Flex Volume Plugin
+      * [https://github.com/kubernetes/kubernetes/pull/26926](https://github.com/kubernetes/kubernetes/pull/26926)
+      * Must have for 1.3.1 release
+    * 5) Volume Operation Executor Should Generate Event
+      * [https://github.com/kubernetes/kubernetes/issues/27590](https://github.com/kubernetes/kubernetes/issues/27590)
+  * Other prioritie
+    * 6) Improve Testing
+      * Huge item
+      * Performance testing
+      * Testing core component
+      * Plugin
+    * 7) Continue to improve stability and robustness of existing code
+    * 8) New Volume plugin
+      * Encourage people who submit volume plugins to stick around and make sure that they continue to work.
+      * Core team does not have the ability to test them.
+    * 9) Local storage
+      * Start on the design, maybe have some alpha level code
+  * Saad’s feature list:
+    * ---Wanted Feature/requests for volumes---
+    * Improve Test Coverage
+    * Continue to improve stability and robustness of existing code
+      * Refactor some existing code
+    * New Feature
+      * Finish Dynamic Provisioning
+        * volume selectors (done)
+        * volume classe
+      * Container volume for pre-populated emptydir container #831 (probably read-only)
+        * Empty dir with a claim?
+      * LogDir
+      * Data gravity/local storage
+        * When scheduling a work loads affinity to certain nodes that provide schedule.
+        * For ephemeral volumes (empty dir): use local storage instead of empty dir
+        * AI (saadali): Open a PR for requirements so others can contribute
+          * [https://github.com/kubernetes/kubernetes/issues/7562](https://github.com/kubernetes/kubernetes/issues/7562)
+      * Enable mount namespace propagation to enable storage providers to run on k8s and to containerize kubelet [https://github.com/kubernetes/kubernetes/pull/20698](https://github.com/kubernetes/kubernetes/pull/20698)
+      * Snapshotting support in volume API
+      * Automatic resize increase/decrease of Attached/mounted disks [https://groups.google.com/forum/#!topic/kubernetes-sig-storage/YLWEbTDKTHE](https://groups.google.com/forum/#!topic/kubernetes-sig-storage/YLWEbTDKTHE)
+        * Steve Watt: Scaling up and snapshotting might be something we can not ignore. We are lagging behind the competition in comparisons.
+      * FUSE FS support: would enable mounting Google Cloud Storage into a container #7890 /FUSE FS [http://stackoverflow.com/questions/35966832/mount-google-storage-bucket-in-google-container?noredirect=1#comment59614874_35966832](http://stackoverflow.com/questions/35966832/mount-google-storage-bucket-in-google-container?noredirect=1#comment59614874_35966832)
+      * Improve Deployment Story
+        * User experience vs extensibility
+        * Establish a concrete API and move plugins out of tree?
+        * Containerize plugin binaries so no dependency on deployment of binaries to node.
+        * Containerize volume plugins to enable dynamic loading of plugins on demand?
+        * Magic: run a kubectl command, and X storage system is deployed with all appropriate binaries and APIs?
+    * New Plugin
+      * Nexenta
+      * EMC
+      * Azure VHD
+      * Others pending?
+    * Bug level work:
+      * Rapid delete/recreation should schedule to same node and not detach (bgrant says p2 low user impact)
+      * GCE PD attach/detach sometimes takes several minutes to complete--follow up with GCE team to figure out if this is normal/expected.
+      * UX issues brought up by Erin (&quot;at least 10GB&quot; is confusing) (bgrant recommends adding limit to api)
+      * Support dynamic max pod per node limit (scheduler)
+    * Misc
+      * Quotas we need a design (esp for creating 1000s of new volumes) (limit claims PR by derekcarr?)
+      * Explore when does dynamic volume deletion happen?
+      * consider using taints/toleration for resource reservation
+
+## June 9, 2016
+
+Agenda/Notes:
+
+* Dynamic Provisioning V2 Proposal (Paul Morie)
+  * [https://github.com/kubernetes/kubernetes/pull/26908](https://github.com/kubernetes/kubernetes/pull/26908)
+  * In-tree vs dynamic loading
+    * Baby steps. Start with what we have today.
+    * Want to eventually have ability to dynamically load plugin
+* Attach/Detach controller
+  * Status update
+* Splitting up attach/detach for plugin
+  * Status update
+  * Issue
+    * Friday branch deadline
+    * Attach/detach split for rbd and flex requires namespace
+      * [https://github.com/kubernetes/kubernetes/pull/26926#issuecomment-224739520](https://github.com/kubernetes/kubernetes/pull/26926#issuecomment-224739520)
+* Kubelet Mount/Unmount redesign
+  * Status update
+* Misc:
+  * hyperkube mounts issue (jing xu investigated)
+    * [https://github.com/kubernetes/kubernetes/pull/27054](https://github.com/kubernetes/kubernetes/pull/27054)
+* Add option to disable dynamic provisioning
+  * [https://github.com/kubernetes/kubernetes/pull/27128/files](https://github.com/kubernetes/kubernetes/pull/27128/files)
+* Introduce Michael Rubin
+  * [mrubin@google.com](mailto:mrubin@google.com)
+  * Github: [https://github.com/matchstick](https://github.com/matchstick)
+
+## May 26, 2016
+
+Agenda/Note
+
+* Status updates on pending work
+  * Persistent Volume Controller Consolidation (jan)
+    * Persistent volume controller sync period [https://github.com/kubernetes/kubernetes/issues/24236](https://github.com/kubernetes/kubernetes/issues/24236)
+  * Status of volume plugins (hchen)
+  * Status of Attach/Detach controller and mount/unmount redesign (saad-ali)
+
+## May 19, 2016
+
+Agenda/Note
+
+* Policy of adding new volume plugins that don’t have e2e yet (for example, Quobyte <https://github.com/kubernetes/kubernetes/pull/24977>) (hchen)
+* Pv-selector PR [https://github.com/kubernetes/kubernetes/pull/25413](https://github.com/kubernetes/kubernetes/pull/25413) (pmorie)
+* Attach / Detach work (saad / jan)
+
+## May 12, 2016
+
+Agenda/Notes:
+
+* The reviewed controller binder is ready for merge (Today?)
+* Storage test coverage - (swatt &amp; hchen)
+  * [Volumes e2e test RFC](https://github.com/kubernetes/kubernetes/issues/25120) and [follow-up PR](https://github.com/kubernetes/kubernetes/pull/25100)
+  * [Persistent Volume e2e and integration test RFC](https://github.com/kubernetes/kubernetes/issues/25120) and [follow-up PR](https://github.com/kubernetes/kubernetes/pull/25216)
+* Storage class proposal (Pmorie)
+* Dynamic Provisioning proposal (Pmorie)
+* Storage Sig next Thursday to finalize storage class and DPv2
+* Status update on in flight PRs (saad, sami, jan)
+
+## April 28, 2016
+
+Agenda/Notes:
+
+* Status update on:
+  * Binder/recycler/provisioner controller
+    * Jan is working on it PR in progress.[https://github.com/kubernetes/kubernetes/pull/24331](https://github.com/kubernetes/kubernetes/pull/24331)
+  * Attach/detach controller
+    * [https://github.com/kubernetes/kubernetes/pull/24838](https://github.com/kubernetes/kubernetes/pull/24838)
+    * [https://github.com/kubernetes/kubernetes/pull/24696](https://github.com/kubernetes/kubernetes/pull/24696)
+  * Mount/unmount redesign
+    * [https://github.com/kubernetes/kubernetes/pull/24557](https://github.com/kubernetes/kubernetes/pull/24557)
+  * E2E and Test Coverage - hchen
+    * [https://docs.google.com/document/d/1UYI0Zm2Vv1-XuSMisl_b5D9AOnG4kR7Dm4VHa8YmRmw/edit#heading=h.cnatx4syp4km](https://docs.google.com/document/d/1UYI0Zm2Vv1-XuSMisl_b5D9AOnG4kR7Dm4VHa8YmRmw/edit#heading=h.cnatx4syp4km)
+  * Brad Childs: What can we do to get volume plugin test coverage to 80%
+    * For v1.3 write the test
+    * For v1.4 worry about deployment/infrastructure for CI
+  * Hchen: azure block storage--ok to implement before Azure cloud provider support?
+    * If it works, yes. Just make sure to prioritize it correctly against other items.
+
+## April 14, 2016
+
+Agenda/Notes:
+
+* Status update on:
+  * Binder/recycler/provisioner controller
+    * Jan is working on it PR in progress.
+  * Attach/detach controller
+    * Some modifications to design
+  * mount/unmount redesign
+    * In progress PR
+* Volume test plan
+  * RH working  on [https://docs.google.com/document/d/1UYI0Zm2Vv1-XuSMisl_b5D9AOnG4kR7Dm4VHa8YmRmw/edit#heading=h.5dimicy6x2yl](https://docs.google.com/document/d/1UYI0Zm2Vv1-XuSMisl_b5D9AOnG4kR7Dm4VHa8YmRmw/edit#heading=h.5dimicy6x2yl)
+
+## March 31, 2016
+
+Agenda/Notes:
+
+* Discuss binder/recycler/provisioner controller consolidation
+  * Psudo code: [https://github.com/pmorie/pv-haxxz](https://github.com/pmorie/pv-haxxz)
+  * Action item:
+    * Will publish link to pseudo-code in sig-storage email list for public comment.
+* Steve Watt: Current dynamic provisioning proposal--two concepts and dynamic provisioning
+  * Propose: Break into two separate design
+  * Storage classes with manually provisioned ideas may be able to be split off
+  * But the two features should be designed together.
+  * How bad would it be to only have classes and not provisioning?
+    * RH: will circle back.
+  * Classes and profiles must be implemented before “next version” of dynamic provisioning.
+  * Decided we’re ok with shipping 1.3 with either, both, or neither features.
+* Let’s get more participation from non-RH/Google folks:
+  * Steve Wong from EMC:
+    * silent because things appear to be going just fine
+  * Chakri from Datawise:
+    * Would like to give a demo in 4 weeks for flex volume.
+  * Tom from ConvergeIO
+    * Notion of profiles that incorporate a lot of the auto-provisioning, dir mounting, etc, in the profile
+    * Standard profile for work profiles.
+    * Documenting REST API, should be in a position to share with the rest of the storage-SIG
+
+## March 17, 2016
+
+Agenda/Notes:
+
+* Proposal to Create new way to match PVC PV “strict” - Erin Boyd
+  * Two Issues:
+    * Need a way to control pod defined storage
+      * Suggestions: Pod sec policy, admission controller
+    * Need a way to specify exactly which PV a PVC should bind to
+      * Proposal: use [Taints/Tolerations](https://github.com/kubernetes/kubernetes/blob/master/docs/design/taint-toleration-dedicated.md)
+  * Action Item: Erin/Brad will create a new page under storage-sig on k8s wiki to track “User Stories”
+* Containerized mount Design Proposal - Huamin Chen
+  * Proposal: ConfigMap + DeamonSet
+  * Issues:
+    * Docker dependency
+    * Deamon is single of of failure for FUSE FS
+    * Single container vs multiple container
+    * Mounter pods should be subject to CPU/mem quota limit
+    * Consider deamonset vs just scheduling a single pod
+      * Only FUSE requires a long running proce
+    * How does mount namespace propogation get triggered for k8s container
+    * Auth mechanisms (so arbitrary user containers can’t trigger mount/unmount
+* Bind/Provision/Recycler Controller Consolidation PRs - Jan Safranek
+  * Existing PR needs review
+  * Suggest diagramming the existing flow and coming up with a detailed design proposal
+* attach/detach controller and mount/unmount redesign status - Sami Wagiaalla
+
+## March 1, 2016
+
+Agenda:
+
+* Containerized Volume Driver
+  * [https://github.com/kubernetes/kubernetes/pull/](https://github.com/kubernetes/kubernetes/pull/22216)[22216](https://github.com/kubernetes/kubernetes/pull/22216)
+* EMEA SME concerns around PVs(Erin / Scott)
+  * Customer concern
+    * Data replication
+      * Moving Data with PVs that are dynamically provisioned
+    * Local storage
+      * Data locality issues that shared storage bring
+    * selector label by security
+    * Non-enforcement of label
+    * Manageability of storage when there is a 1:1 for PV-&gt;PVC (too many)
+
+* Dynamic Provisioning - Level of backwards Compat?  Maintain old way (marked as Experimental), do we need to keep old behavior?
+* Jan Safranek - “Any chance to move SIG to another day?”. Pmorie - “This SIG overlaps with Node-SIG
+
+## February 16, 2016
+
+Agenda:
+
+* Nearly all Dynamic Provisioning talk
+  * Discussed through the various means of parameterizing options to help the “many configMap” issue.  Decided none of the approaches here are blocked by the current proposal.
+  * Discussed using “storage-class” as a special field in claim.Spec.PVSelector.  Decided that allowing arbitrary labels on PVs and Provisioners was better than magic keys.
+* Brought up API PRs that are required for provisioning
+* Brought up status of attach/detach controller.  Work is ongoing.
+
+## February 9, 2016
+
+Agenda:
+
+* Dynamic provisioner
+* 1.2 PR
+
+## February 2, 2016
+
+Agenda:
+
+* Dynamic provisioner PR selector vs resources (eparis)
+* PRs for 1.2 (thockin)
+* Azure Plugin (rootfs)
+* Refactoring catchup / attach-detach (saad-ali)
+* Fake Multi-write - yes or no.
+* XFS quota &amp; emptydir
+
+Dynamic provisioning:
+
+* eparis: selector vs resources, #17056 usability
+  * What goes into a selector?  Why are resources not selector?
+  * Discovering the meaning of a selector is opaque
+  * thockin: could be fixed in kubectl tooling “show me storage classes”
+  * Steve: admin wants to catalog storage without users really understanding
+  * eparis: as a new user what class do I use?
+  * Sami: You know to use class as the key.  Could maybe upgrade to a full-field.
+  * Erin: How does the user know what to request?
+  * thockin: need a default “” class, but admin has to document what classes are available
+  * cargo culting will happen
+  * thockin: could promote class to a field and configmap to an object, eventually
+  * eparis: can I look at a config map and understand the meaning
+  * saad: configmap holds params for provisioners, up to admin
+  * could expose more knobs to users (iops, etc).  Gets crazy quickly.
+  * Steve: can we get tooling of “show me what classes \*I\* can use
+  * thockin: no concept of “I”.  Punting on context-dependent classes for now
+  * could add a description string to config map
+  * eparis: config map blowout?
+  * don’t need combinatoric maps for zones/feature
+  * class says which provisioner, regions, encryption, etc could be features.
+  * not great for discoverability.
+    * could document at the configmap
+    * can we validate this?  UX is not great
+    * events are easy, api validation is much harder - async
+  * provisioners MUST satisfy all fields of the selector
+  * e.g. class=gold-east/gold-west vs class=gold,region=east
+  * if zone is a parameter label, does that affect matching against PV
+  * mapping to PV is looser?  examples: object name == class?  label zone is noise.
+  * what if user does not ask for a zone, but provisioner needs one?  provisioner has to pick a default or choose to fail
+
+1.2 PRs:
+
+* Azure
+* pmoriet:
+* markturansky:
+  * [https://github.com/kubernetes/kubernetes/pull/19600](https://github.com/kubernetes/kubernetes/pull/19600)
+  * [https://github.com/kubernetes/kubernetes/pull/19921](https://github.com/kubernetes/kubernetes/pull/19921)
+  * [https://github.com/kubernetes/kubernetes/pull/20197](https://github.com/kubernetes/kubernetes/pull/20197)
+  * [https://github.com/kubernetes/kubernetes/pull/20213](https://github.com/kubernetes/kubernetes/pull/20213)
+  * [https://github.com/kubernetes/kubernetes/pull/19868](https://github.com/kubernetes/kubernetes/pull/19868)
+* wattsteve: I’d love to see the dynamic provision proposal get merged so we can start work on implementing that.
+* Re-group in 1 week - mark to put on calendar
+
+## December 2, 2015
+
+Moderator: Mark Turansky
+Agenda: Dynamic provisioning technical design discussion, other outstanding PR
+
+* review [https://github.com/kubernetes/kubernetes/pull/17056](https://github.com/kubernetes/kubernetes/pull/17056)

--- a/sig-storage/archive/meeting-notes-2016.md
+++ b/sig-storage/archive/meeting-notes-2016.md
@@ -234,7 +234,7 @@ Agenda/Note
     * AWS Attaches issue: Wrong AWS volume can be mounted
       * [https://github.com/kubernetes/kubernetes/issues/29324](https://github.com/kubernetes/kubernetes/issues/29324)
     * Some flaky test
-* v1.5 Prioritie
+* v1.5 Priorities
   * Testing
   * Debuggability
   * Code hardening
@@ -422,7 +422,7 @@ Agenda/Notes:
     * Justin SB
       * AWS
         * Looks good
-* v1.4 prioritie
+* v1.4 priorities
   * Want early in 1.4 (1.3.x release):
     * 1) Dynamic Provisioning/Storage Classes V2 Proposal (Jan Šafránek)
       * [https://github.com/kubernetes/kubernetes/pull/26908](https://github.com/kubernetes/kubernetes/pull/26908)
@@ -437,7 +437,7 @@ Agenda/Notes:
       * Must have for 1.3.1 release
     * 5) Volume Operation Executor Should Generate Event
       * [https://github.com/kubernetes/kubernetes/issues/27590](https://github.com/kubernetes/kubernetes/issues/27590)
-  * Other prioritie
+  * Other priorities
     * 6) Improve Testing
       * Huge item
       * Performance testing
@@ -631,7 +631,7 @@ Agenda/Notes:
     * Mounter pods should be subject to CPU/mem quota limit
     * Consider deamonset vs just scheduling a single pod
       * Only FUSE requires a long running proce
-    * How does mount namespace propogation get triggered for k8s container
+    * How does mount namespace propagation get triggered for k8s container
     * Auth mechanisms (so arbitrary user containers can’t trigger mount/unmount
 * Bind/Provision/Recycler Controller Consolidation PRs - Jan Safranek
   * Existing PR needs review

--- a/sig-storage/archive/meeting-notes-2017.md
+++ b/sig-storage/archive/meeting-notes-2017.md
@@ -1,0 +1,791 @@
+# Kubernetes Storage SIG Meeting Notes (2017)
+
+The Kubernetes Storage Special-Interest-Group (SIG) is a working group within the Kubernetes contributor community interested in storage and volume plugins. This document contains historical meeting notes from past meeting.
+
+## December 28, 2017
+
+Cancelled. Happy holidays!
+
+## December 14, 2017
+
+Recording: [https://youtu.be/_a_pwZKgtT8](https://youtu.be/_a_pwZKgtT8)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali, 20 minutes] 1.9 Q4 End-of-quarter Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+* Design Review
+  * [Please add any design reviews here]
+* [Saad Ali, 10 minutes] Set Up a one-off “on-boarding to sig-storage” meeting
+  * Proposal by Michael Rubin
+  * Suggested topics (presentations/YouTube):
+    * Local dev environment setup
+    * How to contribute/What does the SIG need help with/appreciate?
+    * How to propose and add new feature
+    * How to add a volume plugin? In-tree vs Flex vs CSI vs External Provisioner
+      * How to write a volume plugin?
+    * How to get a bug fixed?
+    * SIG Planning process?
+    * Where are the docs? The code?
+    * High level overview of storage subsystem -- controller, api?
+    * How to write tests (E2E, Unit, etc.)?
+    * How to make an API change?
+  * Volunteers for presentations:
+    * Saad Ali
+    * Steve Wong
+    * Vladimir Vivien
+    * Jan Safranek (after Christmas)
+    * Erin Boyd
+    * Scott C.
+  * Proposals:
+    * Storage 101 “class” and Slack?
+    * “Buddy system” -- answer one-on-one question
+    * Paris had an idea for “group mentoring”, one-on-one can be intimidating
+    * Check with contributor SIG and see if they have idea
+    * Documentation of how volume plugin interface arch -- should merge
+    * K8s.io docs site should be tailored for different audiences: storage vendor vs users, etc.
+* [Saad Ali, 5 minutes] Meeting December 28, 2017? Or skip that and meet Jan 4?
+  * [Saad Ali, 20 minutes] 1.10 Q1 Planning Kickoff
+    * Suggest delaying to first week of Jan
+  * Conclusion: let’s do it
+* [Yassine Tijani  5 minutes] discuss CSI timeline and coordination with wg-cloud-provider
+* [Erin Boyd, 5 minutes] Prioritization of Raw Block Plugin Update
+  * Seems like there is a lot of community PRs around these, let’s coordinate :)
+  * Please capture any work related to Storage SIG, please add to planning spreadsheet
+  * Flex will have block? If CSI takes too long?
+* [Saad Ali] CSI Statu
+  * [https://docs.google.com/document/d/1-WmRYvqw1FREcD1jmZAOjC0jX6Gop8FMOzsdqXHFoT4/edit#](https://docs.google.com/document/d/1-WmRYvqw1FREcD1jmZAOjC0jX6Gop8FMOzsdqXHFoT4/edit#)
+  * CSI community/meeting info: [https://github.com/container-storage-interface/community](https://github.com/container-storage-interface/community)
+* [Harry Zhang, 6 min] CSI support for KataContainers (hypervisor based container runtime)
+  * How we implement it today
+    * Already support host raw device and mount point
+    * While most common use case of k8s is remote storage:
+      * E.g. rbd/nfs/cif
+      * We use flexvolume to do this for now: [https://github.com/kubernetes/frakti/blob/master/pkg/flexvolume/flexvolume.go](https://github.com/kubernetes/frakti/blob/master/pkg/flexvolume/flexvolume.go)
+  * What we expect from CSI
+    * use CSI to support remote storage case
+      * [https://docs.google.com/document/d/19ZlbX1e7GSYxh_wdk0EZlhEheTelGavo6JIIrpN9cbs/edit](https://docs.google.com/document/d/19ZlbX1e7GSYxh_wdk0EZlhEheTelGavo6JIIrpN9cbs/edit)
+      * [https://docs.google.com/presentation/d/1kPeia7wLqoKQI0oX4pvVdH1UpcPx3lpmFK4P_E6oiIc/edit#slide=id.g2c2e661992_0_90](https://docs.google.com/presentation/d/1kPeia7wLqoKQI0oX4pvVdH1UpcPx3lpmFK4P_E6oiIc/edit#slide=id.g2c2e661992_0_90)
+      * less change in CRI shims (eventually no changes)
+        * So Kata can work with cri-o, cri-containerd etc
+      * Easier to migrate Kata to public cloud
+* [mayank] RBD Provisioner - in-tree vs external
+  * No, not in cloud provider.
+* [lpabon] CSI testing
+  * This is currently being document here: [https://github.com/kubernetes-csi/docs/wiki/Testing](https://github.com/kubernetes-csi/docs/wiki/Testing)
+    * It will include how clients can be tested and how drivers can be tested.
+
+## November 30, 2017
+
+Recording: [https://youtu.be/XK5KVj0SbOE](https://youtu.be/XK5KVj0SbOE)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali, 20 minutes] 1.9 Q4 Statu
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+* Design Review
+  * [Please add any design reviews here]
+* Kubecon
+  * Attendees:
+    * Michelle Au, Google
+    * Jing Xu, Google
+    * Michael Rubin, Google
+    * Adam Litke, Red Hat [alitke@redhat.com](mailto:alitke@redhat.com), 507-884-4657
+    * Jan Safranek, Red Hat [jsafrane@redhat.com](mailto:jsafrane@redhat.com)
+    * Tomas Smetana, Red Hat tsmetana[@redhat.com](mailto:jsafrane@redhat.com)
+    * Gerry Seidman, AuriStor, [gerry@auristor.com](mailto:gerry@auristor.com) 917-501-8287
+    * Sean McGinnis, Huawei, [sean.mcginnis@gmail.com](mailto:sean.mcginnis@gmail.com) 612-386-7883
+    * Ardalan Kangarlou, NetApp, ardalan@netapp.com
+    * Steve Wong, {code}, [steven.wong@dell.com](mailto:steven.wong@dell.com), 562-417-7048, @cantbewong, present Sun-Sat
+    * Yunwen Bai, Huawei. [yunwen.bai@huawei.com](mailto:yunwen.bai@huawei.com) 206-321-8643
+    * Mitsuhiro Tanino, Hitachi Vantara, [mitsuhiro.tanino@hitachivantara.com](mailto:mitsuhiro.tanino@hitachivantara.com)
+  * Storage SIG AMA
+    * Thursday December 7, 2pm-3:30, Room 10C level 3 [http://sched.co/CU8l](http://sched.co/CU8l)
+  * CNCF Storage WG
+    * Face to face, Tuesday, 5pm-7pm, Mezzanine Room 1 level 2 [http://sched.co/D5HO](http://sched.co/D5HO)
+  * Talks:
+    * Tomas Smetana, Red Hat: [https://kccncna17.sched.com/event/CU7O](https://kccncna17.sched.com/event/CU7O)
+    * Kubernetes Storage Evolution, Michelle and Erin: <http://sched.co/CU7R>
+    * Local Ephemeral Storage Management, Jing Xu [http://sched.co/CU7X](http://sched.co/CU7X)
+    * Block Volumes Support in Kubernetes, Mitsuhiro Tanino,
+
+## November 23, 2017
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Cancelled due to U.S. Thanksgiving Holiday
+* [Saad Ali] Shifting meeting by 1 week (since 2 weeks from Nov 23 will overlap with Kubecon).
+
+## November 9, 2017
+
+Recording: [https://youtu.be/Xeup_ATnVEY](https://youtu.be/Xeup_ATnVEY)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali, 20 minutes] 1.9 Q4 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* [Saad Ali] [Kubernetes CSI Implementation Meeting Notes](https://docs.google.com/document/d/1-WmRYvqw1FREcD1jmZAOjC0jX6Gop8FMOzsdqXHFoT4/edit#heading=h.vun6eaytazit)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * Fix dangling volumes - [https://github.com/kubernetes/kubernetes/issues/52573](https://github.com/kubernetes/kubernetes/issues/52573)
+* Design Review
+  * [Please add any design reviews here]
+  * [Sandeep Pissay, 20 mins] Review proposal for “Backup of PVs” - Proposal [doc](https://docs.google.com/document/d/1Xkh7AzYQoVnFowW1pBBC6yLWLXQGmsqWr1L_5bSSh34/edit?usp=sharing)
+  * [Yunwen Bai, 5 minutes] Dynamically provisioning of local storage proposal. Design doc to be shared EOW
+* Kubecon Storage-SIG planning (AMA)
+  * Reminder about [SIG Storage AMA at KubeCon](https://kccncna17.sched.com/event/CU8l/kubernetes-storage-ama-hosted-by-stephen-watt-red-hat). Please come and share your expertise with each other and with the community. Great place to have high bandwidth discussions. Intended to just be an open hangout, but the room comes equipped with flipcharts for drawing as well as AV.
+
+## October 26, 2017
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Eric Forgette] Intro to [Dory, a Flex driver for Docker Volume Plugins](https://github.com/hpe-storage/dory)
+* [Saad Ali] ***Feature freeze for 1.9 is tomorrow, Oct 27 ([link](https://github.com/kubernetes/features/blob/master/release-1.9/release-1.9.md))*** -- if you have a feature in the planning spreadsheet that should be tracked for k8s v1.9, please make sure there is a [issue opened in the feature repo](https://github.com/kubernetes/features/issues/) and [marked with the 1.9 milestone](https://github.com/kubernetes/features/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.9).exte
+* [Brad Childs, 20 minutes] 1.9 Q4 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+* Design Review
+  * Flexvolume driver installation -  [Additional default directories](https://docs.google.com/document/d/1U1oUgZmcGWrLMs4QlmPfLOElyI6D-Gp_6a-KlWRMAjs) - (Rook)
+* ~~[Michael Rubin] Growing the sig-storage community~~
+* [Gerry Seidman]  AuriStor (AFS) Flex Volume
+  * I (and other engineers from AurIStor) will be at LISA next week in San Francisco.
+  * If anyone planning on going, it would be great if we could meet up.
+    * I’d appreciate any feedback on our Volume plugin implementation plans.
+    * Please contact me at [gerry@auristor.com](mailto:gerry@auristor.com) / 917-501-8287
+  * We are also holding an open [BoF at LISA](https://www.usenix.org/conference/lisa17/bofs#auristor) (Wednesday, November 1, 8-9PM)
+    * Please come by if you are local.
+
+## September 28, 2017
+
+Recording: [https://youtu.be/f69IsTKtuvE](https://youtu.be/f69IsTKtuvE)
+
+Agenda/Notes:
+
+* [Palak Dalal] 1.9 Q4 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* [Eric Forgette] Intro to [Dory, a Flex driver for Docker Volume Plugins](https://github.com/hpe-storage/dory)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+* Design Review
+  * [Please add any design reviews here]
+* [Saad Ali] Testing &amp; Documentation
+* [Saad Ali] Next F2F meeting update
+  * Dates: Oct 10-11, 2017
+  * Location confirmed: Google 345 Spear Street San Francisco, CA  94105
+  * Details: [link](https://docs.google.com/document/d/161TItfBWQYRuaPfjBNCVLfvU1LoRv6EAR85jwvXZhsg/edit?usp=sharing)
+  * In-person event attendance at capacity. To attend remotely, add your name to the doc linked above.
+* [Michael Rubin] Growing the sig-storage community
+* [Brad Childs, 10 minutes] Summary of the F2F meeting
+  * Oct 2017 Storage SIG F2F Agenda/Notes/Logistics Doc: [link](https://docs.google.com/document/d/161TItfBWQYRuaPfjBNCVLfvU1LoRv6EAR85jwvXZhsg/edit#heading=h.yw150ejajoo1)
+
+## September 14, 2017
+
+Recording: [https://youtu.be/AEk6mOsJEyw](https://youtu.be/AEk6mOsJEyw)
+
+Agenda/Notes:
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * 1.8 Docs Planning: [https://docs.google.com/spreadsheets/d/1AFksRDgAt6BGA3OjRNIiO3IyKmA-GU7CXaxbihy48ns/edit?usp=sharing](https://docs.google.com/spreadsheets/d/1AFksRDgAt6BGA3OjRNIiO3IyKmA-GU7CXaxbihy48ns/edit?usp=sharing)
+  * Bchilds to update doc list to match features.
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * Detach Fix [https://github.com/kubernetes/kubernetes/pull/52221](https://github.com/kubernetes/kubernetes/pull/52221)
+  * Kubelet wierd output fix [https://github.com/kubernetes/kubernetes/pull/52132](https://github.com/kubernetes/kubernetes/pull/52132)
+* Design Review
+  * [Please add any design reviews here]
+  * 1.7 Local storage: [https://github.com/kubernetes/community/pull/989](https://github.com/kubernetes/community/pull/989)
+    * Scheduler changes in 1.9
+    * Possible beta in 1.10
+  * Local storage provisioner block support: [https://docs.google.com/document/d/1hRRzZpWtbHyJC1lotE8rqp2h1NEXuFv-rAW-vLuQa94/view](https://docs.google.com/document/d/1hRRzZpWtbHyJC1lotE8rqp2h1NEXuFv-rAW-vLuQa94/view)
+  * Volume topology scheduling: [https://github.com/kubernetes/community/pull/1054](https://github.com/kubernetes/community/pull/1054)
+* [Tushar Thole] Process improvements?
+  * Let’s brainstorm how the process of contributing fixes to k8s can be made more agile. Using an example, I will highlight how the existing process is slowing down bug fixing/feature development. I am sure this is an area of improvement that’s not specific to sig-storage alone.
+* [Saad Ali] Next F2F meeting update
+  * Dates confirmed: Oct 10-11, 2017
+  * [https://docs.google.com/document/d/161TItfBWQYRuaPfjBNCVLfvU1LoRv6EAR85jwvXZhsg/edit?usp=sharing](https://docs.google.com/document/d/161TItfBWQYRuaPfjBNCVLfvU1LoRv6EAR85jwvXZhsg/edit?usp=sharing)
+  * Location: Google in the Bay Area, California (most likely in Sunnyvale).
+  * Will share more details around logistics, seeding topics for meeting, etc. as soon as we have a location locked down.
+
+## August 31, 2017
+
+Recording: [https://youtu.be/OWLEMeedi98](https://youtu.be/OWLEMeedi98)
+
+Agenda/Notes:
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * [Code Freeze Sept 1](https://github.com/kubernetes/features/blob/master/release-1.8/release-1.8.md)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+* Design Review
+  * [Please add any design reviews here]
+* [Saad Ali] Next F2F meeting: location? Time?
+  * Erin Boyd sent out a survey: [link](https://groups.google.com/forum/#!topic/kubernetes-sig-storage/99sCQAJD3XI)
+  * Decided on Oct 10-11, 2017 at Google somewhere in the Bay Area, California (details to follow)
+
+## August 17, 2017
+
+Recording: [https://youtu.be/yLkolHV3uiw](https://youtu.be/yLkolHV3uiw)
+
+Agenda/Notes:
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [Pablo Mercado] Digital Ocean Volume Plugin: <https://github.com/kubernetes/kubernetes/pull/50044>
+    * Will take a look Flex.
+* Design Review
+  * [Please add any design reviews here]
+  * [Jing] Local Storage Isolation Revised Design [https://docs.google.com/document/d/1ZVvsMCOhnTNbj2TzkaTfi8cbStN-ErE_DG4KGwgeeUk/](https://docs.google.com/document/d/1ZVvsMCOhnTNbj2TzkaTfi8cbStN-ErE_DG4KGwgeeUk/)
+  * PVC Metrics : [https://github.com/kubernetes/community/pull/930](https://github.com/kubernetes/community/pull/930)
+    * Punt to next meeting.
+* [Saad Ali] Next F2F meeting: location? Time? September?
+  * [Michelle] late august is right before code freeze…
+  * [Steve Wong] Dell could host a meeting again if the location is Santa Clara or Austin
+  * [Saad] How about September 13 and 14 in Los Angeles? To overlap with the Linux Foundation Open Source Summit North America which is Sept 11-14 in LA.
+    * Might be too crowded and hard to find a place to host.
+    * Could have a social gathering.
+  * [Ardalan] If there is interest for meeting in late October (October 25) on the East Coast (Raleigh, NC), NetApp can host the event on the sidelines of All Things Open ([https://allthingsopen.org/](https://allthingsopen.org/)).
+    * May conflict with European OSS
+  * [Steve Watt] Austin + 1
+  * Poll for location and times?
+    * Erin will send out something.
+* CFP for Kubecon closes Monday. Submit something!
+
+## August 3, 2017
+
+Recording: [https://youtu.be/Eh7Qa7KOL8o](https://youtu.be/Eh7Qa7KOL8o)
+
+Agenda/Notes:
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * Expose storage metrics: [https://github.com/kubernetes/community/pull/855](https://github.com/kubernetes/community/pull/855)
+  * [Balu Dontu] VSphere cloud provider code refactoring:
+    [https://github.com/kubernetes/kubernetes/pull/49164](https://github.com/kubernetes/kubernetes/pull/49164)
+  * [Mitsuhiro Tanino] FC volume plugin: Support WWID for volume identifier: [https://github.com/kubernetes/kubernetes/pull/48741](https://github.com/kubernetes/kubernetes/pull/48741)
+  * [Deyuan] [https://github.com/kubernetes/kubernetes/pull/49610](https://github.com/kubernetes/kubernetes/pull/49610)
+  * [Vladimir Vivien] [https://github.com/kubernetes/kubernetes/pull/49973](https://github.com/kubernetes/kubernetes/pull/49973) (cherry-pick 1.7)
+  * [Steve Leon] [https://github.com/kubernetes/community/pull/833](https://github.com/kubernetes/community/pull/833)
+    * [https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/)
+* Design Review
+  * [Please add any design reviews here]
+  * [Erin Boyd] Block Storage Support
+    * Design Doc: [link](https://docs.google.com/a/redhat.com/document/d/1XeNFxc89C54psYqz4RErk1xcso0wMrKtSfWqI6POvaU/edit?usp=sharing)
+* [Saad Ali] Next F2F meeting: location? Time?
+  * [Michelle] late august is right before code freeze...
+
+## July 20, 2017
+
+Recording: [https://youtu.be/_oqj3JwkzVU](https://youtu.be/_oqj3JwkzVU)
+
+Agenda/Notes:
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * [Michelle Au] Feature implementation tracking and coordination
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+* Design Review
+  * [Please add any design reviews here]
+  * API changes for 1.8 (@jsafrane)
+    * fsType in StorageCla
+      * Item in StorageClass.Parameter
+      * [https://github.com/kubernetes/kubernetes/pull/45345](https://github.com/kubernetes/kubernetes/pull/45345#issuecomment-313136730)
+      * [Saad Ali] Ok to add as a new parameter in opaque parameter list, since this is a per-volume plugin option.
+    * reclaimPolicy in StorageCla
+      * Standalone field StorageClass.ReclaimPolicy
+      * [https://github.com/kubernetes/kubernetes/pull/47987](https://github.com/kubernetes/kubernetes/pull/47987#discussion_r125526991)
+      * [Saad Ali] Ok to add as a first class field to SC, since it is a first class filed on PV
+    * [M](https://github.com/kubernetes/kubernetes/pull/47987#discussion_r125526991)o[u](https://github.com/kubernetes/kubernetes/pull/47987#discussion_r125526991)n[t](https://github.com/kubernetes/kubernetes/pull/47987#discussion_r125526991) [O](https://github.com/kubernetes/kubernetes/pull/47987#discussion_r125526991)p[t](https://github.com/kubernetes/kubernetes/pull/47987#discussion_r125526991)i[o](https://github.com/kubernetes/kubernetes/pull/47987#discussion_r125526991)n[s](https://github.com/kubernetes/kubernetes/pull/47987#discussion_r125526991) [G](https://github.com/kubernetes/kubernetes/pull/47987#discussion_r125526991)A
+      * [https://github.com/kubernetes/community/pull/771](https://github.com/kubernetes/community/pull/771)
+      * [Saad Ali] Let’s think about this a bit more. Might want this to be a first class field on storageClass as well.
+  * [Erin Boyd] Block Storage Support
+    * Design Doc: [link](https://docs.google.com/a/redhat.com/document/d/1XeNFxc89C54psYqz4RErk1xcso0wMrKtSfWqI6POvaU/edit?usp=sharing)
+    * Punted to next meeting.
+* [Saad Ali] Future of In-tree Volume vs Flex vs CSI
+* [Jaice Singer DuMars] Release roles [still need volunteers](https://docs.google.com/spreadsheets/d/1kGPfhADIYxDR5kwS5o1kZ_cAc1A_pLqbCc1eVnXwZFo/edit#gid=0) for 1.8
+
+## July 6, 2017
+
+Recording: [https://youtu.be/3A0IHmuqxBs](https://youtu.be/3A0IHmuqxBs)
+
+Agenda/Notes:
+
+* [Saad Ali] Kubernetes v1.8 Q3 Planning - Round 2
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Wish list (Please add any items you want NOT in the planning sheet):
+    * [Requester Name] Example feature request
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * Nutanix volume plugin (<https://github.com/kubernetes/kubernetes/pull/48157>)
+  * Rook volume plugin: [https://github.com/kubernetes/kubernetes/pull/46843](https://github.com/kubernetes/kubernetes/pull/46843)
+    * Propose using a config map instead of CRD
+  * [https://github.com/kubernetes/kubernetes/pull/46821](https://github.com/kubernetes/kubernetes/pull/46821) as a segue for plugin testing, especially CI plugin testing skipped due to [Feature:Volumes] tests.
+    * Michelle will finish reviewing on return next week
+* Design Review
+  * [Please add any design reviews here]
+  * [https://github.com/kubernetes/community/pull/713](https://github.com/kubernetes/community/pull/713) related to [https://github.com/kubernetes/kubernetes/issues/47117](https://github.com/kubernetes/kubernetes/issues/47117) discussion in the last meeting
+    * [Leon] Demo
+    * [Brad] Where does this fit into k8s?
+    * [Leon] Expose local storage on bare metal?
+    * [Steve] Sounds like a volume plugin portal to external host volume discovery which has more than one storage provider at external end. Similar to CSI?
+    * [Leon] CSI, create/delete/etc. This project, attaching volume to host
+    * [Steve] Host local storage?
+    * [Leon] This project can contain many different types of storage protocols.
+    * [Hemant] I think this is trying to be an adapter -- won’t require cloudprovider -- and cinder on for example AWS.
+    * [Steve] Please link URL
+  * [https://docs.google.com/a/redhat.com/document/d/1XeNFxc89C54psYqz4RErk1xcso0wMrKtSfWqI6POvaU/edit?usp=sharing](https://docs.google.com/a/redhat.com/document/d/1XeNFxc89C54psYqz4RErk1xcso0wMrKtSfWqI6POvaU/edit?usp=sharing)
+    * Punt to next meeting.
+* [Tushar] How to improve collaboration between multiple groups on features like Snapshot
+  * [Gerry] New to this community. What is the best way to hook in? Volume plugins? Third party resources?
+    * Brad will talk to Gerry offline.
+  * [Brad] Anyone who doesn’t feel comfortable jumping in on the group feel free to reach out to any of us offline
+
+## June 22, 2017
+
+Recording: [https://youtu.be/oYY-GqhrG2M](https://youtu.be/oYY-GqhrG2M)
+
+Agenda/Notes:
+
+* [Matt DeLio] Kubernetes v1.8 Q3 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Wish list (Please add any items you want NOT in the planning sheet):
+    * [Requester Name] Example feature request
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * Rook volume plugin: [https://github.com/kubernetes/kubernetes/pull/46843](https://github.com/kubernetes/kubernetes/pull/46843)
+  * [https://github.com/kubernetes/kubernetes/pull/46821](https://github.com/kubernetes/kubernetes/pull/46821) as a segue for plugin testing, especially CI plugin testing skipped due to [Feature:Volumes] tests.
+* Design Review
+  * [Please add any design reviews here]
+  * [https://github.com/kubernetes/community/pull/713](https://github.com/kubernetes/community/pull/713) related to [https://github.com/kubernetes/kubernetes/issues/47117](https://github.com/kubernetes/kubernetes/issues/47117) discussion in the last meeting
+  * <https://docs.google.com/a/redhat.com/document/d/1XeNFxc89C54psYqz4RErk1xcso0wMrKtSfWqI6POvaU/edit?usp=sharing>
+* [Brad Childs] [kubernetes-incubator/external-storage](https://github.com/kubernetes-incubator/external-storage) repo updates
+* [Saad Ali] CSI Implementation Discussion
+* [Saad Ali] Flex Volume Issue
+  * Issue [#46882](https://github.com/kubernetes/kubernetes/issues/46882) - FlexVolume unable to mount plugins that do not require an attach
+    * Introduced in 1.7 alpha - Cinder bug fix made a breaking change
+    * Status: Fixed
+  * Issue [#44737](https://github.com/kubernetes/kubernetes/issues/44737) - Flex volumes which implement getvolumename API are getting unmounted during run time
+    * Introduced 1.6 (attacher refactor)
+    * Status:
+      * Architectural Fix - [community/pull/650](https://github.com/kubernetes/community/pull/650)
+        * Missed v1.7, punted to v1.8
+      * Temp Patch Fix
+        * v1.6 patched in PR [#46249](https://github.com/kubernetes/kubernetes/pull/46249) - release in v1.6.5
+        * 1.7 - patched in PR [#47400](https://github.com/kubernetes/kubernetes/pull/47400) - will be released with v1.7.0
+  * Issue [#47109](https://github.com/kubernetes/kubernetes/issues/47109) - “nfs flexvolume example not working”
+    * Non-attacher flex drivers fail to start
+    * Introduced 1.6 (attacher refactor)
+    * Status:
+      * Cheng Xing ([@verult](https://github.com/verult)) working on fix to be patched to 1.7 and 1.6
+* [Tushar] How to improve collaboration between multiple groups on features like Snapshot
+
+## June 8, 2017
+
+Recording: [https://youtu.be/YEVy18n543k](https://youtu.be/YEVy18n543k)
+
+Agenda/Notes:
+
+* Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [https://github.com/kubernetes/kubernetes/pull/46843](https://github.com/kubernetes/kubernetes/pull/46843)
+    * Proposed for 1.7, but will take more work so waiting for 1.8 to get in.  Design discussion in PR.  Will send out an invite for design meeting.  Request that Jordan liggitt joins.
+  * Just noticed: [https://github.com/kubernetes/kubernetes/pull/46597](https://github.com/kubernetes/kubernetes/pull/46597) is there a plan for this for 1.7 or 1.8?
+    * Need to track this and roadmap it for 1.7 or 1.8.  Childsb to talk
+* Design Review
+  * [Please add any design reviews here]
+  * [https://github.com/kubernetes/kubernetes/issues/47117](https://github.com/kubernetes/kubernetes/issues/47117)
+    * Hchen - not sure this feature represents the real problem.
+    * Howard - This is a general purpose storage library that may be useful in kube and could be done as a CSI plugin.  More detailed spec/design to follow.  Demo or sep. call to discuss.
+  * Local Block Storage proposal - Meeting tomorrow, design will be sent before then.
+* On-boarding docs/proce
+  * Want a better defined proce
+  * Others looking for heavier lift PRs to help contribute and hit the amount of code needed to meet criteria
+  * Can pickup “help wanted” PRs and issue
+  * Reviewers and participation in issues is also important.
+  * Side note: currently there are 0 open PRs with a “help-wanted” label =&gt; <https://github.com/kubernetes/kubernetes/pulls?q=is%3Aopen+is%3Apr+label%3Ahelp-wanted>
+  * Storage sig community calendar?
+* Testing Update (Erin)
+  * Hardware donation - CNCF has donated hardware
+  * Representation for plugin
+  * Need community participation in testing.  Great way to contribute as a newbie.
+  * Biweekley E2E testing meeting every Friday.
+* CSI - CNCF meeting tomorrow.   To join the storage working group, create a PR against the CNCF storage repo which will bring you more visibility to the meetings.
+  * [https://groups.google.com/forum/#!topic/kubernetes-sig-storage/sVIDnhMi4oM](https://groups.google.com/forum/#!topic/kubernetes-sig-storage/sVIDnhMi4oM)
+  * Repo for spec: [https://github.com/container-storage-interface/spec](https://github.com/container-storage-interface/spec)
+
+## May 25, 2017
+
+Recording: [https://youtu.be/NCPCqaXG2SQ](https://youtu.be/NCPCqaXG2SQ)
+
+Agenda/Notes:
+
+* Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* Features tracking board should be filled in for 1.7
+  * [link](https://docs.google.com/spreadsheets/d/1IJSTd3MHorwUt8i492GQaKKuAFsZppauT4v1LJ91WHY/edit#gid=0)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [https://github.com/kubernetes/kubernetes/pull/44897](https://github.com/kubernetes/kubernetes/pull/44897) (local storage plugin)
+    * At a stable point. Needs final review.
+    * Saad Ali will take a look
+  * [https://github.com/kubernetes/kubernetes/pull/45518](https://github.com/kubernetes/kubernetes/pull/45518) (fix portworx plugin for GKE)
+    * Jan reviewing looks ok.
+    * Michelle Au will take a look from GKE side
+* Design Review
+  * [Please add any design reviews here]
+  * [Hemant] <https://github.com/kubernetes/community/pull/657> - growing persistent volume
+  * CSI Spec?
+    * Move to next week
+  * Rook Volume Plugin
+    * Pretty much done. Wanted to make it for 1.7. Thin plugin
+    * Would need to go through exception process.
+* On-boarding docs/proce
+  * Punted to next meeeting
+* StorageOS Volume Plugin
+  * [TODO:saadali] Some one from Google should take a look
+
+## May 11, 2017
+
+Recording: [https://youtu.be/RzUVcnue1j0](https://youtu.be/RzUVcnue1j0)
+
+Agenda/Notes:
+
+* [Erick Fejta] Flaky Test Alert
+* SIG PM demo session June 13
+  * Background: the PM group is looking to popularize a lot of the work each SIG is doing.  We’ve been signed up for a 15 minute time-slot; topics are any feature going to beta or stable.
+  * Topics:
+    * [Volume Mount Options](https://github.com/kubernetes/features/issues/168) (beta) - Huamin
+    * [Cloud Provider Storage Metrics](https://github.com/kubernetes/features/issues/182) (beta) - Hemant
+* Status Updates
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [https://github.com/kubernetes/kubernetes/pull/45286](https://github.com/kubernetes/kubernetes/pull/45286)
+    * Should approve today
+  * [https://github.com/kubernetes/kubernetes/pull/41950](https://github.com/kubernetes/kubernetes/pull/41950)
+    * Rootfs has some question
+  * [https://github.com/kubernetes/kubernetes/pull/45346](https://github.com/kubernetes/kubernetes/pull/45346) (need approval)
+    * Saad will do a final pa
+  * [https://github.com/kubernetes/kubernetes/pull/45623](https://github.com/kubernetes/kubernetes/pull/45623)
+    * Bug fix in 1.6. Brad will take a look from storage side
+  * [https://github.com/kubernetes/kubernetes/pull/45423](https://github.com/kubernetes/kubernetes/pull/45423)
+    * Saad will take a look
+  * [https://github.com/kubernetes/kubernetes/pull/45518](https://github.com/kubernetes/kubernetes/pull/45518)
+    * Anthony is release czar for 1.6 he will make the final call
+* Design Review
+  * [Please add any design reviews here]
+  * [Jan] Mount containers design [https://github.com/kubernetes/community/pull/589](https://github.com/kubernetes/community/pull/589)
+    * Let’s set up a separate meeting to discuss this since we are out of time.
+* On-boarding docs/proce
+  * Punting to next week
+
+## April 27, 2017
+
+Recording: [https://youtu.be/YANFlMtue4A](https://youtu.be/YANFlMtue4A)
+
+Agenda/Notes:
+
+* Status Updates
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * [Matt De Lio] Discuss adding feature-repo entries for bug-fixes that impact users
+  * Feature submission deadline extended to [Monday, May 5, 6:00 PM PST](https://groups.google.com/forum/#!topic/kubernetes-pm/GjFIfz_p0Js)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * Kubelet e2e test pr 44592
+  * Design Review
+  * [Please add any design reviews here]
+  * Needs attention: [https://github.com/kubernetes/community/pull/247](https://github.com/kubernetes/community/pull/247)
+* [Luis Pabón (lpabon)] “Quartermaster storage framework” demo
+  * [https://github.com/coreos/quartermaster](https://github.com/coreos/quartermaster)
+  * Slides: <http://bit.ly/2nsoHbW>
+* On-boarding docs/proce
+* OpenStack Boston - anyone going?
+  * [https://www.cncf.io/event/openstack-north-america-2017/](https://www.cncf.io/event/openstack-north-america-2017/)
+  * Some focus during the main event on OpenStack storage integration with K8S
+  * Luis Pabon (I can attend) I also plan on attending RH Summit.
+  * Chris Hoge (OpenStack Foundation, K8S community liason, chris@openstack.org)
+  * Michelle Au (msau42) is going, will be giving a talk about Local Storage
+  * Hayley Swimelar&lt;[hayley@linbit.com](mailto:hayley@linbit.com)&gt; is going
+  * Yin ding&lt;[yin.ding@huawei.com](mailto:yin.ding@huawei.com)&gt; is going, will give a talk with Ton ([Ngoton@us.ibm.com](mailto:Ngoton@us.ibm.com)) about OpenStack &amp; K8S.
+* [Jan] Mount containers design
+
+## April 13, 2017
+
+Recording: [https://youtu.be/UFLl9H17RdQ](https://youtu.be/UFLl9H17RdQ)
+
+Agenda/Notes:
+
+* Face to Face meeting was held this week
+  * Notes: [https://docs.google.com/document/d/1IwL_AMO1N5aN_u5BR4lxw7g5g5z-S-I3rdkD8g81HoI/edit#](https://docs.google.com/document/d/1IwL_AMO1N5aN_u5BR4lxw7g5g5z-S-I3rdkD8g81HoI/edit#)
+* Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [Jan] Shared mounts on GCE e2e test env. I need someone to review and approval, this involves sig-node, cluster-infrastructure and storage:
+    * [https://groups.google.com/forum/?utm_medium=email&amp;utm_source=footer#!topic/kubernetes-dev/nzYev0cr1SU](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/kubernetes-dev/nzYev0cr1SU)
+    * [https://github.com/kubernetes/kubernetes/pull/44389](https://github.com/kubernetes/kubernetes/pull/44389)
+    * [AI-Saad] Find a Google contact to look at this.
+  * [hekumar] Fix missed pod updates - [https://github.com/kubernetes/kubernetes/pull/42033](https://github.com/kubernetes/kubernetes/pull/42033)
+    * Suggestion: get more data about potential perf (memory) issue
+* Design Review
+  * [Please add any design reviews here]
+* [Michelle Au] Persistent local storage prototype demo
+
+## March 30, 2017
+
+Recording: [https://youtu.be/F8HDdJwX_OQ](https://youtu.be/F8HDdJwX_OQ)
+
+Agenda/Notes:
+
+* Kubecon EU Day 2
+* Status Update
+* 2017 Q2 Storage SIG Planning
+  * Storage Wish List for 2017 Q2 and 1.7
+    * Out-of-tree storage e2e testing?
+    * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* Design Review
+  * [Please add any design reviews here]
+  * Final round: [https://github.com/kubernetes/community/pull/306](https://github.com/kubernetes/community/pull/306)
+* PRs to discuss or that need attention
+  * (bchilds) [https://github.com/kubernetes/kubernetes/issues/34242](https://github.com/kubernetes/kubernetes/issues/34242)
+  * (rootfs) iSCSI CHAP [https://github.com/kubernetes/kubernetes/pull/43396](https://github.com/kubernetes/kubernetes/pull/43396) [(](https://github.com/kubernetes/kubernetes/pull/43396)n[e](https://github.com/kubernetes/kubernetes/pull/43396)e[d](https://github.com/kubernetes/kubernetes/pull/43396) [a](https://github.com/kubernetes/kubernetes/pull/43396)p[p](https://github.com/kubernetes/kubernetes/pull/43396)r[o](https://github.com/kubernetes/kubernetes/pull/43396)v[e](https://github.com/kubernetes/kubernetes/pull/43396)r[)](https://github.com/kubernetes/kubernetes/pull/43396)
+* Face to Face meeting
+  * [Steve Wong] Details, agenda proposals, and RSVP here:
+    * [https://docs.google.com/document/d/1IwL_AMO1N5aN_u5BR4lxw7g5g5z-S-I3rdkD8g81HoI/edit#](https://docs.google.com/document/d/1IwL_AMO1N5aN_u5BR4lxw7g5g5z-S-I3rdkD8g81HoI/edit#)
+  * 2 Days (April 11, 12) in Santa Clara
+* Request: Quartermaster storage framework to Kubernetes-incubator
+  * owner: Luis Pabón (lpabon)
+  * [https://github.com/coreos/quartermaster](https://github.com/coreos/quartermaster) Released 3/21/2017
+
+## March 16, 2017
+
+Recording: [https://youtu.be/_dqtg3fURmg](https://youtu.be/_dqtg3fURmg)
+
+Agenda/Notes:
+
+* Status Update
+  * Storage Planning Spreadsheet: [link](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit#gid=647564464)
+  * K8s Release Spreadsheet: [link](https://docs.google.com/spreadsheets/d/1nspIeRVNjAQHRslHQD1-6gPv99OcYZLMezrBe3Pfhhg/edit#gid=0)
+* Design Review
+  * [Please add any design reviews here]
+  * [Tamal Saha] [https://github.com/kubernetes/kubernetes/issues/42677](https://github.com/kubernetes/kubernetes/issues/42677)
+    * Local storage solution for k8s in the work
+    * In the meantime you could use hostpath plus labels/selector
+    * Want StatefulSets to work with local storage.
+  * [Tomas Smetana] Snapshots: next step
+    * Document is not yet public
+      * Jing please share
+    * Folks interested in feature we should meet more frequently
+    * Tomas will send message to sig-storage mailing list.
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [Jan Safranek] StorageClass v1 in 1.6: [https://github.com/kubernetes/kubernetes/pull/42477](https://github.com/kubernetes/kubernetes/pull/42477)
+    * Without this everything will work, but internally we use betav1 instead of v1.
+    * Let’s aim for 1.6.1
+  * [Brad Childs] Attach / Detach fixes for 1.6.z? <https://github.com/kubernetes/kubernetes/issues/34242>
+    * Tomas working on attach/detach controller handling restarts.
+    * Too big for 1.6.0
+    * Target 1.6.1
+    * Tomas writing better Unit Tests.
+* [Saad Ali] Container Storage Interface
+  * Preliminary doc: [link](https://docs.google.com/document/d/1JMNVNP-ZHz8cGlnqckOnpJmHF-DNY7IYP-Di7iuVhQI/edit?usp=sharing)
+* KubeCon EU
+  * Attendees:
+    * @Saad-ali (saadali@google.com
+    * @Matchstick (mrubin@google.com)
+    * @jsafrane (jsafrane@redhat.com)
+    * @h[um](mailto:jsafrane@redhat.com)b[l](mailto:jsafrane@redhat.com)e[c](mailto:jsafrane@redhat.com) ([hchiramm@redhat.com](mailto:jsafrane@redhat.com))
+    * @sergep (serge@gnode.org)
+    * johscheuer
+    * michael.ferranti@portworx.com
+    * felix@quobyte.com
+    * yin.ding@huawei.com
+    * Steven.Tan@huawei.com
+    * Pauline.Yeung@huawei.com
+    * huangzhipeng@huawei.com
+    * @clintonskitson ([clinton.kitson@dell.com](mailto:clinton.kitson@dell.com))
+    * @cantbewong (steven.wong@dell.com)
+  * TODO: Set up a dinner or small informal meeting
+* Face to Face meeting, Santa Clara, April 5 reminder
+  * [Steve Wong] Details, agenda proposals, and RSVP here:
+    * [https://docs.google.com/document/d/1IwL_AMO1N5aN_u5BR4lxw7g5g5z-S-I3rdkD8g81HoI/edit#](https://docs.google.com/document/d/1IwL_AMO1N5aN_u5BR4lxw7g5g5z-S-I3rdkD8g81HoI/edit#)
+  * 2 Day
+  * Proposal move to April 11, 12 instead
+
+## March 2, 2017
+
+Recording (partial): [https://youtu.be/2163WTvqCCI](https://youtu.be/2163WTvqCCI)
+
+Agenda/Notes:
+
+* Status Update
+  * Spreadsheet: [link](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit#gid=647564464)
+* [Steve Kokhang Leon] Rook Intro
+* Design Review
+  * [Please add any design reviews here]
+  * Flex: Is there a need for multiple provisioners per plugin?
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [Jeff Vance] E2E and out-of-tree design. When will there be a more formal discussion of the structure for the out-of-tree storage plugins? Jon and Jeff are interested in drafting a proposal on how e2e could work when we have out-of-tree, but we need more info on what out-of-tree will look like. Also, we may want a doc/proposal for e2e and flex volumes. Incubator doc: <https://github.com/kubernetes-incubator/external-storage/tree/master/docs/demo/hostpath-provisioner>  and e2e code: [https://github.com/kubernetes-incubator/external-storage/tree/master/nfs/test/e2e](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs/test/e2e) . This file ([https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/test/e2e/e2e_test.go](https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/test/e2e/e2e_test.go)), which needs some work, is the main framework for the out-of-tree e2e tests.
+  * [Simon Croome] StorageOS Volume Plugin ([https://github.com/kubernetes/kubernetes/pull/42156](https://github.com/kubernetes/kubernetes/pull/42156))
+* Face to Face meeting date confirmationHas been tentatively discussed as first week in April. Dell EMC would propose to finalize as April 5&amp;6 (Wed &amp; Thur) in Santa Clara
+
+## February 16, 2017
+
+Recording: [https://youtu.be/33ILjxa7l-M](https://youtu.be/33ILjxa7l-M)
+
+Agenda/Notes:
+
+* Status Update
+  * Spreadsheet: [link](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit#gid=647564464)
+  * Release 1.6 Code Freeze 1 week away
+* Design Review
+  * [Please add any design reviews here]
+  * [Steve Watt] Snapshot
+    * Steve and Serge going to take up Snapshots w/Jing.
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [https://github.com/kubernetes/kubernetes/pull/38924](https://github.com/kubernetes/kubernetes/pull/38924) (Vladimir Vivien, Dell EMC)
+    * Needs k8s-bot ok to test incantation
+    * Looking for final LGTM for merge
+  * [https://github.com/kubernetes/kubernetes/pull/39535](https://github.com/kubernetes/kubernetes/pull/39535) (Aditya Dani, Portworx)
+    * Got one successful test run.
+    * Needs a rebase (waiting for lgtm)
+  * [https://github.com/kubernetes/kubernetes/pull/41196](https://github.com/kubernetes/kubernetes/pull/41196)
+    * Any chance of backporting this PR to release 1.4 and 1.5?
+    * Cherry picks?
+* [Erin Boyd] Deprecating Recycler Proce
+  * Follow up with Brian Grant
+  * Original Recycler Dep. PR: [https://github.com/kubernetes/kubernetes/pull/36760](https://github.com/kubernetes/kubernetes/pull/36760)
+* Local Storage Volume
+  * <https://github.com/kubernetes/community/pull/306>
+  * Timeline?
+    * 1.6 Design
+    * 1.7 Alpha
+      * First use case will be stateful set
+  * Design
+    * [Steve Watt] Support for network disks in the PV framework. Data management platform folks can’t use PV framework use host path. If we can take local FS and expose them as PVs, then we can hook them up to StateFul Sets, and update scheduler to handle it, correct?
+      * [msau] Correct
+    * [Steve Watt] Stateful set 6 node cassandra w/6 disks, if 1 dies, we don’t have capability to dynamically provision.
+      * [msau] If a node dies, want pod to release volume and use a different volume, there needs to be an available volume. Pre-provision all local volumes that are available.
+    * [Guo] Node selectors and node labels, how does this differ.
+      * [msau] You don’t have to decide the node ahead of time when deploying pod. It will find any available volume, and then fix node to pod. Second: idea of forgiveness, if that node is having issues, node fails or is unavailable, system can rebind to a different node a new PV.
+      * [Steve Watt] Want to avoid creating a replication storm. Replace it if unavailable for a certain period of time
+        * [msau] Either Completely off, no forgiveness or some time boundary)
+      * [Steve Watt] Allows kubernetes to automatically handle failures vs node selectors/node labels. Huge step forward in self healing capabilities.
+      * [Ardalan] If node goes down, data lost? Want to grab replica not empty scratch disk.
+        * [msau] Wouldn’t other pod already have replica?
+        * [Serge] depends.
+        * [Guo] Portworx another replica set on different node. So ok to go to another node. If one node goes down, ok to schedule on one of the other nodes.
+        * [Steve Watt] Data replication you want to maintain quorum (2 or 3) generally speaking, if one goes down. Spin up a new pod on a new node and have scratch disk replicate
+        * [Serge] We are using replication term with 2 different meanings. MongoDB kind of replication is like you said (1 shard fewer, create a new shard, repopulate). Vs Replicated volumes (start with replica as a seed for the new shard). Not sure what to name them.
+        * [Steve Watt] Application vs block replication?
+        * [Steve Watt] Similar hadoop, multiple disks (blocks) identical copies, if host dies against one, just want scheduler to schedule against one of the replicas (not a random PV).
+        * [Yaron] Active-passive replica may not be logically two PDs, just one that changes location from node A (which crashes) to node B. That makes things simpler.
+        * [Steve Watt] PVs are immutable.
+        * [Serge] Sounds like that is a lower layer. SDS repair would happen under the covers.
+        * [Saad] If PV can move around really local storage?
+        * [Steve Wong] That’s more of a hybrid local. App can take advantage on rebuild.
+
+## February 2, 2017
+
+Recording: [https://youtu.be/EgtyplK3Ilc](https://youtu.be/EgtyplK3Ilc)
+
+Agenda/Notes:
+
+* Status Update
+  * 1.5.3 and 1.4.9 planned for Feb 10
+* Design Review
+  * [Please add any design reviews here]
+  * [Michelle Au] Persistent Local Storage
+    * [https://github.com/kubernetes/community/pull/306](https://github.com/kubernetes/community/pull/306)
+  * [Hemant Kumar] Mount option
+    * [https://github.com/kubernetes/community/pull/321](https://github.com/kubernetes/community/pull/321)
+  * [Hemant Kumar] Cloud Provider metric
+    * [https://github.com/kubernetes/community/pull/288](https://github.com/kubernetes/community/pull/288)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [TODO] Assignee PR
+  * [https://github.com/kubernetes/kubernetes/pull/40000](https://github.com/kubernetes/kubernetes/pull/40000)
+  * [https://github.com/kubernetes/kubernetes/pull/40013](https://github.com/kubernetes/kubernetes/pull/40013)
+  * [https://github.com/kubernetes/kubernetes/pull/40088](https://github.com/kubernetes/kubernetes/pull/40013)
+  * [https://github.com/kubernetes/kubernetes/pull/39425](https://github.com/kubernetes/kubernetes/pull/39425)
+  * [https://github.com/kubernetes/kubernetes/pull/38702](https://github.com/kubernetes/kubernetes/pull/38702)
+  * [https://github.com/kubernetes/kubernetes/pull/37698](https://github.com/kubernetes/kubernetes/pull/37698)
+  * [https://github.com/kubernetes/kubernetes/pull/31515](https://github.com/kubernetes/kubernetes/pull/31515)
+  * [https://github.com/kubernetes/kubernetes/pull/40531](https://github.com/kubernetes/kubernetes/pull/40531)
+* PoC
+  * Quartermaster Storage Controller Framework
+    * Luis Pabón (luis.pabon@coreos.com)  [lpabon]
+    * Slides: [http://bit.ly/2jp5VB9](http://bit.ly/2jp5VB9)
+    * Document: [http://bit.ly/2kikXpF](http://bit.ly/2kikXpF)
+* [Erin Boyd] Deprecating Recycler Proce
+  * Punt to next meeting
+* [Ritesh (kerneltime)]
+  * New e2e tests [https://github.com/kubernetes/kubernetes/pull/40756](https://github.com/kubernetes/kubernetes/pull/40756)
+  * Storage Classes GA
+    * Which issues need closing?
+* KubeCon Europe
+  * Who’s attending?
+    * Saad Ali
+    * Michael Rubin
+    * Luis Pabon (maybe)
+    * Christopher M Luciano
+
+## January 19, 2017
+
+Recording: [https://youtu.be/Yrcx2AgrJYU](https://youtu.be/Yrcx2AgrJYU)
+
+Agenda/Notes:
+
+* [Matt De Lio] 2017 Planning
+  * Spreadsheet: [link](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit#gid=647564464)
+    * We're missing reviewers for many of the features/tasks we're working on.  Please sign up as a reviewer if you are able; and for the feature owners, please start reaching out to reviewers if you're still missing one in the next few days.
+    * The [feature repo](https://github.com/kubernetes/features/issues) will be frozen on January 24th, so we need to create items there that require it ASAP. Feature owners that haven't already done so should do this soon and please update the spreadsheet with issue number.
+* [Saad Ali] All new 1.6 features should have:
+  * Design doc
+  * Tests plan doc to identify what kind of testing is required before development
+  * Tests (E2E, unit, and integration) along with code, or before it (not a follow-up PR).
+  * Deadlines are: [https://github.com/kubernetes/features/blob/master/release-1.6/release-1.6.md](https://github.com/kubernetes/features/blob/master/release-1.6/release-1.6.md)
+    * Tuesday, Jan 24 - Features repo freeze
+    * Monday, Feb 27 - Feature complete date (code freeze goes into effect)
+* [Ardalan Kangarlou] NetApp’s external provisioner for Kubernete
+  * [https://github.com/netapp/trident](https://github.com/netapp/trident)
+* [Huamin Chen]: Out of tree provisioner repo hosting
+  * Bchilds - move NFS provisioner repo to “storage”.  Will home external provisioner and FLEX plugins maintained by community.
+* Design Review
+  * [Please add any design reviews here]
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention here]
+  * [https://github.com/kubernetes/kubernetes/pull/39535](https://github.com/kubernetes/kubernetes/pull/39535) (Aditya, Portworx)
+  * [https://github.com/kubernetes/kubernetes/pull/38924](https://github.com/kubernetes/kubernetes/pull/38924) (Vladimir Vivien, Dell EMC)
+* Next Storage F2F
+  * Some time in April in Santa Clara
+
+## January 5, 2017
+
+Recording: [https://youtu.be/Nksb3w1a2x4](https://youtu.be/Nksb3w1a2x4)
+
+Agenda/Notes:
+
+* Happy New Year!
+* 2017 Planning
+  * Matt’s Spreadsheet: [link](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit#gid=647564464)
+* Design Review
+  * None
+* PRs to discuss or that need attention
+  * Dell EMC ScaleIO Volume Plugin PR
+    * [https://github.com/kubernetes/kubernetes/pull/38924](https://github.com/kubernetes/kubernetes/pull/38924)

--- a/sig-storage/archive/meeting-notes-2017.md
+++ b/sig-storage/archive/meeting-notes-2017.md
@@ -196,7 +196,7 @@ Agenda/Notes:
 * PRs to discuss or that need attention
   * [Please add any PRs that need attention here]
   * Detach Fix [https://github.com/kubernetes/kubernetes/pull/52221](https://github.com/kubernetes/kubernetes/pull/52221)
-  * Kubelet wierd output fix [https://github.com/kubernetes/kubernetes/pull/52132](https://github.com/kubernetes/kubernetes/pull/52132)
+  * Kubelet weird output fix [https://github.com/kubernetes/kubernetes/pull/52132](https://github.com/kubernetes/kubernetes/pull/52132)
 * Design Review
   * [Please add any design reviews here]
   * 1.7 Local storage: [https://github.com/kubernetes/community/pull/989](https://github.com/kubernetes/community/pull/989)
@@ -516,7 +516,7 @@ Agenda/Notes:
   * [https://www.cncf.io/event/openstack-north-america-2017/](https://www.cncf.io/event/openstack-north-america-2017/)
   * Some focus during the main event on OpenStack storage integration with K8S
   * Luis Pabon (I can attend) I also plan on attending RH Summit.
-  * Chris Hoge (OpenStack Foundation, K8S community liason, chris@openstack.org)
+  * Chris Hoge (OpenStack Foundation, K8S community liaison, chris@openstack.org)
   * Michelle Au (msau42) is going, will be giving a talk about Local Storage
   * Hayley Swimelar&lt;[hayley@linbit.com](mailto:hayley@linbit.com)&gt; is going
   * Yin ding&lt;[yin.ding@huawei.com](mailto:yin.ding@huawei.com)&gt; is going, will give a talk with Ton ([Ngoton@us.ibm.com](mailto:Ngoton@us.ibm.com)) about OpenStack &amp; K8S.

--- a/sig-storage/archive/meeting-notes-2018.md
+++ b/sig-storage/archive/meeting-notes-2018.md
@@ -1,0 +1,669 @@
+# Kubernetes Storage SIG Meeting Notes (2018)
+
+The Kubernetes Storage Special-Interest-Group (SIG) is a working group within the Kubernetes contributor community interested in storage and volume plugins. This document contains historical meeting notes from past meeting.
+
+## December 20, 2018
+
+Recording: [https://youtu.be/_0V2We_wRHg](https://youtu.be/_0V2We_wRHg)
+
+Agenda/Note
+
+* [Saad Ali] Q1 2018 v1.14 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Q1 planning
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+
+## December 6, 2018
+
+Recording: [https://youtu.be/lO5tG0d_GWU](https://youtu.be/lO5tG0d_GWU)
+
+Agenda/Note
+
+* [Saad Ali] Q4 2018 v1.13 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Q4 end of quarter statuse
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+  * [pontiyaraja] [#71416](https://github.com/kubernetes/kubernetes/issues/71416) [WIP] inconsistent message in different gke environment.
+    * Saad and msau will take a look offline.
+  * [croomes] [#69782](https://github.com/kubernetes/kubernetes/pull/69782) - StorageOS attach device bug (ready for review)
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Question
+  * How to write a CSI plugin works with both Kubernetes v1.13 and v1.12 - Sheng
+* KubeCon Seattle 2018
+  * F2F Meeting: [link](https://docs.google.com/document/d/1Z_jM7LWkeGqO06iaoJB40ZGETgedsG706up_EOSdQko/edit#heading=h.1hxwalotoj0l)
+    * 12/12/2018 between 9AM to 12noon
+    * Hosted by Diamanti
+    * Open questions:
+      * Official!
+      * Agenda. Half day.
+  * Talks:
+    * Best practices for deploying stateful apps - Cloud Native Storage Day - [https://www.cloudnativestorageday.com/](https://www.cloudnativestorageday.com/)
+    * Kubernetes CSI Panel -  Cloud native Storage Day [https://www.cloudnativestorageday.com/](https://www.cloudnativestorageday.com/)
+    * [How Symlinks Pwned Kubernetes](https://kccna18.sched.com/event/GrZc/how-symlinks-pwned-kubernetes-and-how-we-fixed-it-michelle-au-google-jan-safranek-red-hat) (msau42 &amp; jsafrane)
+    * [Extending Kubernetes or: How I Learned to Stop Worrying and Trust the Spec](https://sched.co/GrUU) - (David Zhu, Google)
+
+## November 22, 2018
+
+Agenda/Note
+
+* Cancelled -- US Holiday - Thanksgiving
+
+## November 8, 2018
+
+Recording: [https://youtu.be/YGn6zoNFOjA](https://youtu.be/YGn6zoNFOjA)
+
+Agenda/Note
+
+* [Saad Ali] Q4 2018 v1.13 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * ***Code Freeze - 11/15***
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+  * [wongma7] block to beta [https://github.com/kubernetes/kubernetes/pull/65829](https://github.com/kubernetes/kubernetes/pull/65829)
+  * [hekumar] online resize to beta [https://github.com/kubernetes/kubernetes/pull/67608](https://github.com/kubernetes/kubernetes/pull/67608)
+    * Should online expansion be opt-in instead of default?
+    * Drawbacks of online expansion:
+      * Bug volume gets detached while mkfs, similar issue could happen with online resizing.
+      * If switching to opt-in would require an API change
+    * Having a switch seems reasonable.
+    * Let’s hold off til 1.14 for this.
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* [Ben Swartzlander] Migration issue
+  * Some vendors who created dynamic provisioners in the pre-CSI era and are now moving to CSI plugins have users who are getting trapped between worlds. We are looking for a way to help users migrate their legacy volumes to CSI volumes, and kubernetes makes this harder than it needs to be. I’d like to explore options that might make this less painful. In particular, a way to rebind a bound PVC/PV pair to a different PV.
+    * Use case:
+      * Old external-provisoners PVs that are in-tree volume source
+      * Now want to change from e.g. intree NFS to netapp CSI driver
+    * Options:
+      * 1) Tool that deletes PVC and create new PVC
+        * Drawback: user sees PVs being deleted.
+      * 2) Tool that deletes PVs, creates new PV and rebind to existing PVC
+        * Drawback: tricky to implement
+      * 3) piggy back on migration.
+        * Drawback: not all NFS should be redirected
+    * Conclusion: 2 is probably the best option. Discuss details offline.
+      * Maybe worth making it a common OSS tool.
+
+## October 25, 2018
+
+Recording: [https://youtu.be/ZvQn14Jq-zg](https://youtu.be/ZvQn14Jq-zg)
+
+Agenda/Note
+
+* [Saad Ali] Q4 2018 v1.13 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Feature (enhancement freeze) - 10/23
+  * ***Code Freeze - 11/15***
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+  * Iscsi-lib [https://github.com/kubernetes-csi/csi-lib-iscsi/pull/1](https://github.com/kubernetes-csi/csi-lib-iscsi/pull/1) jgriffith
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* KubeCon sig-storage Event
+  * [SIG Storage Intro Session](https://kccna18.sched.com/event/GrbP/intro-storage-sig-saad-ali-google?iframe=no&w=100%&sidebar=yes&bg=no)
+    * Saad and/or Brad to lead
+    * QA session at end with panel?
+  * Container Native Storage day (Monday 12-9-2018)
+    * Call for presenters on that. May still have space.
+  * SIG Storage dinner or meeting -- Brad
+  * CNCF Storage Landscape
+    * [CNCF storage intro](https://kccna18.sched.com/event/GrcZ/intro-cncf-storage-wg-alex-chircop-storageos-quinton-hoole-huawei?iframe=no&w=100%&sidebar=yes&bg=no)
+    * [CNCF storage deep dive](https://sched.co/GreV)
+  * KubeCon Storage Talk
+    * [How symlinks pwned Kubernetes](https://kccna18.sched.com/event/GrZc/how-symlinks-pwned-kubernetes-and-how-we-fixed-it-michelle-au-google-jan-safranek-red-hat?iframe=no&w=100%&sidebar=yes&bg=no) - Jan + Michelle
+    * [Extending Kubernetes: Or How I Learned to Stop Worrying and Trust the Spec](https://kccna18.sched.com/event/GrUU/extending-kubernetes-or-how-i-learned-to-stop-worrying-and-trust-the-spec-david-zhu-google?iframe=no&w=100%&sidebar=yes&bg=no) - David
+
+## October 11, 2018
+
+Recording: [https://youtu.be/6IpRsXuELZA](https://youtu.be/6IpRsXuELZA)
+
+Agenda/Note
+
+* [AishSundar] Update in 1.13 timeline and discuss feature load
+  * [11 Enhancements in 1.13](https://github.com/kubernetes/features/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+milestone%3Av1.13+label%3Atracked%2Fyes+label%3Asig%2Fstorage)
+  * Please keep the labels (kind, priority, sig) up-to-todate on the issue
+  * Enhancements Freeze - 10/23 - indicate level of confidence and what’s pending in terms of code, test and docs.
+  * ***Code Freeze - 11/15***
+* [Saad Ali] Q4 2018 v1.13 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+
+## September 27, 2018
+
+Recording: [https://youtu.be/dhMNPCzZnd0](https://youtu.be/dhMNPCzZnd0)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Q4 2018 v1.13 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+
+## September 13, 2018
+
+Recording: [https://youtu.be/2sxgltq1qiI](https://youtu.be/2sxgltq1qiI)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * [Ben Swartzlander] External provisioner vendor dir and deps.
+    * [https://github.com/kubernetes-csi/external-provisioner/pull/126](https://github.com/kubernetes-csi/external-provisioner/pull/126)
+    * [https://github.com/kubernetes/org/issues/88](https://github.com/kubernetes/org/issues/88)
+* Design Review
+  * [Please add any design reviews, with your name, below]
+
+## August 30, 2018
+
+Recording: None
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+  * [jinxu] add detach logic for node shutdown taint
+    * [https://github.com/kubernetes/kubernetes/pull/67977/files](https://github.com/kubernetes/kubernetes/pull/67977/files)
+    * Proposal: Node shutdown taint
+            [https://github.com/kubernetes/kubernetes/issues/58635](https://github.com/kubernetes/kubernetes/issues/58635)[https://github.com/kubernetes/kubernetes/pull/59323](https://github.com/kubernetes/kubernetes/pull/59323)[https://github.com/kubernetes/kubernetes/pull/67254](https://github.com/kubernetes/kubernetes/pull/67254)
+Meeting at 11am Pacific to discuss detach issues related to node being down: meet.google.com/qoi-pknh-bfh
+* Discuss csi-connector library (Move to next / seperate call)
+
+## August 16, 2018
+
+Recording: [https://youtu.be/SavQT4Dx6D4](https://youtu.be/SavQT4Dx6D4)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+  * [jsafrane] Promote mount propagation to GA
+    * [https://github.com/kubernetes/kubernetes/pull/67255](https://github.com/kubernetes/kubernetes/pull/67255)
+* Bugs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+  * [srbrahma] Enable Flex Volume Driver to provide metrics
+    * <https://github.com/kubernetes/kubernetes/pull/67508>
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * Windows support [Feature #116,](https://github.com/kubernetes/features/issues/116) [Release criteria proposed for v1.12](https://docs.google.com/document/d/1YkLZIYYLMQhxdI2esN5PuTkhQHhO0joNvnbHpW68yg8/edit) [Patrick Lang, 10 mins]
+    * Need feedback, approval from impacted SIG
+  * [Michelle] Conformance update
+    * [https://github.com/kubernetes/kubernetes/issues/65155](https://github.com/kubernetes/kubernetes/issues/65155)
+    * [https://docs.google.com/spreadsheets/d/1Yp4mHBaOx86n6CMiEweFfzIkNdSfhgzKZFTRXrnXXkM/edit#gid=0](https://docs.google.com/spreadsheets/d/1Yp4mHBaOx86n6CMiEweFfzIkNdSfhgzKZFTRXrnXXkM/edit#gid=0)
+  * [Erin] Cloning design review tmr
+  * [John] iSCSI has lots going on (internal target driver, built in code in-tree managing pre-provisioned iscsi volumes, need to figure out consolidation story)
+
+## August 2, 2018
+
+Recording: [https://youtu.be/Qu9POBVXTtI](https://youtu.be/Qu9POBVXTtI)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+  * [Ardalan Kangarlou] [https://github.com/kubernetes/kubernetes/pull/66780](https://github.com/kubernetes/kubernetes/pull/66780) (would like to see the PR merged in 1.12)
+    * Mostly looks good. Maybe some questions about naming.
+* Bugs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * Cloning design review tomorrow. Invite sent to sig-storage.
+
+## July 19, 2018
+
+Recording: [https://youtu.be/WQ90iiGH7l0](https://youtu.be/WQ90iiGH7l0)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+  * [Ben Swartzlander] [https://github.com/kubernetes/kubernetes/pull/63176](https://github.com/kubernetes/kubernetes/pull/63176) Should have merged in 1.11
+* Bugs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * [Michelle] Conformance testing
+    * Basic idea of conformance suites: [https://github.com/kubernetes/kubernetes/issues/65155](https://github.com/kubernetes/kubernetes/issues/65155)
+    * Sheet with test ideas for each suite: [https://docs.google.com/spreadsheets/d/1Yp4mHBaOx86n6CMiEweFfzIkNdSfhgzKZFTRXrnXXkM/edit#gid=0](https://docs.google.com/spreadsheets/d/1Yp4mHBaOx86n6CMiEweFfzIkNdSfhgzKZFTRXrnXXkM/edit#gid=0)
+  * [Jan] Volume plugin test
+    * <https://github.com/kubernetes/community/pull/2272>
+    * Goal: run \*existing\* tests, i.e. Ceph and iSCSI.
+    * Adds new test job with MountContainers that runs all [sig-storage] tests, incl. Ceph and iSCSI.
+    * No new tests.
+
+## July 5, 2018
+
+Agenda/Notes (Please include your name and estimated time):
+
+* Cancelled due to US Holiday (Independence Day)
+
+## June 21, 2018
+
+Recording: [https://youtu.be/wWsC4zqS56c](https://youtu.be/wWsC4zqS56c)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * Q3 Kubernetes v1.12 Planning!!
+    * Please add work items to the planning spreadsheet under the v1.12 tab
+  * [Planning sprea](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)[heet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add anyds PRs that need attention, with your name, below]
+* Bugs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * [Jing and Xing] snapshot: [https://github.com/kubernetes/community/pull/1662](https://github.com/kubernetes/community/pull/1662)
+    * SIG-Architecture Decision
+    * SnapshotClass?
+      * Decision:
+        * PR XXX [Erin to add]
+    * Snapshot Meeting Proposal (next Monday or Wednesday 9:00am?)
+      * 9 AM Wed is CSI community meeting
+  * [Jan] Volume plugin test
+    * <https://github.com/kubernetes/community/pull/2272>
+    * Goal: run \*existing\* tests, i.e. Ceph and iSCSI.
+    * Adds new test job with MountContainers that runs all [sig-storage] tests, incl. Ceph and iSCSI.
+    * No new tests.
+  * [Jan] In-line CSI volume
+    * <https://github.com/kubernetes/community/pull/2273>
+    * Get agreement on what do we want to support.
+      * Do we want full feature parity with CSI volumes as PVs?
+      * Troubles with external attacher + secrets.
+
+## June 7, 2018
+
+Recording: [https://youtu.be/oDFjy5v_Myk](https://youtu.be/oDFjy5v_Myk)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * [Jing and Xing] snapshot: [https://github.com/kubernetes/community/pull/1662](https://github.com/kubernetes/community/pull/1662)
+    * Snapshot StorageClass?
+      * Decision:
+        * Let’s reuse existing StorageClass object and add a new alpha “snapshotParameters” field to it.
+        * If a snapshot request does not specify a StorageClass we can use the StorageClass from the source PVC.
+        * Initially, let’s also have API validation that will quickly fail a snapshot request if source and dest provisioners don’t match
+    * Condition for Creating
+      * Decision: ok with that.
+
+## May 24, 2018
+
+Recording: [https://youtu.be/2ZAGV06slo8](https://youtu.be/2ZAGV06slo8)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Brad Childs] Status Update
+  * ~~Code freeze is on Monday! ~~Actually it’s been pushed to June 5
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* [Brad Childs] F2F Last week
+  * [Notes / Recording](https://docs.google.com/document/d/1AoemMxRcRDhc3gpChGk-UwCiVsk7Q7E_yKeIKP-7jL4/edit?ts=5ad14c06)
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * Erin Boyd - Cloning
+* PRs to discuss or that need attention
+  * [Ben Swartzlander] [63176](https://github.com/kubernetes/kubernetes/pull/63176) - Issue about race conditions in the iSCSI login code paths. I think the race condition exists in the existing code, and my PR doesn’t make it any worse, so we could just treat it as a separate issue. If I need to address it, the 4 approaches I can imagine are:
+    * Don’t logout of iscsi sessions (let them leak)
+    * Big giant lock around attach/detach (may cause throughput issues)
+    * Fine grained locking (a lot of new code)
+    * Retry loops (will cause error spam and unbounded attach times)
+
+## May 10, 2018
+
+Recording: [https://youtu.be/TxI9RYE2DwQ](https://youtu.be/TxI9RYE2DwQ)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Brad Childs] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* PRs to discuss or that need attention
+
+* [Steve Wong] Next F2F
+  * Where: Downtown Mountain View
+  * When: May 15 &amp; 16
+  * RSVP deadline: April 27 - a few slots left as of now
+  * Register by adding name posted to Storage SIG mailing list - you must be a member to edit and attend meeting
+  * Agenda doc: [link](https://docs.google.com/document/d/1AoemMxRcRDhc3gpChGk-UwCiVsk7Q7E_yKeIKP-7jL4/edit?usp=sharing_eip&ts=5ad14c06)
+
+## April 26, 2018
+
+Recording: [https://youtu.be/Z89r_qlR-kI](https://youtu.be/Z89r_qlR-kI)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * [***Feature freeze***](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.11/release-1.11.md) ***was April 24*** -- this means that for any new features that are in v1.11 a issue must be open in the [kubernetes/features](https://github.com/kubernetes/features/issues) repo with the 1.11 milestone.
+* Kubecon Next week!
+  * Presentations:
+    * [Efficient IoT with Protocol Buffers and gRPC](http://sched.co/DquJ) (vladimirvivien))
+    * [Extending Kubernetes with gRPC](http://sched.co/Dqwb) (lightning talk, vladimirvivien)
+    * [CNCF Storage working group intro](https://kccnceu18.sched.com/event/DrnW/storage-wg-intro-ben-hindman-clint-kitson-code-quinton-hoole-huawei-any-skill-level) - multiple members attending
+    * [K8s SIG Storage](https://kccnceu18.sched.com/event/Drnk/sig-storage-k8s-intro-saad-ali-google-any-skill-level)
+    * [CNCF Storage Working Group Deep Dive](https://kccnceu18.sched.com/event/DroG/storage-wg-deep-dive-ben-hindman-clint-kitson-code-quinton-hoole-huawei-intermediate-skill-level)
+    * [K8s Storage Lingo 101](https://kccnceu18.sched.com/event/Dqvi/kubernetes-storage-lingo-101-saad-ali-google-beginner-skill-level) (saad-ali)
+    * [K8s Local Storage](https://kccnceu18.sched.com/event/Dqvc/using-kubernetes-local-storage-for-scale-out-storage-services-in-production-michelle-au-google-ian-chakeres-salesforce-intermediate-skill-level) (msau42, ianchakeres)
+    * [Container Storage Past, Present, Future](https://kccnceu18.sched.com/event/Dqvo/container-storage-interface-present-and-future-jie-yu-mesosphere-inc-intermediate-skill-level)
+    * [Policy-Based Volume Snapshots Management in Kubernetes](http://sched.co/Dqw0) (jingxu97)
+  * Who’s attending:
+    * Saad Ali (saad-ali)
+    * Michelle Au (msau42)
+    * Jing Xu (jingxu97)
+    * Jesse Brown
+    * Steve Wong (cantbewong)
+    * Vladimir VIvien (vladimirvivien)
+    * Ardalan Kangarlou (kangarlou)
+    * Kiran Mova (kmova)
+    * Xing Yang (xing-yang)
+    * Shubheksha Jalan (shubheksha)
+    * Masaki Kimura (mkimuram)
+    * Humble Chirammal (humblec)
+    * Patrick Ohly (pohly)
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* PRs to discuss or that need attention
+  * [pospispa won’t attend the meeting] approve/not approve StorageObjectInUseFeature become GA: [https://github.com/kubernetes/kubernetes/pull/62870](https://github.com/kubernetes/kubernetes/pull/62870)
+  * [Ben Swartzlander] [https://github.com/kubernetes/kubernetes/pull/63176](https://github.com/kubernetes/kubernetes/pull/63176)
+  * [Please add any PRs that need attention, with your name, below]
+* [Kiran] node-disk-manager design ([https://github.com/kubernetes-incubator/external-storage/issues/736](https://github.com/kubernetes-incubator/external-storage/issues/736))
+  * Sure! Next steps: Sync up with Brad.
+* [Steve Wong] Next F2F
+  * Where: Downtown Mountain View
+  * When: May 15 &amp; 16
+  * RSVP deadline: April 27 - a few slots left as of now
+  * Register by adding name posted to Storage SIG mailing list - you must be a member to edit and attend meeting
+  * Agenda doc: [link](https://docs.google.com/document/d/1AoemMxRcRDhc3gpChGk-UwCiVsk7Q7E_yKeIKP-7jL4/edit?usp=sharing_eip&ts=5ad14c06)
+* [Erin Boyd] SIG On-boarding
+  * Onboarding doc: [link](https://docs.google.com/document/d/1LHCmHTziMvzfbNVIroSF9gEZvuiBQi38gEQ6INq6eII/edit)
+  * Rescheduled to 2nd week of May -- F2F conflict?
+* [Erin Boyd] Restart Testing at end of May
+  * Kiran: will help review E2E test
+
+## April 12, 2018
+
+Recording: [https://youtu.be/4gcpQax8PMQ](https://youtu.be/4gcpQax8PMQ)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Jordan Liggitt] “emptyDir and subpath” CVE Post-Mortem
+  * Link: [https://docs.google.com/document/d/1mJGxKyYiRigviS5pY5aEtCa-oZjHtTOTdVZE5_w4NmY](https://docs.google.com/document/d/1mJGxKyYiRigviS5pY5aEtCa-oZjHtTOTdVZE5_w4NmY)
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * [Mike Danese] ServiceAccountTokenVolumeProjection
+    * Proposal: [https://github.com/kubernetes/community/pull/1973](https://github.com/kubernetes/community/pull/1973)
+  * [Michelle Au] Generate subpath names based on downward API env
+    * [https://github.com/kubernetes/kubernetes/issues/48677](https://github.com/kubernetes/kubernetes/issues/48677)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+  * [Ian Chakeres] “Return error in mount_unsupported for unsupported platforms” [https://github.com/kubernetes/kubernetes/pull/61914](https://github.com/kubernetes/kubernetes/pull/61914)
+  * [jsafrane] Private mount propagation [https://github.com/kubernetes/kubernetes/pull/62462](https://github.com/kubernetes/kubernetes/pull/62462)
+* Bugs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Finalize Q2 (v1.11) planning and assignment
+* [Kiran] [bchilds] sig-storage projects / proce
+  * [https://docs.google.com/spreadsheets/d/1Gb88gpWMjCsROM31rXdylv0ibvCupLi-KYT_Tez5_2Y/edit?usp=sharing](https://docs.google.com/spreadsheets/d/1Gb88gpWMjCsROM31rXdylv0ibvCupLi-KYT_Tez5_2Y/edit?usp=sharing)
+  * [Kiran] Process for sig-storage subprojects ?
+    * [https://github.com/kubernetes/community/blob/master/incubator.md](https://github.com/kubernetes/community/blob/master/incubator.md)
+    * <https://github.com/kubernetes/kubernetes/issues/58569>
+    * [node-disk-manager](https://github.com/openebs/node-disk-manager) as a subproject?
+    * <https://docs.google.com/presentation/d/1XcCWQL_WfhGzNjIlnL1b0kpiCvqKaUtEh9XXU2gypn4/edit#slide=id.g34dba79a54_0_0>
+* Next F2F (6 minutes)
+  * May 15-16 in Palo Alto area (likely Mountain View), California hosted by VMware
+  * Steve Wong from VMware is finalizing arrangements to secure a venue for up to 50. Expecting to publish details and signup by end of day Friday, but plan is secure for purposes making travel arrangements now .
+  * Additional sponsors for meals are welcome.
+    * Volunteers orgs:
+* [Erin Boyd] SIG On-boarding
+  * Recurring Meeting Invite -- in sig-storage mailing list
+  * Reach out Scott or Erin if you are unable to find it.
+  * Please attend if you are interested in learning how to on-board.
+  * Cal invite has a doc with agenda
+* [Erin Boyd] Restart Testing at end of May
+
+## March 29, 2018
+
+Recording: [https://youtu.be/IRZyODElnlw](https://youtu.be/IRZyODElnlw)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Paris Pittman, 10 min] [ContribX Roadshow](https://docs.google.com/document/d/1hESUJdDy6Q6eysNe_Wyjtq8vI5A3AnrfWCcJFP4yU6I/edit?usp=sharing)
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Kick start Q2 (v1.11) planning
+  * Finalize at next meeting April 12
+* [bchilds] sig-storage project ownership: [https://docs.google.com/spreadsheets/d/1Gb88gpWMjCsROM31rXdylv0ibvCupLi-KYT_Tez5_2Y/edit?usp=sharing](https://docs.google.com/spreadsheets/d/1Gb88gpWMjCsROM31rXdylv0ibvCupLi-KYT_Tez5_2Y/edit?usp=sharing)
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* Bugs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+  * Containerized kubelet issues (msau):
+    * [https://github.com/kubernetes/kubernetes/issues/61446](https://github.com/kubernetes/kubernetes/issues/61446)
+    * [https://github.com/kubernetes/kubernetes/issues/61801](https://github.com/kubernetes/kubernetes/issues/61801)
+    * [https://github.com/kubernetes/kubernetes/issues/61741](https://github.com/kubernetes/kubernetes/issues/61741)
+  * Hostpath reconstruction (msau): [https://github.com/kubernetes/kubernetes/issues/61446](https://github.com/kubernetes/kubernetes/issues/61446)
+* Next F2F
+  * March 29 deadline for responding to survey: [https://www.surveymonkey.com/r/PXZDCP8](https://www.surveymonkey.com/r/PXZDCP8)
+  * Plan for F2F in late May to allow host enough time to prepare.
+  * Potential Topics:
+    * Snapshot
+      * Open questions about current external implementation
+    * Ownerships of projects as we break out of external-storage
+    * In-tree volume plugins to CSI
+    * Home for CSI driver
+  * Anyone interested in hosting F2F (last time we had 50 attendees) [***Add info below***]:
+    * NetApp Research Triangle Park (Raleigh, NC), flexible dates in April or May
+    * NetApp Sunnyvale, May 11th (the day after Red Hat Summit)
+    * San Francisco or Mt. View Google, anytime between May 21-June 1
+    * Palo Alto CA : May 8&amp;9, May 15&amp;16, May 22&amp;23 (VMware or Pivotal Labs)
+  * Backup option: Kubecon EU
+
+## March 15, 2018
+
+Recording: [https://youtu.be/nbejWeaE8fM](https://youtu.be/nbejWeaE8fM)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Kick start Q2 (v1.11) planning
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* Bugs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+  * [v1.10 release blocking bugs](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+is%3Aissue+label%3Asig%2Fstorage+milestone%3Av1.10)
+* [Paris Pittman, 10 min] ContribX Roadshow
+  * Bumped to next meeting.
+* Next F2F
+  * March 30 deadline for responding to survey?
+  * Plan for F2F in late May?
+  * Potential Topics:
+    * Snapshot
+      * Open questions about current external implementation
+    * Ownerships of projects as we break out of external-storage
+    * In-tree volume plugins to CSI
+    * Home for CSI driver
+  * Anyone interested in hosting F2F (last time we had 50 attendees) [***Add info below***]:
+    * NetApp Research Triangle Park (Raleigh, NC), flexible dates in April or May
+    * NetApp Sunnyvale, May 11th (the day after Red Hat Summit)
+  * Backup option: Kubecon EU
+* Updates on Split [external-storage](https://github.com/kubernetes-incubator/external-storage) ?
+  * Reached out to TOC -- feedback pushing back on sig specific orgs, asking for clarification.
+
+## March 1, 2018
+
+Recording: [https://youtu.be/Ko-JSvLR-oA](https://youtu.be/Ko-JSvLR-oA)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* [Jan] Split [external-storage](https://github.com/kubernetes-incubator/external-storage) repo into standalone repositories.
+  * Sig-storage org on github?
+  * Repo for the provisioning library
+  * Each provisioner in its own repo?
+  * Separate releases?
+  * CI?
+  * TODO (Saad/Brad): follow up offline on where to create org and what it should be called. Target to have it ready by next meeting.
+* [Saad] Next F2F?
+  * April?
+  * Potential Topics:
+    * Snapshot
+      * Open questions about current external implementation
+    * Ownerships of projects as we break out of external-storage
+    * In-tree volume plugins to CSI
+    * Home for CSI driver
+  * Anyone interested in hosting F2F (last time we had 50 attendees) [Add info below]:
+    * NetApp Research Triangle Park (Raleigh, NC), flexible dates in April or May
+    * NetApp Sunnyvale, May 11th (the day after Red Hat Summit)
+  * Backup option: Kubecon EU
+
+## February 15, 2018
+
+Recording: [https://youtu.be/7oYdq4l16-Y](https://youtu.be/7oYdq4l16-Y)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Code freeze Feb 26.
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * [https://github.com/kubernetes/community/pull/1700](https://github.com/kubernetes/community/pull/1700)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* [Mohamed] IBM offering space for k8s Storage SIG meetup at IBM Open Developer Community Conference (Index)
+  * First day is community day.
+  * In Moscone West, San Francisco (February 20)
+  * [Meetup planning](https://docs.google.com/document/d/10eEQmOW_5ffrPGhUYUMe9ixmg5JtP_IU9kC5ZTmx2kY/edit)
+* [Erin Boyd] Set Up a one-off “on-boarding to sig-storage” meeting
+  * Created an outline of “classes” (presentations) -- plan to share with the SIG
+  * 5-10 min each -- short and to the point
+  * Add it to SIG storage calendar so folks can attend
+  * Pre-recording vs live recording? Up to presenter.
+  * March time frame
+* [Saad Ali] Created an official Kubernetes Storage SIG channel: [https://www.youtube.com/channel/UCiOeuJ6L4rYNC1jwZFRmC5Q](https://www.youtube.com/channel/UCiOeuJ6L4rYNC1jwZFRmC5Q)
+
+## February 1, 2018
+
+Recording: [https://youtu.be/hYlS7EzUKwk](https://youtu.be/hYlS7EzUKwk)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * Tomas Smetana (@tsmetana) RFC: Proposal to optionally disable recursive chown for pods with fsGroup in PodSecurityContext: [https://github.com/kubernetes/community/pull/1717](https://github.com/kubernetes/community/pull/1717)
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention, with your name, below]
+* [Erin Boyd] Set Up a one-off “on-boarding to sig-storage” meeting
+  * Status: Luis and Erin will sync up.
+  * Suggestion to clean up the topics and make it more sig-storage centric
+  * Lots of volunteers.
+  * Plan to do async presentations.
+  * More info in SIG mailing list from Erin
+
+## January 18, 2018
+
+Recording: [https://youtu.be/0NSMCavPiqQ](https://youtu.be/0NSMCavPiqQ)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Saad Ali] Status Update
+  * 1.10 feature freeze ([Monday, Jan 22](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.10/release-1.10.md))
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* Mount Propagation needs more intensive testing
+  * Test it and send your feedback to [https://groups.google.com/forum/#!topic/kubernetes-sig-storage/7voscnnt3Zs](https://groups.google.com/forum/#!topic/kubernetes-sig-storage/7voscnnt3Zs)
+  * Some larger scale tests are highly appreciated!
+* PRs to discuss or that need attention
+  * [Please add any PRs that need attention below]
+  * [Jing Xu] Scalability Issue[https://github.com/kubernetes/kubernetes/issues/52128](https://github.com/kubernetes/kubernetes/issues/52128)Desired state populator takes long time to recover state for large number of volume
+  * New design of volume reconstruction
+[https://github.com/kubernetes/community/pull/1601](https://github.com/kubernetes/community/pull/1601) /
+* [Shyam Antony &amp; Mayank Kumar (@krmayankk)] User Mode librbd implementation
+* Design Review
+  * [Please add any design reviews below]
+  * Dynamic provisioning of block volumes [https://github.com/kubernetes/community/pull/1595](https://github.com/kubernetes/community/pull/1595)
+    * TODO (saad): take a look
+  * [Jing Xu] Move Snapshot API in-tree support[https://docs.google.com/document/d/1SyViEo1okCJRwrM2LtE-DM6K6G-O46tYCBNCjNaS0Lg/](https://docs.google.com/document/d/1SyViEo1okCJRwrM2LtE-DM6K6G-O46tYCBNCjNaS0Lg/)
+  * postpone pv deletion if it is bound to a pvc  [https://github.com/kubernetes/community/pull/1608](https://github.com/kubernetes/community/pull/1608)
+* [Brad Childs] Storage-Sig Community Statu
+  * Broader community wants status more regularly as part of community meeting
+  * What can we do here?
+    * Focus message in reports to community meeting
+    * Volunteer(s) to set up presentations for scheduled time slots in community meeting.
+* [Erin Boyd, 10 minutes] Set Up a one-off “on-boarding to sig-storage” meeting
+  * Leads: Erin Boyd &amp; Luis Pabon
+  * Next steps?
+    * Pick topic
+      * Email with topics sent out ([Link](https://docs.google.com/document/d/1LHCmHTziMvzfbNVIroSF9gEZvuiBQi38gEQ6INq6eII/edit?usp=sharing))
+    * Volunteers needed!!
+      * Please reply to Erin’s message
+    * Pre-record or live?
+      * Live Meeting - Q/A is helpful
+
+## January 4, 2018
+
+Recording: [https://youtu.be/KEXjN33csT0](https://youtu.be/KEXjN33csT0)
+
+Agenda/Notes (Please include your name and estimated time):
+
+* [Luis Pabon, 10 minutes] Kubernetes 1.9 CSI alpha demo [[Slides](https://docs.google.com/presentation/d/1ErpRlih8CFx96twch3YuH6htsW4uj0adbxDJAow2L_g/edit?usp=sharing)]
+* [Saad Ali, 20 minutes] 1.10 Q1 Planning and Assignment
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing) -- Please add items to 1.10 sheet and we will review and assign during meeting
+  * What does it mean to go beta
+    * Add API to beta group
+    * Remove alpha flag gate
+    * Add E2E test
+    * Add user facing documentation
+* CSI Kubernetes Volunteers (Add name)
+  * Felipe Musse ([felipe.musse@sap.com](mailto:felipe.musse@sap.com))
+  * Pietro Menna ([pietro.menna@sap.com](mailto:pietro.menna@sap.com))
+  * David Zhu
+  * Vladimir VIvien ([vladimir.vivien@dell.com](mailto:vladimir.vivien@dell.com))
+  * Serguei Bezverkhi ([sbezverk@cisco.com](mailto:sbezverk@cisco.com))
+  * Yuquan Ren ([nickren19@gmail.com](mailto:nickren19@gmail.com))
+* [Saad Ali, 10 minutes] Set Up a one-off “on-boarding to sig-storage” meeting
+  * Next steps?
+    * Pick format
+      * Zoom recorded meeting
+    * Pick a date
+      * Late January?
+    * Pick a lead
+      * Erin Boyd
+      * Luis Pabon
+* [Michael Rubin]

--- a/sig-storage/archive/meeting-notes-2018.md
+++ b/sig-storage/archive/meeting-notes-2018.md
@@ -24,7 +24,7 @@ Agenda/Note
 
 * [Saad Ali] Q4 2018 v1.13 Update
   * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
-  * Q4 end of quarter statuse
+  * Q4 end of quarter status
 * PRs to discuss or that need attention:
   * [Please add any PRs that need attention, with your name, below]
   * [pontiyaraja] [#71416](https://github.com/kubernetes/kubernetes/issues/71416) [WIP] inconsistent message in different gke environment.
@@ -179,7 +179,7 @@ Agenda/Notes (Please include your name and estimated time):
     * Proposal: Node shutdown taint
             [https://github.com/kubernetes/kubernetes/issues/58635](https://github.com/kubernetes/kubernetes/issues/58635)[https://github.com/kubernetes/kubernetes/pull/59323](https://github.com/kubernetes/kubernetes/pull/59323)[https://github.com/kubernetes/kubernetes/pull/67254](https://github.com/kubernetes/kubernetes/pull/67254)
 Meeting at 11am Pacific to discuss detach issues related to node being down: meet.google.com/qoi-pknh-bfh
-* Discuss csi-connector library (Move to next / seperate call)
+* Discuss csi-connector library (Move to next / separate call)
 
 ## August 16, 2018
 

--- a/sig-storage/archive/meeting-notes-2019.md
+++ b/sig-storage/archive/meeting-notes-2019.md
@@ -1,0 +1,669 @@
+# Kubernetes Storage SIG Meeting Notes (2019)
+
+The Kubernetes Storage Special-Interest-Group (SIG) is a working group within the Kubernetes contributor community interested in storage and volume plugins. This document contains historical meeting notes from past meeting.
+
+## December 19, 2019
+
+Recording: [https://youtu.be/_LaA-LeRSb4](https://youtu.be/_LaA-LeRSb4)
+
+Agenda/Note
+
+* Q1 2020 v1.18 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Start planning for next release.
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * KEP 1383 “bucket procvisioning” [https://github.com/kubernetes/enhancements/pull/1383](https://github.com/kubernetes/enhancements/pull/1383)
+* Misc
+  * None
+
+## December 4, 2019
+
+Recording: [https://youtu.be/ovljX8ICDVQ](https://youtu.be/ovljX8ICDVQ)
+
+Agenda/Note
+
+* Q4 2019 v1.17 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * End of quarter statu
+  * **Monday, December 9 - Kubernetes 1.17.0 Released**
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * Consistency groups google doc: [https://docs.google.com/document/d/1nmq0rjt7A45w3kRHloDsMbzwGMELaJNNw2_w1B9qirk/edit](https://docs.google.com/document/d/1nmq0rjt7A45w3kRHloDsMbzwGMELaJNNw2_w1B9qirk/edit)
+    * Provide feedback offline. Next step: create a KEP.
+* Misc
+  * [Xing/Dave/Xiangqian] Proposal for Kubernetes Data Protection Working Group
+    * [https://docs.google.com/presentation/d/1qwsu82cDNJ06NvXJ5yDl9fPn8Ub9Sf7n9QIvabTOYh0/edit?usp=sharing](https://docs.google.com/presentation/d/1qwsu82cDNJ06NvXJ5yDl9fPn8Ub9Sf7n9QIvabTOYh0/edit?usp=sharing)
+      * What will happen to Snapshot Workgroup? Do we need 2 groups?
+        * Options:
+          * 1 - Launch a new group, and deprecate the old group and take over the time slot.
+          * 2 - Keep snapshot group, make it a sub-sub-group of data protection.
+            * Concern: same set of people interested -- do we really want to double the number of meetings?
+            * Everyone in snapshot group will want to be part of the new larger group.
+            * Snapshot group is functional, but the new group is not. Do we want to break something that is working?
+            * Snapshot group meetings -- not much design, it’s mostly implementation.
+            * Workgroups are time bound -- not indefinite. We can put snapshot group on hold and consider dissolving it.
+          * 3 - “transform” snapshot workgroup in to data protection group
+            * Expand the scope and ownership (co-own with SIG Apps).
+            * Concern: charter of new group is very large.
+            * Lets have one large group for all of data protection discussions for both SIG Storage and SIG Apps. And we can hold smaller one off or recurring for implementation discussions. Use the existing snapshot workgroup meeting time.
+              * Objection: Volume snapshot has specific topics that need discussions -- it still needs space.
+                * Data Protection group more interested in higher level things like “what are we backing up”, “what are the workflows”… not lower level things like “volume snapshot code”, “not implementation”...
+                * Implementation is not really discussed at the meeting, they sync offline already, do we need a work group.
+              * Objection: Let’s start a new group, and deprecate the old one. New group will make it easier to attract new people.
+            * 4- “freeze volume snapshot group” form new group, and then decide what to do afterwards.
+              * Cancel meetings. And decide in the future what to do.
+          * Conclusion: 4- put existing snapshot group on hold, create new group. Decide what to do with old group later
+            * Next steps:
+              * [Xing/Dave] Put together charter for new group, and do all the paper work.
+              * [Xing] Set up meeting for new group at the same time as existing snapshot meeting. Wait for approval.
+              * [Jing] Cancel meetings for existing snapshot group meeting.
+
+## November 7, 2019
+
+Recording: [https://youtu.be/8ENMzAUWs6s](https://youtu.be/8ENMzAUWs6s)
+
+Agenda/Note
+
+* [Announcement](https://groups.google.com/d/msg/kubernetes-sig-storage/NUIpoTJYqvY/N_bxmz0tAgAJ)
+* Q4 2019 v1.17 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* Video Memorial for Brad Child
+  * Memories and thoughts of what Brad meant to you.
+  * Videos to be shared with Brad’s family and may be part of a memorial montage at KubeCon
+  * Alternate video options: see [Steve’s Message](https://groups.google.com/d/msg/kubernetes-sig-storage/YyLqYtyFZtE/f7JprlPYDwAJ).
+  * [Memorial page](https://github.com/cncf/memorials/pull/1/files)
+* Misc
+  * Face to Face Meeting
+    * Co-Located event at KubeCon NA 2019 (San Diego)
+    * Date: Monday, November 18
+    * Time: 9:00 AM - 5:00 PM
+    * Venue: Marriott Marquis San Diego Marina
+    * Registration: see sig-storage mailing list
+    * [Agenda Items](https://docs.google.com/document/d/1qEIah61M_PrNKYBOJ3uZGFLRjLASz1je9XJkGY25O6g/edit#heading=h.qykpklbiq2qg)
+
+## October 24, 2019
+
+Recording: [https://youtu.be/tcM92rvGERY](https://youtu.be/tcM92rvGERY)
+
+Agenda/Note
+
+* Q4 2019 v1.17 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Important Date
+    * ~~Tuesday, October 15, EOD PST - Enhancements Freeze~~
+    * **Thursday, November 14, EOD PST - Code Freeze**
+    * Tuesday, November 19 - Docs must be completed and reviewed
+    * Monday, December 9 - Kubernetes 1.17.0 Released
+    * Shorter cycle due to Kubecon/Holidays in December
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * [Saad Ali] Face to Face Meeting
+    * Co-Located event at KubeCon NA 2019 (San Diego)
+    * Date: Monday, November 18
+    * Time: 9:00 AM - 5:00 PM
+    * Venue: Marriott Marquis San Diego Marina
+    * Registration: see sig-storage mailing list
+    * [Agenda Items](https://docs.google.com/document/d/1qEIah61M_PrNKYBOJ3uZGFLRjLASz1je9XJkGY25O6g/edit#heading=h.qykpklbiq2qg)
+  * Next meeting - Nov 7
+    * Saad Ali will be OOO.
+    * Brad Childs will host.
+  * Meeting in 4 weeks - Nov 21 - is at same time as Kubecon
+    * Will be canceled.
+
+## October 10, 2019
+
+Recording: [https://youtu.be/NYCUMQKW6oY](https://youtu.be/NYCUMQKW6oY)
+
+Agenda/Note
+
+* Q4 2019 v1.17 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+    * Q4 planning
+  * Important Date
+    * **Tuesday, October 15, EOD PST - Enhancements Freeze**
+    * Thursday, November 14, EOD PST - Code Freeze
+    * Tuesday, November 19 - Docs must be completed and reviewed
+    * Monday, December 9 - Kubernetes 1.17.0 Released
+    * Shorter cycle due to Kubecon/Holidays in December
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * [Saad Ali] Face to Face Meeting
+    * Co-Located event at KubeCon NA 2019 (San Diego)
+    * Date: Monday, November 18
+    * Time: 9:00 AM - 5:00 PM
+    * Venue: Marriott Marquis San Diego Marina
+    * Registration: see sig-storage mailing list
+    * [Agenda Items](https://docs.google.com/document/d/1qEIah61M_PrNKYBOJ3uZGFLRjLASz1je9XJkGY25O6g/edit#heading=h.qykpklbiq2qg)
+
+## September 26, 2019
+
+Recording: [https://youtu.be/mbxvYC6EBwg](https://youtu.be/mbxvYC6EBwg)
+
+Agenda/Note
+
+* Q4 2019 v1.17 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+    * Q4 planning
+  * Important Date
+    * **Tuesday, October 15, EOD PST - Enhancements Freeze**
+    * Thursday, November 14, EOD PST - Code Freeze
+    * Tuesday, November 19 - Docs must be completed and reviewed
+    * Monday, December 9 - Kubernetes 1.17.0 Released
+    * Shorter cycle due to Kubecon/Holidays in December
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+  * Support for Windows iSCSI FlexVolume driver in TargetD ext provisioner [https://github.com/kubernetes-incubator/external-storage/pull/1226](https://github.com/kubernetes-incubator/external-storage/pull/1226)
+    * Jing Xu can help take a look as well as Jan.
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * [Saad Ali] Face to Face Meeting
+    * Co-Located event at KubeCon NA 2019 (San Diego)
+    * Date: Monday, November 18
+    * Time: 9:00 AM - 5:00 PM
+    * Venue: Marriott Marquis San Diego Marina
+    * Registration: will require Kubecon registration, more details to be announced soon.
+
+## September 12, 2019
+
+Recording: [https://youtu.be/jL8A-nbiJYg](https://youtu.be/jL8A-nbiJYg)
+
+Agenda/Note
+
+* Q3 2019 v1.16 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+    * End of quarter wrap up.
+    * Q4 planning next time.
+  * Important Date
+    * Thursday, August 29, EOD PST - Code Freeze
+    * Monday, September 9 - Docs must be completed and reviewed
+    * **Monday, September 16 - Kubernetes 1.16.0 Released**
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * [Joshua Van Leeuwen] cert-manager CSI demo @JoshVanL
+  * [Deep Debroy] Discuss if calls to dismount during graceful detach is necessary for all node OSes: [https://github.com/container-storage-interface/spec/issues/388](https://github.com/container-storage-interface/spec/issues/388) (specifically: [https://github.com/container-storage-interface/spec/issues/388#issuecomment-529155568](https://github.com/container-storage-interface/spec/issues/388#issuecomment-529155568))
+    * Note
+      * Should driver unmount at unstage?
+      * Linux unmount flushes data.
+        * This is assumed by CSI spec.
+      * Windows unmount doesn’t flush data.
+      * Yes, driver should flush data on unpublish calls. Let’s update CSI spec to clarify thi
+      * The entity responsible for the filesystem should be responsible for ensuring data in caches is flushed before unpublish.
+      * Counterpoint: if apps depend on this behavior they may not handle node crashes.
+      * Yes, but CSI should still do “the right thing”.
+    * Conclusion
+      * Yes, driver should flush data on unpublish calls. Let’s update CSI spec to clarify this.
+  * [Saad Ali]
+    * Face to face meeting?
+      * Kubecon San Diego Nov 19-21?
+      * Earlier?
+      * [Ben S] Netapp have space in RTP NC depending on how many people would come/time.
+      * Vote between:
+        * San Diego @ kubcon: 4
+        * East coast in October: 1
+        * Either: 2
+      * Will try to get some space via CNCF in San Diego
+      * What day? Monday before the conference?
+        * Monday has contributor summit -- may be able to get a room there.
+        * Monday: 5
+        * Friday: 0
+
+## August 29, 2019
+
+Recording: [https://youtu.be/54U8r30oQhQ](https://youtu.be/54U8r30oQhQ)
+
+Agenda/Note
+
+* Q3 2019 v1.16 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Important Date
+    * **Thursday, August 29, EOD PST - Code Freeze**
+    * Monday, September 9 - Docs must be completed and reviewed
+    * Monday, September 16 - Kubernetes 1.16.0 Released
+  * For features that did not land, please update enhancement issue to let release team know.
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * N/A
+
+## August 15, 2019
+
+Recording: [https://youtu.be/mmARoySG5iY](https://youtu.be/mmARoySG5iY), [https://youtu.be/pG5chGtHrvs](https://youtu.be/pG5chGtHrvs)
+Agenda/Note
+
+* Q3 2019 v1.16 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Important Date
+    * Tuesday, July 30, EOD PST - Enhancements Freeze
+    * Thursday, August 29, EOD PST - Code Freeze
+    * Monday, September 9 - Docs must be completed and reviewed
+    * Monday, September 16 - Kubernetes 1.16.0 Released
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  *
+
+## August 1, 2019
+
+Recording: [https://youtu.be/o_OU0Hh2Zac](https://youtu.be/o_OU0Hh2Zac)
+
+Agenda/Note
+
+* Q3 2019 v1.16 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Important Date
+    * Tuesday, July 30, EOD PST - Enhancements Freeze
+    * Thursday, August 29, EOD PST - Code Freeze
+    * Monday, September 9 - Docs must be completed and reviewed
+    * Monday, September 16 - Kubernetes 1.16.0 Released
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  *
+
+## July 18, 2019
+
+Recording: [https://youtu.be/cbxR2L3Jx08](https://youtu.be/cbxR2L3Jx08)
+
+Agenda/Note
+
+* Q3 2019 v1.16 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Important Date
+    * Tuesday, July 30, EOD PST - Enhancements Freeze
+    * Thursday, August 29, EOD PST - Code Freeze
+    * Monday, September 9 - Docs must be completed and reviewed
+    * Monday, September 16 - Kubernetes 1.16.0 Released
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * [Michelle] Deprecate kubelet attach/detach: [https://github.com/kubernetes/kubernetes/issues/55517](https://github.com/kubernetes/kubernetes/issues/55517)
+    * Anyone using enable-controller-attach-detach parameter on kubelet? Please reach out.
+    * Haley: Flex volume using it, but trying to deprecate.
+    * Another challenge: some use this for bootstrapping master control plane.
+      * Alternatives: EmptyDir or Hostpath
+      * Need to talk to people who are depending on this.
+      * Please reach out if you care about this.
+    * Will broadcast to mailing list.
+  * [Cheng] Moving controller manager to distroless - actions to take on Flexvolume master-side API
+    * Survey sent to SIG to ask if anyone is using flexVolume master APIs, no response.
+    * Next step, will reach out to kubernetes-dev, if no response will not support in distroless.
+    * Context: shifting binaries to distroless which is missing linux binaries -- so for drivers that expect those to exist on master may break.
+  * [Jan] Deprecate CSI cluster-driver-registrar[https://github.com/kubernetes-csi/cluster-driver-registrar/issues/48](https://github.com/kubernetes-csi/cluster-driver-registrar/issues/48)
+    * 1.14 and 1.15 didn’t ship
+    * Deprecation announcement made 2 weeks ago. It is no longer supported don’t use it.
+    * Alternative: create CSIDriver object in installation manifest or installation of driver. Kubernetes-csi docs being updated to reflect this.
+  * [Youssef] PureStorage thread on migration -- what if there are PVs already created or mounted.
+    * Existing PVC API remains same, when migration enabled, in-tree shims silently redirect to CSI Driver
+    * What about flex volumes? Not currently supported by migration.
+      * Have a CSI driver, how do we update a cluster using Flex to CSI, given PVCs could have been created with Flex.
+      * Two approache
+        * 1) Create new PVs with CSI parameters and swap
+          * Kubelet has a cache -- even if PVs updated, sometimes you get call to Flex or CSI. Depending on kubelet cache.
+          * Stop using volumes and unmount first. Problem: some environments can’t control that
+            * Migrate in place, maintain dual drivers, and then force a restart on pods.
+            * Once pods are restarted, kubelet cache will be updated.
+          * Existing github issue -- feel free to comment on that. If this works, can you share with the community how to do this.
+        * 2) create an “adapter” to translate on the fly without persisting translations.
+      * External-provisioner is separate -- so that would
+
+## June 28, 2019
+
+Recording: [https://youtu.be/sS3tmlJn_VE](https://youtu.be/sS3tmlJn_VE)
+
+Agenda/Note
+
+* Q3 2019 v1.16 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+  * [https://github.com/kubernetes/enhancements/pull/1112](https://github.com/kubernetes/enhancements/pull/1112) jgriffith
+    * Start reviewing early to unblock API review.
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * [Hakan Memisoglu] CSI Spec issue - Calls for CreateVolume have secret, problem read operations like “List” have no operations.
+    * Add to CSI community meeting agenda.
+  * [John Griffithh] Data Populator Design -- how to proceed?
+    * Will set up a meeting
+  * Another Face to Face Meeting?
+    * Anyone interested in hosting?
+    * Topic
+      * Who should deploy/manage side car container
+      * How to push down credentials in to CSI without having it exposed ot namespace of container
+        * CSI Spec issue 370 -
+      * Volume Group API (consistency groups, storage topology, etc.)
+
+## June 20, 2019
+
+Recording: [https://youtu.be/w4M5u_3j8As](https://youtu.be/w4M5u_3j8As)
+
+Agenda/Note
+
+* Q3 2019 v1.16 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+
+## June 6, 2019
+
+Recording: [https://youtu.be/1baPPiahZbY](https://youtu.be/1baPPiahZbY)
+
+Agenda/Note
+
+* Q2 2019 v1.15 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Important dates:
+    * Thursday, May 30th, EOD PST - Code Freeze
+    * Tuesday, June 04 - Docs must be completed and reviewed
+    * Monday, June 17th - Kubernetes 1.15.0 Released
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+  * [jinxu@] [https://github.com/kubernetes/kubernetes/issues/72048](https://github.com/kubernetes/kubernetes/issues/72048)
+    * Proposed fix: force unmount
+      * may be dangerous if process using mount
+      * Does force option actually fix NFS unmount issue? May not actually. Doc says it may not work.
+      * Hard mount means block until server comes back.
+    * Other options:
+      * Restart NFS server
+      * User manually unmount
+    * Can we understand why the NFS server deleted? Maybe network partition.
+    * Can we unblock pod deletion, but save garbage collection for later. If we do, new pod may fail too. Depends on the failure cause.
+    * Users can force kill pod, and kubelet orphaned pod tries to clean up? If NFS server can’t be reached. We don’t start more then 1 unmount operation.
+    * Conclusion: no need for force unmount. Just tell user to force delete pod. Kubelet should clean up mount when nfsserver comes back or reboot.
+    * Even if we clean up user space resources, it won’t clean up hung kernel space resources.
+    * If user really wants force unmount: create a CSI driver that does this (preferably optionally). Dangerous to do it for everything.
+* Design Review
+  * [Please add any design reviews, with your name, below]
+  * [nickren/xing-yang] PV health monitor KEP: [https://github.com/kubernetes/enhancements/pull/1077](https://github.com/kubernetes/enhancements/pull/1077)
+    * Please review KEP if you’re interested in volume health monitoring.
+* Misc
+  * [msau] Help wanted! StatefulSet and PVC Protection integration issue: [https://github.com/kubernetes/kubernetes/issues/74374](https://github.com/kubernetes/kubernetes/issues/74374)
+  * [verult] Flex drivers on master doesn’t work with distrole
+        [https://github.com/kubernetes/kubernetes/issues/78737](https://github.com/kubernetes/kubernetes/issues/78737)
+    * We can suggest that users move to CSI but can’t require it.
+    * Deprecation policy is 1+ year.
+    * Maybe take a survey in SIG.
+
+## May 23, 2019
+
+Agenda/Note
+
+* Cancelled. Lots of people out at Kubecon EU in Barcelona.
+
+## May 9, 2019
+
+Recording: [https://youtu.be/_AqgfdfXBBQ](https://youtu.be/_AqgfdfXBBQ)
+
+Agenda/Note
+
+* Q2 2019 v1.15 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * Kubecon EU in Barcelona
+  * Lots of Storage sessions. See [slide 4 here](https://docs.google.com/presentation/d/1IApIw92SNEt-iE8YZTnP0cxecrj0LQ-3kbDh70E661c/edit#slide=id.g5914713db9_0_3).
+  * Monday, May 20- Kubernetes Contributor Summit
+    * Register [here](https://events.linuxfoundation.org/events/contributor-summit-europe-2019/register/).
+  * Cancel meeting Kubecon week?
+    * Will consider next meeting cancelled.
+
+## April 25, 2019
+
+Recording: [https://youtu.be/T8fVVnnzP3U](https://youtu.be/T8fVVnnzP3U)
+
+Agenda/Note
+
+* Q2 2019 v1.15 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Important dates: [https://github.com/kubernetes/sig-release/tree/master/releases/release-1.15#tldr](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.15#tldr)
+    * Tuesday, April 30th, EOD PST - Enhancements Freeze
+      * An open [enhancement issue](https://github.com/kubernetes/enhancements/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.15) in the 1.15 Milestone
+      * All Enhancements must have a [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage) that is in an implementable state by enhancement freeze. If the enhancement does not have a KEP in an implementable state by enhancement freeze it will be removed from the milestone and will require an exception.
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * Object bucket dyn provisioner (Erin, Jon, Jeff, Scott Creeley)
+    * [https://github.com/yard-turkey/lib-bucket-provisioner](https://github.com/yard-turkey/lib-bucket-provisioner) [https://github.com/yard-turkey/aws-s3-provisioner](https://github.com/yard-turkey/aws-s3-provisioner) [https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/doc/design/object-bucket-lib.md](https://github.com/yard-turkey/lib-bucket-provisioner/blob/master/doc/design/object-bucket-lib.md)
+* Misc
+  * [Ben Swartzlander] CSI plugin version compatibility - If the 1.1 sidecars only support 1.14+, how do we support 1.13 while also implementing new features?
+    * You can use 1.1 CSI sidecar with k8s 1.13 but 1.14 specific features (resize) won’t work
+    * Michelle Au is putting together a version support doc for CSI sidecars, stay tuned.
+
+## April 11, 2019
+
+Recording: [https://youtu.be/taR03H6jAEc](https://youtu.be/taR03H6jAEc)
+
+Agenda/Note
+
+* Q2 2019 v1.15 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Important dates: [https://github.com/kubernetes/sig-release/tree/master/releases/release-1.15#tldr](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.15#tldr)
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * Brief Notes from HEPiX Workshop in San Diego
+    * FYI: The HEPiX forum brings together worldwide Information Technology staff, including system administrators, system engineers, and managers from the High Energy Physics and Nuclear Physics laboratories and institute
+    * [Attendees from many including](https://www.eiseverywhere.com/ehome/201903-hepix/850665/) : SLAC, BNL, FermiLab, DESY, CERN, etc
+    * Many Talks were Storage Related ([See Agenda/Downloads here](https://indico.cern.ch/event/765497/timetable/#all.detailed))
+    * Container RT and Orchestration tools used by
+      * Container RT: Docker, Singularity
+      * Container Orchestration: Kubernetes, HTCondor, SLURM
+  * Singularity
+    * Used Extensively in HEP Community (HIgh Energy Physics / HPC)
+    * [Singularity Kubernetes CRI implementation](https://github.com/sylabs/singularity-cri) in Alpha
+    * QUESTION:
+      * Has anyone played with this?
+      * Any experience using CSI with Singularity CSI?
+      * I have a call with the Sylab folk (Singularity)  Tomorrow (Friday)
+        * If anyone has any items/questions that you’d like me to bring up with them, please let me know (gerry@auristor.com)
+
+## March 28, 2019
+
+Recording: [https://youtu.be/7jeelUiyCcg](https://youtu.be/7jeelUiyCcg)
+
+Agenda/Note
+
+* Q1 2019 v1.14 Update
+  * Q1 v1.14 Wrap up
+  * Q2 v1.15 Planning
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * New API Review proce
+    * [https://git.k8s.io/community/sig-architecture/api-review-process.md](https://git.k8s.io/community/sig-architecture/api-review-process.md) Questions, concerns, comments -&gt; visit sig architecture.
+  * Windows storage roadmap proposal for 1.15+
+    * [https://docs.google.com/document/d/1odyInziM5iu44zuXahxC1utcbKo-03gsQvP1OpDYGT4/edit#](https://docs.google.com/document/d/1odyInziM5iu44zuXahxC1utcbKo-03gsQvP1OpDYGT4/edit#)
+    * CSI node plugin support for Windows, in-tree SMB plugin + iSCSI enhancements for Windows, CSI plugins for SMB
+  * Annotate PVC, using provisioning secret templating
+    * Move to next meeting - ran out of time
+
+## March 14, 2019
+
+Recording: [https://youtu.be/L1Ju3SuUozk](https://youtu.be/L1Ju3SuUozk)
+
+Agenda/Note
+
+* Q1 2019 v1.14 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * (bchilds) KubeCon EU contributor summit sig-storage presentation proposal
+    * CFP Deadline April 1st... send to [bchilds@redhat.com](mailto:bchilds@redhat.com)
+      * Please title [sig-storage CFP contrib] + description
+    * Good Topic
+      * CSI Driver Development
+      * Operator development
+      * Feature design community experience
+      * Any community, design or PR logistical issue
+  * March 28 - Plan for 1.15
+* PRs to discuss or that need attention:
+  * [Simon Croome] StorageOS Volume Expansion <https://github.com/kubernetes/kubernetes/pull/74351>
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  * Would like to see online volume resize into Beta in 1.15 (Srini)
+  * Issue [https://github.com/kubernetes-csi/external-provisioner/issues/86 (Srini/Akash)](https://github.com/kubernetes-csi/external-provisioner/issues/86)
+    * Annotations in PVC is something that should be avoided
+    * Let’s talk about use cases and find workaround
+      * Akash: K8s zones and regions in PVCs -- users decide where to provision PVC.
+        * Use Volume Scheduling feature: “LateBinding” on StorageClass -- scheduler decision for pods is passed to volume creation; all of a pods constraints are used -- so add pod anti-affinity to pods, let the scheduler handle scheduling. At provision time scheduler will tell storage system what zone to provision in.
+      * MattSmith: storage tenancy that aligns with k8s namespaces. Want to align storage tenancy with kubernetes -- need namespace information.
+        * Problem: PV object is non-namespaced. Consider moving PVCs across namespaces? Multiple PVC in different namespaces?
+      * Akash: each user will use own secret to provision volume. Due to number of users, too many storage classe
+        * Solution: provisioning secret templating.
+          * See [https://kubernetes-csi.github.io/docs/secrets-and-credentials.html#createdelete-volume-secret](https://kubernetes-csi.github.io/docs/secrets-and-credentials.html#createdelete-volume-secret)
+          * Plans to make this more flexible.
+            * [https://github.com/kubernetes-csi/external-provisioner/issues/233](https://github.com/kubernetes-csi/external-provisioner/issues/233)
+      * Simon: multiple config params can result in explosion of storageClasses -- which are administered by ClusterAdmin not by App Admin.
+      * ShayBerman: setting filesystem type in PVC level.
+        * How many filesystems do you have? 2-4.
+      * JoseRivera: controller and CRD to abstract away StorageClass explosion.
+        * Ardalan: Important to remember portability at that level as well.
+        * MattSmith: can we get an example. Ben: looks at sample controller example.
+  * [https://github.com/kubernetes/kubernetes/issues/62778](https://github.com/kubernetes/kubernetes/issues/62778) (Srini)
+
+## February 28, 2019
+
+Recording: [https://youtu.be/69yBUQYm4fY](https://youtu.be/69yBUQYm4fY)
+
+Agenda/Note
+
+* Q1 2019 v1.14 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+  * [andrewsykim] promoting beta zone/region labels for volumes/nodes to GA [https://github.com/kubernetes/enhancements/pull/839](https://github.com/kubernetes/enhancements/pull/839)
+    * Motivation: clean-up. Labels have been there since 1.3
+    * For node:
+      * Still required for node even if we don’t do it for volumes.
+    * For storage:
+      * Would prefer to deprecate
+        * Need an answer for Migrating old PVs to new topology feature
+          * Etcd upgrade script only works if object version is bumped.
+          * May need to work with API Machinery to figure out a way to do this.
+      * Post-topology work to enable existing PVs to use new topology.
+* Design Review
+  * [Please add any design reviews, with your name, below]
+* Misc
+  *
+
+## February 14, 2019
+
+Recording: [https://youtu.be/0yn_fbnChdM](https://youtu.be/0yn_fbnChdM)
+
+Agenda/Note
+
+* Q1 2019 v1.14 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * Image Driver - [https://github.com/kubernetes-csi/drivers/pull/133](https://github.com/kubernetes-csi/drivers/pull/133)
+  * Undocumented EBS Volume ID format:  [https://github.com/kubernetes/kubernetes/issues/73730](https://github.com/kubernetes/kubernetes/issues/73730)
+    * awsElasticBlockStore.volumeID has two formats. That causes issues.
+    * Questions about how to proceed for migration.
+* Design Review
+  * User Namespaces  - [https://github.com/kubernetes/community/pull/2595](https://github.com/kubernetes/community/pull/2595)
+    * Proposing to shift the userId and GID of all files in volume to make it accessible to UID in container.
+    * If pod asks for remapped namespace, and it is not possible to move the UID or GID of the volumes (for example, Not all volumes support user namespace remapping, e.g. NFS), then containers can’t use those volumes.
+    * For pod containers asking for hostpath should block remapping
+    * Change in ownership of files -- container UID 3 mapped to 1003 outside container. Propose changing all file ownership to 1003
+      * Issue
+        * 1) containers may all be running as different UID
+    * Counter proposal: Can we just use FSGroups?
+      * If no FSGroup specified -- no change of ownership
+        * Volume can’t be written to.
+      * If FSGroup is specified -- adjust it to based on UID mapping
+    * What about multiwriter volumes?
+      * Now that we have CSI we don’t know which drivers support FSGroup or not -- CSI assumes any single writer consumed as mounted file supports FSGroup and multi-writer does not support FSGroup
+    * There is an option to use user namespace remapping? Yes in pod spec not per container.
+    * Kubelet after mounting -- does a recursive chown -- causes performance issues. Even with remapped UID this will still be an issue.
+      * SIG Storage proposal on how to skip it. [https://github.com/kubernetes/enhancements/pull/696](https://github.com/kubernetes/enhancements/pull/696) (Will only work for PVC, need something more generic that will work for all volumes). Will have to live with perf hit for now.
+    * Can remapping be different per node (i.e. pod rescheduled to different node)? It can be.
+      * Maybe document best practices?
+* [Vault - Linux Storage and Filesystems Conference](https://www.usenix.org/conference/vault19) Boston Feb 25-26
+  * Is anyone planning to attend?
+    * Attendees:
+      * Gerry Seidman (gerry@auristor.com)
+      * Vasily Tarasov (vtarasov@us.ibm.com). Me and my colleagues are giving an introductory tutorial on container storage.
+  * The AuriStor/AFS CSI driver should be announced/shown (PoC) to go along with Fedora-29 including the kAFS kernel driver
+  * **NOTE**: David Howells from Red Hat’s Storage/Security Group will be there which may be of general storage issues for things like his work on [FsCache, Kernel keyrings, etc](https://www.infradead.org/~dhowells/kafs/)
+  * Suggestion: label nodes. Delay provisioning of PV (i.e. block CreateVolume) until it is understood which node data must reside on. Label PV with node labels.
+
+## January 31, 2019
+
+Recording: [https://youtu.be/t0svw4xjwRc](https://youtu.be/t0svw4xjwRc)
+
+Agenda/Note
+
+* Q1 2019 v1.14 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+* Design Review
+* [Vault - Linux Storage and Filesystems Conference](https://www.usenix.org/conference/vault19) Boston Feb 25-26
+  * Is anyone planning to attend?
+    * Attendees:
+      *
+  * The AuriStor/AFS CSI driver should be announced/shown (PoC) to go along with Fedora-29 including the kAFS kernel driver
+  * Suggestion: label nodes. Delay provisioning of PV (i.e. block CreateVolume) until it is understood which node data must reside on. Label PV with node labels.
+
+## January 17, 2019
+
+Recording: [https://youtu.be/aDWVFqL3x5g](https://youtu.be/aDWVFqL3x5g)
+
+Agenda/Note
+
+* Q1 2018 v1.14 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+* PRs to discuss or that need attention:
+  * [Jing] [Fix hang when unmounting disconnected nfs volume](https://github.com/kubernetes/kubernetes/pull/72049)
+  * [Pod is stuck in Terminating status forever after Kubelet restart](https://github.com/kubernetes/kubernetes/issues/72604)
+  * [Hemant] [Add Cinder Max Volume Limit](https://github.com/kubernetes/kubernetes/pull/72980)
+  * [\[Jan\] Include namespace name in random distribution of PVs among availability zones](https://github.com/kubernetes/kubernetes/pull/72736)
+* Design Review
+  * Deprecate cloudprovider specific predicates.
+    * Deprecating the predicates is fine but we need to ensure that CSI migration takes into account
+
+## January 3, 2019
+
+Recording: None.
+
+Agenda/Note
+
+* [Bradley Childs] Q1 2018 v1.14 Update
+  * [Planning spreadsheet](https://docs.google.com/spreadsheets/d/1t4z5DYKjX2ZDlkTpCnp18icRAQqOE85C1T1r2gqJVck/edit?usp=sharing)
+  * Q1 planning
+* PRs to discuss or that need attention:
+  * [Please add any PRs that need attention, with your name, below]
+* Design Review
+  * [Please add any design reviews, with your name, below]


### PR DESCRIPTION
Following practices used by other SIGs, this archives the old meeting
notes from the Google Doc into the repo for historical reference.

After this is merged, the logs can be cleaned up from the working
document to keep its size small, and a link will be added to the bottom
of the doc to point to this archive for anyone that needs to look for
past discussions.
