### PR TITLE
Fix broken link in sig scalability README

### DIFF
--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -131,7 +131,7 @@ driving architectural changes to eliminate those (if such are required) in
 collaboration with other SIGs or directly delegating non cross-cutting
 improvements to individual SIGs.
 
-* [Scalability issues with Services](.blogs/k8s-services-scalability-issues.md)
+* [Scalability issues with Services](./blogs/k8s-services-scalability-issues.md)
 
 ## Kubernetes scalability test frameworks
 


### PR DESCRIPTION
Signed-off-by: Madhav Jivrajani <madhav.jiv@gmail.com>

FIxed broken link in `sig-scalability/README` by changing `.blogs/k8s-services-scalability-issues.md` --> `./blogs/k8s-services-scalability-issues.md`

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5422 
