### PR TITLE
Rename the kubernetes-dev slack channel to kubernetes-contributors

### DIFF
--- a/communication/README.md
+++ b/communication/README.md
@@ -79,7 +79,7 @@ We talk a lot, too.
 Our real-time platform with Kubernetes enthusiasts spread across 250+ channels.
 Owned and operated by sig-contributor-experience.
 
-[Join] | [Slack Guidelines] | [slack moderators] | [#kubernetes-dev]
+[Join] | [Slack Guidelines] | [slack moderators] | [#kubernetes-contributors]
 
 Pro-tip: If you want to add a new channel, simply file a request following
 [these instructions].
@@ -219,7 +219,7 @@ place!
 [the doc]: /events/office-hours.md
 [moderators]: ./moderators.md
 [slack moderators]: ./moderators.md#slack
-[#kubernetes-dev]: https://app.slack.com/client/T09NY5SBT/C09R23FHP
+[#kubernetes-contributors]: https://app.slack.com/client/T09NY5SBT/C09R23FHP
 [#sig-contribex]: https://app.slack.com/client/T09NY5SBT/C1TU9EB9S
 [#office-hours]: https://app.slack.com/client/T09NY5SBT/C6RFQ3T5H
 [office-hours]: /events/office-hours.md

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -202,7 +202,8 @@ channels:
   - name: kubernetes-batch-jobs
   - name: kubernetes-careers
   - name: kubernetes-client
-  - name: kubernetes-dev
+  - name: kubernetes-contributors
+    id: C09R23FHP
   # kubernetes-docs-* channels are defined in sig-docs/
   - name: kubernetes-novice
   - name: kubernetes-operators

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -81,8 +81,8 @@ applicability to the Kubernetes community.
 Some channels have specific rules or guidelines. If they do, they will be listed
 in the purpose or pinned docs of that channel.
 
-- `#kubernetes-dev` - Questions and discourse around upstream contributions and
-development to kubernetes,
+- `#kubernetes-contributors` - Questions and discourse around upstream
+  contributions and development to kubernetes.
 - `#kubernetes-careers` - Job openings for positions working with/on/around
   Kubernetes. Post the job once and pin it. Pins expire after 30 days. Postings
   must include:

--- a/events/elections/README.md
+++ b/events/elections/README.md
@@ -45,7 +45,7 @@ eligibility for voting, eligibility for candidacy, maximal representation, etc.
 2. Announce voting schedule to community
 
 - Should mostly be links to the voter guide and the Steering Committee Charter
-- On kubernetes-dev list, kubernetes-dev slack, and twitter
+- On kubernetes-dev list, kubernetes-contributors slack, and twitter
 
 3. Executing the Election in CIVS
 

--- a/events/events-team/best-practices.md
+++ b/events/events-team/best-practices.md
@@ -64,7 +64,7 @@ The Hallway Track is listed as the favorite track at every event. The social/cel
 ## Communication and Advertising  
 [kubernetes-dev@googlegroups.com][k-dev] is our artery for contributor communication and should be the main news network for contributor events.  
 Other channels:  
-Slack - [#contributor-summit], [#kubecon], [#kubernetes-dev]  
+Slack - [#contributor-summit], [#kubecon], [#kubernetes-contributors]
 [Twitter]  
 [Kubernetes blog]  
 [discuss.kubernetes.io]  
@@ -120,7 +120,7 @@ Links to docs that aren't a fit for markdown:
 [k-dev]: (https://groups.google.com/forum/#!forum/kubernetes-dev)
 [#contributor-summit]: (https://kubernetes.slack.com/messages/contributor-summit)
 [#kubecon]: (https://kubernetes.slack.com/messages/kubecon)
-[#kubernetes-dev]: (https://kubernetes.slack.com/messages/kubernetes-dev)
+[#kubernetes-contributors]: (https://kubernetes.slack.com/messages/kubernetes-contributors)
 [Twitter]: (https://twitter.com/kubernetesio)
 [Kubernetes blog]: (https://kubernetes.io/blog/)
 [discuss.kubernetes.io]: (discuss.kubernetes.io)

--- a/mentoring/programs/group-mentee-guide.md
+++ b/mentoring/programs/group-mentee-guide.md
@@ -58,7 +58,7 @@ TODO: add more here
 
 ### Other Help Resources
 - slack
-	- #kubernetes-dev
+	- #kubernetes-contributors
 	- your respective sig or other sigs that could help
 		- [SIG List]
 		- #sig-contribex


### PR DESCRIPTION
Updates the k-dev slack channel following [conversation on k-dev mailing list](https://groups.google.com/g/kubernetes-dev/c/ShYNQY90k5c/m/CJ1NfC9mDgAJ)

Other references to the channel have also been updated 👍 