### PR TITLE
Update sig-node node-api references

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -57,8 +57,7 @@ The following [subprojects][subproject-definition] are owned by sig-node:
   - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/OWNERS
 ### node-api
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/node-api/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/node-api/master/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/api/master/node/OWNERS
 ### node-feature-discovery
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery-operator/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1722,8 +1722,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/OWNERS
   - name: node-api
     owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/node-api/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/node-api/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/api/master/node/OWNERS
   - name: node-feature-discovery
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery-operator/master/OWNERS


### PR DESCRIPTION
The node-api content has since been moved to k8s.io/api. This updates
the links to the node-api OWNERS to point the current location.

See https://github.com/kubernetes/kubernetes/pull/87503 for more background.
