### PR TITLE
Fix klog.Infof change to klog.InfoS err

### DIFF
--- a/contributors/devel/sig-instrumentation/migration-to-structured-logging.md
+++ b/contributors/devel/sig-instrumentation/migration-to-structured-logging.md
@@ -173,7 +173,7 @@ klog.Infof("delete pod %s with propagation policy %s", ...)
 ```
 should be changed to
 ```go
-klog.Infof("Deleted pod", ...)
+klog.InfoS("Deleted pod", ...)
 ```
 
 Some logs are constructed solely from string formats. In those cases a message needs to be derived from the context of


### PR DESCRIPTION
Signed-off-by: chymy <chang.min1@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:

Fix klog.Infof change to klog.Infof err, should be klog.InfoS

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
