### PR TITLE
sig-instrumentation: add prometheus-adapter repo

### DIFF
--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -83,6 +83,9 @@ The following [subprojects][subproject-definition] are owned by sig-instrumentat
 ### mutating-trace-admission-controller
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS
+### prometheus-adapter
+- **Owners:**
+  - https://raw.githubusercontent.com/kubernetes-sigs/prometheus-adapter/master/OWNERS
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1527,6 +1527,9 @@ sigs:
   - name: mutating-trace-admission-controller
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS
+  - name: prometheus-adapter
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/prometheus-adapter/master/OWNERS
 - dir: sig-multicluster
   name: Multicluster
   mission_statement: >


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2182

/assign @ehashman @logicalhan @brancz @dashpole 
cc @s-urbaniak @lilic @DirectXMan12 

/hold
for lgtm from sig-instrumentation leads