### PR TITLE
add grafana operator maintainer groups

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -182,18 +182,18 @@ usergroups:
       - mrbobbytables
       - nikhita
       - paris
-      
+
   - name: grafana-operator-maintainers
-      long_name: Grafana Operator Maintainers
-      description: Support group for Grafana Operator.
-      channels:
-        - grafana-operator
-      members:
-        - david-martin
-        - grdryn
-        - hubertstefanski
-        - pb82
-        - r-lawton
-        - robshelly
-        - vladimirmukhin
-        - wurbanski
+    long_name: Grafana Operator Maintainers
+    description: Support group for Grafana Operator.
+    channels:
+      - grafana-operator
+    members:
+      - david-martin
+      - grdryn
+      - hubertstefanski
+      - pb82
+      - r-lawton
+      - robshelly
+      - vladimirmukhin
+      - wurbanski

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -194,5 +194,6 @@ usergroups:
         - hubertstefanski
         - pb82
         - r-lawton
+        - robshelly
         - vladimirmukhin
         - wurbanski

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -182,3 +182,17 @@ usergroups:
       - mrbobbytables
       - nikhita
       - paris
+      
+  - name: grafana-operator-maintainers
+      long_name: Grafana Operator Maintainers
+      description: Support group for Grafana Operator.
+      channels:
+        - grafana-operator
+      members:
+        - david-martin
+        - grdryn
+        - hubertstefanski
+        - pb82
+        - r-lawton
+        - vladimirmukhin
+        - wurbanski

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -26,6 +26,7 @@ users:
   cji: U5YSRC21J
   cpanato: U8DFY4TTK
   Dave Smith-Uchida: UDZDED8G2
+  david-martin: ULMJ41U73
   derekwaynecarr: U0A69N5GQ
   dharmit: U0APPPEKE
   dims: U0Y7A2MME
@@ -36,9 +37,11 @@ users:
   feiskyer: U0ASA4398
   gianarb: U0FSCELCR
   girishramnani: U9M4K75EU
+  grdryn: U017628HJL8
   gsquared94: U0131C0PJBU
   hasheddan: ULLQEF30C
   hoegaarden: U7VA4RZS9
+  hubertstefanski: U01941KQ2UT
   iancoldwater: U9VL5SZPX
   idealhack: U5NJ3DQM9
   idvoretskyi: U0CBHE6GM
@@ -85,10 +88,12 @@ users:
   pabloschuhmacher: U01AAGZ06KU
   palnabarun: UBH9NTMBM
   paris: U5SB22BBQ
+  pb82: U019M8295AQ
   pensu91: U44FHF81G
   phenixblue: UB4UVLEAK
   prietyc123: U01D4MBLM52
   puerco: ULGHLJ7TP
+  r-lawton: U019CNHR2E6
   rajula96reddy: U7K9EK1HC
   rashmigottipati: U013T1DD3PW
   Rin Oliver: USF4LMDCN
@@ -110,5 +115,7 @@ users:
   Tunde: UAY977ENN
   varshaprasad96: UK59YP2DA
   Verolop: U7NNE57PU
+  vladimirmukhin: UHVSCSD4G
+  wurbanski: URX7CMK97
   zubron: U7G0KNS86
   xmudrii: U4Q2TNGVD

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -97,6 +97,7 @@ users:
   rajula96reddy: U7K9EK1HC
   rashmigottipati: U013T1DD3PW
   Rin Oliver: USF4LMDCN
+  robshelly: U01LL4P09SR
   sammy: U8NJFL023
   saschagrunert: U53SUDBD4
   savitharaghunathan: UC8U2V3BM


### PR DESCRIPTION
Signed-off-by: Hubert Stefanski <hstefans@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
NA
- This PR adds a user group for grafana-operator maintainers/support
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # NA 
