### PR TITLE
API conventions: escape back-quotes when visible

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -1428,7 +1428,7 @@ specified".
 * When referencing a literal string value, indicate the literal in
 single-quotes. Example: "must not contain '..'".
 * When referencing another field name, indicate the name in back-quotes.
-Example: "must be greater than `request`".
+Example: "must be greater than \`request\`".
 * When specifying inequalities, use words rather than symbols.  Examples: "must
 be less than 256", "must be greater than or equal to 0".  Do not use words
 like "larger than", "bigger than", "more than", "higher than", etc.


### PR DESCRIPTION
> When referencing another field name, indicate the name in back-quotes. Example: "must be greater than `request`". 

In this sentence, we're meant to see "request" surrounded by back-quotes.

In markdown, backticks (back-quotes) are used to create a code section, and thus aren't shown. By escaping them, they are shown to the user.
