### PR TITLE
Add spiffxp as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - mrbobbytables
   - nikhita
   - parispittman
+  - spiffxp
   - committee-steering
 emeritus_approvers:
   - castrojo


### PR DESCRIPTION
I'd like to request approver status for this repo based on:
- experience as steering emeritus
- prior review history (of the last 100 merged prs involving me, I authored 16 and commented on 53)
- experience with sigs.yaml tooling