### PR TITLE
Update kubemark setup guidance

### DIFF
--- a/contributors/devel/sig-scalability/hollow-node_simplified_template.yaml
+++ b/contributors/devel/sig-scalability/hollow-node_simplified_template.yaml
@@ -33,19 +33,18 @@ spec:
         - containerPort: 10250
         - containerPort: 10255
         env:
-        - name: CONTENT_TYPE
-          valueFrom:
-            configMapKeyRef:
-              name: node-configmap
-              key: content.type
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
         command:
-        - /bin/sh
-        - -c
-        - /kubemark --morph=kubelet --name=$(NODE_NAME) --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --alsologtostderr --v=2
+        - /kubemark
+        args:
+        - --morph=kubelet
+        - --name=$(NODE_NAME)
+        - --kubeconfig=/kubeconfig/kubelet.kubeconfig
+        - --alsologtostderr
+        - --v=2
         volumeMounts:
         - name: kubeconfig-volume
           mountPath: /kubeconfig
@@ -61,19 +60,19 @@ spec:
       - name: hollow-proxy
         image: {{kubemark_image_registry}}/kubemark:{{kubemark_image_tag}}
         env:
-        - name: CONTENT_TYPE
-          valueFrom:
-            configMapKeyRef:
-              name: node-configmap
-              key: content.type
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
         command:
-        - /bin/sh
-        - -c
-        - /kubemark --morph=proxy --name=$(NODE_NAME) --use-real-proxier=false --kubeconfig=/kubeconfig/kubeproxy.kubeconfig $(CONTENT_TYPE) --alsologtostderr --v=2
+        - /kubemark
+        args:
+        - --morph=proxy
+        - --name=$(NODE_NAME)
+        - --use-real-proxier=false
+        - --kubeconfig=/kubeconfig/kubeproxy.kubeconfig
+        - --alsologtostderr
+        - --v=2
         volumeMounts:
         - name: kubeconfig-volume
           mountPath: /kubeconfig

--- a/contributors/devel/sig-scalability/kubemark-setup-guide.md
+++ b/contributors/devel/sig-scalability/kubemark-setup-guide.md
@@ -46,13 +46,12 @@ docker push {{kubemark_image_registry}}/kubemark:{{kubemark_image_tag}}
 
 2. Create hollow nodes
 
-- i. create namespace, configmap and secret
+- i. create namespace and secret
 
 Copy kubemark master's kubeconfig which is used to configure access, put it on a master of external cluster, rename it as config.
 
 ```
 kubectl create ns kubemark
-kubectl create configmap node-configmap -n kubemark --from-literal=content.type="test-cluster"
 kubectl create secret generic kubeconfig --type=Opaque --namespace=kubemark --from-file=kubelet.kubeconfig=config --from-file=kubeproxy.kubeconfig=config
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

kubemark setup guidance is outdated. I update guidance to make it work. 

1. `/bin/sh` was removed in distroless image. We need to update to use binary directly
2. `content-type` setting is incorrect. We need to give `--kube-api-content-type` to pair with the env value. However, this is not commonly changed. We can remove it from the general guidance.


**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/community/issues/5475
