### PR TITLE
Slack: Update SIG ContribEx channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -336,6 +336,7 @@ channels:
   - name: sig-configuration
     archived: true
   - name: sig-contribex
+  - name: sig-contribex-meetings
   - name: sig-contribex-triage
     archived: true
   # sig-docs* channels are defined in sig-docs/

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -337,6 +337,7 @@ channels:
     archived: true
   - name: sig-contribex
   - name: sig-contribex-triage
+    archived: true
   # sig-docs* channels are defined in sig-docs/
   - name: sig-high-availability
     archived: true


### PR DESCRIPTION
Two updates: 
- The `#sig-contribex-triage` channel has not been used in some time, and that initiative has largely been spun down.
- The `#sig-contribex-meetings` channel is being added for our bi-weekly slack meetings with the intent of keeping the convos prominent and focused. If it doesn't pan out, the channel can be archived at a later date.

/assign @nikhita @cblecker @alisondy 