### PR TITLE
cleanup: remove stale sig-release subproject hyperkube links

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -78,10 +78,10 @@ Documents and processes related to SIG Release
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
 ### hyperkube
+Best-effort maintaining of hyperkube until 1.18 goes EOL 2021-04-30.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/debian-hyperkube-base/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/hyperkube/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/hyperkube/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.18/cluster/images/hyperkube/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/release/master/images/build/debian-hyperkube-base/OWNERS
 ### kubernetes/repo-infra
 Creates and maintains tools and templates for Kubernetes org repositories.
 Includes bazel tooling for managing dependencies for kubernetes/kubernetes

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1876,10 +1876,11 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
   - name: hyperkube
+    description: |
+      Best-effort maintaining of hyperkube until 1.18 goes EOL 2021-04-30.
     owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/debian-hyperkube-base/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/hyperkube/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/hyperkube/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.18/cluster/images/hyperkube/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/release/master/images/build/debian-hyperkube-base/OWNERS
   - name: kubernetes/repo-infra
     description: |
       Creates and maintains tools and templates for Kubernetes org repositories.


### PR DESCRIPTION
The hyperkube subproject linked OWNERS files 404 since hyperkube went
away a year ago.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
