### PR TITLE
minor update to api_changes to highlight gate on/off scenario

### DIFF
--- a/contributors/devel/sig-architecture/api_changes.md
+++ b/contributors/devel/sig-architecture/api_changes.md
@@ -960,7 +960,7 @@ progress from `alpha` to `beta` and then `stable` the feature might be turned on
 provides some details 
  
    ```go
-   func TestApi(t *testing.T){
+   func TestAPI(t *testing.T){
     testCases:= []struct{
       // ... test definition ...
     }{

--- a/contributors/devel/sig-architecture/api_changes.md
+++ b/contributors/devel/sig-architecture/api_changes.md
@@ -955,7 +955,7 @@ The recommended place to do this is in the REST storage strategy's PrepareForCre
     }
     ```
 
-4. Future proof api testing, when testing with feature gate on and off ensure that the gate is deliberately set as desired. Don't assume that gate is off or on. As your feature
+4. To future-proof your API testing, when testing with feature gate on and off, ensure that the gate is deliberately set as desired. Don't assume that gate is off or on. As your feature
 progress from `alpha` to `beta` and then `stable` the feature might be turned on or off by default across the entire code base. The below example
 provides some details 
  

--- a/contributors/devel/sig-architecture/api_changes.md
+++ b/contributors/devel/sig-architecture/api_changes.md
@@ -980,7 +980,7 @@ provides some details
      })
      t.Run("..name...", func(t *testing.T){
       // run with gate off, *do not assume it is off by default*
-      defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AwesomeFeature, false)()
+      defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features. Frobber2D, false)()
       // ... test gate-off testing logic logic ...
      })
    }

--- a/contributors/devel/sig-architecture/api_changes.md
+++ b/contributors/devel/sig-architecture/api_changes.md
@@ -956,7 +956,7 @@ The recommended place to do this is in the REST storage strategy's PrepareForCre
     ```
 
 4. To future-proof your API testing, when testing with feature gate on and off, ensure that the gate is deliberately set as desired. Don't assume that gate is off or on. As your feature
-progress from `alpha` to `beta` and then `stable` the feature might be turned on or off by default across the entire code base. The below example
+progresses from `alpha` to `beta` and then `stable` the feature might be turned on or off by default across the entire code base. The below example
 provides some details 
  
    ```go

--- a/contributors/devel/sig-architecture/api_changes.md
+++ b/contributors/devel/sig-architecture/api_changes.md
@@ -955,7 +955,38 @@ The recommended place to do this is in the REST storage strategy's PrepareForCre
     }
     ```
 
-4. In validation, validate the field if present:
+4. Future proof api testing, when testing with feature gate on and off ensure that the gate is deliberately set as desired. Don't assume that gate is off or on. As your feature
+progress from `alpha` to `beta` and then `stable` the feature might be turned on or off by default across the entire code base. The below example
+provides some details 
+ 
+   ```go
+   func TestApi(t *testing.T){
+    testCases:= []struct{
+      // ... test definition ...
+    }{
+       {
+        // .. test case ..
+       },
+       {
+       // ... test case ..
+       },
+   }
+   
+   for _, testCase := range testCases{
+     t.Run("..name...", func(t *testing.T){
+      // run with gate on
+      defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AwesomeFeature, true)()
+       // ... test logic ...
+     })
+     t.Run("..name...", func(t *testing.T){
+      // run with gate off, *do not assume it is off by default*
+      defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AwesomeFeature, false)()
+      // ... test gate-off testing logic logic ...
+     })
+   }
+   ``` 
+
+5. In validation, validate the field if present:
 
     ```go
     func ValidateFrobber(f *api.Frobber, fldPath *field.Path) field.ErrorList {

--- a/contributors/devel/sig-architecture/api_changes.md
+++ b/contributors/devel/sig-architecture/api_changes.md
@@ -975,7 +975,7 @@ provides some details
    for _, testCase := range testCases{
      t.Run("..name...", func(t *testing.T){
       // run with gate on
-      defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AwesomeFeature, true)()
+      defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features. Frobber2D, true)()
        // ... test logic ...
      })
      t.Run("..name...", func(t *testing.T){


### PR DESCRIPTION
Adds a note regarding testing with feature gate on and feature gate off. Specifically highlights that contributors shouldn't assume that the status of the gate is off (or on).
 

**Which issue(s) this PR fixes**:

Fixes #
N/A