### PR TITLE
Move local cluster doc from e2e-tests to running-locally

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -3,6 +3,7 @@ Getting started locally
 
 **Table of Contents**
 
+- [Overview](#overview)
 - [Requirements](#requirements)
     - [Linux](#linux)
     - [Docker](#docker)
@@ -20,6 +21,10 @@ Getting started locally
     - [I changed Kubernetes code, how do I run it?](#i-changed-kubernetes-code-how-do-i-run-it)
     - [kubectl claims to start a container but `get pods` and `docker ps` don't show it.](#kubectl-claims-to-start-a-container-but-get-pods-and-docker-ps-dont-show-it)
     - [The pods fail to connect to the services by host names](#the-pods-fail-to-connect-to-the-services-by-host-names)
+
+## Overview
+
+It can be much faster to iterate on a local cluster instead of a cloud-based one.
 
 ## Requirements
 
@@ -72,13 +77,14 @@ In a separate tab of your terminal, run the following:
 
 ```sh
 cd kubernetes
-./hack/local-up-cluster.sh
+# The PATH construction is needed because PATH is one of the special-cased
+# environment variables not passed by sudo -E
+PATH=$PATH ./hack/local-up-cluster.sh
 ```
-
 Since root access is sometimes needed to start/stop Kubernetes daemons, `./hack/local-up-cluster.sh` may need to be run as root. If it reports failures, try this instead:
 
 ```sh
-sudo ./hack/local-up-cluster.sh
+sudo PATH=$PATH ./hack/local-up-cluster.sh
 ```
 
 This will build and start a lightweight local cluster, consisting of a master and a single node. Press Control+C to shut it down.
@@ -90,8 +96,7 @@ This will build and start a lightweight local cluster, consisting of a master an
 ```
 
 You can use the `./cluster/kubectl.sh` script to interact with the local cluster. `./hack/local-up-cluster.sh` will
-print the commands to run to point kubectl at the local cluster.
-
+print the commands to run to point kubectl at the local cluster. It will show you how to generate a valid kubeconfig file.
 
 ## Running a container
 

--- a/contributors/devel/sig-testing/e2e-tests.md
+++ b/contributors/devel/sig-testing/e2e-tests.md
@@ -10,8 +10,7 @@
     - [Extracting a specific version of Kubernetes](#extracting-a-specific-version-of-kubernetes)
     - [Bringing up a cluster for testing](#bringing-up-a-cluster-for-testing)
     - [Debugging clusters](#debugging-clusters)
-    - [Local clusters](#local-clusters)
-      - [Testing against local clusters](#testing-against-local-clusters)
+    - [Testing against local clusters](#testing-against-local-clusters)
     - [Version-skewed and upgrade testing](#version-skewed-and-upgrade-testing)
       - [Test jobs naming convention](#test-jobs-naming-convention)
   - [Kinds of tests](#kinds-of-tests)
@@ -256,24 +255,9 @@ the provided directory (which should already exist).
 The Google-run Jenkins builds automatically collected these logs for every
 build, saving them in the `artifacts` directory uploaded to GCS.
 
-### Local clusters
+### Testing against local clusters
 
-It can be much faster to iterate on a local cluster instead of a cloud-based
-one. To start a local cluster, you can run:
-
-```sh
-# The PATH construction is needed because PATH is one of the special-cased
-# environment variables not passed by sudo -E
-sudo PATH=$PATH hack/local-up-cluster.sh
-```
-
-This will start a single-node Kubernetes cluster than runs pods using the local
-docker daemon. Press Control-C to stop the cluster.
-
-You can generate a valid kubeconfig file by following instructions printed at the
-end of aforementioned script.
-
-#### Testing against local clusters
+For how to set up a local cluster, please refer [running-locally](../../running-locally.md) guide.
 
 In order to run an E2E test against a locally running cluster, first make sure
 to have a local build of the tests:


### PR DESCRIPTION
Signed-off-by: Qiutong Song <songqt01@gmail.com>

**Which issue(s) this PR fixes**: None

I want to merge together the doc of running local cluster so that there is a single place with precise guidance.
