### PR TITLE
Update social media role handbook

### DIFF
--- a/communication/marketing-team/role-handbooks/social-media.md
+++ b/communication/marketing-team/role-handbooks/social-media.md
@@ -2,23 +2,29 @@
 
 ## Overview
 
-TODO
+Social Media leads and members help contribute to the Marketing Team's efforts to communicate with contributors on a broad scale through social media.  At time of writing, the primary social media channel we communicate through is the [@K8sContributors handle on twitter](https://twitter.com/K8sContributors).
+
+Any contributor can help write tweets to be distributed through the twitter handle by utilizing the [kubernetes-sigs/contributor-tweets repo](https://github.com/kubernetes-sigs/contributor-tweets). This repo utilizes the open source [twitter-together](https://github.com/gr2m/twitter-together) project to automate taking PRs to the repo, and distributing them as tweets from the @K8sContributor handle.
+
 
 ## Minimum Skills and Requirements
 
 - Are a member of the [Kubernetes GitHub Org]
 - Familiar with twitter by either having a personal account or managing another account (brand, oss project, employer, local nonprofit, etc)
-- TODO
 
 ### Expected Time Investment
 
-TODO
-3-5 hours a week
+Team members: 1-3 hours a week.
+Team leads: 3-5 hours per week.
 
 ## General Expectations
 
 - Most of this information can be found in our [social guidelines]
 - Be welcoming, be yourself
+
+The leader(s) of the social media team will be expected to monitor the @K8sContributors handle. Retweets, replies, and responding to replies appropriately fall under the purview of the social media lead. Time-sensitive tweets should also be handled directly by the team lead. Team leads should coordinate with team members to plan tweets in advance, particularly for large contributor-focused events such as KubeCon or Contributor Summit.
+
+Team members will be expected to help keep an eye out for news in need of tweeting. Common sources of such announcements are the k-dev mailing list and the #contributor-comms channel on Slack. Team members can submit less time-sensitive tweets to the [kubernetes-sigs/contributor-tweets repo](https://github.com/kubernetes-sigs/contributor-tweets) for review and tweeting.
 
 ## Associates Overview (Shadow)
 


### PR DESCRIPTION
The role handbook for social media hadn't been updated since its initiation. Now that I have been in the role of social media lead for a while, I'm using this space to record what I've learned about the role, and my expectations for how this team should operate.

Please review and make any edits you see fit, @chris-short & @parispittman! (<Current social media advisors)
