### PR TITLE
slack-config: add usergroup for steering-committee

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -168,3 +168,17 @@ usergroups:
       - margocrawf
       - microwavables
       - pabloschuhmacher
+
+  - name: steering-committee
+    long_name: Kubernetes Steering Committee
+    description: Members of the Kubernetes Steering Committee
+    channels:
+      - steering-committee
+    members:
+      - cblecker
+      - derekwaynecarr
+      - dims
+      - liggitt
+      - mrbobbytables
+      - nikhita
+      - paris

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -18,6 +18,7 @@ users:
   camilamacedo86: UJDM393EH
   carlisia: UBDSF40G2
   castrojo: U1W1Q6PRQ
+  cblecker: U3EDWR9FV
   cdrage: U2TU9NPH9
   cfryanr: U0188B6J42H
   chrisshort: U2YGXSD9B
@@ -25,7 +26,9 @@ users:
   cji: U5YSRC21J
   cpanato: U8DFY4TTK
   Dave Smith-Uchida: UDZDED8G2
+  derekwaynecarr: U0A69N5GQ
   dharmit: U0APPPEKE
+  dims: U0Y7A2MME
   dougm: U8GG20UE9
   enj: U2T4CVDTJ
   estroz: UKSEANEC9
@@ -58,6 +61,7 @@ users:
   katharine: UBTBNJ6GL
   kikisdeliveryservice: U9HFFRFT2
   LappleApple: U011C07244F
+  liggitt: U0BGPQ6DS
   listx: UFCU8S8P3
   lukehinds: UN2P2M4F4
   marc-obrien: UL51BRL9Y


### PR DESCRIPTION
Requested by @dims :)

cc @kubernetes/steering-committee 

/assign @mrbobbytables @parispittman 
intersection of slack admins and SC

/hold
for review by slack admins