### PR TITLE
slack-config: rename steering-committee usergroup to steering

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -169,7 +169,7 @@ usergroups:
       - microwavables
       - pabloschuhmacher
 
-  - name: steering-committee
+  - name: steering
     long_name: Kubernetes Steering Committee
     description: Members of the Kubernetes Steering Committee
     channels:


### PR DESCRIPTION
:woman_facepalming: 

channel names and usergroups share the same namespace, so they
can't have the same name.

follow up to https://github.com/kubernetes/community/pull/5552
