### PR TITLE
slack-config: rename steering usergroup to steering-members

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -169,7 +169,7 @@ usergroups:
       - microwavables
       - pabloschuhmacher
 
-  - name: steering
+  - name: steering-members
     long_name: Kubernetes Steering Committee
     description: Members of the Kubernetes Steering Committee
     channels:


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/community/pull/5553 and https://github.com/kubernetes/community/pull/5552

There is a deactivated slack user called `steering`. It looks like
deactivated users still share the same namespace as channels, users
and user groups.

Ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-community-tempelis-apply/1364844966282530816

