### PR TITLE
[WIP] sig-release: Add 2021 annual report

### DIFF
--- a/sig-release/annual-report-2021.md
+++ b/sig-release/annual-report-2021.md
@@ -1,0 +1,85 @@
+# Annual Report - 2021
+
+**Authors:**
+Stephen Augustus ([@justaugustus](https://github.com/justaugustus)),
+Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert))
+
+- [Operational](#operational)
+- [Membership](#membership)
+- [Current initiatives and project health](#current-initiatives-and-project-health)
+
+## Operational
+
+**How are you doing with operational tasks in [sig-governance.md](/committee-steering/governance/sig-governance.md)?**
+
+<!-- TODO -->
+
+**Is your README accurate? have a CONTRIBUTING.md file?**
+
+<!-- TODO -->
+
+**All subprojects correctly mapped and listed in [sigs.yaml](/sig-list.md)?**
+
+<!-- TODO -->
+
+**What’s your meeting culture? Large/small, active/quiet, learnings? Meeting notes up to date? Are you keeping recordings up to date/trends in community members watching recordings?**
+
+<!-- TODO -->
+
+**How does the group get updates, reports, or feedback from subprojects? Are there any springing up or being retired? Are OWNERS files up to date in these areas?**
+
+<!-- TODO -->
+
+**How does the group get updates, reports, or feedback from Working Groups? Are there any springing up or being retired? Are OWNERS files up to date in these areas?**
+
+<!-- TODO -->
+
+**When was your last monthly community-wide update? (provide link to deck and/or recording)**
+
+<!-- TODO -->
+
+## Membership
+
+**Are all listed SIG leaders (chairs, tech leads, and subproject owners) active?**
+
+<!-- TODO -->
+
+**How do you measure membership? By mailing list members, OWNERs, or something else?**
+
+<!-- TODO -->
+
+**How does the group measure reviewer and approver bandwidth? Do you need help in any area now? What are you doing about it?**
+
+<!-- TODO -->
+
+**Is there a healthy onboarding and growth path for contributors in your SIG? What are some activities that the group does to encourage this? What programs are you participating in to grow contributors throughout the contributor ladder?**
+
+<!-- TODO -->
+
+**What programs do you participate in for new contributors?**
+
+<!-- TODO -->
+
+**Does the group have contributors from multiple companies/affiliations? Can end users/companies contribute in some way that they currently are not?**
+
+<!-- TODO -->
+
+## Current initiatives and project health
+
+[ ] Please include links to KEPs and other supporting information that will be beneficial to multiple types of community members.
+
+**What are initiatives that should be highlighted, lauded, shout out, that your group is proud of? Currently underway? What are some of the longer tail projects that your group is working on?**
+
+<!-- TODO -->
+
+**Year to date KEP work review: What’s now stable? Beta? Alpha? Road to alpha?**
+
+<!-- TODO -->
+
+**What areas and/or subprojects does the group need the most help with?**
+
+<!-- TODO -->
+
+**What's the average open days of a PR and Issue in your group? / what metrics does your group care about and/or measure?**
+
+<!-- TODO -->


### PR DESCRIPTION
Currently just the [annual report template](https://docs.google.com/document/d/1HeABRzhgF9NNpM0xGKLDhhc6bRfQuulsIsb59AjyS9M/edit), but tagging folks so they receive notifications on updates.
Requested in https://github.com/kubernetes/community/issues/5508.

Co-author:
/assign @saschagrunert 

Steering liaison:
/assign @dims

SIG Release leads: @kubernetes/sig-release-leads 

Signed-off-by: Stephen Augustus <foo@auggie.dev>