### PR TITLE
sig-release: Jorge Alarcon Ochoa is now an Emeritus Tech Lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -62,7 +62,6 @@ aliases:
     - dchen1107
     - derekwaynecarr
   sig-release-leads:
-    - alejandrox1
     - hasheddan
     - jeremyrickard
     - justaugustus

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -29,12 +29,12 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Jorge Alarcon Ochoa (**[@alejandrox1](https://github.com/alejandrox1)**), Searchable AI
 * Daniel Mangum (**[@hasheddan](https://github.com/hasheddan)**), Upbound
 * Jeremy Rickard (**[@jeremyrickard](https://github.com/jeremyrickard)**), Apple
 
 ## Emeritus Leads
 
+* Jorge Alarcon Ochoa (**[@alejandrox1](https://github.com/alejandrox1)**)
 * Caleb Miles (**[@calebamiles](https://github.com/calebamiles)**)
 * Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**)
 * Tim Pepper (**[@tpepper](https://github.com/tpepper)**)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1807,9 +1807,6 @@ sigs:
       name: Sascha Grunert
       company: SUSE
     tech_leads:
-    - github: alejandrox1
-      name: Jorge Alarcon Ochoa
-      company: Searchable AI
     - github: hasheddan
       name: Daniel Mangum
       company: Upbound
@@ -1817,6 +1814,8 @@ sigs:
       name: Jeremy Rickard
       company: Apple
     emeritus_leads:
+    - github: alejandrox1
+      name: Jorge Alarcon Ochoa
     - github: calebamiles
       name: Caleb Miles
     - github: jdumars


### PR DESCRIPTION
(Discussed [privately](https://kubernetes.slack.com/archives/G01M2GAGDB2/p1611943383000100) between @alejandrox1, @saschagrunert, and I on 1/29.)

Jorge will be tackling some exciting new career opportunities in 2021, which unfortunately for us, will draw him away from SIG Release for the foreseeable future.

@alejandrox1 -- Thank you for all that you've contributed to the SIG Release family over the years!
We hope to see you again soon and wish you tremendous success always. 💕 

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @saschagrunert
cc: @kubernetes/sig-release-leads 