### PR TITLE
Add Program Manager governance docs

### DIFF
--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -42,7 +42,7 @@ The process for setting up a SIG or Working Group (WG) is listed in the
 ### Notes on Roles
 
 Within this section "Lead" refers to someone who is a member of the union
- of a Chair, Tech Lead or Subproject Owner role. There is no one lead to any
+ of a Chair, Tech Lead, Subproject Owner, or Program Manager role. There is no one lead to any
  Kubernetes community group. Leads have specific decision making power over some
  part of a group and thus additional accountability. Each role is detailed below.  
 
@@ -85,6 +85,7 @@ Subproject contributors (as applicable).
 - Number: 2-3
 - Membership tracked in [sigs.yaml]  
   - If no tech lead role is present, Chair assumes responsibilities from [#tech-lead] section.
+  - If no program manager role is present, Chair assumes responsibilities from [#program-manager] section.
   
   In addition, run operations and processes governing the SIG:
 
@@ -139,6 +140,17 @@ curation from other SIG participants
   - *SHOULD* set milestone priorities or delegate this responsibility
   - Number: 2-3
   - Membership tracked in [sigs.yaml]
+
+### Program Manager
+
+- *Optional Role*: SIG Program Managers
+  -  Coordinate the success of their SIGs’ delivery workflow and related practices
+  -  Coordinate cross-SIG coordination
+  -  Set up, launch, and continuously optimize processes
+  -  Drive prioritization, delegation, communication, risk mitigation efforts
+  -  Number: 1-3
+  -  Membership tracked in [sigs.yaml]
+  -  Role description in [program-manager.md] 
 
 ### All Leads
 
@@ -241,8 +253,10 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
 [contributor guide]: /contributors/guide/README.md
 [devel]: /contributors/devel/README.md
 [#tech-lead]: #Tech-Lead
+[#program-manager]: #Program-Manager
 [Google group]: https://groups.google.com/forum/#!forum/kubernetes-sig-config
 [dashboard]: https://testgrid.k8s.io/
 [monthly community meeting]: /events/community-meeting.md
 [inclusive speaker training course]: https://training.linuxfoundation.org/training/inclusive-speaker-orientation/
 [technical-lead.md]: /contributors/chairs-and-techleads/technical-lead.md
+[program-manager.md]: /contributors/chairs-and-techleads/program-manager.md

--- a/contributors/chairs-and-techleads/README.md
+++ b/contributors/chairs-and-techleads/README.md
@@ -12,15 +12,15 @@ TODO - [Meeting agenda templates]
 ## Important Governance Documentation
   
   - [governance.md]
-  - [sig-governanace.md]
-  - [wg-governanace.md]
+  - [sig-governance.md]
+  - [wg-governance.md]
   
   [Code of Conduct]
   - conduct@kubernetes.io if you need anything from them or to report
   - may have training or guidance - ask!
   
   [Kubernetes values]  
-  [Governance Principles]
+  [Governance principles]
   
   ## Communication and feedback loops:
   
@@ -68,8 +68,8 @@ TODO - [Meeting agenda templates]
 [Mentoring, succession planning, and staffing]: https://github.com/kubernetes/community/tree/master/mentoring
 [Kubernetes values]: https://github.com/kubernetes/community/blob/master/values.md
 [governance.md]: https://github.com/kubernetes/community/blob/master/governance.md
-[sig-governanace.md]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md
-[wg-governanace.md]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/wg-governance.md
+[sig-governance.md]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md
+[wg-governance.md]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/wg-governance.md
 [group-mentoring.md]: https://github.com/kubernetes/community/blob/master/mentoring/processes/group-mentoring.md
 [mentoring-programs]: https://github.com/kubernetes/community/tree/master/mentoring/programs
 [maintainers-circle]: https://github.com/cncf/sig-contributor-strategy/tree/master/maintainers-circle

--- a/contributors/chairs-and-techleads/program-manager.md
+++ b/contributors/chairs-and-techleads/program-manager.md
@@ -49,7 +49,8 @@ for feedback and measuring impact with metrics.
 - Coaching/mentoring other SIG leads and contributors to facilitate processes, meetings, and 
 activities that drive achievement of delivery outcomes.
 - Guiding their SIG to adopt prioritisation frameworks that support delivery of the highest-
-value, highest-impact work.
+value, highest-impact work. Ensuring the reliability and ongoing maintenance work is prioritised
+and accounted for.
 - Ensuring their SIG is following established practices in Kubernetes, from adherence to release
 deadlines to enforcing the Code of Conduct.
 - Advising the SIG on tooling that supports delivery effectiveness and smooth workflows, such as

--- a/contributors/chairs-and-techleads/program-manager.md
+++ b/contributors/chairs-and-techleads/program-manager.md
@@ -14,7 +14,7 @@ clarify expectations associated with the role.
 Kubernetes SIGs may choose to implement the Program Manager role as part of their 
 [governance model](https://git.k8s.io/community/committee-steering/governance/sig-governance.md#roles)
 and document the role in their SIG charters. SIG Chairs choose program managers and 
-endow them with the same set of permissions. Based on overall SIG size, 2-3 program 
+endow them with the same set of permissions. Based on overall SIG size, 1-3 program 
 managers are recommended to support the SIG's program and process-related efforts.  
 
 Program Managers are generally responsible for driving process development and improvements 

--- a/contributors/chairs-and-techleads/program-manager.md
+++ b/contributors/chairs-and-techleads/program-manager.md
@@ -1,0 +1,77 @@
+# Program Manager
+
+## Role Description
+
+### About
+
+This document defines and outlines the Program Manager role within
+the Kubernetes community in correspondence with the existing [description of SIG
+Governance](/committee-steering/governance/sig-governance.md#program-manager). 
+Special Interest Groups (SIGs) can use this to onboard new Program Managers and 
+clarify expectations associated with the role.
+
+### Abstract
+Kubernetes SIGs may choose to implement the Program Manager role as part of their 
+[governance model](http://git.k8s.io/community/committee-steering/governance/sig-governance.md#roles)
+and document the role in their SIG charters. SIG Chairs choose program managers and 
+endow them with the same set of permissions. Based on overall SIG size, 2-3 program 
+managers are recommended to support the SIG's program and process-related efforts.  
+
+Program Managers are generally responsible for driving process development and improvements 
+related to SIG communications, delegation of work, and alignment—both within their SIG as 
+well as between their SIG and other groups. The overall aim is to support the SIG in 
+delivering outcomes effectively while reducing risk.
+
+To optimise their success, Kubernetes Program Managers should collaborate with other SIG 
+leadership as early and often as possible when ideating/developing new processes or suggesting 
+improvements. Overly prescriptive, cookie-cutter approaches tend not to gain traction in 
+Kubernetes—those developed in a silo even less so. Focus on delivering value based on 
+expressed needs.
+
+Program Managers are responsible for coordinating the success of their SIGs’ delivery 
+workflow and related practices, including cross-SIG coordination and communication.
+- They maintain an open mind in order to gain a high level of trust with other members of 
+the SIG.
+- They are willing to observe current processes and development practices and listen to 
+SIG leads and contributors before making any recommendations. 
+- They're involved in the day-to-day workings of the SIG—attending meetings, following 
+discussions on Slack, learning about the priorities and technical responsibilities and plans 
+for the group. This heightens their ability to make relevant suggestions and decisions.
+
+Examples of Program Management leadership within a SIG include:
+- Continuously noting delivery obstacles, waste, duplication of effort, and siloing, and 
+raising these risks to the SIG for discussion and remediation.
+- Setting up and launching processes aimed at driving delivery effectiveness, such as issue 
+triage, roadmapping/North Star vision creation, backlog refinement, and KEP planning.
+- Regularly evaluating established processes to ensure they’re working, by asking the group 
+for feedback and measuring impact with metrics.
+- Setting up programs related to cross-SIG delivery of KEPs, and dependency management.
+- Coaching/mentoring other SIG leads and contributors to facilitate processes, meetings, and 
+activities that drive achievement of delivery outcomes.
+- Guiding their SIG to adopt prioritisation frameworks that support delivery of the highest-
+value, highest-impact work.
+- Ensuring their SIG is following established practices in Kubernetes, from adherence to release
+deadlines to enforcing the Code of Conduct.
+- Advising the SIG on tooling that supports delivery effectiveness and smooth workflows, such as
+GitHub project boards and creative use of GitHub Issues to track work.
+- Designing lightweight communication structures that reinforce timely responsiveness to deadlines 
+and external requests; includes regular drumbeats to report progress to the community.
+- Prioritising contributor experience in order to drive delegation of work and reduce risk. 
+Related activities might include refining SIG onboarding for different skillsets, creating “career 
+ladders,” and designing work packages that engaged contributors can drive via small teams.
+
+The common skill set of Program Managers covers three areas:
+
+- **Leadership** – You can coach team members to reach their goals, guiding them to solutions 
+that balance their personal interests with the needs of the SIG and project. You look for ways to 
+include newcomers and make sure they have access to the context that will help them be successful.
+You seek compromise to mitigate conflict and drive the group to focus on outcomes.
+- **Objectivity** – You take actions and propose ideas based on evidence and facts, challenging 
+your own assumptions. You listen closely, seek second and third opinions to weigh different 
+perspectives, and promote the value of fairness.
+- **Strategic thinking** – You design approaches that incorporate short-term wins and tactics to 
+drive long-term growth and innovation. You know how to take complex problems and break them down into 
+increments.
+
+If you are interested in becoming a Program Manager, speak with the [appropriate
+SIG Chairs](https://github.com/kubernetes/community/blob/master/sig-list.md).

--- a/contributors/chairs-and-techleads/program-manager.md
+++ b/contributors/chairs-and-techleads/program-manager.md
@@ -12,7 +12,7 @@ clarify expectations associated with the role.
 
 ### Abstract
 Kubernetes SIGs may choose to implement the Program Manager role as part of their 
-[governance model](http://git.k8s.io/community/committee-steering/governance/sig-governance.md#roles)
+[governance model](https://git.k8s.io/community/committee-steering/governance/sig-governance.md#roles)
 and document the role in their SIG charters. SIG Chairs choose program managers and 
 endow them with the same set of permissions. Based on overall SIG size, 2-3 program 
 managers are recommended to support the SIG's program and process-related efforts.  

--- a/contributors/chairs-and-techleads/program-manager.md
+++ b/contributors/chairs-and-techleads/program-manager.md
@@ -34,7 +34,7 @@ workflow and related practices, including cross-SIG coordination and communicati
 the SIG.
 - They are willing to observe current processes and development practices and listen to 
 SIG leads and contributors before making any recommendations. 
-- They're involved in the day-to-day workings of the SIG—attending meetings, following 
+- They're involved in the day-to-day workings of the SIG—attending (or in some cases hosting) meetings, following 
 discussions on Slack, learning about the priorities and technical responsibilities and plans 
 for the group. This heightens their ability to make relevant suggestions and decisions.
 


### PR DESCRIPTION
This PR includes governance documentation related to the SIG Program Manager role and is a response to [#5563](https://github.com/kubernetes/community/pull/5563).

/assign @saschagrunert @LappleApple @nikhita
cc: @kubernetes/sig-release-leads @kubernetes/sig-contributor-experience-leads @kubernetes/steering-committee

/sig release
/sig contributor-experience