### PR TITLE
Update sig-arch charter for upgrade/downgrade and skew

### DIFF
--- a/sig-architecture/charter.md
+++ b/sig-architecture/charter.md
@@ -18,6 +18,8 @@ The Architecture SIG maintains and evolves the design principles of Kubernetes, 
 - *Design principles*
 - *Deprecation policy*
 - *Kubernetes Enhancement Proposal (KEP) process*
+- *Upgrade and downgrade policy*
+- *Cross-component version support skew*
 
 #### Cross-cutting and Externally Facing Processes
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #4839

As discussed in SIG Arch call on 2/25, clarify skew policy support changes are domain of this SIG along with upgrade/downgrade policy.
