### PR TITLE
sig-instrumentation: remove mutating-trace-admission-controller

### DIFF
--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -80,9 +80,6 @@ The following [subprojects][subproject-definition] are owned by sig-instrumentat
 ### metrics-server
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/OWNERS
-### mutating-trace-admission-controller
-- **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS
 ### prometheus-adapter
 - **Owners:**
   - https://raw.githubusercontent.com/kubernetes-sigs/prometheus-adapter/master/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1525,9 +1525,6 @@ sigs:
   - name: metrics-server
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/OWNERS
-  - name: mutating-trace-admission-controller
-    owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/mutating-trace-admission-controller/master/OWNERS
   - name: prometheus-adapter
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/prometheus-adapter/master/OWNERS


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2527

/assign @ehashman 

/hold
for lgtm from sig-instrumentation leads