### PR TITLE
Update conformance promotion instruction to support Remove Bazel PR

### DIFF
--- a/contributors/devel/sig-architecture/conformance-tests.md
+++ b/contributors/devel/sig-architecture/conformance-tests.md
@@ -312,9 +312,8 @@ To promote a test to the conformance test suite, open a PR as follows:
     than the `framework.It()` function
   - adds a comment immediately before the `ConformanceIt()` call that includes
     all of the required [conformance test comment metadata]
-  - run `bazel build //test/conformance:list_conformance_tests` then
-    `cp bazel-bin/test/conformance/conformance.yaml test/conformance/testdata`
-    which adds the test name to the [conformance.yaml] file
+  - run `hack/update-conformance-yaml.sh` which adds the test name to the [conformance.yaml] file
+    More information [here](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/README.md)
 - add the PR to SIG Architecture's [Conformance Test Review board] in the To
   Triage column
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Update the documentation for promotion of conformance test to match the removal of Bazel by #99561 

**Which issue(s) this PR fixes:**


**Special notes for your reviewer:**
Document update only 

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance