### PR TITLE
Add directories for sig-security subprojects

### DIFF
--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -40,9 +40,11 @@ The following [subprojects][subproject-definition] are owned by sig-security:
 ### security-audit
 Third Party Security Audit
 - **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-security/sig-security-external-audit/OWNERS
 ### security-docs
 Security Documents and Documentation
 - **Owners:**
+  - https://raw.githubusercontent.com/kubernetes/community/master/sig-security/sig-security-docs/OWNERS
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-security/sig-security-docs/OWNERS
+++ b/sig-security/sig-security-docs/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - savitharaghunathan
+approvers:
+  - savitharaghunathan

--- a/sig-security/sig-security-external-audit/OWNERS
+++ b/sig-security/sig-security-external-audit/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - aasmall
+approvers:
+  - aasmall

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2092,10 +2092,12 @@ sigs:
   subprojects:
   - name: security-audit
     description: Third Party Security Audit
-    owners: []
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-security/sig-security-external-audit/OWNERS
   - name: security-docs
     description: Security Documents and Documentation
-    owners: []
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-security/sig-security-docs/OWNERS
 - dir: sig-service-catalog
   name: Service Catalog
   mission_statement: >


### PR DESCRIPTION
For in case they want to store some files, and to get subproject owners listed in an OWNERS file