### PR TITLE
SIG-ContribEx: Migrate contributor site repo

### DIFF
--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -78,8 +78,8 @@ Contributor Communications focuses on amplifying the success of Kubernetes contr
 ### contributors-documentation
 writes and maintains documentation around contributing to Kubernetes, including the Contributor's Guide, Developer's Guide, and contributor website.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
   - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
+  - https://raw.githubusercontent.com/kubernetes/contributor-site/master/OWNERS
 ### devstats
 Maintains and updates https://k8s.devstats.cncf.io, including taking requests for new charts.
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1234,8 +1234,8 @@ sigs:
     description: writes and maintains documentation around contributing to Kubernetes,
       including the Contributor's Guide, Developer's Guide, and contributor website.
     owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-site/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/contributor-site/master/OWNERS
   - name: devstats
     description: Maintains and updates https://k8s.devstats.cncf.io, including taking
       requests for new charts.


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2544

The repo has been migrated from k-sigs to k.

/assign @alisondy @nikhita @cblecker