### PR TITLE
generator: make subproject owners links useful

### DIFF
--- a/committee-product-security/README.md
+++ b/committee-product-security/README.md
@@ -32,7 +32,7 @@ The following [subprojects][subproject-definition] are owned by the Product Secu
 ### security
 Policies and documentation for the Product Security Committee
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/security/master/OWNERS
+  - [kubernetes/security](https://github.com/kubernetes/security/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/committee-steering/README.md
+++ b/committee-steering/README.md
@@ -42,11 +42,11 @@ The following [subprojects][subproject-definition] are owned by the Steering Com
 ### funding
 Funding requests for project infrastructure, events, and consulting
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/funding/master/OWNERS
+  - [kubernetes/funding](https://github.com/kubernetes/funding/blob/master/OWNERS)
 ### steering
 Steering Committee policy and documentation
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS
+  - [kubernetes/steering](https://github.com/kubernetes/steering/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/generator/app.go
+++ b/generator/app.go
@@ -374,6 +374,7 @@ func getExistingContent(path string, fileFormat string) (string, error) {
 var funcMap = template.FuncMap{
 	"tzUrlEncode": tzURLEncode,
 	"trimSpace":   strings.TrimSpace,
+	"trimSuffix":  strings.TrimSuffix,
 	"githubURL":   githubURL,
 	"orgRepoPath": orgRepoPath,
 }

--- a/generator/app.go
+++ b/generator/app.go
@@ -250,7 +250,8 @@ func (c *Context) Sort() {
 func (c *Context) Validate() []error {
 	errors := []error{}
 	people := make(map[string]Person)
-	rawGitHubURL := regexp.MustCompile(regexRawGitHubURL)
+	reRawGitHubURL := regexp.MustCompile(regexRawGitHubURL)
+	reGitHubURL := regexp.MustCompile(regexGitHubURL)
 	for prefix, groups := range c.PrefixToGroupMap() {
 		for _, group := range groups {
 			expectedDir := group.DirName(prefix)
@@ -309,7 +310,7 @@ func (c *Context) Validate() []error {
 					errors = append(errors, fmt.Errorf("%s/%s: subproject has no owners", group.Dir, subproject.Name))
 				}
 				for _, ownerURL := range subproject.Owners {
-					if !rawGitHubURL.MatchString(ownerURL) {
+					if !reRawGitHubURL.MatchString(ownerURL) && !reGitHubURL.MatchString(ownerURL) {
 						errors = append(errors, fmt.Errorf("%s/%s: subproject owners should match regexp %s, found: %s", group.Dir, subproject.Name, regexRawGitHubURL, ownerURL))
 					}
 				}

--- a/generator/app_test.go
+++ b/generator/app_test.go
@@ -236,3 +236,73 @@ func TestFullGeneration(t *testing.T) {
 		}
 	}
 }
+
+func TestGitHubURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "kubernetes-sigs root raw github url",
+			url:      "https://raw.githubusercontent.com/kubernetes-sigs/boskos/main/OWNERS",
+			expected: "https://github.com/kubernetes-sigs/boskos/blob/main/OWNERS",
+		},
+		{
+			name:     "kubernetes non-root raw github url",
+			url:      "https://raw.githubusercontent.com/kubernetes/kubernetes/main/test/OWNERS",
+			expected: "https://github.com/kubernetes/kubernetes/blob/main/test/OWNERS",
+		},
+		{
+			name:     "kubernetes github url should be unchanged",
+			url:      "https://github.com/kubernetes/kubernetes/blob/main/test/OWNERS",
+			expected: "https://github.com/kubernetes/kubernetes/blob/main/test/OWNERS",
+		},
+		{
+			name:     "non-github url should be unchanged",
+			url:      "https://viewsource.com/github/kubernetes/community/generator/app.go",
+			expected: "https://viewsource.com/github/kubernetes/community/generator/app.go",
+		},
+	}
+	for _, c := range cases {
+		actual := githubURL(c.url)
+		if actual != c.expected {
+			t.Errorf("FAIL %s: got: '%s' but expected: '%s'", c.name, actual, c.expected)
+		}
+	}
+}
+
+func TestOrgRepoPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "kubernetes-sigs root raw github url",
+			url:      "https://raw.githubusercontent.com/kubernetes-sigs/boskos/main/OWNERS",
+			expected: "kubernetes-sigs/boskos/OWNERS",
+		},
+		{
+			name:     "kubernetes non-root raw github url",
+			url:      "https://raw.githubusercontent.com/kubernetes/kubernetes/main/test/OWNERS",
+			expected: "kubernetes/kubernetes/test/OWNERS",
+		},
+		{
+			name:     "kubernetes github url",
+			url:      "https://github.com/kubernetes/kubernetes/blob/main/test/OWNERS",
+			expected: "kubernetes/kubernetes/test/OWNERS",
+		},
+		{
+			name:     "non-github url should be unchanged",
+			url:      "https://viewsource.com/github/kubernetes/community/generator/app.go",
+			expected: "https://viewsource.com/github/kubernetes/community/generator/app.go",
+		},
+	}
+	for _, c := range cases {
+		actual := orgRepoPath(c.url)
+		if actual != c.expected {
+			t.Errorf("FAIL %s: got: '%s' but expected: '%s'", c.name, actual, c.expected)
+		}
+	}
+}

--- a/generator/app_test.go
+++ b/generator/app_test.go
@@ -155,19 +155,22 @@ func TestGroupDirName(t *testing.T) {
 func TestCreateGroupReadmes(t *testing.T) {
 	baseGeneratorDir = "generated"
 	templateDir = "../../generator"
+	const groupType = "sig"
 
-	groups := []Group{
-		{Name: "Foo"},
-		{Name: "Bar"},
+	groups := []Group{}
+	for _, n := range []string{"Foo", "Bar"} {
+		g := Group{Name: n}
+		g.Dir = g.DirName(groupType)
+		groups = append(groups, g)
 	}
 
-	err := createGroupReadme(groups, "sig")
+	err := createGroupReadme(groups, groupType)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, group := range groups {
-		path := filepath.Join(baseGeneratorDir, group.DirName("sig"), "README.md")
+		path := filepath.Join(baseGeneratorDir, group.DirName(groupType), "README.md")
 		if !pathExists(path) {
 			t.Fatalf("%s should exist", path)
 		}

--- a/generator/committee_readme.tmpl
+++ b/generator/committee_readme.tmpl
@@ -66,7 +66,7 @@ The following [subprojects][subproject-definition] are owned by the {{.Name}} Co
 {{- end }}
 - **Owners:**
 {{- range .Owners }}
-  - {{.}}
+  - [{{trimSuffix (orgRepoPath .) "/OWNERS"}}]({{githubURL .}})
 {{- end }}
 {{- if .Contact }}
 - **Contact:**

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -76,7 +76,7 @@ The following [subprojects][subproject-definition] are owned by sig-{{.Label}}:
 {{- end }}
 - **Owners:**
 {{- range .Owners }}
-  - {{.}}
+  - [{{trimSuffix (orgRepoPath .) "/OWNERS"}}]({{githubURL .}})
 {{- end }}
 {{- if .Contact }}
 - **Contact:**

--- a/generator/testdata/sigs.yaml
+++ b/generator/testdata/sigs.yaml
@@ -1,5 +1,19 @@
 sigs:
-  - name: Foo
-  - name: Bar
+  - dir: sig-foo
+    name: Foo
+    label: foo
+    charter_link: foo-charter
+    mission_statement: covers foo
+    subprojects:
+    - name: sub-foo
+  - dir: sig-bar
+    name: Bar
+    label: bar
+    charter_link: charter-bar
+    mission_statement: owns areas related to bar
+    subprojects:
+    - name: sub-bar
 workinggroups:
-  - name: Baz
+  - dir: wg-baz
+    name: Baz
+    label: baz

--- a/generator/testdata/sigs.yaml
+++ b/generator/testdata/sigs.yaml
@@ -6,6 +6,8 @@ sigs:
     mission_statement: covers foo
     subprojects:
     - name: sub-foo
+      owners:
+      - "https://raw.githubusercontent.com/org/foo/main/OWNERS"
   - dir: sig-bar
     name: Bar
     label: bar
@@ -13,6 +15,8 @@ sigs:
     mission_statement: owns areas related to bar
     subprojects:
     - name: sub-bar
+      owners:
+      - "https://raw.githubusercontent.com/org/bar/main/test/OWNERS"
 workinggroups:
   - dir: wg-baz
     name: Baz

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -53,85 +53,85 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 The following [subprojects][subproject-definition] are owned by sig-api-machinery:
 ### component-base
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/legacyflag/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/component-base/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/OWNERS
+  - [kubernetes-sigs/legacyflag](https://github.com/kubernetes-sigs/legacyflag/blob/master/OWNERS)
+  - [kubernetes/component-base](https://github.com/kubernetes/component-base/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/component-base](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/OWNERS)
 ### control-plane-features
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/kubectl-check-ownerreferences/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/resourcequota/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/v1/OWNERS
+  - [kubernetes-sigs/kube-storage-version-migrator](https://github.com/kubernetes-sigs/kube-storage-version-migrator/blob/master/OWNERS)
+  - [kubernetes-sigs/kubectl-check-ownerreferences](https://github.com/kubernetes-sigs/kubectl-check-ownerreferences/blob/master/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/garbagecollector](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/garbagecollector/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/namespace](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/namespace/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/resourcequota](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/resourcequota/OWNERS)
+  - [kubernetes/kubernetes/pkg/quota/v1](https://github.com/kubernetes/kubernetes/blob/master/pkg/quota/v1/OWNERS)
 ### idl-schema-client-pipeline
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/structured-merge-diff/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/code-generator/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/gengo/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kube-openapi/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/code-generator/OWNERS
+  - [kubernetes-client/gen](https://github.com/kubernetes-client/gen/blob/master/OWNERS)
+  - [kubernetes-sigs/structured-merge-diff](https://github.com/kubernetes-sigs/structured-merge-diff/blob/master/OWNERS)
+  - [kubernetes/code-generator](https://github.com/kubernetes/code-generator/blob/master/OWNERS)
+  - [kubernetes/gengo](https://github.com/kubernetes/gengo/blob/master/OWNERS)
+  - [kubernetes/kube-openapi](https://github.com/kubernetes/kube-openapi/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/code-generator](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/code-generator/OWNERS)
 ### kubernetes-clients
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-client/c/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/csharp/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/go-base/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/go/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/haskell/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/java/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/javascript/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/perl/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/python-base/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/python/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-client/ruby/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/clientgofix/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/client-go/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/OWNERS
+  - [kubernetes-client/c](https://github.com/kubernetes-client/c/blob/master/OWNERS)
+  - [kubernetes-client/csharp](https://github.com/kubernetes-client/csharp/blob/master/OWNERS)
+  - [kubernetes-client/go-base](https://github.com/kubernetes-client/go-base/blob/master/OWNERS)
+  - [kubernetes-client/go](https://github.com/kubernetes-client/go/blob/master/OWNERS)
+  - [kubernetes-client/haskell](https://github.com/kubernetes-client/haskell/blob/master/OWNERS)
+  - [kubernetes-client/java](https://github.com/kubernetes-client/java/blob/master/OWNERS)
+  - [kubernetes-client/javascript](https://github.com/kubernetes-client/javascript/blob/master/OWNERS)
+  - [kubernetes-client/perl](https://github.com/kubernetes-client/perl/blob/master/OWNERS)
+  - [kubernetes-client/python-base](https://github.com/kubernetes-client/python-base/blob/master/OWNERS)
+  - [kubernetes-client/python](https://github.com/kubernetes-client/python/blob/master/OWNERS)
+  - [kubernetes-client/ruby](https://github.com/kubernetes-client/ruby/blob/master/OWNERS)
+  - [kubernetes-sigs/clientgofix](https://github.com/kubernetes-sigs/clientgofix/blob/master/OWNERS)
+  - [kubernetes/client-go](https://github.com/kubernetes/client-go/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/OWNERS)
 ### server-api-aggregation
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kube-aggregator/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/kube-aggregator/OWNERS
+  - [kubernetes/kube-aggregator](https://github.com/kubernetes/kube-aggregator/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/kube-aggregator](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kube-aggregator/OWNERS)
 ### server-binaries
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/controller-manager/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-apiserver/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-controller-manager/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/master/OWNERS
+  - [kubernetes/kubernetes/cmd/cloud-controller-manager](https://github.com/kubernetes/kubernetes/blob/master/cmd/cloud-controller-manager/OWNERS)
+  - [kubernetes/kubernetes/cmd/controller-manager](https://github.com/kubernetes/kubernetes/blob/master/cmd/controller-manager/OWNERS)
+  - [kubernetes/kubernetes/cmd/kube-apiserver](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/OWNERS)
+  - [kubernetes/kubernetes/cmd/kube-controller-manager](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-controller-manager/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubeapiserver](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubeapiserver/OWNERS)
+  - [kubernetes/kubernetes/pkg/master](https://github.com/kubernetes/kubernetes/blob/master/pkg/master/OWNERS)
 ### server-crd
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/apiextensions-apiserver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+  - [kubernetes/apiextensions-apiserver](https://github.com/kubernetes/apiextensions-apiserver/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiextensions-apiserver](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/OWNERS)
 ### server-frameworks
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/apiserver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/controller-manager/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/controller-manager/OWNERS
+  - [kubernetes/apiserver](https://github.com/kubernetes/apiserver/blob/master/OWNERS)
+  - [kubernetes/controller-manager](https://github.com/kubernetes/controller-manager/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/controller-manager](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/controller-manager/OWNERS)
 ### server-sdk
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/apiserver-builder-alpha/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/apiserver-runtime/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder-declarative-pattern/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder-release-tools/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-apiserver/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-controller/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/sample-apiserver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/sample-controller/master/OWNERS
+  - [kubernetes-sigs/apiserver-builder-alpha](https://github.com/kubernetes-sigs/apiserver-builder-alpha/blob/master/OWNERS)
+  - [kubernetes-sigs/apiserver-runtime](https://github.com/kubernetes-sigs/apiserver-runtime/blob/master/OWNERS)
+  - [kubernetes-sigs/controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/blob/master/OWNERS)
+  - [kubernetes-sigs/controller-tools](https://github.com/kubernetes-sigs/controller-tools/blob/master/OWNERS)
+  - [kubernetes-sigs/kubebuilder-declarative-pattern](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/OWNERS)
+  - [kubernetes-sigs/kubebuilder-release-tools](https://github.com/kubernetes-sigs/kubebuilder-release-tools/blob/master/OWNERS)
+  - [kubernetes-sigs/kubebuilder](https://github.com/kubernetes-sigs/kubebuilder/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/sample-apiserver](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/sample-apiserver/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/sample-controller](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/sample-controller/OWNERS)
+  - [kubernetes/sample-apiserver](https://github.com/kubernetes/sample-apiserver/blob/master/OWNERS)
+  - [kubernetes/sample-controller](https://github.com/kubernetes/sample-controller/blob/master/OWNERS)
 - **Contact:**
   - [Mailing List](https://groups.google.com/forum/#!forum/kubebuilder)
 ### universal-machinery
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/apimachinery/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apimachinery/OWNERS
+  - [kubernetes/apimachinery](https://github.com/kubernetes/apimachinery/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apimachinery](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/OWNERS)
 ### yaml
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/yaml/master/OWNERS
+  - [kubernetes-sigs/yaml](https://github.com/kubernetes-sigs/yaml/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -47,44 +47,44 @@ The following [subprojects][subproject-definition] are owned by sig-apps:
 ### application
 Application metadata descriptor CRD
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/application/master/OWNERS
+  - [kubernetes-sigs/application](https://github.com/kubernetes-sigs/application/blob/master/OWNERS)
 ### examples
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/examples/master/OWNERS
+  - [kubernetes/examples](https://github.com/kubernetes/examples/blob/master/OWNERS)
 ### execution-hook
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/execution-hook/master/OWNERS
+  - [kubernetes-sigs/execution-hook](https://github.com/kubernetes-sigs/execution-hook/blob/master/OWNERS)
 ### kompose
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kompose/master/OWNERS
+  - [kubernetes/kompose](https://github.com/kubernetes/kompose/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#kompose](https://kubernetes.slack.com/messages/kompose)
 ### workloads-api
 The core workloads API, which is composed of the CronJob, DaemonSet, Deployment, Job, ReplicaSet, ReplicationController, and StatefulSet kinds
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/apps/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/batch/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/core/v1/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/extensions/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cronjob/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/daemon/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/deployment/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/disruption/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/history/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/job/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replicaset/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replication/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/statefulset/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/apps/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/batch/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/extensions/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/apps/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/batch/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/core/v1/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/extensions/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/apps/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/daemonset/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/deployment/OWNERS
+  - [kubernetes/kubernetes/pkg/apis/apps](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/apps/OWNERS)
+  - [kubernetes/kubernetes/pkg/apis/batch](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/batch/OWNERS)
+  - [kubernetes/kubernetes/pkg/apis/core/v1](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/v1/OWNERS)
+  - [kubernetes/kubernetes/pkg/apis/extensions](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/extensions/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/cronjob](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cronjob/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/daemon](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/daemon/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/deployment](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/deployment/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/disruption](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/disruption/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/history](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/history/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/job](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/job/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/replicaset](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/replicaset/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/replication](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/replication/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/statefulset](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/statefulset/OWNERS)
+  - [kubernetes/kubernetes/pkg/registry/apps](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/apps/OWNERS)
+  - [kubernetes/kubernetes/pkg/registry/batch](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/batch/OWNERS)
+  - [kubernetes/kubernetes/pkg/registry/extensions](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/extensions/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/apps](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/apps/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/batch](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/batch/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/core/v1](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/core/v1/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/extensions](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/extensions/OWNERS)
+  - [kubernetes/kubernetes/test/e2e/apps](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/apps/OWNERS)
+  - [kubernetes/kubernetes/test/integration/daemonset](https://github.com/kubernetes/kubernetes/blob/master/test/integration/daemonset/OWNERS)
+  - [kubernetes/kubernetes/test/integration/deployment](https://github.com/kubernetes/kubernetes/blob/master/test/integration/deployment/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -58,25 +58,25 @@ The following [subprojects][subproject-definition] are owned by sig-architecture
 ### architecture-and-api-governance
 [Described below](#architecture-and-api-governance)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/community/master/contributors/design-proposals/architecture/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
+  - [kubernetes/api](https://github.com/kubernetes/api/blob/master/OWNERS)
+  - [kubernetes/community/contributors/design-proposals/architecture](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/OWNERS)
 ### code-organization
 [Described below](#code-organization)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/component-helpers/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-helpers/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/vendor/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
+  - [kubernetes/component-helpers](https://github.com/kubernetes/component-helpers/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging](https://github.com/kubernetes/kubernetes/blob/master/staging/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/component-helpers](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-helpers/OWNERS)
+  - [kubernetes/kubernetes/third_party](https://github.com/kubernetes/kubernetes/blob/master/third_party/OWNERS)
+  - [kubernetes/kubernetes/vendor](https://github.com/kubernetes/kubernetes/blob/master/vendor/OWNERS)
+  - [kubernetes/utils](https://github.com/kubernetes/utils/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#k8s-code-organization](https://kubernetes.slack.com/messages/k8s-code-organization)
 ### conformance-definition
 [Described below](#conformance-definition)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
+  - [kubernetes/kubernetes/test/conformance](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/OWNERS)
+  - [kubernetes/kubernetes/test/conformance/testdata](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/OWNERS)
 - **Contact:**
   - Slack: [#k8s-conformance](https://kubernetes.slack.com/messages/k8s-conformance)
   - GitHub Teams:
@@ -84,13 +84,13 @@ The following [subprojects][subproject-definition] are owned by sig-architecture
 ### enhancements
 [Described below](#enhancements)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/enhancements/master/OWNERS
+  - [kubernetes/enhancements](https://github.com/kubernetes/enhancements/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#enhancements](https://kubernetes.slack.com/messages/enhancements)
 ### production-readiness
 [Described below](#production-readiness)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-architecture/OWNERS
+  - [kubernetes/community/sig-architecture](https://github.com/kubernetes/community/blob/master/sig-architecture/OWNERS)
 - **Contact:**
   - Slack: [#prod-readiness](https://kubernetes.slack.com/messages/prod-readiness)
 

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -64,94 +64,94 @@ The following [subprojects][subproject-definition] are owned by sig-auth:
 ### audit-logging
 Kubernetes API support for audit logging.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/auditregistration/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/apis/audit/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/audit/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/audit/OWNERS
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/auditregistration](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/auditregistration/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/audit](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/apis/audit/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/pkg/audit](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/audit/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/audit](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/plugin/pkg/audit/OWNERS)
 ### authenticators
 Kubernetes API support for authentication.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authentication/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authenticator/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authentication/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authenticator/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authentication/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authentication/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authentication/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/plugin/pkg/client/auth/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/tools/auth/OWNERS
+  - [kubernetes/kubernetes/pkg/apis/authentication](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/authentication/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubeapiserver/authenticator](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubeapiserver/authenticator/OWNERS)
+  - [kubernetes/kubernetes/pkg/registry/authentication](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/authentication/OWNERS)
+  - [kubernetes/kubernetes/plugin/pkg/auth/authenticator](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authenticator/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/authentication](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/authentication/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/authentication/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authentication](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/kubernetes/typed/authentication/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/listers/authentication](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/listers/authentication/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/pkg/apis/clientauthentication](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/plugin/pkg/client/auth](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/plugin/pkg/client/auth/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/tools/auth](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/auth/OWNERS)
 ### authorizers
 Kubernetes API support for authorization.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authorization/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/rbac/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authorizer/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/cmd/auth/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authorization/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/rbac/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authorization/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/rbac/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authorization/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authorization/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/rbac/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authorization/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/rbac/OWNERS
+  - [kubernetes/kubernetes/pkg/apis/authorization](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/authorization/OWNERS)
+  - [kubernetes/kubernetes/pkg/apis/rbac](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/rbac/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubeapiserver/authorizer](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubeapiserver/authorizer/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubectl/cmd/auth](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/auth/OWNERS)
+  - [kubernetes/kubernetes/pkg/registry/authorization](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/authorization/OWNERS)
+  - [kubernetes/kubernetes/pkg/registry/rbac](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/rbac/OWNERS)
+  - [kubernetes/kubernetes/plugin/pkg/auth/authorizer](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/authorization](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/authorization/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/rbac](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/rbac/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/authorization/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authorizer](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authorization](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/kubernetes/typed/authorization/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/rbac](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/kubernetes/typed/rbac/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/listers/authorization](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/listers/authorization/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/listers/rbac](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/listers/rbac/OWNERS)
 ### certificates
 Certificates APIs and client infrastructure to support PKI.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/certificates/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/certificates/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/cert/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/certificate/OWNERS
+  - [kubernetes/kubernetes/pkg/apis/certificates](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/certificates/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/certificates](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/certificates/OWNERS)
+  - [kubernetes/kubernetes/pkg/registry/certificates](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/certificates/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/x509](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/util/cert](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/util/cert/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/client-go/util/certificate](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/util/certificate/OWNERS)
 ### encryption-at-rest
 API storage support for storing data encrypted at rest in etcd.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/OWNERS
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/OWNERS)
 ### multi-tenancy
 Proposals and prototypes for introducing tenant model to enable multi-tenant cluster
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/OWNERS
+  - [kubernetes-sigs/multi-tenancy](https://github.com/kubernetes-sigs/multi-tenancy/blob/master/OWNERS)
 ### node-identity-and-isolation
 Node identity management (co-owned with sig-lifecycle), and authorization restrictions for isolating workloads on separate nodes (co-owned with sig-node).
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/approver/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/certificate/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/noderestriction/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/node/OWNERS
+  - [kubernetes/kubernetes/pkg/controller/certificates/approver](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/certificates/approver/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubelet/certificate](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/certificate/OWNERS)
+  - [kubernetes/kubernetes/plugin/pkg/admission/noderestriction](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/noderestriction/OWNERS)
+  - [kubernetes/kubernetes/plugin/pkg/auth/authorizer/node](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/node/OWNERS)
 ### policy-management
 API validation and policies enforced during admission, such as PodSecurityPolicy. Excludes run-time policies like NetworkPolicy and Seccomp.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/wg-policy-prototypes/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/imagepolicy/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/policy/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/policy/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/security/podsecuritypolicy/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/imagepolicy/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/security/podsecuritypolicy/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/imagepolicy/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/policy/OWNERS
+  - [kubernetes-sigs/wg-policy-prototypes](https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/master/OWNERS)
+  - [kubernetes/kubernetes/pkg/apis/imagepolicy](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/imagepolicy/OWNERS)
+  - [kubernetes/kubernetes/pkg/apis/policy](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/policy/OWNERS)
+  - [kubernetes/kubernetes/pkg/registry/policy](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/policy/OWNERS)
+  - [kubernetes/kubernetes/pkg/security/podsecuritypolicy](https://github.com/kubernetes/kubernetes/blob/master/pkg/security/podsecuritypolicy/OWNERS)
+  - [kubernetes/kubernetes/plugin/pkg/admission/imagepolicy](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/imagepolicy/OWNERS)
+  - [kubernetes/kubernetes/plugin/pkg/admission/security/podsecuritypolicy](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/security/podsecuritypolicy/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/imagepolicy](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/imagepolicy/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/policy](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/policy/OWNERS)
 ### secrets-store-csi-driver
 Integrates secrets stores with Kubernetes via a CSI volume.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/OWNERS
+  - [kubernetes-sigs/secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#csi-secrets-store](https://kubernetes.slack.com/messages/csi-secrets-store)
   - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-secrets-store-csi-driver)
 ### service-accounts
 Infrastructure implementing Kubernetes service account based workload identity.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/serviceaccount/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/token/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/serviceaccount/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/serviceaccount/OWNERS
+  - [kubernetes/kubernetes/pkg/controller/serviceaccount](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/serviceaccount/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubelet/token](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/token/OWNERS)
+  - [kubernetes/kubernetes/pkg/serviceaccount](https://github.com/kubernetes/kubernetes/blob/master/pkg/serviceaccount/OWNERS)
+  - [kubernetes/kubernetes/plugin/pkg/admission/serviceaccount](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/serviceaccount/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -43,20 +43,20 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-autoscaling:
 ### addon-resizer
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
+  - [kubernetes/autoscaler/addon-resizer](https://github.com/kubernetes/autoscaler/blob/master/addon-resizer/OWNERS)
 ### cluster-autoscaler
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+  - [kubernetes/autoscaler](https://github.com/kubernetes/autoscaler/blob/master/OWNERS)
 ### horizontal-pod-autoscaler
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
+  - [kubernetes/api/autoscaling](https://github.com/kubernetes/api/blob/master/autoscaling/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/podautoscaler](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/podautoscaler/OWNERS)
 ### scale-client
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/client-go/master/scale/OWNERS
+  - [kubernetes/client-go/scale](https://github.com/kubernetes/client-go/blob/master/scale/OWNERS)
 ### vertical-pod-autoscaler
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+  - [kubernetes/autoscaler](https://github.com/kubernetes/autoscaler/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -61,31 +61,31 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 The following [subprojects][subproject-definition] are owned by sig-cli:
 ### cli-experimental
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cli-experimental/master/OWNERS
+  - [kubernetes-sigs/cli-experimental](https://github.com/kubernetes-sigs/cli-experimental/blob/master/OWNERS)
 ### cli-sdk
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/cli-runtime/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cli-runtime/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-cli-plugin/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/sample-cli-plugin/master/OWNERS
+  - [kubernetes/cli-runtime](https://github.com/kubernetes/cli-runtime/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/cli-runtime](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cli-runtime/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/sample-cli-plugin](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/sample-cli-plugin/OWNERS)
+  - [kubernetes/sample-cli-plugin](https://github.com/kubernetes/sample-cli-plugin/blob/master/OWNERS)
 ### cli-utils
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cli-utils/master/OWNERS
+  - [kubernetes-sigs/cli-utils](https://github.com/kubernetes-sigs/cli-utils/blob/master/OWNERS)
 ### krew
 Plugin manager for kubectl.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/krew/master/OWNERS
+  - [kubernetes-sigs/krew](https://github.com/kubernetes-sigs/krew/blob/master/OWNERS)
 ### krew-index
 Centralized plugin index for krew.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/OWNERS
+  - [kubernetes-sigs/krew-index](https://github.com/kubernetes-sigs/krew-index/blob/master/OWNERS)
 ### kubectl
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubectl/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/OWNERS
+  - [kubernetes/kubectl](https://github.com/kubernetes/kubectl/blob/master/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubectl](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/OWNERS)
 ### kustomize
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/OWNERS
+  - [kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#kustomize](https://kubernetes.slack.com/messages/kustomize)
 

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -50,46 +50,46 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-cloud-provider:
 ### cloud-provider-extraction-migration
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/apiserver-network-proxy/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-cloud-provider/cloud-provider-extraction-migration/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/legacy-cloud-providers/master/OWNERS
+  - [kubernetes-sigs/apiserver-network-proxy](https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/master/OWNERS)
+  - [kubernetes/community/sig-cloud-provider/cloud-provider-extraction-migration](https://github.com/kubernetes/community/blob/master/sig-cloud-provider/cloud-provider-extraction-migration/OWNERS)
+  - [kubernetes/legacy-cloud-providers](https://github.com/kubernetes/legacy-cloud-providers/blob/master/OWNERS)
 - **Meetings:**
   - Weekly Sync removing the in-tree cloud providers led by @cheftako and @mcrute: [Thursdays at 13:30 PT (Pacific Time)](https://docs.google.com/document/d/1KLsGGzNXQbsPeELCeF_q-f0h0CEGSe20xiwvcR2NlYM/edit) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:30&tz=PT%20%28Pacific%20Time%29).
 ### kubernetes-cloud-provider
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/cloud-provider-sample/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/cloud-provider/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/cloudprovider/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cloud/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/OWNERS
+  - [kubernetes/cloud-provider-sample](https://github.com/kubernetes/cloud-provider-sample/blob/master/OWNERS)
+  - [kubernetes/cloud-provider](https://github.com/kubernetes/cloud-provider/blob/master/OWNERS)
+  - [kubernetes/kubernetes/cmd/cloud-controller-manager](https://github.com/kubernetes/kubernetes/blob/master/cmd/cloud-controller-manager/OWNERS)
+  - [kubernetes/kubernetes/pkg/cloudprovider](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/cloud](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cloud/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/cloud-provider](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cloud-provider/OWNERS)
 ### provider-alibaba-cloud
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/alibaba-cloud-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/cloud-provider-alibaba-cloud/master/OWNERS
+  - [kubernetes-sigs/alibaba-cloud-csi-driver](https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/blob/master/OWNERS)
+  - [kubernetes/cloud-provider-alibaba-cloud](https://github.com/kubernetes/cloud-provider-alibaba-cloud/blob/master/OWNERS)
 - **Meetings:**
   - Regular Alibaba Cloud Subproject Meeting: [Tuesdays at 12:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (monthly 2020 start date: Jan. 7th). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:00&tz=UTC).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1x7E2Brzx8rAEI4IIsfOZuZUBIf-J4NTIGuDaKb8z_sM/edit).
     - [Meeting recordings](https://www.youtube.com/playlist?list=PLWpmsLfcyyD7HAhlLTuwmI9KWuoiaN9nO).
 ### provider-aws
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/aws-encryption-provider/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/aws-fsx-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/aws-iam-authenticator/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS
+  - [kubernetes-sigs/aws-alb-ingress-controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/OWNERS)
+  - [kubernetes-sigs/aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/OWNERS)
+  - [kubernetes-sigs/aws-efs-csi-driver](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/OWNERS)
+  - [kubernetes-sigs/aws-encryption-provider](https://github.com/kubernetes-sigs/aws-encryption-provider/blob/master/OWNERS)
+  - [kubernetes-sigs/aws-fsx-csi-driver](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/blob/master/OWNERS)
+  - [kubernetes-sigs/aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/OWNERS)
+  - [kubernetes/cloud-provider-aws](https://github.com/kubernetes/cloud-provider-aws/blob/master/OWNERS)
 - **Meetings:**
   - Regular AWS Subproject Meeting: [Fridays at 9:00 PT (Pacific Time)](https://zoom.us/my/k8ssigaws) (biweekly 2019 start date: Jan. 11th). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit).
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29DzPOBBaJi-SO3AQ_b4HC).
 ### provider-azure
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/blobfuse-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/OWNERS
+  - [kubernetes-sigs/azuredisk-csi-driver](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/OWNERS)
+  - [kubernetes-sigs/azurefile-csi-driver](https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/OWNERS)
+  - [kubernetes-sigs/blobfuse-csi-driver](https://github.com/kubernetes-sigs/blobfuse-csi-driver/blob/master/OWNERS)
+  - [kubernetes-sigs/cloud-provider-azure](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/OWNERS)
 - **Meetings:**
   - Azure Subproject Meeting (every four weeks): [Mondays at 18:00 PT (Pacific Time)](https://zoom.us/j/586836662) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=18:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1SpxvmOgHDhnA72Z0lbhBffrfe9inQxZkU9xqlafOW9k/edit).
@@ -99,35 +99,35 @@ The following [subprojects][subproject-definition] are owned by sig-cloud-provid
     - [Meeting recordings](https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4).
 ### provider-baiducloud
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-baiducloud/master/OWNERS
+  - [kubernetes-sigs/cloud-provider-baiducloud](https://github.com/kubernetes-sigs/cloud-provider-baiducloud/blob/master/OWNERS)
 ### provider-gcp
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/gcp-filestore-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
+  - [kubernetes-sigs/gcp-compute-persistent-disk-csi-driver](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/OWNERS)
+  - [kubernetes-sigs/gcp-filestore-csi-driver](https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/OWNERS)
+  - [kubernetes/cloud-provider-gcp](https://github.com/kubernetes/cloud-provider-gcp/blob/master/OWNERS)
 - **Meetings:**
   - Regular GCP Subproject Meeting: [Thursdays at 16:00 UTC](https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1mtmwZ4oVSSWhbEw8Lfzvc7ig84qxUpdK6uHyJp8rSGU/edit).
 ### provider-huaweicloud
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-huaweicloud/master/OWNERS
+  - [kubernetes-sigs/cloud-provider-huaweicloud](https://github.com/kubernetes-sigs/cloud-provider-huaweicloud/blob/master/OWNERS)
 ### provider-ibmcloud
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-ibmcloud/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-ibmcloud](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/master/OWNERS)
 - **Meetings:**
   - Regular IBM Subproject Meeting: [Wednesdays at 14:00 EST](https://zoom.us/j/9392903494) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:00&tz=EST).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1qd_LTu5GFaxUhSWTHigowHt3XwjJVf1L57kupj8lnwg/edit).
 ### provider-openstack
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
+  - [kubernetes/cloud-provider-openstack](https://github.com/kubernetes/cloud-provider-openstack/blob/master/OWNERS)
 - **Meetings:**
   - Regular OpenStack Subproject Meeting: [Wednesdays at 08:00 PT (Pacific Time)](https://docs.google.com/document/d/1bW3j4hFN4D8rv2LFv-DybB3gcE5ISAaOO_OpvDCgrGg/edit) (biweekly starting Wednesday March 20, 2019). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=08:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/15UwgLbEyZyXXxVtsThcSuPiJru4CuqU9p3ttZSfTaY4/edit).
     - [Meeting recordings](https://www.youtube.com/watch?v=iCfUx7ilh0E&list=PL69nYSiGNLP20iTSChQ_i2QQmTBl3M7ax).
 ### provider-vsphere
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/OWNERS
+  - [kubernetes-sigs/vsphere-csi-driver](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/OWNERS)
+  - [kubernetes/cloud-provider-vsphere](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/OWNERS)
 - **Meetings:**
   - Cloud Provider vSphere monthly syncup: [Wednesdays at 09:00 PT (Pacific Time)](https://zoom.us/j/584244729) (monthly - first Wednesday every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1B0NmmKVh8Ea5hnNsbUsJC7ZyNCsq_6NXl5hRdcHlJgY/edit?usp=sharing).

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -50,12 +50,12 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 The following [subprojects][subproject-definition] are owned by sig-cluster-lifecycle:
 ### bootkube
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/bootkube/master/OWNERS
+  - [kubernetes-sigs/bootkube](https://github.com/kubernetes-sigs/bootkube/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#bootkube](https://kubernetes.slack.com/messages/bootkube)
 ### cluster-addons
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-addons/master/OWNERS
+  - [kubernetes-sigs/cluster-addons](https://github.com/kubernetes-sigs/cluster-addons/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#cluster-addons](https://kubernetes.slack.com/messages/cluster-addons)
 - **Meetings:**
@@ -63,8 +63,8 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
     - [Meeting notes and Agenda](https://docs.google.com/document/d/10_tl_SXcFGb-2109QpcFVrdrfnVEuQ05MBrXtasB0vk/edit).
 ### cluster-api
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
+  - [kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm](https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/blob/master/OWNERS)
+  - [kubernetes-sigs/cluster-api](https://github.com/kubernetes-sigs/cluster-api/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#cluster-api](https://kubernetes.slack.com/messages/cluster-api)
 - **Meetings:**
@@ -73,53 +73,53 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 ### cluster-api-provider-aws
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-aws](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/OWNERS)
 - **Meetings:**
   - Cluster API Provider AWS office hours: [Mondays at 10:00 PT (Pacific Time)](https://zoom.us/j/423312508?pwd=Tk9OWnZ4WHg2T2xRek9xZXA1eFQ4dz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1iW-kqcX-IhzVGFrRKTSPGBPOc-0aUvygOVoJ5ETfEZU/).
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 ### cluster-api-provider-azure
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/OWNERS)
 - **Meetings:**
   - Cluster API Provider Azure office hours: [Thursdays at 08:00 PT (Pacific Time)](https://zoom.us/j/566930821?pwd=N2JuRWljc3hGS3ZnVlBLTk42TFlzQT09) (bi-weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=08:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](http://bit.ly/k8s-capz-agenda).
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 ### cluster-api-provider-digitalocean
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-digitalocean](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/blob/master/OWNERS)
 - **Meetings:**
   - Cluster API Provider DigitalOcean office hours: [Thursdays at 09:00 PT (Pacific Time)](https://zoom.us/j/91312171751?pwd=bndnMDdJMkhySDVncjZoR1VhdFBTZz09) (monthly, second Thursday of the month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](http://bit.ly/k8s-capdo-agenda).
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 ### cluster-api-provider-docker
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-docker/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-docker](https://github.com/kubernetes-sigs/cluster-api-provider-docker/blob/master/OWNERS)
 ### cluster-api-provider-gcp
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-gcp](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/master/OWNERS)
 ### cluster-api-provider-ibmcloud
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-ibmcloud/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-ibmcloud](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/blob/master/OWNERS)
 ### cluster-api-provider-kubemark
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-kubemark/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-kubemark](https://github.com/kubernetes-sigs/cluster-api-provider-kubemark/blob/master/OWNERS)
 ### cluster-api-provider-nested
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-nested](https://github.com/kubernetes-sigs/cluster-api-provider-nested/blob/master/OWNERS)
 - **Meetings:**
   - Cluster API Provider Nested Office Hours: [Tuesdays at 10:00 PT (Pacific Time)](https://zoom.us/j/91929881559?pwd=WllxazhTUzBFN1BNWTRadTA3NGtQQT09) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/10aTeq2lhXW_3aFQAd_MdGjY8PtZPslKhZCCcXxFp3_Q/edit).
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 ### cluster-api-provider-openstack
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-openstack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/OWNERS)
 ### cluster-api-provider-packet
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-packet/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-packet](https://github.com/kubernetes-sigs/cluster-api-provider-packet/blob/master/OWNERS)
 ### cluster-api-provider-vsphere
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-vsphere/master/OWNERS
+  - [kubernetes-sigs/cluster-api-provider-vsphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#cluster-api-vsphere](https://kubernetes.slack.com/messages/cluster-api-vsphere)
 - **Meetings:**
@@ -128,7 +128,7 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
     - [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIovV-AONxMa2cyv-_5LAYiu).
 ### etcdadm
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/etcdadm/master/OWNERS
+  - [kubernetes-sigs/etcdadm](https://github.com/kubernetes-sigs/etcdadm/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#etcdadm](https://kubernetes.slack.com/messages/etcdadm)
 - **Meetings:**
@@ -136,7 +136,7 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1b_J0oBvi9lL0gsPgTOrCw1Zlx3e7BYEuXnB3d2S15pA/edit).
 ### image-builder
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/image-builder/master/OWNERS
+  - [kubernetes-sigs/image-builder](https://github.com/kubernetes-sigs/image-builder/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#image-builder](https://kubernetes.slack.com/messages/image-builder)
 - **Meetings:**
@@ -145,19 +145,19 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 ### kops
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS
+  - [kubernetes/kops](https://github.com/kubernetes/kops/blob/master/OWNERS)
 - **Meetings:**
   - kops Office Hours: [Fridays at 09:00 PT (Pacific Time)](https://zoom.us/j/97072789944?pwd=VVlUR3dhN2h5TEFQZHZTVVd4SnJUdz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/12QkyL0FkNbWPcLFxxRGSPt_tNPBHbmni3YLY-lHny7E/edit).
 ### kube-up
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS
+  - [kubernetes/kubernetes/cluster](https://github.com/kubernetes/kubernetes/blob/master/cluster/OWNERS)
 ### kubeadm
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/system-validators/master/OWNERS
+  - [kubernetes/cluster-bootstrap](https://github.com/kubernetes/cluster-bootstrap/blob/master/OWNERS)
+  - [kubernetes/kubeadm](https://github.com/kubernetes/kubeadm/blob/master/OWNERS)
+  - [kubernetes/kubernetes/cmd/kubeadm](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/OWNERS)
+  - [kubernetes/system-validators](https://github.com/kubernetes/system-validators/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#kubeadm](https://kubernetes.slack.com/messages/kubeadm)
 - **Meetings:**
@@ -166,7 +166,7 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 ### kubespray
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS
+  - [kubernetes-sigs/kubespray](https://github.com/kubernetes-sigs/kubespray/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#kubespray](https://kubernetes.slack.com/messages/kubespray)
 - **Meetings:**
@@ -174,7 +174,7 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1oDI1rTwla393k6nEMkqz0RU9rUl3J1hov0kQfNcl-4o/edit).
 ### minikube
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/minikube/master/OWNERS
+  - [kubernetes/minikube](https://github.com/kubernetes/minikube/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#minikube](https://kubernetes.slack.com/messages/minikube)
 - **Meetings:**

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -56,12 +56,12 @@ The following [subprojects][subproject-definition] are owned by sig-contributor-
 ### community
 Owns and manages overall community repo, including community group documentation and operations.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/OWNERS
+  - [kubernetes/community](https://github.com/kubernetes/community/blob/master/OWNERS)
 ### community-management
 Manages operations and policy for upstream community group communication platforms.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/discuss-theme/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/community/master/communication/OWNERS
+  - [kubernetes-sigs/discuss-theme](https://github.com/kubernetes-sigs/discuss-theme/blob/master/OWNERS)
+  - [kubernetes/community/communication](https://github.com/kubernetes/community/blob/master/communication/OWNERS)
 - **Meetings:**
   - APAC Coordinator Meeting: [Thursdays at 5:00 UTC](https://zoom.us/j/144440337?pwd=VEVBejdPYkE2MGdUSDZZZnVlNFdrdz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=5:00&tz=UTC).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/).
@@ -69,8 +69,8 @@ Manages operations and policy for upstream community group communication platfor
 ### contributor-comms
 Contributor Communications focuses on amplifying the success of Kubernetes contributors through marketing.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/contributor-tweets/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/community/master/communication/marketing-team/OWNERS
+  - [kubernetes-sigs/contributor-tweets](https://github.com/kubernetes-sigs/contributor-tweets/blob/master/OWNERS)
+  - [kubernetes/community/communication/marketing-team](https://github.com/kubernetes/community/blob/master/communication/marketing-team/OWNERS)
 - **Meetings:**
   - Contributor Comms - Upstream Marketing Team Meeting: [Fridays at 8:00 PT (Pacific Time)](https://zoom.us/j/596959769?pwd=TURBNlZPb3BEWVFmbWlCYXlMVVJiUT09) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=8:00&tz=PT%20%28Pacific%20Time%29).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1KDoqbw2A6W7rLSbIRuOlqH8gkoOnp2IHHuV9KyJDD2c/edit).
@@ -78,18 +78,18 @@ Contributor Communications focuses on amplifying the success of Kubernetes contr
 ### contributors-documentation
 writes and maintains documentation around contributing to Kubernetes, including the Contributor's Guide, Developer's Guide, and contributor website.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/contributor-site/master/OWNERS
+  - [kubernetes/community/contributors/guide](https://github.com/kubernetes/community/blob/master/contributors/guide/OWNERS)
+  - [kubernetes/contributor-site](https://github.com/kubernetes/contributor-site/blob/master/OWNERS)
 ### devstats
 Maintains and updates https://k8s.devstats.cncf.io, including taking requests for new charts.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
+  - [kubernetes/community/sig-contributor-experience/devstats](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/devstats/OWNERS)
 - **Contact:**
   - Slack: [#devstats](https://kubernetes.slack.com/messages/devstats)
 ### events
 Creates and runs contributor-focused events, such as the Contributor Summit.  Event Teams are part of this subproject.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/events/OWNERS
+  - [kubernetes/community/events](https://github.com/kubernetes/community/blob/master/events/OWNERS)
 - **Contact:**
   - Slack: [#events](https://kubernetes.slack.com/messages/events)
 - **Meetings:**
@@ -100,13 +100,13 @@ Creates and runs contributor-focused events, such as the Contributor Summit.  Ev
 ### github-management
 Manages and controls Github permissions, repos, and groups, including Org Membership.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-client/.github/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/.github/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/.github/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/.github/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
+  - [kubernetes-client/.github](https://github.com/kubernetes-client/.github/blob/master/OWNERS)
+  - [kubernetes-csi/.github](https://github.com/kubernetes-csi/.github/blob/master/OWNERS)
+  - [kubernetes-sigs/.github](https://github.com/kubernetes-sigs/.github/blob/master/OWNERS)
+  - [kubernetes/.github](https://github.com/kubernetes/.github/blob/master/OWNERS)
+  - [kubernetes/community/github-management](https://github.com/kubernetes/community/blob/master/github-management/OWNERS)
+  - [kubernetes/kubernetes-template-project](https://github.com/kubernetes/kubernetes-template-project/blob/master/OWNERS)
+  - [kubernetes/org](https://github.com/kubernetes/org/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#github-management](https://kubernetes.slack.com/messages/github-management)
 - **Meetings:**
@@ -116,12 +116,12 @@ Manages and controls Github permissions, repos, and groups, including Org Member
 ### k8s.io
 Creates and maintains shortcuts and automation apps running in the k8s.io domain.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/k8s.io/master/OWNERS
+  - [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io/blob/master/OWNERS)
 ### mentoring
 Oversees and develops programs for helping contributors ascend the contributor ladder, including the New Contributor Workshops, Meet Our Contributors, and other programs.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
+  - [kubernetes-sigs/contributor-playground](https://github.com/kubernetes-sigs/contributor-playground/blob/master/OWNERS)
+  - [kubernetes/community/mentoring](https://github.com/kubernetes/community/blob/master/mentoring/OWNERS)
 - **Meetings:**
   - Mentoring Subproject Meeting (NA/APAC): [Mondays at 4:00 PT](https://zoom.us/j/95894431386?pwd=RFdmQzlZeVZDVWJzcFVXZXR5djNwUT09) (Biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=4:00&tz=PT).
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1XiXjDWCc087VKqX2b6LMGRnlaRyLYGh2-eWQQr6dAmc/edit).
@@ -129,7 +129,7 @@ Oversees and develops programs for helping contributors ascend the contributor l
 ### slack-infra
 Creates and maintains tools and automation for Kubernetes Slack.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/slack-infra/master/OWNERS
+  - [kubernetes-sigs/slack-infra](https://github.com/kubernetes-sigs/slack-infra/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#slack-infra](https://kubernetes.slack.com/messages/slack-infra)
 

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -81,13 +81,13 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 The following [subprojects][subproject-definition] are owned by sig-docs:
 ### kubernetes-blog
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/website/master/content/en/blog/OWNERS
+  - [kubernetes/website/content/en/blog](https://github.com/kubernetes/website/blob/master/content/en/blog/OWNERS)
 ### reference-docs
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/reference-docs/master/OWNERS
+  - [kubernetes-sigs/reference-docs](https://github.com/kubernetes-sigs/reference-docs/blob/master/OWNERS)
 ### website
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
+  - [kubernetes/website](https://github.com/kubernetes/website/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -56,36 +56,36 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 The following [subprojects][subproject-definition] are owned by sig-instrumentation:
 ### custom-metrics-apiserver
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/custom-metrics-apiserver/master/OWNERS
+  - [kubernetes-sigs/custom-metrics-apiserver](https://github.com/kubernetes-sigs/custom-metrics-apiserver/blob/master/OWNERS)
 ### instrumentation-tools
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/instrumentation-tools/master/OWNERS
+  - [kubernetes-sigs/instrumentation-tools](https://github.com/kubernetes-sigs/instrumentation-tools/blob/master/OWNERS)
 ### klog
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
+  - [kubernetes/klog](https://github.com/kubernetes/klog/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#klog](https://kubernetes.slack.com/messages/klog)
 ### kube-state-metrics
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS
+  - [kubernetes/kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#kube-state-metrics](https://kubernetes.slack.com/messages/kube-state-metrics)
 ### metric-stability-framework
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/metrics/OWNERS
+  - [kubernetes/kubernetes/staging/src/k8s.io/component-base/metrics](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/metrics/OWNERS)
 ### metrics
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/metrics/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
+  - [kubernetes/kubernetes/staging/src/k8s.io/metrics](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/metrics/OWNERS)
+  - [kubernetes/metrics](https://github.com/kubernetes/metrics/blob/master/OWNERS)
 ### metrics-server
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/OWNERS
+  - [kubernetes-sigs/metrics-server](https://github.com/kubernetes-sigs/metrics-server/blob/master/OWNERS)
 ### prometheus-adapter
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/prometheus-adapter/master/OWNERS
+  - [kubernetes-sigs/prometheus-adapter](https://github.com/kubernetes-sigs/prometheus-adapter/blob/master/OWNERS)
 ### structured-logging
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/logs/OWNERS
+  - [kubernetes/kubernetes/staging/src/k8s.io/component-base/logs](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/logs/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -48,22 +48,22 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-multicluster:
 ### Kubefed
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/OWNERS
+  - [kubernetes-sigs/kubefed](https://github.com/kubernetes-sigs/kubefed/blob/master/OWNERS)
 ### cluster-registry
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/cluster-registry/master/OWNERS
+  - [kubernetes/cluster-registry](https://github.com/kubernetes/cluster-registry/blob/master/OWNERS)
 ### federation-v1
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/federation/master/OWNERS
+  - [kubernetes/federation](https://github.com/kubernetes/federation/blob/master/OWNERS)
 ### kubemci
 - **Owners:**
-  - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS
+  - [GoogleCloudPlatform/k8s-multicluster-ingress](https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/blob/master/OWNERS)
 ### mcs-api
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/master/OWNERS
+  - [kubernetes-sigs/mcs-api](https://github.com/kubernetes-sigs/mcs-api/blob/master/OWNERS)
 ### work-api
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/work-api/master/OWNERS
+  - [kubernetes-sigs/work-api](https://github.com/kubernetes-sigs/work-api/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -49,41 +49,41 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-network:
 ### cluster-proportional-autoscaler
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-proportional-autoscaler/master/OWNERS
+  - [kubernetes-sigs/cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/blob/master/OWNERS)
 ### cluster-proportional-vertical-autoscaler
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler/master/OWNERS
+  - [kubernetes-sigs/cluster-proportional-vertical-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler/blob/master/OWNERS)
 ### external-dns
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/external-dns/master/OWNERS
+  - [kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#external-dns](https://kubernetes.slack.com/messages/external-dns)
 ### gateway-api
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
+  - [kubernetes-sigs/gateway-api](https://github.com/kubernetes-sigs/gateway-api/blob/master/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/endpoint](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/endpoint/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/service](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/service/OWNERS)
+  - [kubernetes/kubernetes/pkg/proxy](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/OWNERS)
 - **Contact:**
   - Slack: [#sig-network-gateway-api](https://kubernetes.slack.com/messages/sig-network-gateway-api)
 ### ingress
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/ingress-controller-conformance/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/ingress-gce/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/OWNERS
+  - [kubernetes-sigs/ingress-controller-conformance](https://github.com/kubernetes-sigs/ingress-controller-conformance/blob/master/OWNERS)
+  - [kubernetes/ingress-gce](https://github.com/kubernetes/ingress-gce/blob/master/OWNERS)
+  - [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/master/OWNERS)
 ### iptables-wrappers
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/master/OWNERS
+  - [kubernetes-sigs/iptables-wrappers](https://github.com/kubernetes-sigs/iptables-wrappers/blob/master/OWNERS)
 ### kube-dns
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
+  - [kubernetes/dns](https://github.com/kubernetes/dns/blob/master/OWNERS)
 ### network-policy
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
+  - [kubernetes/api/networking](https://github.com/kubernetes/api/blob/master/networking/OWNERS)
 ### pod-networking
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/ip-masq-agent/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
+  - [kubernetes-sigs/ip-masq-agent](https://github.com/kubernetes-sigs/ip-masq-agent/blob/master/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubelet/network](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -45,35 +45,35 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-node:
 ### cri-api
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/cri-api/master/OWNERS
+  - [kubernetes/cri-api](https://github.com/kubernetes/cri-api/blob/master/OWNERS)
 ### cri-tools
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cri-tools/master/OWNERS
+  - [kubernetes-sigs/cri-tools](https://github.com/kubernetes-sigs/cri-tools/blob/master/OWNERS)
 ### frakti
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/frakti/master/OWNERS
+  - [kubernetes/frakti](https://github.com/kubernetes/frakti/blob/master/OWNERS)
 ### kubelet
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubelet/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/OWNERS
+  - [kubernetes/kubernetes/cmd/kubelet](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubelet](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/OWNERS)
 ### node-api
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/api/master/node/OWNERS
+  - [kubernetes/api/node](https://github.com/kubernetes/api/blob/master/node/OWNERS)
 ### node-feature-discovery
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery-operator/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/OWNERS
+  - [kubernetes-sigs/node-feature-discovery-operator](https://github.com/kubernetes-sigs/node-feature-discovery-operator/blob/master/OWNERS)
+  - [kubernetes-sigs/node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/OWNERS)
 ### node-problem-detector
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
+  - [kubernetes/node-problem-detector](https://github.com/kubernetes/node-problem-detector/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
 ### noderesourcetopology-api
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/noderesourcetopology-api/master/OWNERS
+  - [kubernetes/noderesourcetopology-api](https://github.com/kubernetes/noderesourcetopology-api/blob/master/OWNERS)
 ### security-profiles-operator
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/master/OWNERS
+  - [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#security-profiles-operator](https://kubernetes.slack.com/messages/security-profiles-operator)
 

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -56,16 +56,16 @@ The following [subprojects][subproject-definition] are owned by sig-release:
 ### Release Engineering
 The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/downloadkubernetes/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/k8s-container-image-promoter/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/mdtoc/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/release-notes/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/release-sdk/main/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/release-utils/main/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/zeitgeist/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS
+  - [kubernetes-sigs/downloadkubernetes](https://github.com/kubernetes-sigs/downloadkubernetes/blob/master/OWNERS)
+  - [kubernetes-sigs/k8s-container-image-promoter](https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/OWNERS)
+  - [kubernetes-sigs/mdtoc](https://github.com/kubernetes-sigs/mdtoc/blob/master/OWNERS)
+  - [kubernetes-sigs/release-notes](https://github.com/kubernetes-sigs/release-notes/blob/master/OWNERS)
+  - [kubernetes-sigs/release-sdk](https://github.com/kubernetes-sigs/release-sdk/blob/main/OWNERS)
+  - [kubernetes-sigs/release-utils](https://github.com/kubernetes-sigs/release-utils/blob/main/OWNERS)
+  - [kubernetes-sigs/zeitgeist](https://github.com/kubernetes-sigs/zeitgeist/blob/master/OWNERS)
+  - [kubernetes/publishing-bot](https://github.com/kubernetes/publishing-bot/blob/master/OWNERS)
+  - [kubernetes/release](https://github.com/kubernetes/release/blob/master/OWNERS)
+  - [kubernetes/sig-release/release-engineering](https://github.com/kubernetes/sig-release/blob/master/release-engineering/OWNERS)
 - **Contact:**
   - Slack: [#release-management](https://kubernetes.slack.com/messages/release-management)
 - **Meetings:**
@@ -75,22 +75,22 @@ The Release Engineering subproject is responsible for the [process/procedures](h
 ### Release Team
 The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
+  - [kubernetes/sig-release/release-team](https://github.com/kubernetes/sig-release/blob/master/release-team/OWNERS)
 ### SIG Release Process Documentation
 Documents and processes related to SIG Release
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
+  - [kubernetes/sig-release](https://github.com/kubernetes/sig-release/blob/master/OWNERS)
 ### hyperkube
 Best-effort maintaining of hyperkube until 1.18 goes EOL 2021-04-30.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.18/cluster/images/hyperkube/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/release/master/images/build/debian-hyperkube-base/OWNERS
+  - [kubernetes/kubernetes/cluster/images/hyperkube](https://github.com/kubernetes/kubernetes/blob/release-1.18/cluster/images/hyperkube/OWNERS)
+  - [kubernetes/release/images/build/debian-hyperkube-base](https://github.com/kubernetes/release/blob/master/images/build/debian-hyperkube-base/OWNERS)
 ### kubernetes/repo-infra
 Creates and maintains tools and templates for Kubernetes org repositories.
 Includes bazel tooling for managing dependencies for kubernetes/kubernetes
 and kubernetes/test-infra.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
+  - [kubernetes/repo-infra](https://github.com/kubernetes/repo-infra/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -51,30 +51,30 @@ The following [subprojects][subproject-definition] are owned by sig-scalability:
 ### kubernetes-scalability-and-performance-tests-and-validation
 [Described below](#kubernetes-scalability-and-performance-tests-and-validation)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/processes/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/scalability/OWNERS
+  - [kubernetes/community/sig-scalability/processes](https://github.com/kubernetes/community/blob/master/sig-scalability/processes/OWNERS)
+  - [kubernetes/kubernetes/test/e2e/scalability](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/scalability/OWNERS)
 ### kubernetes-scalability-bottlenecks-detection
 [Described below](#kubernetes-scalability-bottlenecks-detection)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/blogs/OWNERS
+  - [kubernetes/community/sig-scalability/blogs](https://github.com/kubernetes/community/blob/master/sig-scalability/blogs/OWNERS)
 ### kubernetes-scalability-definition
 [Described below](#kubernetes-scalability-definition)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/configs-and-limits/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/slos/OWNERS
+  - [kubernetes/community/sig-scalability/configs-and-limits](https://github.com/kubernetes/community/blob/master/sig-scalability/configs-and-limits/OWNERS)
+  - [kubernetes/community/sig-scalability/slos](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/OWNERS)
 ### kubernetes-scalability-governance
 [Described below](#kubernetes-scalability-governance)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/governance/OWNERS
+  - [kubernetes/community/sig-scalability/governance](https://github.com/kubernetes/community/blob/master/sig-scalability/governance/OWNERS)
 ### kubernetes-scalability-test-frameworks
 [Described below](#kubernetes-scalability-test-frameworks)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/kubemark/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubemark/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubemark/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/kubemark/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/perf-tests/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/perf-tests/master/clusterloader2/OWNERS
+  - [kubernetes/kubernetes/cluster/images/kubemark](https://github.com/kubernetes/kubernetes/blob/master/cluster/images/kubemark/OWNERS)
+  - [kubernetes/kubernetes/cmd/kubemark](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubemark/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubemark](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubemark/OWNERS)
+  - [kubernetes/kubernetes/test/kubemark](https://github.com/kubernetes/kubernetes/blob/master/test/kubemark/OWNERS)
+  - [kubernetes/perf-tests](https://github.com/kubernetes/perf-tests/blob/master/OWNERS)
+  - [kubernetes/perf-tests/clusterloader2](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -49,23 +49,23 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-scheduling:
 ### cluster-capacity
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/cluster-capacity/master/OWNERS
+  - [kubernetes-sigs/cluster-capacity](https://github.com/kubernetes-sigs/cluster-capacity/blob/master/OWNERS)
 ### descheduler
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/OWNERS
+  - [kubernetes-sigs/descheduler](https://github.com/kubernetes-sigs/descheduler/blob/master/OWNERS)
 ### kube-batch
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS
+  - [kubernetes-sigs/kube-batch](https://github.com/kubernetes-sigs/kube-batch/blob/master/OWNERS)
 ### poseidon
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS
+  - [kubernetes-sigs/poseidon](https://github.com/kubernetes-sigs/poseidon/blob/master/OWNERS)
 ### scheduler
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-scheduler/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/scheduler/OWNERS
+  - [kubernetes/kubernetes/cmd/kube-scheduler](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-scheduler/OWNERS)
+  - [kubernetes/kubernetes/pkg/scheduler](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/OWNERS)
 ### scheduler-plugins
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/master/OWNERS
+  - [kubernetes-sigs/scheduler-plugins](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -40,11 +40,11 @@ The following [subprojects][subproject-definition] are owned by sig-security:
 ### security-audit
 Third Party Security Audit
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-security/sig-security-external-audit/OWNERS
+  - [kubernetes/community/sig-security/sig-security-external-audit](https://github.com/kubernetes/community/blob/master/sig-security/sig-security-external-audit/OWNERS)
 ### security-docs
 Security Documents and Documentation
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/community/master/sig-security/sig-security-docs/OWNERS
+  - [kubernetes/community/sig-security/sig-security-docs](https://github.com/kubernetes/community/blob/master/sig-security/sig-security-docs/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -55,11 +55,11 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-service-catalog:
 ### minibroker
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/minibroker/master/OWNERS
+  - [kubernetes-sigs/minibroker](https://github.com/kubernetes-sigs/minibroker/blob/master/OWNERS)
 ### service-catalog
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/go-open-service-broker-client/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/service-catalog/master/OWNERS
+  - [kubernetes-sigs/go-open-service-broker-client](https://github.com/kubernetes-sigs/go-open-service-broker-client/blob/master/OWNERS)
+  - [kubernetes-sigs/service-catalog](https://github.com/kubernetes-sigs/service-catalog/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -55,63 +55,63 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 The following [subprojects][subproject-definition] are owned by sig-storage:
 ### external-storage
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-lib-external-provisioner/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/OWNERS
+  - [kubernetes-sigs/sig-storage-lib-external-provisioner](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/blob/master/OWNERS)
+  - [kubernetes-sigs/sig-storage-local-static-provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/master/OWNERS)
 ### git-sync
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/git-sync/master/OWNERS
+  - [kubernetes/git-sync](https://github.com/kubernetes/git-sync/blob/master/OWNERS)
 ### gluster-provisioner
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/gluster-block-external-provisioner/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/gluster-file-external-provisioner/master/OWNERS
+  - [kubernetes-sigs/gluster-block-external-provisioner](https://github.com/kubernetes-sigs/gluster-block-external-provisioner/blob/master/OWNERS)
+  - [kubernetes-sigs/gluster-file-external-provisioner](https://github.com/kubernetes-sigs/gluster-file-external-provisioner/blob/master/OWNERS)
 ### kubernetes-cosi
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-controller/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-csi-adapter/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-spec/master/OWNERS
+  - [kubernetes-sigs/container-object-storage-interface-api](https://github.com/kubernetes-sigs/container-object-storage-interface-api/blob/master/OWNERS)
+  - [kubernetes-sigs/container-object-storage-interface-controller](https://github.com/kubernetes-sigs/container-object-storage-interface-controller/blob/master/OWNERS)
+  - [kubernetes-sigs/container-object-storage-interface-csi-adapter](https://github.com/kubernetes-sigs/container-object-storage-interface-csi-adapter/blob/master/OWNERS)
+  - [kubernetes-sigs/container-object-storage-interface-provisioner-sidecar](https://github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/blob/master/OWNERS)
+  - [kubernetes-sigs/container-object-storage-interface-spec](https://github.com/kubernetes-sigs/container-object-storage-interface-spec/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#sig-storage-cosi](https://kubernetes.slack.com/messages/sig-storage-cosi)
 ### kubernetes-csi
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-fc/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-iscsi/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-utils/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-proxy/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/csi-test/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/docs/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/driver-registrar/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/drivers/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/kubernetes-csi.github.io/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/livenessprobe/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-csi/node-driver-registrar/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/csi-translation-lib/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-translation-lib/OWNERS
+  - [kubernetes-csi/cluster-driver-registrar](https://github.com/kubernetes-csi/cluster-driver-registrar/blob/master/OWNERS)
+  - [kubernetes-csi/csi-driver-host-path](https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/OWNERS)
+  - [kubernetes-csi/csi-driver-image-populator](https://github.com/kubernetes-csi/csi-driver-image-populator/blob/master/OWNERS)
+  - [kubernetes-csi/csi-driver-iscsi](https://github.com/kubernetes-csi/csi-driver-iscsi/blob/master/OWNERS)
+  - [kubernetes-csi/csi-driver-nfs](https://github.com/kubernetes-csi/csi-driver-nfs/blob/master/OWNERS)
+  - [kubernetes-csi/csi-driver-smb](https://github.com/kubernetes-csi/csi-driver-smb/blob/master/OWNERS)
+  - [kubernetes-csi/csi-lib-fc](https://github.com/kubernetes-csi/csi-lib-fc/blob/master/OWNERS)
+  - [kubernetes-csi/csi-lib-iscsi](https://github.com/kubernetes-csi/csi-lib-iscsi/blob/master/OWNERS)
+  - [kubernetes-csi/csi-lib-utils](https://github.com/kubernetes-csi/csi-lib-utils/blob/master/OWNERS)
+  - [kubernetes-csi/csi-proxy](https://github.com/kubernetes-csi/csi-proxy/blob/master/OWNERS)
+  - [kubernetes-csi/csi-release-tools](https://github.com/kubernetes-csi/csi-release-tools/blob/master/OWNERS)
+  - [kubernetes-csi/csi-test](https://github.com/kubernetes-csi/csi-test/blob/master/OWNERS)
+  - [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs/blob/master/OWNERS)
+  - [kubernetes-csi/driver-registrar](https://github.com/kubernetes-csi/driver-registrar/blob/master/OWNERS)
+  - [kubernetes-csi/drivers](https://github.com/kubernetes-csi/drivers/blob/master/OWNERS)
+  - [kubernetes-csi/external-attacher](https://github.com/kubernetes-csi/external-attacher/blob/master/OWNERS)
+  - [kubernetes-csi/external-health-monitor](https://github.com/kubernetes-csi/external-health-monitor/blob/master/OWNERS)
+  - [kubernetes-csi/external-provisioner](https://github.com/kubernetes-csi/external-provisioner/blob/master/OWNERS)
+  - [kubernetes-csi/external-resizer](https://github.com/kubernetes-csi/external-resizer/blob/master/OWNERS)
+  - [kubernetes-csi/external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter/blob/master/OWNERS)
+  - [kubernetes-csi/kubernetes-csi.github.io](https://github.com/kubernetes-csi/kubernetes-csi.github.io/blob/master/OWNERS)
+  - [kubernetes-csi/livenessprobe](https://github.com/kubernetes-csi/livenessprobe/blob/master/OWNERS)
+  - [kubernetes-csi/node-driver-registrar](https://github.com/kubernetes-csi/node-driver-registrar/blob/master/OWNERS)
+  - [kubernetes/csi-api](https://github.com/kubernetes/csi-api/blob/master/OWNERS)
+  - [kubernetes/csi-translation-lib](https://github.com/kubernetes/csi-translation-lib/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/csi-api](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/csi-api/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/csi-translation-lib](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/csi-translation-lib/OWNERS)
 ### mount-utils
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/mount-utils/OWNERS
+  - [kubernetes/kubernetes/staging/src/k8s.io/mount-utils](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/mount-utils/OWNERS)
 ### nfs-provisioner
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes-sigs/nfs-subdir-external-provisioner/master/OWNERS
+  - [kubernetes-sigs/nfs-ganesha-server-and-external-provisioner](https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/blob/master/OWNERS)
+  - [kubernetes-sigs/nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/blob/master/OWNERS)
 ### volumes
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/OWNERS
+  - [kubernetes/kubernetes/pkg/volume](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -46,46 +46,46 @@ The following [subprojects][subproject-definition] are owned by sig-testing:
 ### boskos
 Boskos is a resource manager service that handles different kinds of resources and transitions between different states. We use it on the Kubernetes project to manage pools of GCP projects for CI/CD.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/boskos/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
+  - [kubernetes-sigs/boskos](https://github.com/kubernetes-sigs/boskos/blob/master/OWNERS)
+  - [kubernetes/test-infra/boskos](https://github.com/kubernetes/test-infra/blob/master/boskos/OWNERS)
 ### e2e-framework
 An experimental e2e testing framework for Kubernetes clusters.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/e2e-framework/master/OWNERS
+  - [kubernetes-sigs/e2e-framework](https://github.com/kubernetes-sigs/e2e-framework/blob/master/OWNERS)
 ### k8s-gsm-tools
 Controllers to sync and rotate kubernetes secrets with google cloud secret manager
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/k8s-gsm-tools/master/OWNERS
+  - [kubernetes-sigs/k8s-gsm-tools](https://github.com/kubernetes-sigs/k8s-gsm-tools/blob/master/OWNERS)
 ### kind
 Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
+  - [kubernetes-sigs/kind](https://github.com/kubernetes-sigs/kind/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#kind](https://kubernetes.slack.com/messages/kind)
 ### kubetest2
 Kubetest2 is the framework for launching and running end-to-end tests on kubernetes.
 It is the next significant iteration of kubetest. We will be deprecating kubetest going forward.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/kubetest2/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/test-infra/master/kubetest/OWNERS
+  - [kubernetes-sigs/kubetest2](https://github.com/kubernetes-sigs/kubetest2/blob/master/OWNERS)
+  - [kubernetes/test-infra/kubetest](https://github.com/kubernetes/test-infra/blob/master/kubetest/OWNERS)
 ### prow
 Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
+  - [kubernetes/test-infra/prow](https://github.com/kubernetes/test-infra/blob/master/prow/OWNERS)
 - **Contact:**
   - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
 ### sig-testing
 Home for SIG Testing discussion and documents.
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/sig-testing/master/OWNERS
+  - [kubernetes/sig-testing](https://github.com/kubernetes/sig-testing/blob/master/OWNERS)
 ### test-infra
 Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/test-infra/master/OWNERS
+  - [kubernetes/test-infra](https://github.com/kubernetes/test-infra/blob/master/OWNERS)
 ### testing-commons
 **[best-effort]** The testing-commons subproject focuses on matters of code structure, layout, and execution of kubernetes/kubernetes test code. It is currently staffed on a best-effort basis; please bring discussions to the sig-testing slack channel or meeting. For historical context, please see the [former testing-commons meeting agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit) and [archived testing-commons slack channel](https://kubernetes.slack.com/archives/C9NK9KFFW)
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/OWNERS
+  - [kubernetes/kubernetes/test](https://github.com/kubernetes/kubernetes/blob/master/test/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -41,8 +41,8 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-ui:
 ### dashboard
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/dashboard-metrics-scraper/master/OWNERS
-  - https://raw.githubusercontent.com/kubernetes/dashboard/master/OWNERS
+  - [kubernetes-sigs/dashboard-metrics-scraper](https://github.com/kubernetes-sigs/dashboard-metrics-scraper/blob/master/OWNERS)
+  - [kubernetes/dashboard](https://github.com/kubernetes/dashboard/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-usability/README.md
+++ b/sig-usability/README.md
@@ -48,7 +48,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The following [subprojects][subproject-definition] are owned by sig-usability:
 ### sig-usability
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/sig-usability/master/OWNERS
+  - [kubernetes-sigs/sig-usability](https://github.com/kubernetes-sigs/sig-usability/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -53,16 +53,16 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 The following [subprojects][subproject-definition] are owned by sig-windows:
 ### windows-gmsa
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/windows-gmsa/master/OWNERS
+  - [kubernetes-sigs/windows-gmsa](https://github.com/kubernetes-sigs/windows-gmsa/blob/master/OWNERS)
 ### windows-samples
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-samples/master/OWNERS
+  - [kubernetes-sigs/sig-windows-samples](https://github.com/kubernetes-sigs/sig-windows-samples/blob/master/OWNERS)
 ### windows-testing
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/OWNERS
+  - [kubernetes-sigs/windows-testing](https://github.com/kubernetes-sigs/windows-testing/blob/master/OWNERS)
 ### windows-tools
 - **Owners:**
-  - https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/OWNERS
+  - [kubernetes-sigs/sig-windows-tools](https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->


### PR DESCRIPTION
reduce the visual noise, and make the links go to githubs UI

before: `https://raw.githubusercontent.com/org/repo/branch/path/to/OWNERS` 
after: `[org/repo/path/to](https://github.com/org/repo/blob/branch/path/to/OWNERS)`

e.g. sig-api-machinery/component-base owners:
- [kubernetes-sigs/legacyflag](https://github.com/kubernetes-sigs/legacyflag/blob/master/OWNERS)
- [kubernetes/component-base](https://github.com/kubernetes/component-base/blob/master/OWNERS)
- [kubernetes/kubernetes/staging/src/k8s.io/component-base](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/OWNERS)


meta comments:
- before I got started, I got `make test` passing again
- added a litte validation for subprojects (e.g. wgs/ugs can't have them)
- split into commits for easier review, with `make generate` being the
  last commit