### PR TITLE
Update development.md to match new Go version

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -282,7 +282,8 @@ different versions of Kubernetes.
 | 1.13           | 1.11.13     |
 | 1.14 - 1.16    | 1.12.9      |
 | 1.17 - 1.18    | 1.13.15     |
-| 1.18+          | 1.15        |
+| 1.18 - 1.20    | 1.15        |
+| 1.20.4+        | 1.16        |
 
 ##### A Note on Changing Go Versions
 


### PR DESCRIPTION
Update the needed version of Go for Kubernetes 1.18+.

It still mentioned that 1.18+ needs Go version 1.15, even though I could the error that I should use Go version 1.16 when building Kubernetes version 1.20.4 (most recent)