### PR TITLE
sig-storage: remove k-csi/drivers repo

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -89,7 +89,6 @@ The following [subprojects][subproject-definition] are owned by sig-storage:
   - [kubernetes-csi/csi-test](https://github.com/kubernetes-csi/csi-test/blob/master/OWNERS)
   - [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs/blob/master/OWNERS)
   - [kubernetes-csi/driver-registrar](https://github.com/kubernetes-csi/driver-registrar/blob/master/OWNERS)
-  - [kubernetes-csi/drivers](https://github.com/kubernetes-csi/drivers/blob/master/OWNERS)
   - [kubernetes-csi/external-attacher](https://github.com/kubernetes-csi/external-attacher/blob/master/OWNERS)
   - [kubernetes-csi/external-health-monitor](https://github.com/kubernetes-csi/external-health-monitor/blob/master/OWNERS)
   - [kubernetes-csi/external-provisioner](https://github.com/kubernetes-csi/external-provisioner/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2278,7 +2278,6 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-csi/csi-test/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/docs/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/driver-registrar/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-csi/drivers/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2568

/assign @msau42 

/hold
for lgtm from sig-storage leads