### PR TITLE
Adds a kube-vip channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -181,6 +181,7 @@ channels:
   - name: kube-score
   - name: kube-spawn
   - name: kube-state-metrics
+  - name: kube-vip
   - name: kubeadm
   - name: kubeadm-cn
   - name: kubeapps


### PR DESCRIPTION
Hello,

A project that I maintain for HA Kubernetes clusters and LoadBalancer type services in Kubernetes, has started to get a little bit of traction. Currently I'm getting questions in channels such as `#cluster-api` or `#cluster-api-vsphere` and I think it might make things easier to have somewhere dedicated for conversations, support, feature requests and general inquiries about this topic. 

Kube-Vip page: [https://kube-vip.io](https://kube-vip.io)
Kube-Vip GitHub: [https://github.com/plunder-app/kube-vip](https://github.com/plunder-app/kube-vip)

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # N/A
