### PR TITLE
Update meetup time link for clearer result

### DIFF
--- a/communication/README.md
+++ b/communication/README.md
@@ -188,7 +188,7 @@ place!
 [Discuss Kubernetes]: https://discuss.kubernetes.io
 [Join]: http://slack.k8s.io
 [Slack Guidelines]: /communication/slack-guidelines.md
-[10am US Pacific Time]: https://www.google.com/search?q=1000+am+in+pst
+[10am US Pacific Time]: https://www.google.com/search?q=1000+am+in+pacific+time
 [troubleshooting guide]: https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/
 [@kubernetesio]: https://twitter.com/kubernetesio
 [website guidelines]: ./website-guidelines.md

--- a/communication/README.md
+++ b/communication/README.md
@@ -188,7 +188,7 @@ place!
 [Discuss Kubernetes]: https://discuss.kubernetes.io
 [Join]: http://slack.k8s.io
 [Slack Guidelines]: /communication/slack-guidelines.md
-[10am US Pacific Time]: https://www.google.com/search?q=1000+am+in+pacific+time
+[10am US Pacific Time]: https://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29
 [troubleshooting guide]: https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/
 [@kubernetesio]: https://twitter.com/kubernetesio
 [website guidelines]: ./website-guidelines.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
<!-- Fixes # -->

The link changed resulted in a Google search result that translated **local time into Pacific Time**. But the opposite was intended. This change fixes that. It also, removes some subtle ambiguity of reference to Standard Time vs Daylight-Saving Time - even though Google insightfully overlooks the error.