### PR TITLE
Remove retired subprojects from SIG MC

### DIFF
--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -49,12 +49,6 @@ The following [subprojects][subproject-definition] are owned by sig-multicluster
 ### Kubefed
 - **Owners:**
   - [kubernetes-sigs/kubefed](https://github.com/kubernetes-sigs/kubefed/blob/master/OWNERS)
-### cluster-registry
-- **Owners:**
-  - [kubernetes/cluster-registry](https://github.com/kubernetes/cluster-registry/blob/master/OWNERS)
-### federation-v1
-- **Owners:**
-  - [kubernetes/federation](https://github.com/kubernetes/federation/blob/master/OWNERS)
 ### kubemci
 - **Owners:**
   - [GoogleCloudPlatform/k8s-multicluster-ingress](https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1615,12 +1615,6 @@ sigs:
   - name: Kubefed
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/OWNERS
-  - name: cluster-registry
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/cluster-registry/master/OWNERS
-  - name: federation-v1
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/federation/master/OWNERS
   - name: kubemci
     owners:
     - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS


### PR DESCRIPTION
Removes cluster-registry and federation-v1 from the SIG MC list as both have been retired.
