### PR TITLE
Add devops-stack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -25,6 +25,7 @@ channels:
   - name: bindings-discuss
   - name: bootkube
   - name: brigade
+  - name: camptocamp-devops-stack
   - name: cdk
   - name: cert-manager
   - name: cert-manager-dev


### PR DESCRIPTION
Add a Slack channel for the DevOps Stack

The DevOps Stack is an Open Source project that aims to ease the deployment of
Kubernetes and its ecosystem in a GitOps fashion, using Terraform & ArgoCD.

https://devops-stack.io/


<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
