### PR TITLE
Add #ko-project to channels.yaml

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -157,6 +157,7 @@ channels:
   - name: kcli
   - name: klog
   - name: knative
+  - name: ko-project
   - name: kompose
   - name: kong
   - name: konveyor


### PR DESCRIPTION
Adding a Slack channel in accordance with the [guidelines](https://github.com/kubernetes/community/blob/master/communication/slack-guidelines.md#requesting-a-channel).

[`ko`](https://github.com/google/ko) is a tool for [building Go container images](https://github.com/google/ko#build-an-image), and easily [deploying them to Kubernetes](https://github.com/google/ko#kubernetes-integration). The channel will be used to discuss `ko` with end users and contributors, answer questions, gather bugs and feature requests, etc.

There's currently a `#ko` room in the [Knative Slack workspace](https://slack.knative.dev) for historical reasons, but since `ko` isn't limited to Knative, and is regularly used to deploy to Kubernetes, I think it makes sense to move folks from that room to the Kubernetes Slack.

cc @jonjohnsonjr 