### PR TITLE
Add #undistro to channels.yaml

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -390,7 +390,6 @@ channels:
     id: C0ELB338T
   - name: ug-vmware
   - name: undistro
-  - name: velero
   - name: velero-dev
   - name: velero-users
     id: C6VCGP4MT

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -390,10 +390,10 @@ channels:
     id: C0ELB338T
   - name: ug-vmware
   - name: undistro
+  - name: velero
   - name: velero-dev
   - name: velero-users
     id: C6VCGP4MT
-  - name: velero
   - name: virtlet
   - name: virtual-kubelet
   - name: virtualization

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -389,9 +389,11 @@ channels:
   - name: ug-big-data
     id: C0ELB338T
   - name: ug-vmware
+  - name: undistro
   - name: velero-dev
   - name: velero-users
     id: C6VCGP4MT
+  - name: velero
   - name: virtlet
   - name: virtual-kubelet
   - name: virtualization


### PR DESCRIPTION
Adding a Slack channel in accordance with the guidelines. 

[UnDistro](https://undistro.io) is a Kubernetes distribution.  The channel will be used to discuss UnDistro with end users and contributors, answer questions, gather bugs and feature requests, etc.