### PR TITLE
Update sig security external audit subgroup chair to Rey Lejano

### DIFF
--- a/sig-security/sig-security-external-audit/OWNERS
+++ b/sig-security/sig-security-external-audit/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - aasmall
+  - reylejano
 approvers:
-  - aasmall
+  - reylejano


### PR DESCRIPTION
Update SIG Security External Audit Subgroup chair to Rey Lejano

/assign @tabbysable @IanColdwater 
/cc @aasmall 