### PR TITLE
Rename kubernetes-sigs/slack-infra default branch

### DIFF
--- a/communication/slack-config/README.md
+++ b/communication/slack-config/README.md
@@ -61,4 +61,4 @@ this:
     - idealhack
 ```
 
-[Tempelis]: https://github.com/kubernetes-sigs/slack-infra/tree/master/tempelis
+[Tempelis]: https://github.com/kubernetes-sigs/slack-infra/tree/main/tempelis

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -129,7 +129,7 @@ Oversees and develops programs for helping contributors ascend the contributor l
 ### slack-infra
 Creates and maintains tools and automation for Kubernetes Slack.
 - **Owners:**
-  - [kubernetes-sigs/slack-infra](https://github.com/kubernetes-sigs/slack-infra/blob/master/OWNERS)
+  - [kubernetes-sigs/slack-infra](https://github.com/kubernetes-sigs/slack-infra/blob/main/OWNERS)
 - **Contact:**
   - Slack: [#slack-infra](https://kubernetes.slack.com/messages/slack-infra)
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1326,7 +1326,7 @@ sigs:
     contact:
       slack: slack-infra
     owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/slack-infra/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/slack-infra/main/OWNERS
 - dir: sig-docs
   name: Docs
   mission_statement: >


### PR DESCRIPTION
Updates docs and links that pointed to the old default branch name

Part of https://github.com/kubernetes-sigs/slack-infra/issues/50