### PR TITLE
communication: add cpanato to k-dev moderator group

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -53,10 +53,10 @@ Primary moderators seats: 6
 | Name                | Kubernetes Slack ID | Region   | Timezone                                                |
 | ------------------- | ------------------- | -------- | ------------------------------------------------------- |
 | Bob Killen          | @mrbobbytables      | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
+| Carlos Panato       | @cpanato            | EMEA     | [CET - Central European Time](https://time.is/CET)      |
 | Ihor Dvoretskyi     | @ihor.dvoretskyi    | EMEA     | [EET - Eastern European Time](https://time.is/EET)      |
 | Jaice Singer DuMars | @jdumars            | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Nikhita Raghunath   | @nikhita            | APAC     | [IST - Indian Standard Time](https://time.is/India)     |
-| _Open_              | _Open_              |          |                                                         |
 | _Open_              | _Open_              |          |                                                         |
 
 #### Moderators Pro Tempore


### PR DESCRIPTION
Added my self to the primary, but I'm not sure if this is the right place or I should add it to the `Moderators Pro Tempore`
slack 🧵 https://kubernetes.slack.com/archives/C1TU9EB9S/p1617299576121200?thread_ts=1617297417.117000&cid=C1TU9EB9S

Also, I saw there is a `Regional Category Moderators` I can help for the Portuguese part if we want to have something in this area


**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes/community/issues/5685


/assign @Paris @dims @spiffxp 
/cc @mrbobbytables @nikhita