### PR TITLE
Include documentation for listTypes in api conventions

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -491,9 +491,12 @@ particularly in an edge-based manner.
 
 #### Lists of named subobjects preferred over maps
 
-Discussed in [#2004](http://issue.k8s.io/2004) and elsewhere. There are no maps
-of subobjects in any API objects. Instead, the convention is to use a list of
-subobjects containing name fields.
+Discussed in [#2004](http://issue.k8s.io/2004) and elsewhere. There are
+no maps of subobjects in any API objects. Instead, the convention is to
+use a list of subobjects containing name fields. These conventions, and
+how one can change the semantics of lists, structs and maps are
+described in more details in the Kubernetes
+[documentation](https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy).
 
 For example:
 


### PR DESCRIPTION
Point to the place where we document the semantics for lists in the API Conventions since the current documentation is pretty light.

I also couldn't find reasonable documentation for `patchMergeKey` or `patchMergeStrategy` but that could probably be linked here too.