### PR TITLE
sig-multicluster: add about-api subproject

### DIFF
--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -49,6 +49,9 @@ The following [subprojects][subproject-definition] are owned by sig-multicluster
 ### Kubefed
 - **Owners:**
   - [kubernetes-sigs/kubefed](https://github.com/kubernetes-sigs/kubefed/blob/master/OWNERS)
+### about-api
+- **Owners:**
+  - [kubernetes-sigs/about-api](https://github.com/kubernetes-sigs/about-api/blob/master/OWNERS)
 ### kubemci
 - **Owners:**
   - [GoogleCloudPlatform/k8s-multicluster-ingress](https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1615,6 +1615,9 @@ sigs:
   - name: Kubefed
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/OWNERS
+  - name: about-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/about-api/master/OWNERS
   - name: kubemci
     owners:
     - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2609

/assign @JeremyOT 
cc @lauralorenz

/hold
for lgtm from sig-multicluster leads