### PR TITLE
Add #kubewarden slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -217,6 +217,7 @@ channels:
   - name: kubespray
   - name: kubespray-dev
   - name: kubevirt-dev
+  - name: kubewarden
   - name: kubicorn
   - name: kudo
   - name: kurl


### PR DESCRIPTION
Kubewarden is an open source project policy engine for Kubernetes. It
allows users to write validation and mutating policies in a language
agnostic way by leveraging the power of WebAssembly.

The goal of this channel is for users, developers and in general,
community stakeholders to discuss about the project, its goals and
provide mutual help.

Kubewarden project page: https://kubewarden.io
Policy hub: https://hub.kubewarden.io
Documentation: https://docs.kubewarden.io
Helm charts: https://charts.kubewarden.io