### PR TITLE
Fixing links on group-mentoring.md

### DIFF
--- a/mentoring/programs/group-mentoring.md
+++ b/mentoring/programs/group-mentoring.md
@@ -72,9 +72,9 @@ mentor.
 [Mentor Guide]  
 [Mentee Guide]
 
-[Mentee Guide]: /mentoring/group-mentee-guide.md
+[Mentee Guide]: /mentoring/programs/group-mentee-guide.md
 [Mentoring/Contributor Info Form]: https://goo.gl/forms/SHWAiZ9Ih1qwuJbs1
-[Mentor Guide]: /mentoring/mentor-guide.md
+[Mentor Guide]: /mentoring/processes/mentor-guide.md
 [community membership guidelines]: /community-membership.md
 [Chair]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md#chair
 [Tech Lead]: https://github.com/kubernetes/community/blob/master/contributors/chairs-and-techleads/technical-lead.md


### PR DESCRIPTION
Fixing links to Mentee/Mentor guide on group-mentoring.md

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

/assign @ehashman @parispittman 