### PR TITLE
docs: clarify github tokens and cherry-pick script

### DIFF
--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -91,10 +91,10 @@ patch release branches.
     [active](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md#detailed-release-history-for-active-branches)
     release branches where the fix is applicable.
 
-  - Set the value of the environment variable `GITHUB_TOKEN` to your personal
-    access token to avoid an interactive prompt. If `GITHUB_TOKEN` is not set
-    you will be asked for your github password: provide the github personal
-    access token rather than your actual github password.
+  - If `GITHUB_TOKEN` is not set you will be asked for your github password:
+    provide the github personal access token rather than your actual github
+    password. If you can securely set the environment variable `GITHUB_TOKEN`
+    to your personal access token then you can avoid an interactive prompt.
     Refer [https://github.com/github/hub/issues/2655#issuecomment-735836048](https://github.com/github/hub/issues/2655#issuecomment-735836048)
 
 

--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -92,7 +92,7 @@ patch release branches.
     release branches where the fix is applicable.
 
   - If `GITHUB_TOKEN` is not set you will be asked for your github password:
-    provide the github personal access token rather than your actual github
+    provide the github [personal access token](https://github.com/settings/tokens) rather than your actual github
     password. If you can securely set the environment variable `GITHUB_TOKEN`
     to your personal access token then you can avoid an interactive prompt.
     Refer [https://github.com/github/hub/issues/2655#issuecomment-735836048](https://github.com/github/hub/issues/2655#issuecomment-735836048)

--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -27,7 +27,7 @@ branches.
 - Have `hub` installed, which is most easily installed via
   `go get github.com/github/hub` assuming you have a standard golang
   development environment.
-- A github token which has permissions to create a PR in an upstream branch.
+- A github personal access token which has permissions to access public repositories.
 
 ## What Kind of PRs are Good for Cherry Picks
 
@@ -90,9 +90,11 @@ patch release branches.
     release you want to cherry pick to. Cherry picks should be applied to all
     [active](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md#detailed-release-history-for-active-branches)
     release branches where the fix is applicable.
-  
-  - When asked for your github password, provide the created github token 
-    rather than your actual github password. 
+
+  - Set the value of the environment variable `GITHUB_TOKEN` to your personal
+    access token to avoid an interactive prompt. If `GITHUB_TOKEN` is not set
+    you will be asked for your github password: provide the github personal
+    access token rather than your actual github password.
     Refer [https://github.com/github/hub/issues/2655#issuecomment-735836048](https://github.com/github/hub/issues/2655#issuecomment-735836048)
 
 
@@ -123,14 +125,14 @@ pull requests on the `master` branch in that they:
 
 - The original change to the `master` branch is expected to be merged for
   some time and no related CI failures or test flakiness must be discovered.
-  
+
 - The easy way to compare changes from the original change and cherry-pick
   is to compare PRs `.patch` files. To generate the patch from
   PR, just add the `.patch` to PR url. For example, for PR #100972 in
   kubernetes repositry, ptach can be downloaded following this URL:
-  
+
   `https://github.com/kubernetes/kubernetes/pull/100972.patch`
-  
+
 - Milestones must be set on the PR reflecting the milestone for the target
   release branch (for example, milestone v1.11 for a cherry pick onto branch
   `release-1.11`). This is normally done for you by automation.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

This PR adds some guidance around using the `hub`-aware `GITHUB_TOKEN` environment variable to make using the cherry-pick script a bit easier.

Also makes some of the language more exactly correct so folks who are unfamiliar with github personal access tokens can bootstrap from these concepts more easily.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
