### PR TITLE
slack-config: add 1.22 RT Leads to the release-team-lead usergroup

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -46,16 +46,18 @@ usergroups:
       - release-notes
       - sig-release
     members:
+      - annajung # 1.22 Release Team Lead Shadow
       - alejandrox1 # SIG Release Technical Lead
-      - bai # 1.21 Release Team Lead Shadow
+      - divya-mohan0209 # 1.22 Release Team Lead Shadow
+      - erismaster # 1.22 Release Team Lead Shadow
+      - guineveresaenger # 1.22 Release Team EA
       - hasheddan # SIG Release Technical Lead
       - jeremyrickard # SIG Release Technical Lead
       - justaugustus # SIG Release Chair
-      - kikisdeliveryservice # 1.21 Release Team Lead Shadow
+      - kikisdeliveryservice # 1.22 Release Team Lead Shadow
       - LappleApple # SIG Release Program Manager
-      - palnabarun # 1.21 Release Team Lead
       - saschagrunert # SIG Release Chair
-      - savitharaghunathan # 1.21 Release Team Lead Shadow
+      - savitharaghunathan # 1.22 Release Team Lead
 
   # Should match SIG Release Leads at all times:
   # https://git.k8s.io/community/sig-release/README.md#leadership

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -7,6 +7,7 @@ users:
   AlexB138: U3JA3MDGV
   alisondy: U9CBCBLCV
   ameukam: U68KPQ448
+  annajung: U8SLB1P2Q
   ankeesler: UBAA1KQ4A
   aravindputrevu: U1G27SDU6
   ashish-amarnath: U65JLLS0J
@@ -31,8 +32,10 @@ users:
   derekwaynecarr: U0A69N5GQ
   dharmit: U0APPPEKE
   dims: U0Y7A2MME
+  divya-mohan0209: UV4J7K97Z
   dougm: U8GG20UE9
   enj: U2T4CVDTJ
+  erismaster: U0162FJ79LY
   estroz: UKSEANEC9
   fabianvf: UAJ3UH29F
   feiskyer: U0ASA4398
@@ -40,6 +43,7 @@ users:
   girishramnani: U9M4K75EU
   grdryn: U017628HJL8
   gsquared94: U0131C0PJBU
+  guineveresaenger: U4H2QU3DW
   hasheddan: ULLQEF30C
   hoegaarden: U7VA4RZS9
   hubertstefanski: U01941KQ2UT


### PR DESCRIPTION
Adding 1.22 RT Leads to release-team-leads Slack usergroup.

Which issue(s) this PR fixes:

ref: https://github.com/kubernetes/sig-release/issues/1522

/assign
/sig release
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @hasheddan
/cc @annajung @divya-mohan0209 @erismaster @kikisdeliveryservice 
