### PR TITLE
slack/sig-release: Update usergroup memberships

### DIFF
--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -34,7 +34,7 @@ restrictions:
     usergroups:
       - "^sig-release-"
       - "^release-"
-      - "^security-release-team$"
+      - "^security-rel-team$"
   - path: "sig-security/*.yaml"
     channels:
       - "^sig-security$"

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -95,7 +95,6 @@ usergroups:
       - sig-release
     members:
       - cjcullen # Product Security Committee
-      - cji # Product Security Committee
       - cpanato # Release Manager
       - feiskyer # Release Manager
       - hasheddan # subproject owner / Release Manager
@@ -107,5 +106,6 @@ usergroups:
       - puerco # Release Manager
       - saschagrunert # subproject owner / Release Manager
       - swamymsft # Product Security Committee
+      - tabbysable # Product Security Committee
       - tallclair # Product Security Committee
       - xmudrii # Release Manager

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -85,7 +85,7 @@ usergroups:
   # Should match the membership of the following teams at all times:
   # - https://git.k8s.io/security/#product-security-committee-psc
   # - https://git.k8s.io/sig-release/release-managers.md#release-managers
-  - name: security-release-team
+  - name: security-rel-team
     long_name: Security Release Team
     description: >-
       Composite of Product Security Committee members and Release Managers. Ping

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -28,6 +28,7 @@ usergroups:
       - saschagrunert # subproject owner / Release Manager
       - sethmccombs # Release Manager Associate
       - Verolop # Release Manager Associate
+      - wilsonehusin # Release Manager Associate
       - xmudrii # Release Manager
 
   # Should match the membership of the following groups at all times:

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -30,8 +30,13 @@ usergroups:
       - Verolop # Release Manager Associate
       - xmudrii # Release Manager
 
-  # Should match the Release Team Leads of the current cycle and SIG Chairs at all times
-  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.20/release_team.md
+  # Should match the membership of the following groups at all times:
+  # - Release Team Lead
+  # - Release Team Lead shadows
+  # - Emeritus Adviser
+  # - SIG Release leads
+  #
+  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.22/release_team.md
   - name: release-team-leads
     long_name: Release Team Leads
     description: >-

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -75,7 +75,6 @@ usergroups:
       - release-management
       - sig-release
     members:
-      - alejandrox1 # SIG Release Technical Lead
       - hasheddan # SIG Release Technical Lead
       - jeremyrickard # SIG Release Technical Lead
       - justaugustus # SIG Release Chair

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -44,6 +44,9 @@ usergroups:
 
   # Should match the membership of the following teams at all times:
   # - https://git.k8s.io/security/#product-security-committee-psc
+  #
+  # Ensure any changes are also reflected in the Security Release Team
+  # usergroup (within the SIG Release config directory).
   - name: product-security-committee
     long_name: Product Security Committee
     description: |-

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -58,8 +58,8 @@ usergroups:
       - lukehinds
       - micahhausler
       - swamymsft
-      - tallclair
       - tabbysable
+      - tallclair
 
   - name: velero-maintainers
     long_name: Velero Maintainers

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -7,8 +7,8 @@ users:
   AlexB138: U3JA3MDGV
   alisondy: U9CBCBLCV
   ameukam: U68KPQ448
-  annajung: U8SLB1P2Q
   ankeesler: UBAA1KQ4A
+  annajung: U8SLB1P2Q
   aravindputrevu: U1G27SDU6
   ashish-amarnath: U65JLLS0J
   asmacdo: UNVH7RY9J

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -126,6 +126,7 @@ users:
   varshaprasad96: UK59YP2DA
   Verolop: U7NNE57PU
   vladimirmukhin: UHVSCSD4G
+  wilsonehusin: U0100068GF2
   wurbanski: URX7CMK97
   xmudrii: U4Q2TNGVD
   zubron: U7G0KNS86


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/community/pull/5744#discussion_r621729357 (cc: @jeefy) and https://github.com/kubernetes/community/pull/5682 (cc: @Katharine).

/area release-eng
/committee security

/assign @hasheddan @jeefy @mrbobbytables 
cc: @kubernetes/release-managers @kubernetes/product-security-committee @kubernetes/sig-release-leads 

- Update guidance on release-team-leads membership
- Alpha-sort Anna's username
- Offboard @alejandrox1 from sig-release-leads
- Add @wilsonehusin to release-managers
- Alpha-sort Tabby in product-security-committee
- Add @tabbysable to Security Release Team usergroup
- s/security-release-team/security-rel-team

  When initially attempting to create this usergroup, its description
  was too long for Slack to accept. The original group name exists...
  somewhere... in Slack, but it's no longer possible to update it (despite
  shortening the description in previous follow-ups).
  
  Here we rename the group so it can be properly created by Tempelis.