### PR TITLE
slack: create new channel for nginx-ingress development and rename the existing

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -126,7 +126,9 @@ channels:
   - name: in-dev
   - name: in-events
   - name: in-users
-  - name: ingress-nginx
+  - name: ingress-nginx-dev
+  - name: ingress-nginx-users
+    id: CANQGM8BA
   - name: inspektor-gadget
   - name: it-events
   - name: it-users


### PR DESCRIPTION
- create new channel to use for nginx ingress development
- rename existing ingress-nginx to be ingress-nginx-users for
support/general chat and also match other channels name.


We would like to have a channel to discuss the future and current development of nginx-ingress but not in the existing channel that is being used for support/questions.

also, rename the existing channel to match other channels that the main idea is for users of the tool/service ask questions/socialize/support. 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

cc @rikatz @strongjz @ElvinEfendi 