### PR TITLE
Velero Slack channel updates

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -389,7 +389,9 @@ channels:
   - name: ug-big-data
     id: C0ELB338T
   - name: ug-vmware
-  - name: velero
+  - name: velero-dev
+  - name: velero-users
+    id: C6VCGP4MT
   - name: virtlet
   - name: virtual-kubelet
   - name: virtualization

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -68,7 +68,8 @@ usergroups:
     long_name: Velero Maintainers
     description: Velero Maintainers group.
     channels:
-      - velero
+      # - velero-dev
+      - velero-users
     members:
       - ashish-amarnath
       - carlisia


### PR DESCRIPTION
Rename the existing velero channel to velero-users to better reflect its user-to-user nature, and add velero-dev.

As requested by the Velero team.