### PR TITLE
Add #kcp-prototype Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -152,6 +152,7 @@ channels:
     archived: true
   - name: k8spin
   - name: kapitan
+  - name: kcp-prototype
   - name: keda
   - name: keda-dev
   - name: keel


### PR DESCRIPTION
Adding a Slack channel in accordance with the [guidelines](https://github.com/kubernetes/community/blob/master/communication/slack-guidelines.md#requesting-a-channel).

[`kcp`](https://github.com/kcp-dev/kcp) is an experimental prototype to separate K8s the API server (kubectl, YAML, RBAC, etcd) from K8s the container orchestrator (pods, nodes, deployments), shared by @smarterclayton at today's KubeCon EU keynote. We hope to use this channel to talk with potential users and contributors, answer questions, gather ideas and feedback from the community, etc.

Note: #kcp is also available, but we'd prefer to highlight that it's a prototype, to set expectations early and often. If we graduate beyond a prototype we could rename the channel at that time.