### PR TITLE
communication/slack-config: split #headlamp into dev and users

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -107,7 +107,9 @@ channels:
   - name: gloo
   - name: grafana-operator
   - name: haproxy-ingress
-  - name: headlamp
+  - name: headlamp-users
+    id: C01FXB5E8ER
+  - name: headlamp-dev
   - name: helm-chart-testing
   - name: helm-deprecated
     archived: true


### PR DESCRIPTION
Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

This split keeps the existing `#headlamp` channel as the -users, and adds a new -dev channel.

The Headlamp project is opening up all its development iterations, which also includes moving conversations from an internal slack channel to the public community.