### PR TITLE
Add incident response and triage processes

### DIFF
--- a/committee-code-of-conduct/incident-process.md
+++ b/committee-code-of-conduct/incident-process.md
@@ -1,0 +1,120 @@
+---
+title: "Code of Conduct Committee Incident Reporting and Response Process"
+weight: 550
+aliases: [ "/coc-process" ]
+description: | 
+  Overview of the the Code of Conduct Committee's workflow when receiving and
+  responding to an incident report.
+---
+
+# Incident reporting and response process
+
+This document outlines the Code of Conduct Committee's workflow when receiving and responding to an incident report. As each report is unique, the process is described at a high level.
+
+## When and Where does the Kubernetes Code of Conduct apply?
+
+### What is an incident report?
+
+An **incident report** is a description of an event, interaction, or public statement submitted to the Kubernetes Code of Conduct Committee, which the reporter feels violates the [Kubernetes Code of Conduct](https://kubernetes.io/community/code-of-conduct/). 
+
+### Who can submit a report? 
+
+The Code of Conduct Committee accepts reports from everyone who interacts with the Kubernetes project community, contributor or otherwise. This includes, but is not limited to, the following:
+
+- Contributors and maintainers
+- Members of the Kubernetes Slack instance 
+- Attendees and vendors at KubeCon/CloudNativeCon
+- CNCF Ambassadors
+- Vendors/companies/projects which use Kubernetes and need to interact with the community as a result
+
+At times we encourage community members to email us if an incident is ongoing and we have not been contacted.
+
+### What are the boundaries of the Kubernetes community?
+
+There are no hard boundaries of the community, but common places we are asked to extend guidance to are:
+
+- Official Kubernetes communication channels
+- Kubernetes events
+- Media and web presences
+- Social media
+    - In some cases, where individual social media messages are not related to Kubernetes but have been reported to the Code of Conduct Committee and are making project members feel unsafe or unwelcome, we might choose to act.
+
+### Where do private incident reports happen? 
+
+The Code of Conduct Committee's primary means of contact is our email address, conduct@kubernetes.io. 
+
+We can also be reached via Slack direct messages to individual committee members (see [member list](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct#members)) or otherwise, though we might direct you to contact us via email. 
+
+### How is the privacy of a report protected?
+
+### Why does this process exist?
+
+The reporting process exists to provide the community with mechanisms to keep people safe, and to ensure that poor behavior, regardless of who the initator is, is not accepted.
+
+The Code of Conduct Committee has unilateral power to address harms as needed and appropriate to restore community safety after any incident(s). We are separate from the Steering Committee and all other bodies in the Kubernetes community to provide a mechanism by which anyone can report, regardless of roles and organizational power dynamics which often lead to systemic underreporting.
+
+## Incident report workflow 
+ 
+### Initial triage 
+
+The Code of Conduct Committee responds to all emails in a timely manner, usually within a few days.
+
+### Recusal 
+
+Before beginning investigation on an incident, members can recuse (or refuse to pass judgement on) an incident if they feel a relationship with someone in the incident may hinder impartiality or create a perception of impropriety with respect to individuals involved in the reported incident. Code of Conduct Committee Members might recuse for the following reasons:
+
+- Direct reporting relationships, or company work relationships 
+- Close working relationships in the Kubernetes community, for example co-leading a SIG with the reporter or someone else mentioned in the report
+
+
+If all members of the Code of Conduct Committee felt the need to recuse themselves from an incident, the incident would be handled by our thid party mediator.
+
+### Reaching out to involved parties
+
+The Code of Conduct Committee will privately discuss the incident report, and may or may not decide that we need more information prior to determining whether to take any action.
+
+We consider the following at this stage:
+
+- Do we need clarification from the reporter beyond the initial report?
+- Do we need clarification from other individuals who may have been involved in, or witnesses to, the incident? 
+- Is there a public record of the incident which we can review, such as a chat log or video recording? 
+- Are there any privacy or safety considerations that we must take into account? For example, if we reach out to an individual named in the report, could this jeapordize the safety of the reporter or other individuals?
+
+It is our intention to put as little emotional labor on those who have been harmed as possible, and to protect the safety (both physical and emotional) of all community members. We labor to be supportive and non-judgemental and to make the reporting process as safe and low anxiety as possible.
+
+In all instances these clarifying discussions are confidential.
+
+
+
+## Incident response workflow
+
+### Reconvening the Committee
+
+When we have more information, the Code of Conduct Committee reconvenes, shares all information gathered, and moves on to incident response. 
+
+Depending on the complexity and severity of the incident, reaching a consensus may take some time. It may require follow up conversations with affected individuals, or other inquiries.
+
+### Deciding on a Course of Action 
+
+We do not act recklessly, and in deciding on a course of action, we work as a team to include diverse perspectives, support the immediate safety needs of our community members, and support the long-term health of this community.
+
+When deciding how to address an incident, the Code of Conduct Committee follows a trauma-informed restorative justice framework. Our decisions on a course of action are informed by the following goals:
+
+- Continuously working towards a community that is a safe and professional space in which individuals from any background can do their best work, authentically and free from harassment
+- Preferring non-punitive punishments when possible
+- Prioritizing the safety of individuals to support the overall health of the community
+- Prioritizing education and coaching for those involved, when possible
+- Prioritizing the protection of contributing members of the Kubernetes project over external parties. This does not mean that we protect people with a higher number of commits or more seniority in the project, however.
+
+In general, the committee strives for unanimous consensus before taking an action.
+
+For example, we may choose to do nothing, to issue a private warning, to offer coaching, to recommend organizational changes, or to ban someone from a community platform. 
+
+
+### Taking Actions and Communicating our Recommendations 
+
+When we have decided on a course of action, we do the following:
+
+- We clearly communicate our decision to those who need to hear it, without violating the confidentiality of those who requested it during an investigative process (if one was undertaken).
+- If and only if it is needed, we work with other leadership bodies (e.g., Steering Committee and the Linux Foundation) to issue a public statement.
+


### PR DESCRIPTION
Signed-off-by: Celeste Horgan <celeste@cncf.io>

**Which issue(s) this PR fixes**:

Add CoCC incident response and triage processes.
