### PR TITLE
Add a public Code of Conduct Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -55,6 +55,7 @@ channels:
   - name: cn-dev
   - name: cn-events
   - name: cn-users
+  - name: code-of-conduct
   - name: community-sites
   - name: compliance-hipaa
   - name: contour


### PR DESCRIPTION
CoC Committee is increasing transparency into what we do and
working to improve community's ability to interact with us in
order to support various projects and teams.

So, we'd like to add a public channel to help with that.

Details will be discussed in our keynote tomorrow.

Signed-off-by: Aeva Black <806320+AevaOnline@users.noreply.github.com>
