### PR TITLE
update CoCC Slack management onboarding/offboarding

### DIFF
--- a/committee-code-of-conduct/governance/onboarding-offboarding.md
+++ b/committee-code-of-conduct/governance/onboarding-offboarding.md
@@ -8,12 +8,18 @@ Different actions on this list must be carried out by different members:
 
 ## Permissions 
 
-### Slack
+### Slack Channel Membership
 
 **Who executes:** When offboarding, outgoing members must remove themselves from Slack channels. When onboarding, carryover members must add incoming members.
 
-- [ ] Code of conduct committee Slack channel on `kubernetes.slack.com`
+- [ ] Code of conduct committee Slack channel(s) (public and private) on `kubernetes.slack.com`
 - [ ] Code of conduct sync Slack channel on `cloud-native.slack.com`
+
+### Slack Channel Admin Privileges
+
+**Who executes:** During transition, carryover members initiate promotion/removal by pinging project Slack admins
+
+- [ ] Ping project Slack admins to add/remove Slack admin privileges for incoming/outgoing members in CoCC channel(s)
 
 ### Kubernetes/community permissions and google permissions
 


### PR DESCRIPTION
We've added a public channel and also admin privileges within for CoCC
members.  These privileges need rotated during transitions.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

