### PR TITLE
sig-network: add network-policy-api

### DIFF
--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -84,6 +84,7 @@ The following [subprojects][subproject-definition] are owned by sig-network:
   - [kubernetes/dns](https://github.com/kubernetes/dns/blob/master/OWNERS)
 ### network-policy
 - **Owners:**
+  - [kubernetes-sigs/network-policy-api](https://github.com/kubernetes-sigs/network-policy-api/blob/master/OWNERS)
   - [kubernetes/api/networking](https://github.com/kubernetes/api/blob/master/networking/OWNERS)
 ### pod-networking
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1737,6 +1737,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
   - name: network-policy
     owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
   - name: pod-networking
     owners:


### PR DESCRIPTION
Fixes https://github.com/kubernetes/org/issues/2678

/assign @caseydavenport 

/hold
for lgtm from sig-network leads