### PR TITLE
request slack channel for Kilo

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -159,6 +159,7 @@ channels:
   - name: keda-dev
   - name: keel
   - name: kiam
+  - name: kilo
   - name: kiosk
   - name: kcli
   - name: klog


### PR DESCRIPTION
Hi! I'd like to request a slack channel for [Kilo](https://github.com/squat/kilo), a networking provider for Kubernetes built on WireGuard. This would be helpful to provide a designated place for the community members and maintainers to talk, discuss issues, and brainstorm.

As this is my first such request, please let me know if I need to do anything else.

Thanks!
