### PR TITLE
Add documentaion for tide/squash-on-merge

### DIFF
--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -374,7 +374,7 @@ git rebase -i HEAD~3
 git push --force
 ```
 
-
+**Note**: you can also ask your reviewer to add the `tide/merge-method-squash` label to your PR (this can be done by a reviewer by issuing the command: `/label tide/merge-method-squash`), this will let the bot take care of squashing _all_ commits that are part of this PR and will not result in removal of the `LGTM` label (if already applied) or re-run of the CI tests.
 
 [contributor guide]: /contributors/guide/README.md
 [developer guide]: /contributors/devel/README.md

--- a/contributors/guide/pull-requests.md
+++ b/contributors/guide/pull-requests.md
@@ -291,6 +291,8 @@ For more information, see [squash commits](./github-workflow.md#squash-commits).
  Don't squash when there are independent changes layered to achieve a single goal.
  For instance, writing a code munger could be one commit, applying it could be another, and adding a precommit check could be a third.
  One could argue they should be separate pull requests, but there's really no way to test/review the munger without seeing it applied, and there needs to be a precommit check to ensure the munged output doesn't immediately get out of date.
+ 
+**Note**: you can also ask your reviewer to add the `tide/merge-method-squash` label to your PR (this can be done by a reviewer by issuing the command: `/label tide/merge-method-squash`), this will let the bot take care of squashing _all_ commits that are part of this PR and will not result in removal of the `LGTM` label (if already applied) or re-run of the CI tests.
 
 ## Commit Message Guidelines
 


### PR DESCRIPTION
Add documentaion for tide/squash-on-merge to pull-request.md and contributor-cheatsheet

- adding documentation increases awareness that this label exists and can help PRs get merged quicker
- Manual squash causes removal of lgtm label and re-run of CI tests.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
Suggestion provided and discussed on the [sig-contribex slack](https://kubernetes.slack.com/archives/C1TU9EB9S/p1620824009426800?thread_ts=1620824009.426800&cid=C1TU9EB9S).
