### PR TITLE
SIG ContribEx: Move markyjackson-taulia to emeritus

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -152,8 +152,8 @@ Moderators seats: 10
 | Jeffrey Sica   | @jeefy              | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Bob Killen     | @mrbobbytables      | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Chris Short    | @chrisshort         | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
-| Marky Jackson  | @markyjackson       | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Taylor Dolezal | @onlydole           | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
+| _Open_          | _Open_             |          |                                                         |
 
 ### Moderators Pro Tempore
 
@@ -191,7 +191,7 @@ Moderators seats: 10
 | Roy Lenferink       | @rlenferink         | EMEA     | [CET - Central European Time](https://time.is/CET)      |
 | Yang Li             | @idealhack          | APAC     | [JST - Japan Standard Time](https://time.is/Japan)      |
 | Josh Berkus         | @jberkus            | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
-| Marky Jackson       | @markyjackson       | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
+| _Open_              | _Open_              |          |                                                         |
 
 ### Moderators Pro Tempore
 
@@ -220,10 +220,10 @@ Administrators seats: 6
 | Paris Pittman   | @paris              | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Naeil Ezzoueidi | @nzoueidi           | EMEA     | [CET - Central European Time](https://time.is/CET)      |
 | Yang Li         | @idealhack          | APAC     | [JST - Japan Standard Time](https://time.is/Japan)      |
-| Marky Jackson   | @markyjackson       | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Taylor Dolezal  | @onlydole           | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Jeffrey Sica    | @jeefy              | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Ihor Dvoretskyi | @ihor.dvoretskyi    | EMEA     | [EET - Eastern European Time](https://time.is/EET)      |
+| _Open_          | _Open_              |          |                                                         |
 
 - License and main account controlled by the CNCF
 

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -86,7 +86,6 @@ usergroups:
       - alisondy
       - castrojo
       - jeefy
-      - markyjackson-taulia
       - mrbobbytables
       - onlydole
       - paris
@@ -100,7 +99,6 @@ usergroups:
       - alejandrox1
       - castrojo
       - idealhack
-      - markyjackson-taulia
       - mrbobbytables
       - nzoueidi
       - onlydole

--- a/mentoring/OWNERS
+++ b/mentoring/OWNERS
@@ -3,12 +3,12 @@
 reviewers:
   - parispittman
   - nikhita
-  - markyjackson-taulia
 approvers:
-  - markyjackson-taulia # for community-bridge and meeting bosun
   - parispittman
   - nikhita
   - sig-contributor-experience-leads
+emeritus_approvers:
+  - markyjackson-taulia # for community-bridge and meeting bosun
 labels:
   - sig/contributor-experience
   - area/mentorship-planning

--- a/mentoring/programs/outreachy.md
+++ b/mentoring/programs/outreachy.md
@@ -35,7 +35,6 @@ The README in the [community repo](https://github.com/kubernetes/community) deta
 |----------|-----------|-----------|
 | [Paris Pittman](https://github.com/parispittman) | @paris |  parispittman@google.com |
 | [Nikhita Raghunath](https://github.com/nikhita) | @nikhita | nikitaraghunath@gmail.com |
-| [Marky Jackson](https://github.com/markyjackson-taulia) | @markyjackson | marky.r.jackson@gmail.com |
 
 The coordinators can be contacted at any time. The easiest way is to send a slack message.
 


### PR DESCRIPTION
Marky has asked to step down for a bit. This PR moves him to emeritus where possible. ❤️ 

Thank you @markyjackson-taulia for all your work and hope to see you back when you can :) 

/cc @markyjackson-taulia 

