### PR TITLE
CoCC: describe more the info clarifying process

### DIFF
--- a/committee-code-of-conduct/incident-process.md
+++ b/committee-code-of-conduct/incident-process.md
@@ -99,6 +99,8 @@ It is our intention to put as little emotional labor on those who have been harm
 
 In all instances these clarifying discussions are confidential.
 
+Clarifying discussions typically take the form of email, Slack DM, or Zoom meeting 1:1 between a member of the Code of Conduct Committee selected during our triaging of an incident report and the individual from whom clarification is sought.  The Code of Conduct Committee member will explicitly identify themselves and indicate they are engaging in conversation as a representative of the Code of Conduct Committee.  If the individual prefers we will endeavor to make the meeting/conversation not 1:1, but rather also include an observer/scribe agreed by both parties and still with all discussion being confidential.
+
 ## Incident response workflow
 
 ### Reconvening the Committee


### PR DESCRIPTION
As CoCC collects information on an incident report it is important
that folks understand not just that this is done confidentially,
but also a little more about how it is done, eg: in which forums
and by which people.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
