### PR TITLE
New channel for security assessment of cluster api

### DIFF
--- a/communication/slack-config/sig-security/config.yaml
+++ b/communication/slack-config/sig-security/config.yaml
@@ -2,3 +2,4 @@ channels:
   - name: sig-security
   - name: sig-security-docs
   - name: sig-security-tooling
+  - name: sig-security-assess-capi

--- a/communication/slack-config/sig-security/config.yaml
+++ b/communication/slack-config/sig-security/config.yaml
@@ -1,5 +1,6 @@
 channels:
   - name: sig-security
+  - name: sig-security-assess-capi
   - name: sig-security-docs
   - name: sig-security-tooling
-  - name: sig-security-assess-capi
+


### PR DESCRIPTION
From SIG-Security's last weekly [meeting](https://docs.google.com/document/d/1GgmmNYN88IZ2v2NBiO3gdU8Riomm0upge_XNVxEYXp0/edit#heading=h.7u1tzh1qn1z4) an action item was to create a new channel in order to facilitate a focussed discussion on security assessment of cluster-api (a sub project of kubernetes). This is a first attempt of a security assessment of a sub-project performed in collaboration with sig-security of the parent graduated project. 

Since we are breaking new ground here, I am happy to revisit if this channel should be prefixed as `wg` or `sig`.  We intend to periodically revisit the results from our assessments, so I do not see this as a time-bound effort but more of a continuous improvement cycle.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->


