### PR TITLE
Changed the Meeting Details to match the Notes

### DIFF
--- a/wg-policy/README.md
+++ b/wg-policy/README.md
@@ -20,7 +20,7 @@ Provide an overall architecture that describes both the current policy related i
 * SIG Storage
 
 ## Meetings
-* Regular WG Meeting: [Wednesdays at 16:00 PT (Pacific Time)](https://zoom.us/j/7375677271) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=16:00&tz=PT%20%28Pacific%20Time%29).
+* Regular WG Meeting: [Wednesdays at 16:00 UTC](https://zoom.us/j/7375677271) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1ihFfEfgViKlUMbY2NKxaJzBkgHh-Phk5hqKTzK-NEEs/edit?usp=sharing).
 
 ## Organizers


### PR DESCRIPTION
Looks like the readme does not reflect the current time of the work group. I don't know timezoneconverter well enough to put in the parameters

I read the contributor details (and STILL feel like I'm doing this wrong) 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/community/issues/5798


