### PR TITLE
sig-release: Add Carlos Tadeu Panato Jr. & Adolfo García Veytia as TLs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -62,9 +62,11 @@ aliases:
     - dchen1107
     - derekwaynecarr
   sig-release-leads:
+    - cpanato
     - hasheddan
     - jeremyrickard
     - justaugustus
+    - puerco
     - saschagrunert
   sig-scalability-leads:
     - mm4tt

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -29,8 +29,10 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
+* Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**), Mattermost
 * Daniel Mangum (**[@hasheddan](https://github.com/hasheddan)**), Upbound
 * Jeremy Rickard (**[@jeremyrickard](https://github.com/jeremyrickard)**), Apple
+* Adolfo García Veytia (**[@puerco](https://github.com/puerco)**), uServers
 
 ## Emeritus Leads
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1860,12 +1860,18 @@ sigs:
       name: Sascha Grunert
       company: Red Hat
     tech_leads:
+    - github: cpanato
+      name: Carlos Tadeu Panato Jr.
+      company: Mattermost
     - github: hasheddan
       name: Daniel Mangum
       company: Upbound
     - github: jeremyrickard
       name: Jeremy Rickard
       company: Apple
+    - github: puerco
+      name: Adolfo García Veytia
+      company: uServers
     emeritus_leads:
     - github: alejandrox1
       name: Jorge Alarcon Ochoa


### PR DESCRIPTION
From https://groups.google.com/a/kubernetes.io/g/release-managers/c/zzk3naZhS4A:

> @kubernetes/release-engineering,
> 
> After some discussion with the leads, we'd like to propose both @cpanato and @puerco as Technical Leads for SIG Release, and more specifically, the Release Engineering subproject.
> 
> They are both dedicated Release Managers and never fail to lend a helping hand to contributors or jump into unfamiliar territory to support the subproject.
> 
> We're opening this for discussion with Release Managers, before formally proposing this on the mailing list.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @saschagrunert @hasheddan @LappleApple @jeremyrickard 
cc: @kubernetes/sig-release 