### PR TITLE
Add translation for tide/squash-on-merge to contributor-cheatsheet

### DIFF
--- a/contributors/guide/contributor-cheatsheet/README-ja.md
+++ b/contributors/guide/contributor-cheatsheet/README-ja.md
@@ -290,6 +290,15 @@ git checkout -b myfeature
 [スカッシュコミット]の主な目的はきれいに読めるgitの履歴や加えられた変更のログを作成することです。通常これはPRの改定の最終段階に行われます。
 コミットをスカッシュするべきかわからない場合は、作業を止めてPRのレビューと承認を担当する他のコントリビューターの判断に任せることをおすすめします。
 
+`git rebase` を対話モードで実行して、保持するコミットとまとめるコミットを選択し、ブランチを強制的にプッシュします:
+
+```
+git rebase -i HEAD~3
+...
+git push --force
+```
+
+**備考**: レビュー担当者にPRへの `tide/merge-method-squash` ラベルの付与を依頼することも可能です。（このラベルはレビュー担当者が `/label tide/merge-method-squash` コマンドを実行すると付与されます。）`tide/merge-method-squash` ラベルを付与すると、botはこのPRを構成する*すべての*コミットをまとめ、それにより `LGTM` ラベル（既に適用されている場合）の削除やCIテストの再実行が行われなくなります。
 
 [コントリビューターガイド]: /contributors/guide/README.md
 [開発者ガイド]: /contributors/devel/README.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
This PR adds translation for tide/squash-on-merge to contributor-cheatsheet/README-ja.md

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE