### PR TITLE
Add ehashman as a SIG Node community repo approver

### DIFF
--- a/contributors/devel/sig-node/OWNERS
+++ b/contributors/devel/sig-node/OWNERS
@@ -2,7 +2,9 @@
 
 reviewers:
   - sig-node-leads
+  - ehashman
 approvers:
   - sig-node-leads
+  - ehashman
 labels:
   - sig/node

--- a/sig-node/OWNERS
+++ b/sig-node/OWNERS
@@ -2,7 +2,9 @@
 
 reviewers:
   - sig-node-leads
+  - ehashman
 approvers:
   - sig-node-leads
+  - ehashman
 labels:
   - sig/node


### PR DESCRIPTION
/kind cleanup
/sig node

I would like to propose getting approver access on the SIG Node repo as I have been active in maintaining and updating our community docs, meeting times, etc.

/assign @dchen1107 @derekwaynecarr 