### PR TITLE
Add ginkgo slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -99,6 +99,7 @@ channels:
   - name: garden-dev
   - name: gardener
   - name: gimbal
+  - name: ginkgo
   - name: github
     archived: true
   - name: github-management


### PR DESCRIPTION
Ginkgo and Gomega heavily used to test k8s and I’m one of the core maintainers.  I’d like to open up a new channel to have a faster feedback loop with the k8s community and field k8s+ginkgo specific questions.