### PR TITLE
sig-storage: remove cosi-driver-minio repo

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -71,7 +71,6 @@ The following [subprojects][subproject-definition] are owned by sig-storage:
   - [kubernetes-sigs/container-object-storage-interface-csi-adapter](https://github.com/kubernetes-sigs/container-object-storage-interface-csi-adapter/blob/master/OWNERS)
   - [kubernetes-sigs/container-object-storage-interface-provisioner-sidecar](https://github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/blob/master/OWNERS)
   - [kubernetes-sigs/container-object-storage-interface-spec](https://github.com/kubernetes-sigs/container-object-storage-interface-spec/blob/master/OWNERS)
-  - [kubernetes-sigs/cosi-driver-minio](https://github.com/kubernetes-sigs/cosi-driver-minio/blob/master/OWNERS)
   - [kubernetes-sigs/cosi-driver-sample](https://github.com/kubernetes-sigs/cosi-driver-sample/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#sig-storage-cosi](https://kubernetes.slack.com/messages/sig-storage-cosi)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2309,7 +2309,6 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-csi-adapter/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-spec/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/cosi-driver-minio/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/cosi-driver-sample/master/OWNERS
   - name: kubernetes-csi
     owners:


### PR DESCRIPTION
The repo is being archived.
Fixes https://github.com/kubernetes/org/issues/2687

/assign @xing-yang 

/hold
for lgtm from a sig-storage lead