### PR TITLE
Add guidance on SHA vs tags in dependencies

### DIFF
--- a/contributors/devel/sig-architecture/vendor.md
+++ b/contributors/devel/sig-architecture/vendor.md
@@ -34,6 +34,16 @@ The `go.mod` file in the root of `k8s.io/kubernetes` describes dependencies usin
 * `require` directives list the preferred version of dependencies (this is auto-updated by go tooling to the maximum preferred version of the module)
 * `replace` directives pin to specific tags or commits
 
+## Dependency versions
+
+As a project we prefer that all entries in `go.mod` should be tags in their
+respective repositories. There may be exceptions that will be up to the
+dependency approvers to approve. If there are issues with go mod tooling itself
+then there has to be explicit comment (trailing `// comment`) with details on
+exact tag/release that this SHA corresponds to. Also please ensure tracking
+isssues are open to ensure these SHA(s) are cleaned up over time and switched
+over to tags.
+
 ## Adding or updating a dependency
 
 The most common things people need to do with deps are add and update them.

--- a/contributors/devel/sig-architecture/vendor.md
+++ b/contributors/devel/sig-architecture/vendor.md
@@ -36,12 +36,12 @@ The `go.mod` file in the root of `k8s.io/kubernetes` describes dependencies usin
 
 ## Dependency versions
 
-As a project we prefer that all entries in `go.mod` should be tags in their
+As a project we prefer that all entries in `go.mod` should be tagged in their
 respective repositories. There may be exceptions that will be up to the
 dependency approvers to approve. If there are issues with go mod tooling itself
-then there has to be explicit comment (trailing `// comment`) with details on
+then there has to be an explicit comment (trailing `// comment`) with details on
 exact tag/release that this SHA corresponds to. Also please ensure tracking
-isssues are open to ensure these SHA(s) are cleaned up over time and switched
+issues are open to ensure these SHA(s) are cleaned up over time and switched
 over to tags.
 
 ## Adding or updating a dependency


### PR DESCRIPTION
Proposing this as follow up to slack conversation:
https://kubernetes.slack.com/archives/CHGFYJVAN/p1623348521105500

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
