### PR TITLE
Add SIG Node bug scrub channel for upcoming event

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -357,6 +357,7 @@ channels:
   - name: sig-multicluster
   - name: sig-network
   - name: sig-node
+  - name: sig-node-bug-scrub
   - name: sig-node-rkt
   - name: sig-scalability
   - name: sig-scheduling


### PR DESCRIPTION
**Purpose of channel:** comms for upcoming SIG Node Bug Scrub on June 24-25 2021
**Mailing list thread:** https://groups.google.com/g/kubernetes-sig-node/c/ZpMJ0TAn490/m/cyp3vi3ZAgAJ

We don't want to use the main #sig-node channel as it will add a lot of noise.

/cc @SergeyKanzhelev 
/sig node