### PR TITLE
Archive unused #sig-node-rkt channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -358,6 +358,7 @@ channels:
   - name: sig-network
   - name: sig-node
   - name: sig-node-rkt
+    archived: true
   - name: sig-scalability
   - name: sig-scheduling
   # sig-security* channels are defined in sig-security/


### PR DESCRIPTION
The #sig-node-rkt Slack channel appears to be unused. The last major activity was in 2018 and there have been no posts since early 2020.

/hold
for one week for lazy consensus (will also post in the channel)

Please cancel hold on June 17, 2021.

/sig node