### PR TITLE
Update members of the Velero Group

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -71,10 +71,9 @@ usergroups:
       # - velero-dev
       - velero-users
     members:
-      - ashish-amarnath
-      - carlisia
       - Dave Smith-Uchida
-      - nrb
+      - jiangd
+      - yinw
       - zubron
 
   - name: youtube-admins

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -10,7 +10,6 @@ users:
   ankeesler: UBAA1KQ4A
   annajung: U8SLB1P2Q
   aravindputrevu: U1G27SDU6
-  ashish-amarnath: U65JLLS0J
   asmacdo: UNVH7RY9J
   bai: U4XAULHL3
   Bart Farrell: U01DZM7PJDT
@@ -18,7 +17,6 @@ users:
   bubblemelon: U7K9C643G
   calebamiles: U1ZDD4CUR
   camilamacedo86: UJDM393EH
-  carlisia: UBDSF40G2
   castrojo: U1W1Q6PRQ
   cblecker: U3EDWR9FV
   cdrage: U2TU9NPH9
@@ -57,6 +55,7 @@ users:
   jdumars: U0YJS6LHL
   jeefy: U5MCFK468
   jeremyrickard: U72ESU398
+  jiangd: WAATBLVD3
   jimangel: U4HSVFA5U
   jmccormick2001: UMPLV0G0H
   jmrodri: U4KATPQ48
@@ -90,7 +89,6 @@ users:
   munnerz: U0EC03FTN
   nikhita: U2PQHGMLN
   nkubala: UA90QL2BE
-  nrb: U7S597E00
   nzoueidi: UBU72MWP2
   onlydole: U1DD4AZND
   pabloschuhmacher: U01AAGZ06KU
@@ -130,4 +128,5 @@ users:
   wilsonehusin: U0100068GF2
   wurbanski: URX7CMK97
   xmudrii: U4Q2TNGVD
+  yinw: WAAPAQ1R8
   zubron: U7G0KNS86


### PR DESCRIPTION
Add jiangd and yinw to the Velero group.
Remove nrb, calisia, ashish-amarnath.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

