### PR TITLE
Add object reference naming best practices for lists

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -906,6 +906,9 @@ It is okay to have the "{field}" component indicate the resource type. For examp
 a secret. However, this comes with the risk of the field being a misnomer in the case that the field is expanded to
 reference more than one type.
 
+In the case of a list of object references, the field should be of the format "{field}Refs", with the same guidance
+as the singular case above.
+
 ### Referencing resources with multiple versions
 
 Most resources will have multiple versions. For example, core resources


### PR DESCRIPTION
Clarifying the naming recommendations for naming of lists
of object references, as the guidance was not explicit.