### PR TITLE
Remove broken analytics links

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -225,4 +225,3 @@ All contributors must sign the CNCF CLA, as described [here](CLA.md).
 [SIG Governance Requirements]: /committee-steering/governance/sig-governance-requirements.md
 [Annual Report]: /committee-steering/governance/annual-reports.md
 [monthly community meeting]: /events/community-meeting.md
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/governance.md?pixel)]()


### PR DESCRIPTION
Remove broken analytics links, same as https://github.com/kubernetes/kubernetes/issues/93949

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

/kind cleanup
