### PR TITLE
Add aws-account-users group for alerting

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -38,7 +38,7 @@ usergroups:
       - "Sladyn Nunes"
       - "Kunal Kushwaha"
       - "Bart Farrell"
-      - pensu91 
+      - pensu91
       - "Joel Barker"
       - Jason
 
@@ -207,3 +207,13 @@ usergroups:
       - robshelly
       - vladimirmukhin
       - wurbanski
+
+  - name: aws-account-users
+    long_name: Users of AWS Accounts
+    description: Group used to send AlertManager alerts around AWS accounts issues
+    channels:
+      - cluster-api-aws-alerts
+    members:
+      - naadir
+      - richcase
+      - sedefsavas

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -133,3 +133,6 @@ users:
   xmudrii: U4Q2TNGVD
   yinw: WAAPAQ1R8
   zubron: U7G0KNS86
+  naadir: D6SJC6KK9
+  sedefsavas: D01FZEPA2PL
+  richcase: D017X07D5M5


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Adding a Slack group for test-infra alerting