### PR TITLE
Removing myself as Slack moderator

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -189,7 +189,6 @@ Moderators seats: 10
 | Paris Pittman       | @paris              | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Noah Kantrowitz     | @coderanger         | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Ihor Dvoretskyi     | @ihor.dvoretskyi    | EMEA     | [EET - Eastern European Time](https://time.is/EET)      |
-| Roy Lenferink       | @rlenferink         | EMEA     | [CET - Central European Time](https://time.is/CET)      |
 | Yang Li             | @idealhack          | APAC     | [JST - Japan Standard Time](https://time.is/Japan)      |
 | Josh Berkus         | @jberkus            | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | _Open_              | _Open_              |          |                                                         |

--- a/communication/slack-config/OWNERS
+++ b/communication/slack-config/OWNERS
@@ -11,7 +11,6 @@ approvers:
   - parispitmann
   - coderanger
   - idvoretskyi
-  - rlenferink
   - idealhack
   - munnerz
 labels:


### PR DESCRIPTION
Hereby I am removing myself as Slack moderator. I don't have the time anymore to volunteer for this task at this point. By removing myself someone else can potentially take over.

**Which issue(s) this PR fixes**:
None

/cc @jberkus 