### PR TITLE
communication: add Nabarun Pal as primary moderator for k-dev

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -56,8 +56,8 @@ Primary moderators seats: 6
 | Carlos Panato       | @cpanato            | EMEA     | [CET - Central European Time](https://time.is/CET)      |
 | Ihor Dvoretskyi     | @ihor.dvoretskyi    | EMEA     | [EET - Eastern European Time](https://time.is/EET)      |
 | Jaice Singer DuMars | @jdumars            | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
+| Nabarun Pal         | @palnabarun         | APAC     | [IST - Indian Standard Time](https://time.is/India)     |
 | Nikhita Raghunath   | @nikhita            | APAC     | [IST - Indian Standard Time](https://time.is/India)     |
-| _Open_              | _Open_              |          |                                                         |
 
 #### Moderators Pro Tempore
 


### PR DESCRIPTION
Ref: https://github.com/kubernetes/community/issues/5685

Nabarun has been around in the Kubernetes community for a long time and
has been in high-trust roles like the Kubernetes release lead and
the New Membership Coordinator (with approval access to k8s GitHub org
config) so he is a good fit for the moderator role for the k-dev
mailing list (which is a high trust role as well).

Additionally, Nabarun is in APAC so this helps us distribute the
moderation load better.

---

/hold
for lgtms from the following folks

/assign @palnabarun 
have already discussed with him, would like an ack on this PR

/assign @mrbobbytables 
have already discussed with Bob, would like to see a lgtm here as contribex chair

/cc @spiffxp @parispittman @dims 
k-dev "owners"

/assign @dims 
would like to see a lgtm from one of the k-dev owners

I will add Nabarun as a moderator once this PR merges.