### PR TITLE
Add slack channel for Krator sandbox project.

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -178,6 +178,7 @@ channels:
   - name: kr-users
   - name: kraken
   - name: krane
+  - name: krator
   - name: krew
   - name: krex
   - name: krustlet


### PR DESCRIPTION
This pull request adds a dedicated Slack channel for [Krator](https://github.com/krator-rs/krator), a newly accepted CNCF Sandbox project. See [Krator onboarding](https://github.com/cncf/toc/issues/691). 

Historically, Krator has used the Slack channel for Krustlet on the Kubernetes slack, however both projects have now been accepted as separate sandbox projects, so it seems reasonable to use separate Slack channels. 

[Issue tracking Slack channel creation](https://github.com/krator-rs/krator/issues/34). 
