### PR TITLE
remove girishramnani from odo-devs slack group

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -38,7 +38,7 @@ usergroups:
       - "Sladyn Nunes"
       - "Kunal Kushwaha"
       - "Bart Farrell"
-      - pensu91 
+      - pensu91
       - "Joel Barker"
       - Jason
 
@@ -156,7 +156,6 @@ usergroups:
     members:
       - cdrage
       - dharmit
-      - girishramnani
       - mohammedzee1000
       - mik-dass
       - prietyc123


### PR DESCRIPTION
He is no longer a member of the core odo development team.

