### PR TITLE
sig-testing: make chair/tech_lead explicit

### DIFF
--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -26,6 +26,14 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Aaron Crickenberger (**[@spiffxp](https://github.com/spiffxp)**), Google
 * Steve Kuznetsov (**[@stevekuznetsov](https://github.com/stevekuznetsov)**), Red Hat
 
+### Technical Leads
+The Technical Leads of the SIG establish new subprojects, decommission existing
+subprojects, and resolve cross-subproject technical issues and decisions.
+
+* Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**), Google
+* Aaron Crickenberger (**[@spiffxp](https://github.com/spiffxp)**), Google
+* Steve Kuznetsov (**[@stevekuznetsov](https://github.com/stevekuznetsov)**), Red Hat
+
 ## Emeritus Leads
 
 * Erick Fejta (**[@fejta](https://github.com/fejta)**)

--- a/sig-testing/charter.md
+++ b/sig-testing/charter.md
@@ -97,7 +97,6 @@ This sig adheres to the Roles and Organization Management outlined in
 
 ### Deviations from [sig-governance]
 
-- Chairs also fulfill the role of Tech Lead
 - Proposing and making decisions _MAY_ be done without the use of KEPS so long
   as the decision is documented in a linkable medium. We prefer to use issues
   on [kubernetes/test-infra] to document technical decisions, and mailing list
@@ -109,7 +108,6 @@ This sig adheres to the Roles and Organization Management outlined in
 ### Subproject Creation
 
 Subprojects are created by Tech Leads following the process defined in [sig-governance]
-
 
 [sig-governance]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md
 [Kubernetes Charter README]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2373,6 +2373,16 @@ sigs:
     - github: stevekuznetsov
       name: Steve Kuznetsov
       company: Red Hat
+    tech_leads:
+    - github: BenTheElder
+      name: Benjamin Elder
+      company: Google
+    - github: spiffxp
+      name: Aaron Crickenberger
+      company: Google
+    - github: stevekuznetsov
+      name: Steve Kuznetsov
+      company: Red Hat
     emeritus_leads:
     - github: fejta
       name: Erick Fejta


### PR DESCRIPTION
Rather than call out a deviation from governance in our chair, make it
clear that current SIG Testing Chairs are doing double-duty as Tech
Leads