### PR TITLE
Fix typo in triage/needs-information label

### DIFF
--- a/contributors/guide/issue-triage.md
+++ b/contributors/guide/issue-triage.md
@@ -177,7 +177,7 @@ If you can't reproduce it:
 * Close the issue if both the parties agree that it could not be reproduced.
 
 If you need more information to further work on the issue:
-* Let the reporter know it by adding an issue comment followed by label `lifecycle/needs-information`.
+* Let the reporter know it by adding an issue comment. Include `/triage needs-information` in the comment to apply the `triage/needs-information` label.
 
 In all cases, if you do not get a response in 20 days then close the issue with an appropriate comment. If you have permission to close someone else's issue, first `/assign` the issue to yourself, then `/close` it. If you do not, please leave a comment describing your findings.
 


### PR DESCRIPTION
The issue triage instructions referenced `lifecycle/needs-information`, but the correct label is `triage/needs-information`. I also added the Prow command corresponding to this label.

This tripped me up on https://github.com/kubernetes/ingress-nginx/issues/6191#issuecomment-883548832 when the incorrectly documented label was not accepted.