### PR TITLE
Add note to api conventions about kind: List

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -128,6 +128,10 @@ lists should support filtering by fields (see
 
    Examples: `PodList`, `ServiceList`, `NodeList`.
 
+Note that`kubectl` and other tools sometimes output collections of resources
+as `kind: List`. Keep in mind that `kind: List`" is not an API object but is
+simply used by those tools to present groups of mixed resources.
+
 3. **Simple** kinds are used for specific actions on objects and for
 non-persistent entities.
 


### PR DESCRIPTION
There has been some confusion about `kind: List`, which is not an API object but is used by `kubectl` to display groups of mixed resources. This [docs issue](https://github.com/kubernetes/website/issues/25944) describes the problem and this [docs PR ](https://github.com/kubernetes/website/pull/28608) addresses it in the Kubernetes docs.

However, since many descriptions of lists in the API docs and from `kubectl explain` point directly to the[ api-conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds) page, I thought it would be useful to have a short warning about `kind: List` on that page as well.
