### PR TITLE
Fix owners guide: approver in the reviewers section

### DIFF
--- a/contributors/guide/owners.md
+++ b/contributors/guide/owners.md
@@ -53,8 +53,8 @@ approvers:
   - alice
   - bob     # this is a comment
 reviewers:
-  - alice
-  - carol   # this is another comment
+  - carol
+  - david   # this is another comment
   - sig-foo # this is an alias
 ```
 


### PR DESCRIPTION
As the guide says: 

> Good examples of OWNERS usage:
>   the approvers are not in the reviewers section


<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
