### PR TITLE
Fixing broken link in sig-network README

### DIFF
--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -68,8 +68,8 @@ The following [subprojects][subproject-definition] are owned by sig-network:
 - **Owners:**
   - [kubernetes-sigs/gateway-api](https://github.com/kubernetes-sigs/gateway-api/blob/master/OWNERS)
   - [kubernetes/kubernetes/pkg/controller/endpoint](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/endpoint/OWNERS)
-  - [kubernetes/kubernetes/pkg/controller/service](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/service/OWNERS)
   - [kubernetes/kubernetes/pkg/proxy](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/cloud-provider/controllers/service](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cloud-provider/controllers/service/OWNERS)
 - **Contact:**
   - Slack: [#sig-network-gateway-api](https://kubernetes.slack.com/messages/sig-network-gateway-api)
 ### ingress

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1739,8 +1739,8 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/controllers/service/OWNERS
   - name: ingress
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/ingress-controller-conformance/master/OWNERS


### PR DESCRIPTION
There was a refactor last year which left a broken link in the sig-network README. This PR corrects the broken link.

Refactor: https://github.com/kubernetes/kubernetes/pull/90976

Reported in: https://github.com/kubernetes/kubernetes/issues/104159

Fixes https://github.com/kubernetes/kubernetes/issues/104159

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>

