### PR TITLE
Update External Security Audit RFP vendor selection date

### DIFF
--- a/sig-security/security-audit-2021/RFP.md
+++ b/sig-security/security-audit-2021/RFP.md
@@ -79,7 +79,7 @@ Proposals should be submitted to kubernetes-security-audit-2021@googlegroups.com
 * 2021/02/08: RFP Open, Question period open
 * 2021/06/22: Fourth proposal received
 * 2021/07/06: RFP Closes, Question period closes
-* 2021/08/10: The working group will announce vendor selection
+* 2021/08/13: The working group will announce vendor selection
 
 ## Methodology
 


### PR DESCRIPTION
This PR updates the vendor selection date of the external security audit RFP for 2021.
Vendors were notified of the delay.

/sig security
/assign @tabbysable @IanColdwater 
/cc @aasmall 