### PR TITLE
slack-config/sig-release: Add 1.23 RT leads to release-team-leads

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -51,19 +51,18 @@ usergroups:
       - release-notes
       - sig-release
     members:
-      - annajung # 1.22 Release Team Lead Shadow
       - cpanato # SIG Release Technical Lead
-      - divya-mohan0209 # 1.22 Release Team Lead Shadow
-      - erismaster # 1.22 Release Team Lead Shadow
-      - guineveresaenger # 1.22 Release Team EA
       - hasheddan # SIG Release Technical Lead
-      - jeremyrickard # SIG Release Technical Lead
+      - JamesLaverack # 1.23 Release Team Lead Shadow
+      - jeremyrickard # SIG Release Technical Lead /  1.23 Release Team EA
+      - jrsapi # 1.23 Release Team Lead Shadow
       - justaugustus # SIG Release Chair
-      - kikisdeliveryservice # 1.22 Release Team Lead Shadow
       - LappleApple # SIG Release Program Manager
+      - mkorbi # 1.23 Release Team Lead Shadow
+      - MonzElmasry # 1.23 Release Team Lead Shadow
       - puerco # SIG Release Technical Lead
+      - reylejano # 1.23 Release Team Lead
       - saschagrunert # SIG Release Chair
-      - savitharaghunathan # 1.22 Release Team Lead
 
   # Should match SIG Release Leads at all times:
   # https://git.k8s.io/community/sig-release/README.md#leadership

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -52,6 +52,7 @@ users:
   idvoretskyi: U0CBHE6GM
   ilya-zuyev: U018UF2G42F
   IsaacPD: U01B0C1R9NZ
+  JamesLaverack: U9MK7274Y
   Jason: UB272379N
   jberkhahn: U7Q21LH2S
   jdumars: U0YJS6LHL
@@ -66,6 +67,7 @@ users:
   joelsmith: U5SLG8T8F
   johnbelamaric: U246A1A0N
   jonasrosland: U0A4G34S2
+  jrsapi: U0DS2L6E8
   justaugustus: U0E0E78AK
   kadel: U0DE6E8JY
   kaslin: U5ENKU0AE
@@ -87,6 +89,7 @@ users:
   mik-dass: UCUULSG1W
   mkorbi: UEBLUUA0P
   mohammedzee1000: U3PFFE8CD
+  MonzElmasry: U018U96HYDQ
   mrbobbytables: U511ZSKHD
   munnerz: U0EC03FTN
   nikhita: U2PQHGMLN
@@ -104,6 +107,7 @@ users:
   r-lawton: U019CNHR2E6
   rajula96reddy: U7K9EK1HC
   rashmigottipati: U013T1DD3PW
+  reylejano: U01GDNJL5MW
   Rin Oliver: USF4LMDCN
   rnapoles-rh: U01KDAMSWJD
   robshelly: U01LL4P09SR


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Adds the 1.23 RT Leads to release-team-leads Slack usergroup.

Fixes #
Ref: https://github.com/kubernetes/sig-release/issues/1652

/assign
/sig release
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @cpanato @puerco @hasheddan
/cc @JamesLaverack @jrsapi @mkorbi @MonzElmasry
