### PR TITLE
sig-scheduling: add kube-scheduler-simulator subproject

### DIFF
--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -56,6 +56,9 @@ The following [subprojects][subproject-definition] are owned by sig-scheduling:
 ### kube-batch
 - **Owners:**
   - [kubernetes-sigs/kube-batch](https://github.com/kubernetes-sigs/kube-batch/blob/master/OWNERS)
+### kube-scheduler-simulator
+- **Owners:**
+  - [kubernetes-sigs/kube-scheduler-simulator](https://github.com/kubernetes-sigs/kube-scheduler-simulator/blob/main/OWNERS)
 ### poseidon
 - **Owners:**
   - [kubernetes-sigs/poseidon](https://github.com/kubernetes-sigs/poseidon/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2096,6 +2096,9 @@ sigs:
   - name: kube-batch
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS
+  - name: kube-scheduler-simulator
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kube-scheduler-simulator/main/OWNERS
   - name: poseidon
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS


### PR DESCRIPTION
Related:
- repo creation request: https://github.com/kubernetes/org/issues/2878