### PR TITLE
Add release-enhancements channel

### DIFF
--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -4,6 +4,7 @@ channels:
   - name: release-ci-signal
   - name: release-comms
   - name: release-docs
+  - name: release-enhancements
   - name: release-management
     id: CJH2GBF7Y
   - name: release-notes


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

During release 1.22 retro, it was decided that the enhancements team should have a dedicated public channel to allow collaboration with the community.

In addition to already existing release-x slack channels, this request creates a missing channel for the enhancements team.

cc @kubernetes/sig-release-leads @reylejano @JamesLaverack @salaxander 