### PR TITLE
Should be `cube` and not `kube`

### DIFF
--- a/sig-scalability/configs-and-limits/thresholds.md
+++ b/sig-scalability/configs-and-limits/thresholds.md
@@ -18,7 +18,7 @@ configurations that Kubernetes supports create `Scalability Envelope`:
 ![Scalability Envelope](./scalability-envelope.png)
 
 Some the properties of the envelope:
-1. It's NOT a kube, because dimensions are sometimes not independent.
+1. It's NOT a cube, because dimensions are sometimes not independent.
 1. It's NOT convex.
 1. As you move farther along one dimension, your cross-section wrt other
    dimensions gets smaller.


### PR DESCRIPTION
The text should say `cube` and not `kube` as mentioned in the kubecon talk

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
