### PR TITLE
archive slack channel k8s-dual-stack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -151,6 +151,7 @@ channels:
   - name: kalm
   - name: kaniko
   - name: k8s-dual-stack
+    archived: true
   - name: k8s-infra-alerts
   - name: k8s-release
     archived: true


### PR DESCRIPTION
The channel is no longer needed and we want users to use sig-network channel instead to discuss specific issues.

ref: https://kubernetes.slack.com/archives/CGF3A900N/p1614883236000400
