### PR TITLE
sig-node: add doc with basic info for pause image updates

### DIFF
--- a/contributors/devel/sig-node/updating-pause-images.md
+++ b/contributors/devel/sig-node/updating-pause-images.md
@@ -1,0 +1,49 @@
+# Updating Pause Image References
+
+The Kubernetes `pause` image is used to run a 'parent' container for all
+the other containers inside your pod. This image is referenced across many
+projects within the Kubernetes ecosystem, and it's important that we keep them
+all up to date to ensure stable platform support and to avoid confusing things
+for end users.
+
+However, we do need to update those images in a somewhat staggered way across
+the ecosystem, rather than doing it all at once.
+
+### Useful Links
+
+- [Pause Image Changelog][pause-cl]
+- [What is the role of 'pause' container?](https://groups.google.com/g/kubernetes-users/c/jVjv0QK4b_o)
+- [The Almighty Pause Container](https://www.ianlewis.org/en/almighty-pause-container)
+
+### Coordinating updates
+
+When a new `pause` image is released, we generally try to update it in the
+following order, this is to try and ensure that repositories stay in sync, while
+keeping changes well tested and developers unblocked.
+
+#### First level (core projects)
+
+- [kubernetes/kubernetes][k-k-repo]
+- [kubernetes/test-infra][k-infra-repo]
+
+#### Second level (kubernetes-sigs)
+
+- [kubernetes-sigs/image-builder][ks-image-builder]
+- [kubernetes-sigs/kind][ks-kind]
+
+#### Third level (runtimes)
+
+- [cri-o/cri-o][crio]
+- [containerd/containerd][containerd]
+
+#### Fourth level (other projects)
+
+- [kubernetes/minikube][k-minikube]
+
+[k-k-repo]: https://github.com/kubernetes/kubernetes
+[k-infra-repo]: https://github.com/kubernetes/test-infra
+[ks-kind]: https://github.com/kubernetes-sigs/kind
+[crio]: https://github.com/cri-o/cri-o
+[containerd]: https://github.com/containerd/containerd
+[k-minikube]: https://github.com/kubernetes/minikube
+[pause-cl]: https://github.com/kubernetes/kubernetes/blob/master/build/pause/CHANGELOG.md


### PR DESCRIPTION
This doc serves as a rough tracker of where we bump kubernetes Pause images, and how we try to coordinate them when new pause releases happen.

This is a first attempt to formalize roughly what happens in staggered PRs historically, and tries to keep things well tested while moving fairly quickly to unblock developers who may rely on new features for their testing (e.g Windows Server 2022 support in the latest release).

We may want to add a tracking issue template to this document after @kerthcet drafts the first issue.

Slack Discussion: https://kubernetes.slack.com/archives/C0BP8PW9G/p1631032292078800

/cc @dims
/cc @SergeyKanzhelev
/cc @BenTheElder 
/cc @kerthcet 