### PR TITLE
slack: add channel cluster-api-kubevirt

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -49,6 +49,7 @@ channels:
   - name: cluster-api-docker
     archived: true
   - name: cluster-api-gcp
+  - name: cluster-api-kubevirt
   - name: cluster-api-nested
   - name: cluster-api-openstack
   - name: cluster-api-packet


### PR DESCRIPTION
Request the slack channel for `cluster-api-kubevirt`, similar to aws, azure, gcp, etc., to facilitate discussions around CAPK.