### PR TITLE
cherry-pick policy for alpha features

### DIFF
--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -42,10 +42,8 @@ Again, the emphasis is on critical bug fixes, e.g.,
 - Panic, crash, hang
 - Security
 
-As a counter example, we would not support backporting a bug fix to an alpha
-feature in general. One condition where we would consider is if that bug caused
-an issue for in another part of the system even when the alpha feature was
-switched off / not in use.
+A bugfix for a functional issue (not a data loss or security issue) that only
+affects an alpha feature does not qualify as a critical bug fix.
 
 If you are proposing a cherry pick and it is not a clear and obvious critical
 bug fix, please reconsider. If upon reflection you wish to continue, bolster


### PR DESCRIPTION
Follow up on https://github.com/kubernetes/community/pull/6027 on Jordan's comment https://github.com/kubernetes/community/pull/6027#discussion_r711614882 about backports for alpha features, making it extensive to beta features too.