### PR TITLE
Archive the #kubernetes-batch-jobs channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -213,6 +213,7 @@ channels:
   - name: kuberhealthy
   - name: kubernetes-arm
   - name: kubernetes-batch-jobs
+    archived: true
   - name: kubernetes-careers
   - name: kubernetes-client
   - name: kubernetes-contributors


### PR DESCRIPTION
It is a magnet for recruiter spam so no one uses it for discussion anymore.

Sigh, can't have nice things. If we did want to keep it, just need to remove `jobs` from the title I bet.