### PR TITLE
Added slack channel for cert-manager/aws-privateca-issuer

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -29,6 +29,7 @@ channels:
   - name: camptocamp-devops-stack
   - name: cdk
   - name: cert-manager
+  - name: cert-manager-aws-privateca-issuer
   - name: cert-manager-dev
   - name: chairs-and-techleads
   - name: chartcenter


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
Adding a slack Channel
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
* Slack Channel Name: cert-manager-aws-privateca-issuer

* Purpose of the Channel: To communicate with the users of the cert-manager/aws-privateca-issuer plugin for Kubernetes and keep the users informed about on potential issues and Plugin updates.

* GitHub Link: https://github.com/cert-manager/aws-privateca-issuer

