### PR TITLE
Fix owner aliases for provider-aws

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -167,9 +167,9 @@ aliases:
     - parispittman
 ## BEGIN CUSTOM CONTENT
   provider-aws:
-    - d-nishi
     - justinsb
-    - kris-nova
+    - nckturner
+    - wongma7
   provider-azure:
     - craiglpeters
     - justaugustus


### PR DESCRIPTION
Replace inactive owners with active provider-aws contributors. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5671
