### PR TITLE
Update election schedule due to the 1 week technical delay.

### DIFF
--- a/events/elections/2021/README.md
+++ b/events/elections/2021/README.md
@@ -10,7 +10,7 @@ member will serve a two (2) year term.
 
 This year is the first year we will be using [Elekto] to conduct the election.
 Elekto is a new application, commissioned as an internship by the CNCF.  As
-well as having a new, shiny web UI, it relies entirely on GitHub Oauth for
+well as having a new web UI, it relies entirely on GitHub Oauth for
 voting, and as such does not use email at all.  Elekto also handles exceptions,
 eligibility checks, and other aspects of the election.
 
@@ -102,16 +102,16 @@ Examples of contributions that would NOT be considered:
 | Date         | Event                    |
 | ------------ | ------------------------ |
 | August 19    | Steering Committee selects Election Committee |
-| September 21 | Announcement of Election and publication of voters.md |
+| September 28 | Announcement of Election and publication of voters.md |
 | September XX | Steering Committee Meeting with Q+A with the candidates and community |
-| October 6    | All candidate bios due by 0000 UTC (5pm PST) |
-| October 8    | Election Begins via email ballots |
-| October 24   | Deadline to submit voter exception forms and request a replacement ballot |
-| October 27   | Election Closes by 0000 UTC (5pm PST) |
-| October 28   | Private announcement of Results to SC members not up for election |
-| October 30   | Private announcement of Results to all candidates |
-| November 1   | Public announcement of Results at Public Steering Committee Meeting |
-| November 4?   | Election Retro |
+| October 14    | All candidate bios due by 0000 UTC (5pm PST) |
+| October 18    | Election Begins via email ballots |
+| October 31   | Deadline to submit voter exception requests |
+| November 4   | Election Closes by 0000 UTC (5pm PST) |
+| November 5  | Private announcement of Results to SC members not up for election |
+| November 6   | Private announcement of Results to all candidates |
+| November 7   | Public announcement of Results at Public Steering Committee Meeting |
+| November 10?   | Election Retro |
 
 ## Candidacy Process
 
@@ -196,6 +196,7 @@ roles you may hold.
 Contributors may check their voter eligibility at any time once the election
 process starts, by going to the [election app], logging in, navigating to
 the 2021 election, and seeing if the screen there says that they are eligible.
+That screen takes its data from the [voters.yaml] file.
 
 If the app does not say that you are eligible, because you have worked on 
 Kubernetes in a way that is NOT reflected in GitHub contributions, you can use 
@@ -208,7 +209,8 @@ Employer diversity is encouraged, and thus maximal representation will be
 enforced as spelled out in the [Steering Committee Election Charter].
 
 You will be ranking your choices of the candidates with an option for
-"no opinion". In the event of a tie, a coin will be flipped.
+"no opinion". In the event of a tie, a non-involved SC member will flip
+a coin.
 
 The election will open for voting starting on the dates specified on the calendar
 at the top of this document. You will be reminded that voting has opened by an
@@ -266,3 +268,4 @@ Nominees may be found in the [election app].
 [Org Members]: https://github.com/kubernetes/community/blob/master/community-membership.md
 [Elekto]: https://elekto.dev
 [election app]: https://election.k8s.io
+[voters.yaml]: https://github.com/kubernetes/community/blob/master/events/elections/2021/voters.yaml

--- a/events/elections/2021/election.yaml
+++ b/events/elections/2021/election.yaml
@@ -1,7 +1,7 @@
 name: 2021 Steering Committee Election
 organization: Kubernetes
-start_datetime: 2021-10-07 00:00:01
-end_datetime: 2021-10-28 23:59:00
+start_datetime: 2021-10-14 00:00:01
+end_datetime: 2021-11-04 23:59:00
 no_winners: 4
 allow_no_opinion: True
 delete_after: True
@@ -14,4 +14,4 @@ election_officers:
   - coderanger
 eligibility: Kubernetes Org members with 50 or more contributions in the last year can vote.  See [the election guide](https://github.com/kubernetes/community/tree/master/events/elections/2021)
 exception_description: Not all contributions are measured by DevStats.  If you have contributions that are not so measured, then please request an exception to allow you to vote via the Elekto application.
-exception_due: 2021-10-24 10:00:00
+exception_due: 2021-10-31 10:00:00

--- a/events/elections/2021/election_desc.md
+++ b/events/elections/2021/election_desc.md
@@ -4,10 +4,8 @@ As is now customary, this fall is [Steering Committee](https://github.com/kubern
 
 If you’d like to vote or run for a seat, all details and next steps are outlined in the [election process doc](https://git.k8s.io/steering/elections.md) and this application. The application will be the single source of truth of information for this cycle. It will be updated live as new bios of candidates get committed. Please pay attention to the scheduled dates:
 
-| Start Date | End Date | Activity |
-| ---------- | -------- | -----------------|
-| 2021-09-21 | 2021-10-07 | Nominate Candidates |
-| 2021-09-21 | 2021-10-24 | Request voter exceptions |
-| 2021-10-09 | 2021-10-27 | Vote |
+September 28 to October 14 - Nominate candidates
+Septebmer 28 to October 31 - Request voting exceptions
+October 18 to November 4 - Vote
 
-As mentioned in the process doc, eligibility for voting will be determined by 50 contributions to a Kubernetes project over the past year and [Kubernetes Org membership](https://github.com/kubernetes/community/blob/master/community-membership.md).  Eligible voters will be shown as such by this site when logged in.  If you should be eligible, but are not, you may also file for an exception on this site.
+Eligibility for voting will be determined by 50 contributions to a Kubernetes project over the past year and [Kubernetes Org membership](https://github.com/kubernetes/community/blob/master/community-membership.md).  Eligible voters will be shown as such by this site when logged in.  If you should be eligible, but are not, you may also [file for an exception](https://elections.k8s.io/app/elections/2021/exception).


### PR DESCRIPTION
Also add link to voters.yaml and a few other documents.

This update moves the entire election back one week given the late starting date.  This means that the new SC won't be seated until November 7th.  However, it doesn't seem reasonable to compress the timeline any more than that -- particularly since we'll be finishing the nomination period during Kubecon as it is.

As such, I need an LGTM from a member of the SC as well as the EC; placing hold until we have both of those.
/hold

/sig contributor-experience
/committee steering

attn: @coderanger @alisondy @mrbobbytables @spiffxp 

Signed-off-by: Josh Berkus <josh@agliodbs.com>

