### PR TITLE
sig-testing: propose new TLs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -90,6 +90,8 @@ aliases:
     - xing-yang
   sig-testing-leads:
     - BenTheElder
+    - alvaroaleman
+    - cjwagner
     - spiffxp
     - stevekuznetsov
   sig-ui-leads:

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -31,8 +31,8 @@ The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
 * Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**), Google
-* Aaron Crickenberger (**[@spiffxp](https://github.com/spiffxp)**), Google
-* Steve Kuznetsov (**[@stevekuznetsov](https://github.com/stevekuznetsov)**), Red Hat
+* Alvaro Aleman (**[@alvaroaleman](https://github.com/alvaroaleman)**), Red Hat
+* Cole Wagner (**[@cjwagner](https://github.com/cjwagner)**), Google
 
 ## Emeritus Leads
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2455,12 +2455,12 @@ sigs:
     - github: BenTheElder
       name: Benjamin Elder
       company: Google
-    - github: spiffxp
-      name: Aaron Crickenberger
-      company: Google
-    - github: stevekuznetsov
-      name: Steve Kuznetsov
+    - github: alvaroaleman
+      name: Alvaro Aleman
       company: Red Hat
+    - github: cjwagner
+      name: Cole Wagner
+      company: Google
     emeritus_leads:
     - github: fejta
       name: Erick Fejta


### PR DESCRIPTION
For the last 5.5 years, SIG Testing Chairs have also acted as Tech Leads. A
few months ago, we changed our charter to make the Tech Lead role explicit,
but left things as they were by explicitly listing our Chairs as filling
both roles

Today we would like to change that, and recognize the work that two of our
awesome contributors have been doing to further the vision of this SIG

To that end, we are proposing:

- Cole Wagner (@cjwagner) to replace Aaron Crickenberger (@spiffxp) as Tech Lead
- Alvaro Aleman (@alvaroaleman) to replace Steve Kuznetsov (@stevekuznetsov) as Tech Lead
- Aaron and Steve to remain as Chairs

We recognize this means we will remain a SIG with some of the longest-serving
Chairs in the Kubernetes community. Anyone interested in helping us work
through how to improve that state of affairs, please reach out to us.

Lazy consensus deadline for this will be 12:00 PT 2020-10-01