### PR TITLE
slack: add channel cluster-api-kubemark

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -51,6 +51,7 @@ channels:
     archived: true
   - name: cluster-api-gcp
   - name: cluster-api-ibmcloud
+  - name: cluster-api-kubemark
   - name: cluster-api-kubevirt
   - name: cluster-api-nested
   - name: cluster-api-openstack


### PR DESCRIPTION
Request the slack channel for `cluster-api-kubemark`, similar to kubevirt, aws, azure, gcp, etc., to facilitate discussions around CAPK.