### PR TITLE
Changed the broken link to Meet our Contributors in Zoom guidelines

### DIFF
--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -217,7 +217,7 @@ Thanks for making Kubernetes meetings work great!
 [community meeting]: /events/community-meeting.md
 [SIG/WG meetings]: /sig-list.md
 [Office Hours]: /events/office-hours.md
-[Meet Our Contributors]: /mentoring/meet-our-contributors.md
+[Meet Our Contributors]: https://github.com/kubernetes/community/blob/master/mentoring/programs/meet-our-contributors.md
 [moderation]: ./moderation.md
 [zoom admins]: /communication/moderators.md#zoom
 [host key]: https://support.zoom.us/hc/en-us/articles/205172555-Host-Key

--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -217,7 +217,7 @@ Thanks for making Kubernetes meetings work great!
 [community meeting]: /events/community-meeting.md
 [SIG/WG meetings]: /sig-list.md
 [Office Hours]: /events/office-hours.md
-[Meet Our Contributors]: https://github.com/kubernetes/community/blob/master/mentoring/programs/meet-our-contributors.md
+[Meet Our Contributors]: /mentoring/programs/meet-our-contributors.md
 [moderation]: ./moderation.md
 [zoom admins]: /communication/moderators.md#zoom
 [host key]: https://support.zoom.us/hc/en-us/articles/205172555-Host-Key


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
There was a broken link in line 220 of the zoom-guidelines.md doc which is supposed to link to `Meet our Contributors` page. Refer to [this issue](https://github.com/kubernetes/community/issues/6079)