### PR TITLE
communication/slack-config: archive headlamp-dev and rename -users

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -112,9 +112,10 @@ channels:
   - name: gloo
   - name: grafana-operator
   - name: haproxy-ingress
-  - name: headlamp-users
+  - name: headlamp
     id: C01FXB5E8ER
   - name: headlamp-dev
+    archived: true
   - name: helm-chart-testing
   - name: helm-deprecated
     archived: true


### PR DESCRIPTION
A while ago, the #headlamp channel was split into -users and -dev
because some members were concerned that an eventual dev conversation
increase would bother non-dev users.
However, our community is still small, and the Slack channels are
very low traffic, so this split only makes the communication more
difficult.

Therefore, as Headlamp's project manager, I would like to request
that the -users channel be renamed back to the prefixless case, and
the -dev channel to be archived.
