### PR TITLE
Archive abandoned channel #community-sites per discussion

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -61,6 +61,7 @@ channels:
   - name: cn-users
   - name: code-of-conduct
   - name: community-sites
+    archived: true
   - name: compliance-hipaa
   - name: contour
   - name: contributor-summit


### PR DESCRIPTION
#community-sites was created in 2016.  It has not carried any legit discussion in at least a year.

/sig contributor-experience
/area slack-management