### PR TITLE
Add a kubetest2 link to contributors/README.md

### DIFF
--- a/contributors/devel/README.md
+++ b/contributors/devel/README.md
@@ -155,7 +155,7 @@ See the [kubernetes/release](https://github.com/kubernetes/release) repository f
 
 * **Integration Testing in Kubernetes** [integration-tests.md](sig-testing/integration-tests.md)
 
-* **End-to-End Testing in Kubernetes** [e2e-tests.md](sig-testing/e2e-tests.md)
+* **End-to-End Testing in Kubernetes** [e2e-tests.md](sig-testing/e2e-tests.md) and [e2e-tests-kubetest2.md](sig-testing/e2e-tests-kubetest2.md) 
 
 * **Debugging with Gubernator** [gubernator.md](sig-testing/gubernator.md)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
None

It seems kubetest is deprecated so it would be nice if we have a link to kubetest2 in the README.md too. Thank you for your review!

