### PR TITLE
Add documentation for remaining hack/verify* tests

### DIFF
--- a/contributors/devel/sig-testing/verify-tests.md
+++ b/contributors/devel/sig-testing/verify-tests.md
@@ -181,3 +181,13 @@ klog methods which have few disallowed keywords like,
 
 More info is available
 [here](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#change-log-functions-to-structured-equivalent).
+
+
+## `verify-gofmt`
+
+This script is used to check whether the go source code needs to be
+formatted or not using, the gofmt tool. Gofmt tool automatically
+formats the code and the formatted code is easier to read, write and
+maintain.
+
+

--- a/contributors/devel/sig-testing/verify-tests.md
+++ b/contributors/devel/sig-testing/verify-tests.md
@@ -163,3 +163,21 @@ k8s.io/metrics
 
 Once it completes checking for code updates, later the script calls
 `update-codegen.sh` scripts.
+
+
+## `verify-structured-logging`
+
+This script verifies if a package is properly migrated to structured
+logging or not. The script involves verification steps based on new
+klog methods which have few disallowed keywords like,
+
+```bash
+* klog.Infof, klog.Info, klog.Infoln
+* klog.InfoDepth
+* klog.WarningDepth
+* klog.Error, klog.Errorf, klog.Errorln
+* klog.ErrorDepth
+```
+
+More info is available
+[here](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#change-log-functions-to-structured-equivalent).

--- a/contributors/devel/sig-testing/verify-tests.md
+++ b/contributors/devel/sig-testing/verify-tests.md
@@ -191,3 +191,10 @@ formats the code and the formatted code is easier to read, write and
 maintain.
 
 
+## `verify-spelling`
+
+This script uses `client9/misspell` package to search and correct
+commonly misspelled words as per the English language in all the files
+and directories under `kubernetes/kubernetes`.
+
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/community/issues/5532

As part of this PR, I've added documentation for below two scripts:

- hack/verify-structured-logging.sh
- hack/verify-gofmt.sh
