### PR TITLE
Remove kind/design from release doc

### DIFF
--- a/contributors/devel/sig-release/release.md
+++ b/contributors/devel/sig-release/release.md
@@ -337,7 +337,6 @@ issue kind labels must be set:
 - `kind/api-change`: Adds, removes, or changes an API
 - `kind/bug`: Fixes a newly discovered bug.
 - `kind/cleanup`: Adding tests, refactoring, fixing old bugs.
-- `kind/design`: Related to design
 - `kind/documentation`: Adds documentation
 - `kind/failing-test`: CI test case is failing consistently.
 - `kind/feature`: New functionality.


### PR DESCRIPTION
In lieu of #5641, removing kind/design from the devel release doc.
/sig release

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
NA

/hold
until `kind/design` is removed from k/k by a gh admin.
