### PR TITLE
Add a Slack channel for operator-builder from VMware

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -310,6 +310,7 @@ channels:
   - name: openshift-users
   - name: openstack-helm
   - name: openstack-kolla
+  - name: operator-builder
   - name: operator-sdk-dev
   - name: ops-status
     archived: true


### PR DESCRIPTION
Add channel for operator-builder, an open source project created to enable those who wish to use the Kubernetes operator pattern to manage their Kubernetes distributions.  Based upon the plugin architecture from Kubebuilder, operator-builder creates a working operator for Kubernetes workloads given existing input YAML manifests.

https://github.com/vmware-tanzu-labs/operator-builder
https://flings.vmware.com/operator-builder-for-tanzu

Signed-off-by: Dustin Scott <sdustin@vmware.com>
