### PR TITLE
sig-scheduling: Propose new TLs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -77,6 +77,7 @@ aliases:
   sig-scheduling-leads:
     - Huang-Wei
     - ahg-g
+    - alculquicondor
   sig-security-leads:
     - IanColdwater
     - tabbysable

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -25,6 +25,14 @@ The Chairs of the SIG run operations and processes governing the SIG.
 * Wei Huang (**[@Huang-Wei](https://github.com/Huang-Wei)**), IBM
 * Abdullah Gharaibeh (**[@ahg-g](https://github.com/ahg-g)**), Google
 
+### Technical Leads
+The Technical Leads of the SIG establish new subprojects, decommission existing
+subprojects, and resolve cross-subproject technical issues and decisions.
+
+* Wei Huang (**[@Huang-Wei](https://github.com/Huang-Wei)**), IBM
+* Abdullah Gharaibeh (**[@ahg-g](https://github.com/ahg-g)**), Google
+* Aldo Culquicondor (**[@alculquicondor](https://github.com/alculquicondor)**), Google
+
 ## Emeritus Leads
 
 * Bobby (Babak) Salamat (**[@bsalamat](https://github.com/bsalamat)**)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2122,6 +2122,16 @@ sigs:
     - github: ahg-g
       name: Abdullah Gharaibeh
       company: Google
+    tech_leads:
+    - github: Huang-Wei
+      name: Wei Huang
+      company: IBM
+    - github: ahg-g
+      name: Abdullah Gharaibeh
+      company: Google
+    - github: alculquicondor
+      name: Aldo Culquicondor
+      company: Google
     emeritus_leads:
     - github: bsalamat
       name: Bobby (Babak) Salamat


### PR DESCRIPTION
For the last three years, SIG Scheduling Chairs have also acted as Tech Leads. Today we would like to explicitly list our Chairs as filling both roles.

We would also like to recognize the work of one of our awesome contributors in influencing the technical direction of the sig and we are proposing to add @alculquicondor as a TL.


Lazy consensus deadline for this will be 12:00 PT 2020-10-20

/sig scheduling
