### PR TITLE
Fixing broken links in election info page

### DIFF
--- a/events/elections/2021/README.md
+++ b/events/elections/2021/README.md
@@ -296,7 +296,9 @@ Nominees may be found in the [election app].
 [Org Members]: https://github.com/kubernetes/community/blob/master/community-membership.md
 [Elekto]: https://elekto.dev
 [election app]: https://elections.k8s.io
-[Elekto documentation]: https://elekto.dev/docs/voting/
+[Elekto voting documentation]: https://elekto.dev/docs/voting/
 [voters.yaml]: https://github.com/kubernetes/community/blob/master/events/elections/2021/voters.yaml
 [election page]: https://elections.k8s.io/app/elections/2021
 [voter exception form]: https://elections.k8s.io/app/elections/2021/exception
+[public Steering Committee Meeting]: https://github.com/kubernetes/steering/#meetings
+[Eligible voters]: https://github.com/kubernetes/community/tree/master/events/elections/2021#eligibility


### PR DESCRIPTION
I noticed a few broken links in the election info page found at https://github.com/kubernetes/community/blob/master/events/elections/2021/README.md 
To fix the cases with `[words lacking a link]` we need additional or different targets, which I've added. /cc @jberkus 

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
