### PR TITLE
cluster-lifecycle/kubeadm: update OWNERS URL to use main branch

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -150,7 +150,7 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
 ### kubeadm
 - **Owners:**
   - [kubernetes/cluster-bootstrap](https://github.com/kubernetes/cluster-bootstrap/blob/master/OWNERS)
-  - [kubernetes/kubeadm](https://github.com/kubernetes/kubeadm/blob/master/OWNERS)
+  - [kubernetes/kubeadm](https://github.com/kubernetes/kubeadm/blob/main/OWNERS)
   - [kubernetes/kubernetes/cmd/kubeadm](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/OWNERS)
   - [kubernetes/system-validators](https://github.com/kubernetes/system-validators/blob/master/OWNERS)
 - **Contact:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1117,7 +1117,7 @@ sigs:
       slack: kubeadm
     owners:
     - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubeadm/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
     - https://raw.githubusercontent.com/kubernetes/system-validators/master/OWNERS
     meetings:


### PR DESCRIPTION
The kubeadm repository is moving to 'main' as the default branch.
https://github.com/kubernetes/kubeadm/issues/2589

this should be on hold until the change happens.
in the meantime looking for lgtm/approve. thanks.

/hold