### PR TITLE
[WIP] github-management: add rotation program

### DIFF
--- a/github-management/rotation.md
+++ b/github-management/rotation.md
@@ -1,0 +1,62 @@
+# GitHub Management Rotation
+
+GitHub Management Rotation refers to a rotation program both for the
+[GitHub Administration Team] and the [New Membership Coordinators].
+Rotations are volunteer-driven and best-effort during business hours only.
+The GitHub Management team is spread across the globe so please keep timezones
+in mind while expecting responses from the rotating member.
+
+The rotation program is **not equivalent to oncall** and our SLO remains
+one week.
+
+## Rotation Schedule
+
+You can find the rotation schedule and the current rotating member at this [calendar].
+To know a member's timezone and GitHub username, please refer to [README.md].
+
+As a reminder, please reach out to the appropriate team depending on your request.
+
+| Role | Description |
+| ---- | ----------- |
+| [GitHub Administration Team] | Repository creation or migration, security, moderation, etc |
+| [New Membership Coordinators] | New Membership Requests |
+
+## Managing the Rotation Schedule
+
+This section is meant for the GitHub Management team.
+
+Each rotation is for one week. If you would be unavailable during
+your assigned rotation schedule, you should swap with another member or
+find coverage for that week.
+
+To update the schedule, directly update this [google calendar]. Only GitHub Admins
+and NMCs have access to update this calendar.
+
+### Handoff
+
+When your shift ends, you may be involved in one or more ongoing
+issues. If you are already invested in the issues and have the bandwidth
+for it, you can continue managing the issue (thanks!), but _you are not
+obligated to continue managing the issue!_
+
+If you would like to handoff issue command:
+
+1.  Start by **ensuring the tracking issue is up to date** - review the
+    information in the issue description, and fill in or correct any missing
+    details.
+2.  **Leave a comment** to add any additional context you have on the
+    issue. Make sure to list any open questions or decisions and any pending
+    action items.
+3.  Reassign the issue to the next rotating member.
+
+Finally, reach out to the next rotating member (email/slack) to make
+sure they are aware of the handoff and to answer any questions. _Until they've
+explicitly acknowledged the handoff you are still the issue commander!_
+
+
+[GitHub Administration Team]: /github-management/README.md#github-administration-team
+[New Membership Coordinators]: /github-management/README.md#new-membership-coordinator
+<!-- TODO: publish calendar to k8s.dev -->
+[calendar]: TODO
+[google calendar]: TODO
+[README.md]: /github-management/README.md


### PR DESCRIPTION
This commit adds a rotation program for both GitHub Admins and NMCs
to create a sustainable culture and avoid burn out. This is also
important to ensure that requests from community members are handled
as per our SLO of one week.

Note that this is not an oncall program. Our SLO continues to remain
one week.

This was discussed in [GitHub Management meeting](https://docs.google.com/document/d/1IiVrr1hcFWmbboExk971FsMUGfr2Wp68mdMribCuzLs/edit#heading=h.ym9s0wypuv81) on 2 September 2021.

This is WIP because we still need to create the rotation calendar and publish it.

---

/assign @cblecker @spiffxp @mrbobbytables @idvoretskyi @fejta 
github admins

/assign @palnabarun @ameukam @savitharaghunathan 
NMCs
