### PR TITLE
Fix: Inaccurate Description for Kubernetes Community Values

### DIFF
--- a/values.md
+++ b/values.md
@@ -2,7 +2,7 @@
 title: "Kubernetes Community Values"
 weight: 2
 description: |
-  This page indexes all of the mentoring initiatives for contributing to the Kubernetes project. For end user mentoring initiatives, check out KubeCon and other CNCF events and programs.
+  This page indexes all of the community values that are part of the Kubernetes Community culture. The indexed values have evolved over time, pushing our project and peers toward constant improvement.
 ---
 
 # Kubernetes Community Values

--- a/values.md
+++ b/values.md
@@ -2,7 +2,7 @@
 title: "Kubernetes Community Values"
 weight: 2
 description: |
-  This page indexes all of the community values that are part of the Kubernetes Community culture. The indexed values have evolved over time, pushing our project and peers toward constant improvement.
+  The Kubernetes Community values are the keystone to the ongoing success of the project. These principles guide every aspect of the Kubernetes project.
 ---
 
 # Kubernetes Community Values


### PR DESCRIPTION
The description for the Kubernetes Community Values in values.md was inaccurate (the existing description was relevant to mentoring initiatives).

Changed it to better reflect the content.

Fixes #6188
