### PR TITLE
Request channel krafternetes.

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -186,6 +186,7 @@ channels:
   - name: kpt
   - name: kr-dev
   - name: kr-users
+  - name: krafternetes
   - name: kraken
   - name: krane
   - name: krator


### PR DESCRIPTION
Requesting channel "krafternetes"

Purpose: This channel is for discussion and coordination among Kubernetes contributors and users who also do things in the visual, culinary, and performing arts and want to discuss them in our slack and use our artistic abilities to support the project.  Among other things, I plan to use the channel to coordinate work on (a) a visual arts event for the Contributor Celebration, (b) contributor event tshirts and swag design, and (c) other arts needs that the project has.

The name is somewhat whimsical, if you find it too much so we can go with something more direct, like "kube-artists".

I will be on the channel to moderate.  @kaslin is likely to be available to co-moderate.