### PR TITLE
cocc/onboarding: Add steps for kubernetes/org GitHub teams and OWNERS

### DIFF
--- a/committee-code-of-conduct/governance/onboarding-offboarding.md
+++ b/committee-code-of-conduct/governance/onboarding-offboarding.md
@@ -32,6 +32,9 @@ Different actions on this list must be carried out by different members:
 
     - [ ] `conduct@kubernetes.io` mailing list
     - [ ] Google drive
+- [ ] Update `kubernetes/org`:
+  - [ ] [`OWNERS_ALIASES`](https://git.k8s.io/org/OWNERS_ALIASES)
+  - [ ] [`config/kubernetes/org.yaml`](https://git.k8s.io/org/config/kubernetes/org.yaml)
 
 ## Communications 
 

--- a/committee-code-of-conduct/governance/onboarding-offboarding.md
+++ b/committee-code-of-conduct/governance/onboarding-offboarding.md
@@ -26,10 +26,12 @@ Different actions on this list must be carried out by different members:
 **Who executes:** Carryover members should ensure that outgoing members are removed and incoming members are invited.
 
 - [ ] Update `kubernetes/community` [`sigs.yaml`](/sigs.yaml)
-- [ ] Update `kubernetes/k8s.io` [`groups.yaml`](https://git.k8s.io/k8s.io/groups/committee-code-of-conduct/groups.yaml)
-  > **Note:** This file controls access to the mailing list and Google Drive! If you do not update this file, adding people manually (via the UIs) continually revert until this file is updated.
-  - [ ] `conduct@kubernetes.io` mailing list
-  - [ ] Google drive
+- [ ] Update `kubernetes/k8s.io`:
+  - [ ] [`OWNERS_ALIASES`](https://git.k8s.io/k8s.io/OWNERS_ALIASES)
+  - [ ] [`groups.yaml`](https://git.k8s.io/k8s.io/groups/committee-code-of-conduct/groups.yaml)
+    > **Note:** This file controls access to the mailing list and Google Drive! If you do not update this file, adding people manually (via the UIs) continually revert until this file is updated.
+    - [ ] `conduct@kubernetes.io` mailing list
+    - [ ] Google drive
 - [ ] Update `kubernetes/org`:
   - [ ] [`OWNERS_ALIASES`](https://git.k8s.io/org/OWNERS_ALIASES)
   - [ ] [`config/kubernetes/org.yaml`](https://git.k8s.io/org/config/kubernetes/org.yaml)

--- a/committee-code-of-conduct/governance/onboarding-offboarding.md
+++ b/committee-code-of-conduct/governance/onboarding-offboarding.md
@@ -1,12 +1,12 @@
 # Onboarding and offboarding new Code of Conduct Committee members
 
-Different actions on this list must be carried out by different members: 
+Different actions on this list must be carried out by different members:
 
 - **Outgoing members:** members who are ending their term
 - **Incoming members:** members beginning their term
 - **Carryover members:** members mid-way through their term
 
-## Permissions 
+## Permissions
 
 ### Slack Channel Membership
 
@@ -23,20 +23,18 @@ Different actions on this list must be carried out by different members:
 
 ### Kubernetes/community permissions and google permissions
 
-**Who executes:** Carryover members should ensure that outgoing members are removed and incoming members are invited. 
+**Who executes:** Carryover members should ensure that outgoing members are removed and incoming members are invited.
 
-- [ ] Update `kubernetes/community` [`sigs.yaml`](https://github.com/kubernetes/community/blob/master/sigs.yaml) 
-- [ ] Update `kubernetes/k8s.io` [`groups.yaml`](https://github.com/kubernetes/k8s.io/blob/main/groups/groups.yaml)
-
-    > **Note:** This file controls access to the mailing list and Google Drive! If you do not update this file, adding people manually (via the UIs) continually revert until this file is updated.
-
-    - [ ] `conduct@kubernetes.io` mailing list
-    - [ ] Google drive
+- [ ] Update `kubernetes/community` [`sigs.yaml`](/sigs.yaml)
+- [ ] Update `kubernetes/k8s.io` [`groups.yaml`](https://git.k8s.io/k8s.io/groups/committee-code-of-conduct/groups.yaml)
+  > **Note:** This file controls access to the mailing list and Google Drive! If you do not update this file, adding people manually (via the UIs) continually revert until this file is updated.
+  - [ ] `conduct@kubernetes.io` mailing list
+  - [ ] Google drive
 - [ ] Update `kubernetes/org`:
   - [ ] [`OWNERS_ALIASES`](https://git.k8s.io/org/OWNERS_ALIASES)
   - [ ] [`config/kubernetes/org.yaml`](https://git.k8s.io/org/config/kubernetes/org.yaml)
 
-## Communications 
+## Communications
 
 **Who executes:** Anyone but outgoing members!
 


### PR DESCRIPTION
From https://github.com/kubernetes/org/pull/3090#issuecomment-965802315:

> (FYI, this should be added to https://github.com/kubernetes/community/blob/master/committee-code-of-conduct/governance/onboarding-offboarding.md)

- cocc/onboarding: Add steps for kubernetes/org GitHub teams and OWNERS
- cocc/onboarding: Fix markdown lint warnings

Signed-off-by: Stephen Augustus <foo@auggie.dev>

ref: https://kubernetes.slack.com/archives/CPNFRNLTS/p1636583166079300?thread_ts=1636482065.073000&cid=CPNFRNLTS

/assign @celestehorgan @tpepper 
cc: @kubernetes/code-of-conduct-committee 