### PR TITLE
OWNERS(justaugustus): Prune extraneous reviewer roles

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -169,7 +169,6 @@ aliases:
     - wongma7
   provider-azure:
     - craiglpeters
-    - justaugustus
     - feiskyer
     - khenidak
   provider-gcp:

--- a/contributors/guide/OWNERS
+++ b/contributors/guide/OWNERS
@@ -5,7 +5,6 @@ reviewers:
   - guineveresaenger
   - idvoretskyi
   - tpepper
-  - justaugustus
 approvers:
   - castrojo
   - parispittman

--- a/github-management/OWNERS
+++ b/github-management/OWNERS
@@ -7,7 +7,6 @@ approvers:
 reviewers:
   - fejta
   - idvoretskyi
-  - justaugustus
   - mrbobbytables
   - nikhita
 


### PR DESCRIPTION
Taking an opportunity to prune myself from some aliases/review paths
to reduce my workload.

Signed-off-by: Stephen Augustus <foo@auggie.dev>