### PR TITLE
slack-config(enhancements): Update subproject owners

### DIFF
--- a/communication/slack-config/sig-architecture/usergroups.yaml
+++ b/communication/slack-config/sig-architecture/usergroups.yaml
@@ -11,5 +11,5 @@ usergroups:
     members:
       - jeremyrickard # subproject owner
       - johnbelamaric # subproject owner
-      - justaugustus # subproject owner
+      - kikisdeliveryservice # subproject owner
       - mrbobbytables # subproject owner


### PR DESCRIPTION
I'm moving to emeritus and Kirsten was missing from the usergroup!

ref: https://github.com/kubernetes/enhancements/pull/3046, https://github.com/kubernetes/enhancements/blob/c342fea7acb59059b400e7206671bea751699799/OWNERS_ALIASES#L166-L170, https://kubernetes.slack.com/archives/C1L57L91V/p1636653299011400

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @mrbobbytables @kikisdeliveryservice 
cc: @kubernetes/enhancements 