### PR TITLE
Fixes broken URL in scheduler_algorithm for a deleted documentation

### DIFF
--- a/contributors/devel/sig-scheduling/scheduler_algorithm.md
+++ b/contributors/devel/sig-scheduling/scheduler_algorithm.md
@@ -1,6 +1,6 @@
 # Scheduler Algorithm in Kubernetes
 
-For each unscheduled Pod, the Kubernetes scheduler tries to find a node across the cluster according to a set of rules. A general introduction to the Kubernetes scheduler can be found at [scheduler.md](scheduler.md). In this document, the algorithm of how to select a node for the Pod is explained. There are two steps before a destination node of a Pod is chosen. The first step is filtering all the nodes and the second is ranking the remaining nodes to find a best fit for the Pod.
+For each unscheduled Pod, the Kubernetes scheduler tries to find a node across the cluster according to a set of rules. A general introduction to the Kubernetes scheduler can be found at [scheduling_code_hierarchy_overview.md](scheduling_code_hierarchy_overview.md). In this document, the algorithm of how to select a node for the Pod is explained. There are two steps before a destination node of a Pod is chosen. The first step is filtering all the nodes and the second is ranking the remaining nodes to find a best fit for the Pod.
 
 ## Filtering the nodes
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

The `scheduler.md` file was deleted in this [PR](https://github.com/kubernetes/community/pull/6198), but the `scheduler_algorithm` file still references the deleted file.

According to the linked PR, all the information in the `scheduler.md` are already in [scheduling_code_hierarchy_overview.md](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-scheduling/scheduling_code_hierarchy_overview.md), so the link is replaced with a link to this file instead.
