### PR TITLE
Change 'master' to 'main' in github-workflow markdown

### DIFF
--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -55,7 +55,7 @@ cd $working_dir/kubernetes
 git remote add upstream https://github.com/kubernetes/kubernetes.git
 # or: git remote add upstream git@github.com:kubernetes/kubernetes.git
 
-# Never push to upstream main
+# Never push to upstream master
 git remote set-url --push upstream no_push
 
 # Confirm that your remotes make sense:
@@ -64,13 +64,16 @@ git remote -v
 
 ### 3 Branch
 
-Get your local main up to date:
+Get your local master up to date:
 
 ```sh
 cd $working_dir/kubernetes
 git fetch upstream
-git checkout main
-git rebase upstream/main
+git checkout master
+git rebase upstream/master
+
+# Depending on which repository you are working from,
+# the default branch may be called 'main' instead of 'master'.
 ```
 
 Branch from it:
@@ -89,7 +92,10 @@ This workflow is process-specific; for quick start build instructions for [kuber
 ```sh
 # While on your myfeature branch
 git fetch upstream
-git rebase upstream/main
+git rebase upstream/master
+
+# Depending on which repository you are working from,
+# the default branch may be called 'main' instead of 'master'.
 ```
 
 Please don't use `git pull` instead of the above `fetch` / `rebase`. `git pull`
@@ -217,7 +223,7 @@ rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History):
 
    ...
 
-  Successfully rebased and updated refs/heads/main.
+  Successfully rebased and updated refs/heads/master.
   ```
 4. Force push your changes to your remote branch:
 
@@ -251,7 +257,10 @@ will create the PR branch inside the main repository rather than inside your for
 
   # sync the branch with upstream
   git fetch upstream
-  git rebase upstream/main
+  git rebase upstream/master
+  
+  # Depending on which repository you are working from,
+  # the default branch may be called 'main' instead of 'master'.
   ```
 - If the commit you wish to revert is a:<br>
   - **merge commit:**

--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -55,7 +55,7 @@ cd $working_dir/kubernetes
 git remote add upstream https://github.com/kubernetes/kubernetes.git
 # or: git remote add upstream git@github.com:kubernetes/kubernetes.git
 
-# Never push to upstream master
+# Never push to upstream main
 git remote set-url --push upstream no_push
 
 # Confirm that your remotes make sense:
@@ -64,13 +64,13 @@ git remote -v
 
 ### 3 Branch
 
-Get your local master up to date:
+Get your local main up to date:
 
 ```sh
 cd $working_dir/kubernetes
 git fetch upstream
-git checkout master
-git rebase upstream/master
+git checkout main
+git rebase upstream/main
 ```
 
 Branch from it:
@@ -89,7 +89,7 @@ This workflow is process-specific; for quick start build instructions for [kuber
 ```sh
 # While on your myfeature branch
 git fetch upstream
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 Please don't use `git pull` instead of the above `fetch` / `rebase`. `git pull`
@@ -217,7 +217,7 @@ rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History):
 
    ...
 
-  Successfully rebased and updated refs/heads/master.
+  Successfully rebased and updated refs/heads/main.
   ```
 4. Force push your changes to your remote branch:
 
@@ -251,7 +251,7 @@ will create the PR branch inside the main repository rather than inside your for
 
   # sync the branch with upstream
   git fetch upstream
-  git rebase upstream/master
+  git rebase upstream/main
   ```
 - If the commit you wish to revert is a:<br>
   - **merge commit:**

--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -67,13 +67,13 @@ git remote -v
 Get your local master up to date:
 
 ```sh
+# Depending on which repository you are working from,
+# the default branch may be called 'main' instead of 'master'.
+
 cd $working_dir/kubernetes
 git fetch upstream
 git checkout master
 git rebase upstream/master
-
-# Depending on which repository you are working from,
-# the default branch may be called 'main' instead of 'master'.
 ```
 
 Branch from it:
@@ -90,12 +90,12 @@ This workflow is process-specific; for quick start build instructions for [kuber
 ### 4 Keep your branch in sync
 
 ```sh
+# Depending on which repository you are working from,
+# the default branch may be called 'main' instead of 'master'.
+
 # While on your myfeature branch
 git fetch upstream
 git rebase upstream/master
-
-# Depending on which repository you are working from,
-# the default branch may be called 'main' instead of 'master'.
 ```
 
 Please don't use `git pull` instead of the above `fetch` / `rebase`. `git pull`
@@ -252,15 +252,15 @@ will create the PR branch inside the main repository rather than inside your for
 - Create a branch and sync it with upstream.
 
   ```sh
+  # Depending on which repository you are working from,
+  # the default branch may be called 'main' instead of 'master'.
+  
   # create a branch
   git checkout -b myrevert
 
   # sync the branch with upstream
   git fetch upstream
   git rebase upstream/master
-  
-  # Depending on which repository you are working from,
-  # the default branch may be called 'main' instead of 'master'.
   ```
 - If the commit you wish to revert is a:<br>
   - **merge commit:**


### PR DESCRIPTION
ᕕ(ᐛ)ᕗ New contributor here!

I have been using this very helpful github-workflow guide while I make my first contributions- thank you!

With this PR I am changing all references to 'master' and replacing them with 'main'.  I am so pleased that the default branch is now called 'main'!

The diagram on the page is now out-of-date and if you accept these changes it will be inconsistent with the text.  But we have to start somewhere!

\(^-^)/  Have a great day!