### PR TITLE
Add channel for controller-runtime

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -67,6 +67,7 @@ channels:
   - name: compliance-hipaa
   - name: contour
   - name: contributor-summit
+  - name: controller-runtime
   - name: craft
   - name: crash-diagnostics
   - name: crd-installation


### PR DESCRIPTION
#### Purpose
The channel serves as a medium for discussions related to [`controller-runtime`](https://github.com/kubernetes-sigs/controller-runtime/). Till now, the discussions for controller-runtime took place in the `#kubebuilder` slack channel. As controller-runtime grows as a project and adoption increases, having a dedicated channel will help.

/sig api-machinery