### PR TITLE
steering: Update governance group liaisons

### DIFF
--- a/liaisons.md
+++ b/liaisons.md
@@ -27,35 +27,35 @@ of SIGs, WGs and UGs.
 | [SIG Apps](sig-apps/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Architecture](sig-architecture/README.md) | Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) |
 | [SIG Auth](sig-auth/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
-| [SIG Autoscaling](sig-autoscaling/README.md) | Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**) |
-| [SIG CLI](sig-cli/README.md) | Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**) |
-| [SIG Cloud Provider](sig-cloud-provider/README.md) | Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**) |
+| [SIG Autoscaling](sig-autoscaling/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
+| [SIG CLI](sig-cli/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
+| [SIG Cloud Provider](sig-cloud-provider/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Cluster Lifecycle](sig-cluster-lifecycle/README.md) | Davanum Srinivas (**[@dims](https://github.com/dims)**) |
 | [SIG Contributor Experience](sig-contributor-experience/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
-| [SIG Docs](sig-docs/README.md) | Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) |
+| [SIG Docs](sig-docs/README.md) | Paris Pittman (**[@parispittman](https://github.com/parispittman)**) |
 | [SIG Instrumentation](sig-instrumentation/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
-| [SIG K8s Infra](sig-k8s-infra/README.md) | Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**) |
-| [SIG Multicluster](sig-multicluster/README.md) | Paris Pittman (**[@parispittman](https://github.com/parispittman)**) |
-| [SIG Network](sig-network/README.md) | Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**) |
-| [SIG Node](sig-node/README.md) | Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**) |
+| [SIG K8s Infra](sig-k8s-infra/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
+| [SIG Multicluster](sig-multicluster/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
+| [SIG Network](sig-network/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
+| [SIG Node](sig-node/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
 | [SIG Release](sig-release/README.md) | Davanum Srinivas (**[@dims](https://github.com/dims)**) |
 | [SIG Scalability](sig-scalability/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Scheduling](sig-scheduling/README.md) | Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) |
 | [SIG Security](sig-security/README.md) | Paris Pittman (**[@parispittman](https://github.com/parispittman)**) |
-| [SIG Service Catalog](sig-service-catalog/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
+| [SIG Service Catalog](sig-service-catalog/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Storage](sig-storage/README.md) | Paris Pittman (**[@parispittman](https://github.com/parispittman)**) |
 | [SIG Testing](sig-testing/README.md) | Paris Pittman (**[@parispittman](https://github.com/parispittman)**) |
-| [SIG UI](sig-ui/README.md) | Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**) |
+| [SIG UI](sig-ui/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Usability](sig-usability/README.md) | Davanum Srinivas (**[@dims](https://github.com/dims)**) |
 | [SIG Windows](sig-windows/README.md) | Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) |
 | [WG API Expression](wg-api-expression/README.md) | Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) |
-| [WG Data Protection](wg-data-protection/README.md) | Paris Pittman (**[@parispittman](https://github.com/parispittman)**) |
-| [WG IoT Edge](wg-iot-edge/README.md) | Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**) |
+| [WG Data Protection](wg-data-protection/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
+| [WG IoT Edge](wg-iot-edge/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
 | [WG Multitenancy](wg-multitenancy/README.md) | Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) |
 | [WG Policy](wg-policy/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
 | [WG Structured Logging](wg-structured-logging/README.md) | Davanum Srinivas (**[@dims](https://github.com/dims)**) |
-| [UG Big Data](ug-big-data/README.md) | Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**) |
-| [UG VMware Users](ug-vmware-users/README.md) | Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**) |
+| [UG Big Data](ug-big-data/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
+| [UG VMware Users](ug-vmware-users/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -36,7 +36,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-autoscaling-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-autoscaling-pr-reviews) - PR Reviews
     - [@kubernetes/sig-autoscaling-proposals](https://github.com/orgs/kubernetes/teams/sig-autoscaling-proposals) - Design Proposals
     - [@kubernetes/sig-autoscaling-test-failures](https://github.com/orgs/kubernetes/teams/sig-autoscaling-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**)
+- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 
 ## Subprojects
 

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -59,7 +59,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-cli-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-cli-pr-reviews) - PR Reviews
     - [@kubernetes/sig-cli-proposals](https://github.com/orgs/kubernetes/teams/sig-cli-proposals) - Design Proposals
     - [@kubernetes/sig-cli-test-failures](https://github.com/orgs/kubernetes/teams/sig-cli-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**)
+- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
 
 ## Subprojects
 

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -43,7 +43,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-cloud-provider-proposals](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-proposals) - Design Proposals
     - [@kubernetes/sig-cloud-provider-test-failures](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-test-failures) - Test Failures and Triage
     - [@kubernetes/sig-cloud-providers-misc](https://github.com/orgs/kubernetes/teams/sig-cloud-providers-misc) - General Discussion
-- Steering Committee Liaison: Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**)
+- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
 
 ## Subprojects
 

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -75,7 +75,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-docs-pt-owners](https://github.com/orgs/kubernetes/teams/sig-docs-pt-owners) - Portuguese language content
     - [@kubernetes/sig-docs-uk-owners](https://github.com/orgs/kubernetes/teams/sig-docs-uk-owners) - Ukrainian language content
     - [@kubernetes/sig-docs-zh-owners](https://github.com/orgs/kubernetes/teams/sig-docs-zh-owners) - Chinese language content
-- Steering Committee Liaison: Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**)
+- Steering Committee Liaison: Paris Pittman (**[@parispittman](https://github.com/parispittman)**)
 
 ## Subprojects
 

--- a/sig-k8s-infra/README.md
+++ b/sig-k8s-infra/README.md
@@ -44,7 +44,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 - GitHub Teams:
     - [@kubernetes/sig-k8s-infra](https://github.com/orgs/kubernetes/teams/sig-k8s-infra) - active contributors in sig-k8s-infra
     - [@kubernetes/sig-k8s-infra-leads](https://github.com/orgs/kubernetes/teams/sig-k8s-infra-leads) - sig-k8s-infra chairs and tech leads
-- Steering Committee Liaison: Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**)
+- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
 
 ## Subprojects
 

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -41,7 +41,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-multicluster-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-multicluster-pr-reviews) - PR Reviews
     - [@kubernetes/sig-multicluster-test-failures](https://github.com/orgs/kubernetes/teams/sig-multicluster-test-failures) - Test Failures and Triage
     - [@kubernetes/sig-mutlicluster-proposals](https://github.com/orgs/kubernetes/teams/sig-mutlicluster-proposals) - Design Proposals
-- Steering Committee Liaison: Paris Pittman (**[@parispittman](https://github.com/parispittman)**)
+- Steering Committee Liaison: Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**)
 
 ## Subprojects
 

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -48,7 +48,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-network-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-network-pr-reviews) - PR Reviews
     - [@kubernetes/sig-network-proposals](https://github.com/orgs/kubernetes/teams/sig-network-proposals) - Design Proposals
     - [@kubernetes/sig-network-test-failures](https://github.com/orgs/kubernetes/teams/sig-network-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**)
+- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 
 ## Subprojects
 

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -40,7 +40,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-node-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) - PR Reviews
     - [@kubernetes/sig-node-proposals](https://github.com/orgs/kubernetes/teams/sig-node-proposals) - Design Proposals
     - [@kubernetes/sig-node-test-failures](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**)
+- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 
 ## Subprojects
 

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -48,7 +48,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-service-catalog-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-service-catalog-pr-reviews) - PR Reviews
     - [@kubernetes/sig-service-catalog-proposals](https://github.com/orgs/kubernetes/teams/sig-service-catalog-proposals) - Design Proposals
     - [@kubernetes/sig-service-catalog-test-failures](https://github.com/orgs/kubernetes/teams/sig-service-catalog-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
+- Steering Committee Liaison: Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**)
 
 ## Subprojects
 

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -35,7 +35,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 - Slack: [#sig-ui](https://kubernetes.slack.com/messages/sig-ui)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fui)
-- Steering Committee Liaison: Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**)
+- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
 
 ## Subprojects
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -596,8 +596,8 @@ sigs:
     - name: sig-autoscaling-test-failures
       description: Test Failures and Triage
     liaison:
-      github: derekwaynecarr
-      name: Derek Carr
+      github: tpepper
+      name: Tim Pepper
   subprojects:
   - name: addon-resizer
     owners:
@@ -699,8 +699,8 @@ sigs:
     - name: sig-cli-test-failures
       description: Test Failures and Triage
     liaison:
-      github: derekwaynecarr
-      name: Derek Carr
+      github: justaugustus
+      name: Stephen Augustus
   subprojects:
   - name: cli-experimental
     owners:
@@ -788,8 +788,8 @@ sigs:
     - name: sig-cloud-providers-misc
       description: General Discussion
     liaison:
-      github: nikhita
-      name: Nikhita Raghunath
+      github: justaugustus
+      name: Stephen Augustus
   subprojects:
   - name: cloud-provider-extraction-migration
     owners:
@@ -1438,8 +1438,8 @@ sigs:
     - name: sig-docs-zh-owners
       description: Chinese language content
     liaison:
-      github: liggitt
-      name: Jordan Liggitt
+      github: parispittman
+      name: Paris Pittman
   subprojects:
   - name: kubernetes-blog
     owners:
@@ -1595,8 +1595,8 @@ sigs:
     - name: sig-k8s-infra-leads
       description: sig-k8s-infra chairs and tech leads
     liaison:
-      github: nikhita
-      name: Nikhita Raghunath
+      github: justaugustus
+      name: Stephen Augustus
   subprojects:
   - name: k8s-infra-dns
     description: Code and configuration to manage DNS records for domains owned by
@@ -1667,8 +1667,8 @@ sigs:
     - name: sig-mutlicluster-proposals
       description: Design Proposals
     liaison:
-      github: parispittman
-      name: Paris Pittman
+      github: mrbobbytables
+      name: Bob Killen
   subprojects:
   - name: Kubefed
     owners:
@@ -1766,8 +1766,8 @@ sigs:
     - name: sig-network-test-failures
       description: Test Failures and Triage
     liaison:
-      github: derekwaynecarr
-      name: Derek Carr
+      github: tpepper
+      name: Tim Pepper
   subprojects:
   - name: cluster-proportional-autoscaler
     owners:
@@ -1866,8 +1866,8 @@ sigs:
     - name: sig-node-test-failures
       description: Test Failures and Triage
     liaison:
-      github: nikhita
-      name: Nikhita Raghunath
+      github: tpepper
+      name: Tim Pepper
   subprojects:
   - name: cri-api
     owners:
@@ -2304,8 +2304,8 @@ sigs:
     - name: sig-service-catalog-test-failures
       description: Test Failures and Triage
     liaison:
-      github: cblecker
-      name: Christoph Blecker
+      github: mrbobbytables
+      name: Bob Killen
   subprojects:
   - name: minibroker
     owners:
@@ -2587,8 +2587,8 @@ sigs:
     slack: sig-ui
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-ui
     liaison:
-      github: nikhita
-      name: Nikhita Raghunath
+      github: justaugustus
+      name: Stephen Augustus
   subprojects:
   - name: dashboard
     owners:
@@ -2807,8 +2807,8 @@ workinggroups:
     slack: wg-data-protection
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-data-protection
     liaison:
-      github: parispittman
-      name: Paris Pittman
+      github: cblecker
+      name: Christoph Blecker
 - dir: wg-iot-edge
   name: IoT Edge
   mission_statement: >
@@ -2852,8 +2852,8 @@ workinggroups:
     slack: wg-iot-edge
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge
     liaison:
-      github: derekwaynecarr
-      name: Derek Carr
+      github: cblecker
+      name: Christoph Blecker
 - dir: wg-multitenancy
   name: Multitenancy
   mission_statement: >
@@ -3049,8 +3049,8 @@ usergroups:
     - name: ug-big-data
       description: General Discussion
     liaison:
-      github: derekwaynecarr
-      name: Derek Carr
+      github: tpepper
+      name: Tim Pepper
 - dir: ug-vmware-users
   name: VMware Users
   mission_statement: >
@@ -3084,8 +3084,8 @@ usergroups:
     slack: ug-vmware
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-ug-vmware
     liaison:
-      github: nikhita
-      name: Nikhita Raghunath
+      github: tpepper
+      name: Tim Pepper
 committees:
 - dir: committee-code-of-conduct
   name: Code of Conduct

--- a/ug-big-data/README.md
+++ b/ug-big-data/README.md
@@ -27,7 +27,7 @@ Serve as a community resource for advising big data and data science related sof
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fbig-data)
 - GitHub Teams:
     - [@kubernetes/ug-big-data](https://github.com/orgs/kubernetes/teams/ug-big-data) - General Discussion
-- Steering Committee Liaison: Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**)
+- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 <!-- BEGIN CUSTOM CONTENT -->
 
 ### Goals

--- a/ug-vmware-users/README.md
+++ b/ug-vmware-users/README.md
@@ -22,7 +22,7 @@ The VMware User Group facilitates communication among Kubernetes users and contr
 - Slack: [#ug-vmware](https://kubernetes.slack.com/messages/ug-vmware)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-ug-vmware)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/ug%2Fvmware-users)
-- Steering Committee Liaison: Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**)
+- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/wg-data-protection/README.md
+++ b/wg-data-protection/README.md
@@ -31,7 +31,7 @@ The [charter](charter.md) defines the scope and governance of the Data Protectio
 - Slack: [#wg-data-protection](https://kubernetes.slack.com/messages/wg-data-protection)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-data-protection)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fdata-protection)
-- Steering Committee Liaison: Paris Pittman (**[@parispittman](https://github.com/parispittman)**)
+- Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/wg-iot-edge/README.md
+++ b/wg-iot-edge/README.md
@@ -34,7 +34,7 @@ A Working Group dedicated to discussing, designing and documenting using Kuberne
 - Slack: [#wg-iot-edge](https://kubernetes.slack.com/messages/wg-iot-edge)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fiot-edge)
-- Steering Committee Liaison: Derek Carr (**[@derekwaynecarr](https://github.com/derekwaynecarr)**)
+- Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
 <!-- BEGIN CUSTOM CONTENT -->
 This working group is a cross-SIG effort currently sponsored by _sig-networking_ and _sig-multicluster_ with
 a focus on improving Kubernetes IoT and Edge deployments. Community members are encouraged to share their ideas in this working group to reach broad consensus across the SIGs. Once consensus is reached, the enhancements


### PR DESCRIPTION
Part of @tpepper and my onboarding in https://github.com/kubernetes/steering/issues/219.

We're also taking the opportunity to rebalance some of the load for a few of the continuing @kubernetes/steering-committee members.

Signed-off-by: Stephen Augustus <foo@auggie.dev>
ref: https://docs.google.com/spreadsheets/d/14jfFbZYZi1QVy_l6RZXD2kIt8aTqa9wxh-br2Od1FpI/edit?usp=sharing

/assign @tpepper @parispittman @mrbobbytables @liggitt @cblecker @dims 
/hold