### PR TITLE
doc: update link to where need to update the cocc group in k/k8s.io

### DIFF
--- a/committee-code-of-conduct/governance/onboarding-offboarding.md
+++ b/committee-code-of-conduct/governance/onboarding-offboarding.md
@@ -1,12 +1,12 @@
 # Onboarding and offboarding new Code of Conduct Committee members
 
-Different actions on this list must be carried out by different members: 
+Different actions on this list must be carried out by different members:
 
 - **Outgoing members:** members who are ending their term
 - **Incoming members:** members beginning their term
 - **Carryover members:** members mid-way through their term
 
-## Permissions 
+## Permissions
 
 ### Slack Channel Membership
 
@@ -23,17 +23,17 @@ Different actions on this list must be carried out by different members:
 
 ### Kubernetes/community permissions and google permissions
 
-**Who executes:** Carryover members should ensure that outgoing members are removed and incoming members are invited. 
+**Who executes:** Carryover members should ensure that outgoing members are removed and incoming members are invited.
 
-- [ ] Update `kubernetes/community` [`sigs.yaml`](https://github.com/kubernetes/community/blob/master/sigs.yaml) 
-- [ ] Update `kubernetes/k8s.io` [`groups.yaml`](https://github.com/kubernetes/k8s.io/blob/main/groups/groups.yaml)
+- [ ] Update `kubernetes/community` [`sigs.yaml`](https://github.com/kubernetes/community/blob/master/sigs.yaml)
+- [ ] Update `kubernetes/k8s.io` [`groups.yaml`](https://github.com/kubernetes/k8s.io/blob/main/groups/committee-code-of-conduct/groups.yaml)
 
     > **Note:** This file controls access to the mailing list and Google Drive! If you do not update this file, adding people manually (via the UIs) continually revert until this file is updated.
 
     - [ ] `conduct@kubernetes.io` mailing list
     - [ ] Google drive
 
-## Communications 
+## Communications
 
 **Who executes:** Anyone but outgoing members!
 


### PR DESCRIPTION
the link for the `groups.yaml` is outdated and points to another file, this PR update the link


notice that while doing https://github.com/kubernetes/k8s.io/pull/3105 / https://github.com/kubernetes/community/pull/6245


/assign @celestehorgan @palnabarun @karenhchu @vllry 
