### PR TITLE
Add accountability section to cocc charter

### DIFF
--- a/committee-code-of-conduct/charter.md
+++ b/committee-code-of-conduct/charter.md
@@ -16,6 +16,10 @@ involved, and that the process is never perfect by nature of its need to serve
 everyone in the community equally. That said, the committee is oriented toward
 the protection of our community and takes that duty seriously.
 
+## Accountability
+
+All participants in the project at all levels, from one-time GitHub commenter to Steering Committee member, are accountable to the code of conduct and any actions the Code of Conduct Committee decides to take. 
+
 ## Communication with the committee
 The committee maintains a private mailing list for reporting incidents, asking
 confidential questions, and internal committee communication:


### PR DESCRIPTION
Per [discussions in slack](https://kubernetes.slack.com/archives/C020XMVHFF0/p1637603177004200) and https://github.com/kubernetes/community/pull/6243, clearly define in the charter who is accountable to the CoC. 

This is particularly relevant given things in the Rust community today, but I know it's been on Steering Committee's and the CoCC's mind for a while, too, to clearly state the accountability here. 

This is a first draft and intentionally not too specific. Let's talk about it ❤️ 