### PR TITLE
Removes [Exclude:WindowsDocker] test tag

### DIFF
--- a/contributors/devel/sig-architecture/conformance-tests.md
+++ b/contributors/devel/sig-architecture/conformance-tests.md
@@ -134,10 +134,9 @@ implicitly by Docker or ContainerD, not by the kubelet. Do not check properties 
 - Storage
   - File permissions cannot be set on volumes. Tests using `DefaultMode` or `Mode` and checking the resulting permissions will fail.
   - Only NTFS volumes are supported. Volume mounts specifying other filesystems (ext4, xfs) or mediums (memory) are not supported
-  - Mappings of individual files are not supported. Tests which are mounting or expecting such files to be mounted (including /etc/hosts, /etc/resolv.conf, /dev/termination-log) will fail.
   - Bidirectional mount propagation, specifically propagating mounts from a container to host, does not work.
 - Networking
-  - Pods set `HostNetwork=true`. Is not supported on Windows, and the Pod will not start.
+  - Pods set `HostNetwork=true`. For Windows, this can only be enabled for Windows Privileged Containers. In other cases, the Pod will not start.
   - Network and DNS settings must be passed through CNI. Windows does not use `/etc/resolv.conf`, so tests should not rely on reading that file to check DNS settings.
     - If you to check network settings such as dns search lists, please use [agnhost](https://github.com/kubernetes/kubernetes/tree/master/test/images/agnhost) to output needed data from the container.
   - Windows treats all DNS lookups with a `.` to be FQDN, not PQDN. For example `kubernetes` will resolve as a PQDN,

--- a/contributors/devel/sig-testing/e2e-tests.md
+++ b/contributors/devel/sig-testing/e2e-tests.md
@@ -576,13 +576,6 @@ to be eligible for this tag. This tag does not supersed any other labels.
 (e.g.: seLinuxOptions) or is unable to run on Windows nodes, it is labeled
 `[LinuxOnly]`. When using Windows nodes, this tag should be added to the
 `skip` argument.
-  - `[Exclude:WindowsDocker]`: Windows Kubelet supports both Docker and Containerd,
-however, Containerd has a few additional features (e.g.: Single file mapping). This
-means that there are tests that can run on Containerd Windows nodes, but they will
-fail on Docker Windows nodes. These tests are labeled `[Exclude:WindowsDocker]`, thus,
-when using Windows Docker nodes, this tag should be added to the `skip` argument. This
-tag is intended to be removed when Containerd becomes the default for Windows nodes in
-1.24 (https://github.com/kubernetes/community/issues/6123)
 
   - The following tags are not considered to be exhaustively applied, but are
 intended to further categorize existing `[Conformance]` tests, or tests that are


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

/kind cleanup

/sig windows

/milestone v1.24

We've removed support for Windows Docker in Kubernetes v1.24, so we no longer need this tag.

Updates a few of the Windows tests considerations, since a few of them are supported by Windows Containerd.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6123
