### PR TITLE
steering: Add Committee liaisons

### DIFF
--- a/committee-code-of-conduct/README.md
+++ b/committee-code-of-conduct/README.md
@@ -26,6 +26,7 @@ The [charter](charter.md) defines the scope and governance of the Code of Conduc
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/committee%2Fcode-of-conduct)
 - GitHub Teams:
     - [@kubernetes/code-of-conduct-committee](https://github.com/orgs/kubernetes/teams/code-of-conduct-committee) - General Discussion
+- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/committee-security-response/README.md
+++ b/committee-security-response/README.md
@@ -26,6 +26,7 @@ The Kubernetes Security Response Committee is the body that is responsible for r
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/committee%2Fsecurity-response)
 - GitHub Teams:
     - [@kubernetes/security-response-committee](https://github.com/orgs/kubernetes/teams/security-response-committee) - General Discussion
+- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
 
 ## Subprojects
 

--- a/liaisons.md
+++ b/liaisons.md
@@ -56,6 +56,8 @@ of SIGs, WGs and UGs.
 | [WG Structured Logging](wg-structured-logging/README.md) | Davanum Srinivas (**[@dims](https://github.com/dims)**) |
 | [UG Big Data](ug-big-data/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
 | [UG VMware Users](ug-vmware-users/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
+| [Committee Code of Conduct](committee-code-of-conduct/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
+| [Committee Security Response](committee-security-response/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3130,6 +3130,9 @@ committees:
     teams:
     - name: code-of-conduct-committee
       description: General Discussion
+    liaison:
+      github: tpepper
+      name: Tim Pepper
 - dir: committee-security-response
   name: Security Response
   mission_statement: >
@@ -3166,6 +3169,9 @@ committees:
     teams:
     - name: security-response-committee
       description: General Discussion
+    liaison:
+      github: justaugustus
+      name: Stephen Augustus
   subprojects:
   - name: committee-security-response
     description: Policies and documentation for the Security Response Committee


### PR DESCRIPTION
Proposing Steering Committee liaisons for the following groups:
- @kubernetes/code-of-conduct-committee (@tpepper)
- @kubernetes/security-response-committee (@justaugustus)

Choosing Tim and Stephen here, because:
- they're newly-appointed @kubernetes/steering-committee members with a lighter liaison load
- they have served on (or [have] operate[d] in) the respective
  committee's private spaces and are familiar with their processes

Signed-off-by: Stephen Augustus <foo@auggie.dev>

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/steering/issues/170

/assign @parispittman @dims 
/hold for any discussion