### PR TITLE
contributors/devel/sig-api-machinery/controllers: Errorf %w for Unwrap

### DIFF
--- a/contributors/devel/sig-api-machinery/controllers.md
+++ b/contributors/devel/sig-api-machinery/controllers.md
@@ -177,7 +177,7 @@ func (c *Controller) processNextWorkItem() bool {
 	// there was a failure so be sure to report it.  This method allows for
 	// pluggable error handling which can be used for things like
 	// cluster-monitoring
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %w", key, err))
 
 	// since we failed, we should requeue the item to work on later.  This
 	// method will add a backoff to avoid hotlooping on particular items


### PR DESCRIPTION
Catching up with [`Errorf`'s current functionality][1].  `HandleError` is probably not going to `Unwrap` the error we pass in, but it's easy enough for us to wrap the error to give `HandleError` the flexibility if it decides to drill in.

[1]: https://pkg.go.dev/fmt#Errorf