### PR TITLE
github-mgmt: Add `kubernetes-nightly` as a community-owned org

### DIFF
--- a/github-management/README.md
+++ b/github-management/README.md
@@ -72,6 +72,7 @@ project
 | [kubernetes](https://github.com/kubernetes) | Core |
 | [kubernetes-client](https://github.com/kubernetes-client) | API Client Libraries |
 | [kubernetes-csi](https://github.com/kubernetes-csi) | Container Storage Interface Components |
+| [kubernetes-nightly](https://github.com/kubernetes-nightly) | Testing org for [publishing-bot](https://github.com/kubernetes/publishing-bot) tooling |
 | [kubernetes-retired](https://github.com/kubernetes-retired) | Retired/Archived Projects |
 | [kubernetes-security](https://github.com/kubernetes-security) | Private Security Fix Mirror |
 | [kubernetes-sigs](https://github.com/kubernetes-sigs) | SIG-related Projects |


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/1772.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cblecker @mrbobbytables 
cc: @kubernetes/owners @kubernetes/publishing-bot-maintainers @kubernetes/release-engineering 
/hold for https://github.com/kubernetes/org/pull/3131
Slack convo: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1638832884428700