### PR TITLE
Added the Contributor Katacoda owners file under SIG-Contribex mentoring subproject

### DIFF
--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -117,6 +117,7 @@ Manages and controls Github permissions, repos, and groups, including Org Member
 ### mentoring
 Oversees and develops programs for helping contributors ascend the contributor ladder, including the New Contributor Workshops, Meet Our Contributors, and other programs.
 - **Owners:**
+  - [kubernetes-sigs/contributor-katacoda](https://github.com/kubernetes-sigs/contributor-katacoda/blob/main/OWNERS)
   - [kubernetes-sigs/contributor-playground](https://github.com/kubernetes-sigs/contributor-playground/blob/master/OWNERS)
   - [kubernetes/community/mentoring](https://github.com/kubernetes/community/blob/master/mentoring/OWNERS)
 - **Meetings:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1308,7 +1308,7 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
-    - https://github.com/kubernetes-sigs/contributor-katacoda/blob/main/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-katacoda/main/OWNERS
     meetings:
     - description: Mentoring Subproject Meeting
       day: Monday

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1306,9 +1306,9 @@ sigs:
       contributor ladder, including the New Contributor Workshops, Meet Our Contributors,
       and other programs.
     owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-katacoda/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-katacoda/main/OWNERS
     meetings:
     - description: Mentoring Subproject Meeting
       day: Monday

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1308,6 +1308,7 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
+    - https://github.com/kubernetes-sigs/contributor-katacoda/blob/main/OWNERS
     meetings:
     - description: Mentoring Subproject Meeting
       day: Monday


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

Added the owners file for newly made repository [Contributor Katacoda](https://github.com/kubernetes-sigs/contributor-katacoda) under the SIG-Contributor Experience Mentoring subproject as mentioned [here](https://github.com/kubernetes/org/issues/3095#issuecomment-985179525)