### PR TITLE
add draft mod/comm mgmt lead role

### DIFF
--- a/sig-contributor-experience/role-handbooks/comm-mgmt-lead.md
+++ b/sig-contributor-experience/role-handbooks/comm-mgmt-lead.md
@@ -1,0 +1,41 @@
+# (Community Management Subproject Lead) OR (Lead Moderator) Role Description
+
+The lead moderator is the glue between our many communication platforms geared 
+towards upstream development, the volunteers that moderate them, and project 
+leadership, specifically SIG-Contributor-Experience.  
+
+### [Title] MUST:
+- Ensure onboarding and offboarding for all platform [moderators]
+- Provide data about the platforms, moderators (no personal info), incidents, 
+and more to Code of Conduct Committee for annual transparency report or ad hoc 
+for [OWNERs of kubernetes/community] for various community reporting
+- Ensure all moderator positions are full and if not, create a recruitment plan
+- Establish check-ins with current moderators
+- Stay on top of all platform changes and what that means for our processes, 
+moderation, and administration
+- Keep all moderation guidelines and relevant documentation and up to date
+- Act as liasion between moderation team and Code of Conduct Committee
+
+### [Title] MAY:
+- Delegate the above responsonibilities to the shadow or another moderator 
+- Suggest automation or process improvements to a communication platform
+- Remove another moderators permissions 
+
+### Term:
+- 1 year for bootstrap crew; then on a 6 month cadence for rotation of shadow 
+- Role requires a shadow or to be re-elected 
+
+### How to be a Lead:
+Bootstrapping the role will require two co-leads and an eventual shadow for 
+succession. 
+
+OWNERs for k/community/communition will nominate a lead/successor post bootstrap
+ (current lead is welcome to help nominate) and lazy consensus from current mod 
+ team and SIG Contribex Leads will bring confirmation (+1)
+
+Must have been a moderator on at least one Kubernetes community 
+property for one year in good standing; however, other open source moderation 
+can be considered.
+
+[moderators]: https://github.com/kubernetes/community/blob/master/communication/moderators.md 
+[OWNERS of kubernetes/community]: https://github.com/kubernetes/community/blob/master/OWNERS 


### PR DESCRIPTION
discussion: 
- title 
- location of this file: should it live here or root of this dir: https://github.com/kubernetes/community/tree/master/communication
- what else?

/sig contributor-experience 