### PR TITLE
Add devfile channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -76,6 +76,7 @@ channels:
   - name: csi-secrets-store #this channel is for secrets-store-csi-driver which is a subproject of sig-auth
   - name: de-events
   - name: de-users
+  - name: devfile
   - name: devspace
   - name: devstats
   - name: dexidp


### PR DESCRIPTION
Signed-off-by: eyuen <eyuen@redhat.com>

**Which issue(s) this PR fixes**:
N/A

Hi! This request is to create a slack channel for discussing things related to the devfiles. 

**Information about us:**
Devfile is an open-source project that provides an open standard defining containerized development environments that enable developer tools to simplify and accelerate workflows. It helps to make the development environment easily reproducible as well.

Our project has a strong tie to Kubernetes. Some of the existing Kubernetes-specific tools are using the devfile support, e.g. odo (https://odo.dev/), Eclipse Che (https://eclipse.org/che/), Dev Workspace (https://github.com/devfile/devworkspace-operator), and OpenShift Developer Console. 
If you want to know more about the devfile project, here are some starting points:
* Project page: https://devfile.io/
* GitHub org: https://github.com/devfile
* Main GitHub repo for issue tracking is here: https://github.com/devfile/api

**Purpose of the channel:**
In the past, we've been using Gitter for the communication channel but most of the project members are on slack. Amazon AWS, JetBrains, and IBM have also joined the devfile project. Moving to slack will make it much easier to discuss the devfile related topics. And many of our existing members are already on the Kubernetes slack so we are hoping to use Kubernetes slack as our main chatting channel.

**Criteria:**
I believe we fit all the criteria, we're:
* An open-source project
* Strong tie to Kubernetes
* Not product focused / proprietary

**Chatroom name requested:**
devfile

If you have any questions on this request, feel free to reach out to us!
