### PR TITLE
slack: update release-managers group config

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -20,12 +20,12 @@ usergroups:
       - justaugustus # subproject owner / Release Manager
       - mkorbi # Release Manager Associate
       - onlydole # Release Manager Associate
-      - palnabarun # Release Manager Associate
+      - palnabarun # Release Manager
       - puerco # Release Manager
       - saschagrunert # subproject owner / Release Manager
       - sethmccombs # Release Manager Associate
       - thejoycekung # Release Manager Associate
-      - Verolop # Release Manager Associate
+      - Verolop # Release Manager
       - wilsonehusin # Release Manager Associate
       - xmudrii # Release Manager
 


### PR DESCRIPTION
Promote palnabarun and Verolop to Release Managers

Part of https://github.com/kubernetes/sig-release/issues/1713 and https://github.com/kubernetes/sig-release/issues/1789

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>
