### PR TITLE
sig-release/charter: Update link to KEP directory

### DIFF
--- a/sig-release/charter.md
+++ b/sig-release/charter.md
@@ -96,7 +96,7 @@ Additional requirements:
 - [sigs.yaml] must be updated to include subproject information and OWNERS files with subproject chairs
 
 
-[KEP]: https://git.k8s.io/enhancements/keps/YYYYMMDD-kep-template.md
+[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/README.md
 [Kubernetes Charter README]: /committee-steering/governance/README.md
 [lazy-consensus]: https://communitymgt.fandom.com/wiki/Lazy_consensus
 [sig-governance]: /committee-steering/governance/sig-governance.md

--- a/sig-release/charter.md
+++ b/sig-release/charter.md
@@ -96,7 +96,7 @@ Additional requirements:
 - [sigs.yaml] must be updated to include subproject information and OWNERS files with subproject chairs
 
 
-[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/README.md
+[KEP]: https://git.k8s.io/enhancements/keps
 [Kubernetes Charter README]: /committee-steering/governance/README.md
 [lazy-consensus]: https://communitymgt.fandom.com/wiki/Lazy_consensus
 [sig-governance]: /committee-steering/governance/sig-governance.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
A broken link to KEP template in the charter.md documentation is fixed here.
