### PR TITLE
Fix link to OWNERS path for kube-scheduler-simulator

### DIFF
--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -67,7 +67,7 @@ The following [subprojects][subproject-definition] are owned by sig-scheduling:
   - [kubernetes-sigs/kube-batch](https://github.com/kubernetes-sigs/kube-batch/blob/master/OWNERS)
 ### kube-scheduler-simulator
 - **Owners:**
-  - [kubernetes-sigs/kube-scheduler-simulator](https://github.com/kubernetes-sigs/kube-scheduler-simulator/blob/main/OWNERS)
+  - [kubernetes-sigs/kube-scheduler-simulator](https://github.com/kubernetes-sigs/kube-scheduler-simulator/blob/master/OWNERS)
 ### poseidon
 - **Owners:**
   - [kubernetes-sigs/poseidon](https://github.com/kubernetes-sigs/poseidon/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2193,7 +2193,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS
   - name: kube-scheduler-simulator
     owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/kube-scheduler-simulator/main/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/kube-scheduler-simulator/master/OWNERS
   - name: poseidon
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS


### PR DESCRIPTION
Fixes #6309
