### PR TITLE
Add sftim as blog editor (SIG Docs)

### DIFF
--- a/sig-docs/blog-subproject/README.md
+++ b/sig-docs/blog-subproject/README.md
@@ -13,7 +13,7 @@ Regular Blog Meeting: Tuesdays at 18:30 UTC (biweekly). [Convert Your Timezone](
 
 ## Leadership
 
-- **Technical Editors:** [Bob Killen](https://github.com/mrbobbytables), [Taylor Dolezal](https://github.com/onlydole)
+- **Technical Editors:** [Bob Killen](https://github.com/mrbobbytables), [Taylor Dolezal](https://github.com/onlydole), [Tim Bannister](https://github.com/sftim)
 
 ## Contact
 


### PR DESCRIPTION
@sftim (that's me) is now a blog editor
Adopt change from https://github.com/kubernetes/website/pull/30798
