### PR TITLE
Propose Damien Grisonnet as new SIG Instrumentation TL

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -45,8 +45,8 @@ aliases:
     - onlydole
     - sftim
   sig-instrumentation-leads:
-    - brancz
     - dashpole
+    - dgrisonnet
     - ehashman
     - logicalhan
   sig-k8s-infra-leads:

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -31,11 +31,12 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Frederic Branczyk (**[@brancz](https://github.com/brancz)**), Polar Signals
 * David Ashpole (**[@dashpole](https://github.com/dashpole)**), Google
+* Damien Grisonnet (**[@dgrisonnet](https://github.com/dgrisonnet)**), Red Hat
 
 ## Emeritus Leads
 
+* Frederic Branczyk (**[@brancz](https://github.com/brancz)**)
 * Piotr Szczesniak (**[@piosz](https://github.com/piosz)**)
 
 ## Contact

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1489,13 +1489,15 @@ sigs:
       name: Han Kang
       company: Google
     tech_leads:
-    - github: brancz
-      name: Frederic Branczyk
-      company: Polar Signals
     - github: dashpole
       name: David Ashpole
       company: Google
+    - github: dgrisonnet
+      name: Damien Grisonnet
+      company: Red Hat
     emeritus_leads:
+    - github: brancz
+      name: Frederic Branczyk
     - github: piosz
       name: Piotr Szczesniak
   meetings:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Lazy consensus period is one week (~Jan. 13~ Jan. 19, 2022). Email: https://groups.google.com/a/kubernetes.io/g/dev/c/EgLQ5ynIbaw
/hold

Frederic [stepped down](https://groups.google.com/g/kubernetes-sig-instrumentation/c/kWsG-3XHzoM/m/fEmkYlu9BwAJ) as SIG Instrumentation TL in December 2021.

[At today's meeting,](https://docs.google.com/document/d/1FE4AQ8B49fYbKhfg4Tx0cui1V0eI4o3PxoqQPUwNEiU/edit#heading=h.t61dmzcxx1g) the SIG Instrumentation leads have proposed Damien Grisonnet (@dgrisonnet) as our new Technical Lead. Congratulations, Damien! :tada: :cake: 

/assign @logicalhan @dashpole 
/cc @brancz 
/sig instrumentation