### PR TITLE
slack: add palnabarun and Verolop to security-rel-team usergroup

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -99,9 +99,11 @@ usergroups:
       - justaugustus # subproject owner / Release Manager
       - lukehinds # Product Security Committee
       - micahhausler # Product Security Committee
+      - palnabarun # Release Manager
       - puerco # Release Manager
       - saschagrunert # subproject owner / Release Manager
       - swamymsft # Product Security Committee
       - tabbysable # Product Security Committee
       - tallclair # Product Security Committee
       - xmudrii # Release Manager
+      - Verolop # Release Manager


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/1713 and https://github.com/kubernetes/sig-release/issues/1789