### PR TITLE
slack-config/sig-release: Add #release-team-leads channel

### DIFF
--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -8,4 +8,4 @@ channels:
   - name: release-management
     id: CJH2GBF7Y
   - name: release-notes
-  - name: release-leads
+  - name: release-team-leads

--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -8,3 +8,4 @@ channels:
   - name: release-management
     id: CJH2GBF7Y
   - name: release-notes
+  - name: release-leads

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -49,6 +49,7 @@ usergroups:
       - release-enhancements
       - release-management
       - release-notes
+      - release-leads
       - sig-release
     members:
       - cpanato # SIG Release Technical Lead

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -49,7 +49,6 @@ usergroups:
       - release-enhancements
       - release-management
       - release-notes
-      - release-leads
       - sig-release
     members:
       - cpanato # SIG Release Technical Lead


### PR DESCRIPTION
Presently there are a number of Release Team "area" channels such as #release-docs, #release-enahncements, etc. These are used for parts of the release team to discuss release team internal matters that are not confidential.

However there is no similar state for the release team leads (the Release Lead, Release Lead Shadows, EA, and role leads). So this ends up *either* cluttering up #sig-release itself or just happening in DM. In a desire to make the internal discussions of the release team more open, I'd like a public channel that is a space for the release lead, area leads, and others to discuss "day-to-day" topics such as:

- Scheduling meetings
- Organising and drafting emails
- asking for general advice from each other
