### PR TITLE
Updating the timings for APAC friendly meetings

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -14,7 +14,7 @@ The [charter](charter.md) defines the scope and governance of the Docs Special I
 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs) for the group will typically add invites for the following meetings to your calendar.*
-* APAC SIG Meeting: [Wednesdays at 01:00 UTC](https://docs.google.com/document/d/1emuO4nmaQq3K8JZ9-MQeIygtrCPO9kWv7U7RzTaW4F8/edit) (monthly - Wednesday, after the fourth Tuesday, every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=01:00&tz=UTC).
+* APAC SIG Meeting: [Wednesdays at 05:30 UTC](https://docs.google.com/document/d/1emuO4nmaQq3K8JZ9-MQeIygtrCPO9kWv7U7RzTaW4F8/edit) (monthly - Wednesday, after the fourth Tuesday, every month). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=01:00&tz=UTC).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1ddHwLK3kUMX1wVFIwlksjTk0MsqitBnWPe1LRa1Rx5A/edit).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8).
 * Korean Team Meeting: [Thursdays at 13:00 UTC](https://docs.google.com/document/d/1h5sMhBpPB5unJmBAS7KzDiPs-_eFQOu5o4UyHwMtFCA/edit) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=13:00&tz=UTC).


### PR DESCRIPTION
The new APAC friendly meetings for SIG Docs have been moved per community consensus to account for all timezones under APAC per [this slack thread](https://kubernetes.slack.com/archives/C1J0BPD2M/p1638888987356000) and [this email](https://groups.google.com/g/kubernetes-sig-docs/c/P7iLejmEIFA). Amending the same in the README to reflect the new timings.