### PR TITLE
Revert "slack-config/sig-release: Add #release-team-leads channel (#6…

### DIFF
--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -8,4 +8,3 @@ channels:
   - name: release-management
     id: CJH2GBF7Y
   - name: release-notes
-  - name: release-team-leads


### PR DESCRIPTION
Slack channels and usergroups share a namespace and cannot be called the same thing.

FYI -  @kubernetes/sig-release-leads @JamesLaverack 