### PR TITLE
Fix cloud-provider-extraction-migration/OWNERS file with correct structure

### DIFF
--- a/sig-cloud-provider/cloud-provider-extraction-migration/OWNERS
+++ b/sig-cloud-provider/cloud-provider-extraction-migration/OWNERS
@@ -8,7 +8,7 @@ approvers:
   - andrewsykim
   - cheftako
   - nckturner
-emeritus_reviewers:
+emeritus_approvers:
   - mcrute
 labels:
   - sig/cloud-provider

--- a/sig-cloud-provider/cloud-provider-extraction-migration/OWNERS
+++ b/sig-cloud-provider/cloud-provider-extraction-migration/OWNERS
@@ -8,7 +8,7 @@ approvers:
   - andrewsykim
   - cheftako
   - nckturner
-emeritus:
+emeritus_reviewers:
   - mcrute
 labels:
   - sig/cloud-provider


### PR DESCRIPTION
`emeritus` is not the right key. it should be `emeritus_approvers`

Please see the PR where this was introduced:
https://github.com/kubernetes/community/commit/1a9db591729f34fec2ec4491aa420c0f1812d73b

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
