### PR TITLE
Krm functions channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -358,6 +358,7 @@ channels:
   - name: sig-autoscaling
   - name: sig-autoscaling-api
   - name: sig-cli
+  - name: sig-cli-krm-functions
   - name: sig-clstr-life-leads
   - name: sig-cluster-lifecycle
   - name: sig-cluster-ops

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -91,6 +91,8 @@ Centralized plugin index for krew.
 ### krm-functions
 - **Owners:**
   - [kubernetes-sigs/krm-functions-registry](https://github.com/kubernetes-sigs/krm-functions-registry/blob/main/OWNERS)
+- **Contact:**
+  - Slack: [#sig-cli-krm-functions](https://kubernetes.slack.com/messages/sig-cli-krm-functions)
 ### kubectl
 - **Owners:**
   - [kubernetes/kubectl](https://github.com/kubernetes/kubectl/blob/master/OWNERS)

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -18,7 +18,7 @@ The [charter](charter.md) defines the scope and governance of the CLI Special In
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF).
 * KRM Functions Subproject Meeting: [Wednesdays at 10:30 PT (Pacific Time)](https://zoom.us/j/288426795?pwd=UDdoYnFyNjBiS1RHcXRxS1BCNy9wUT09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:30&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1x80l4i88F27zSCxSjlhvwFdH6jQAHou1k1ibuXrDTaw/edit).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF).
 * Kustomize Bug Scrub: [Wednesdays at 09:00 PT (Pacific Time)](https://zoom.us/j/288426795?pwd=UDdoYnFyNjBiS1RHcXRxS1BCNy9wUT09) (monthly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing).

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -668,7 +668,7 @@ sigs:
     tz: PT (Pacific Time)
     frequency: biweekly
     url: https://zoom.us/j/288426795?pwd=UDdoYnFyNjBiS1RHcXRxS1BCNy9wUT09
-    archive_url: https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing
+    archive_url: https://docs.google.com/document/d/1x80l4i88F27zSCxSjlhvwFdH6jQAHou1k1ibuXrDTaw/edit
     recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF
   - description: Kustomize Bug Scrub
     day: Wednesday

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -731,6 +731,8 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/OWNERS
   - name: krm-functions
+    contact:
+      slack: sig-cli-krm-functions
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/krm-functions-registry/main/OWNERS
   - name: kubectl


### PR DESCRIPTION
Adds a Slack channel for the KRM Functions subproject of SIG-CLI, which was created here: https://github.com/kubernetes/community/pull/6249

Also fixes that subproject's agenda link.
