### PR TITLE
Update release-team-leads Slack usergroup for 1.24

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -35,7 +35,7 @@ usergroups:
   # - Emeritus Adviser
   # - SIG Release leads
   #
-  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.23/release-team.md
+  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.24/release-team.md
   - name: release-team-leads
     long_name: Release Team Leads
     description: >-
@@ -51,17 +51,17 @@ usergroups:
       - release-notes
       - sig-release
     members:
+      - cici37 # 1.24 Release Team Lead Shadow
       - cpanato # SIG Release Technical Lead
-      - JamesLaverack # 1.23 Release Team Lead Shadow
+      - JamesLaverack # 1.24 Release Team Lead
       - jeremyrickard # SIG Release Technical Lead / 1.23 Release Team EA
-      - jrsapi # 1.23 Release Team Lead Shadow
+      - Jesse Butler # 1.24 Release Team Lead Shadow
       - justaugustus # SIG Release Chair
       - LappleApple # SIG Release Program Manager
-      - mkorbi # 1.23 Release Team Lead Shadow
-      - MonzElmasry # 1.23 Release Team Lead Shadow
+      - mkorbi # 1.24 Release Team Lead Shadow
       - puerco # SIG Release Technical Lead
-      - reylejano # 1.23 Release Team Lead
       - saschagrunert # SIG Release Chair
+      - Xander # 1.24 Release Team Lead Shadow
 
   # Should match SIG Release Leads at all times:
   # https://git.k8s.io/community/sig-release/README.md#leadership

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -25,6 +25,7 @@ users:
   cdrage: U2TU9NPH9
   cfryanr: U0188B6J42H
   chrisshort: U2YGXSD9B
+  cici37: UTY5J12L9
   CIPHERTron: U024FK4NLAH
   cjcullen: U0ALJAVMF
   cji: U5YSRC21J
@@ -62,6 +63,7 @@ users:
   jdumars: U0YJS6LHL
   jeefy: U5MCFK468
   jeremyrickard: U72ESU398
+  Jesse Butler: U0122V3T932
   jiangd: UFS2C9JEA
   jimangel: U4HSVFA5U
   jmccormick2001: UMPLV0G0H
@@ -141,6 +143,7 @@ users:
   vladimirmukhin: UHVSCSD4G
   wilsonehusin: U0100068GF2
   wurbanski: URX7CMK97
+  Xander: UDHV1RXB2
   xmudrii: U4Q2TNGVD
   yinw: UMVD1GDCY
   zubron: U7G0KNS86


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

This is a part of [1.24 onboarding](https://github.com/kubernetes/sig-release/issues/1791).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A
