### PR TITLE
Add the netmaker channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -298,6 +298,7 @@ channels:
   - name: navigator
     archived: true
   - name: ncw-staff
+  - name: netmaker
   - name: nl-users
   - name: node-feature-discovery
   - name: node-problem-detector


### PR DESCRIPTION
Netmaker is a virtual networking project with a strong focus on Kubernetes. Adoption has been growing pretty quickly in the K8S space and we would like to have a place in the Kubernetes Slack to talk with users. Here are some related resources for reference:

https://github.com/gravitl/netmaker
https://github.com/gravitl/netmaker-helm
https://nm-k8s.readthedocs.io/
