### PR TITLE
Update Adolfo García Veytia company affiliation

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -32,7 +32,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 
 * Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**), Mattermost
 * Jeremy Rickard (**[@jeremyrickard](https://github.com/jeremyrickard)**), Apple
-* Adolfo García Veytia (**[@puerco](https://github.com/puerco)**), uServers
+* Adolfo García Veytia (**[@puerco](https://github.com/puerco)**), Chainguard, Inc
 
 ## Emeritus Leads
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1943,7 +1943,7 @@ sigs:
       company: Apple
     - github: puerco
       name: Adolfo García Veytia
-      company: uServers
+      company: Chainguard, Inc
     emeritus_leads:
     - github: alejandrox1
       name: Jorge Alarcon Ochoa


### PR DESCRIPTION
Update Adolfo García Veytia (@puerco) company affiliation from @uServers to @chainguard-dev 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

