### PR TITLE
Add surveys channel.

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -398,6 +398,7 @@ channels:
   - name: sre
   - name: steering-committee
   - name: submariner
+  - name: surveys
   - name: summit-staff
   - name: suse-caasp
   - name: talk-proposals


### PR DESCRIPTION
Add a surveys channel for folks who want to do market surveys against our user base.

Once this channel is deployed and ready, we will change Slack policy so that such surveys will no longer be allowed in kubernetes-users, and instead have to go in the surveys channel.  Users will be notified of the new channel so that they can join it if they're interested in taking surveys.

/sig contributor-experience

/assign @mrbobbytables 
cc: @coderanger @markyjackson-taulia 