### PR TITLE
Add slack channel for kpack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -186,6 +186,7 @@ channels:
   - name: kops-users
   - name: kots
     id: CFFKXV0JZ
+  - name: kpack
   - name: kpt
   - name: kr-dev
   - name: kr-users


### PR DESCRIPTION
Add channel for kpack, an open source project created to build application source code into OCI compliant images leveraging Cloud Native Buildpacks (buildpacks.io). We plan to use this channel to discuss all things kpack with the OSS community.

https://github.com/pivotal/kpack