### PR TITLE
sig-release: Audit sigs.yaml

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -57,6 +57,7 @@ The following [subprojects][subproject-definition] are owned by sig-api-machiner
   - [kubernetes-sigs/legacyflag](https://github.com/kubernetes-sigs/legacyflag/blob/master/OWNERS)
   - [kubernetes/component-base](https://github.com/kubernetes/component-base/blob/master/OWNERS)
   - [kubernetes/kubernetes/staging/src/k8s.io/component-base](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/component-base/version](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/version/OWNERS)
 ### control-plane-features
 - **Owners:**
   - [kubernetes-sigs/kube-storage-version-migrator](https://github.com/kubernetes-sigs/kube-storage-version-migrator/blob/master/OWNERS)

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -79,6 +79,7 @@ The following [subprojects][subproject-definition] are owned by sig-architecture
 [Described below](#conformance-definition-1)
 - **Owners:**
   - [kubernetes/kubernetes/test/conformance](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/OWNERS)
+  - [kubernetes/kubernetes/test/conformance/image](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/image/OWNERS)
   - [kubernetes/kubernetes/test/conformance/testdata](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/OWNERS)
 - **Contact:**
   - Slack: [#k8s-conformance](https://kubernetes.slack.com/messages/k8s-conformance)

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -48,9 +48,6 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Frelease)
 - GitHub Teams:
     - [@kubernetes/milestone-maintainers](https://github.com/orgs/kubernetes/teams/milestone-maintainers) - [Milestone Maintainers](https://git.k8s.io/sig-release/release-team#milestone-maintainers)
-    - [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers) - [Release Managers](https://kubernetes.io/releases/release-managers/)
-    - [@kubernetes/release-team](https://github.com/orgs/kubernetes/teams/release-team) - Members of the current Release Team and subproject owners
-    - [@kubernetes/release-team-leads](https://github.com/orgs/kubernetes/teams/release-team-leads) - Release Team Leads for the current Kubernetes release cycle
     - [@kubernetes/sig-release](https://github.com/orgs/kubernetes/teams/sig-release) - SIG Release Members
     - [@kubernetes/sig-release-admins](https://github.com/orgs/kubernetes/teams/sig-release-admins) - Admins for SIG Release repositories
     - [@kubernetes/sig-release-leads](https://github.com/orgs/kubernetes/teams/sig-release-leads) - Chairs, Technical Leads, and Program Managers for SIG Release
@@ -70,13 +67,26 @@ The Release Engineering subproject is responsible for the [process/procedures](h
   - [kubernetes-sigs/release-sdk](https://github.com/kubernetes-sigs/release-sdk/blob/main/OWNERS)
   - [kubernetes-sigs/release-utils](https://github.com/kubernetes-sigs/release-utils/blob/main/OWNERS)
   - [kubernetes-sigs/zeitgeist](https://github.com/kubernetes-sigs/zeitgeist/blob/master/OWNERS)
+  - [kubernetes/kubernetes/CHANGELOG](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/OWNERS)
+  - [kubernetes/kubernetes/build/build-image](https://github.com/kubernetes/kubernetes/blob/master/build/build-image/OWNERS)
+  - [kubernetes/kubernetes/staging/publishing](https://github.com/kubernetes/kubernetes/blob/master/staging/publishing/OWNERS)
   - [kubernetes/publishing-bot](https://github.com/kubernetes/publishing-bot/blob/master/OWNERS)
   - [kubernetes/release](https://github.com/kubernetes/release/blob/master/OWNERS)
+  - [kubernetes/repo-infra](https://github.com/kubernetes/repo-infra/blob/master/OWNERS)
   - [kubernetes/sig-release/release-engineering](https://github.com/kubernetes/sig-release/blob/master/release-engineering/OWNERS)
   - [kubernetes/website/content/en/releases](https://github.com/kubernetes/website/blob/main/content/en/releases/OWNERS)
   - [kubernetes/website/data/releases](https://github.com/kubernetes/website/blob/main/data/releases/OWNERS)
 - **Contact:**
   - Slack: [#release-management](https://kubernetes.slack.com/messages/release-management)
+  - [Mailing List](https://groups.google.com/a/kubernetes.io/g/release-managers)
+  - GitHub Teams:
+    - [@kubernetes/build-admins](https://github.com/orgs/kubernetes/teams/build-admins)
+    - [@kubernetes/publishing-bot-admins](https://github.com/orgs/kubernetes/teams/publishing-bot-admins)
+    - [@kubernetes/publishing-bot-maintainers](https://github.com/orgs/kubernetes/teams/publishing-bot-maintainers)
+    - [@kubernetes/release-engineering](https://github.com/orgs/kubernetes/teams/release-engineering)
+    - [@kubernetes/release-managers](https://github.com/orgs/kubernetes/teams/release-managers) - [Release Managers](https://kubernetes.io/releases/release-managers/)
+    - [@kubernetes/repo-infra-admins](https://github.com/orgs/kubernetes/teams/repo-infra-admins)
+    - [@kubernetes/repo-infra-maintainers](https://github.com/orgs/kubernetes/teams/repo-infra-maintainers)
 - **Meetings:**
   - Release Engineering: [Tuesdays at 14:30 UTC](https://zoom.us/j/240812475?pwd=bmhDQjN3N3dhV1dNSm9walJmTG5tUT09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=14:30&tz=UTC).
     - [Meeting notes and Agenda](https://bit.ly/k8s-releng-meeting).
@@ -85,16 +95,16 @@ The Release Engineering subproject is responsible for the [process/procedures](h
 The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
 - **Owners:**
   - [kubernetes/sig-release/release-team](https://github.com/kubernetes/sig-release/blob/master/release-team/OWNERS)
+- **Contact:**
+  - [Mailing List](https://groups.google.com/a/kubernetes.io/g/release-team)
+  - GitHub Teams:
+    - [@kubernetes/ci-signal](https://github.com/orgs/kubernetes/teams/ci-signal)
+    - [@kubernetes/release-team](https://github.com/orgs/kubernetes/teams/release-team) - Members of the current Release Team and subproject owners
+    - [@kubernetes/release-team-leads](https://github.com/orgs/kubernetes/teams/release-team-leads) - Release Team Leads for the current Kubernetes release cycle
 ### SIG Release Process Documentation
 Documents and processes related to SIG Release
 - **Owners:**
   - [kubernetes/sig-release](https://github.com/kubernetes/sig-release/blob/master/OWNERS)
-### kubernetes/repo-infra
-Creates and maintains tools and templates for Kubernetes org repositories.
-Includes bazel tooling for managing dependencies for kubernetes/kubernetes
-and kubernetes/test-infra.
-- **Owners:**
-  - [kubernetes/repo-infra](https://github.com/kubernetes/repo-infra/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -66,6 +66,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/legacyflag/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/component-base/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/version/OWNERS
   - name: control-plane-features
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
@@ -357,6 +358,7 @@ sigs:
       - name: cncf-conformance-wg
     owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/image/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
   - name: enhancements
     description: '[Described below](#enhancement-proposals)'
@@ -2008,6 +2010,9 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/release-sdk/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/release-utils/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/zeitgeist/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/build-image/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/OWNERS
     - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1977,15 +1977,10 @@ sigs:
   contact:
     slack: sig-release
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-release
+    private_mailing_list: https://groups.google.com/a/kubernetes.io/g/sig-release-leads
     teams:
     - name: milestone-maintainers
       description: '[Milestone Maintainers](https://git.k8s.io/sig-release/release-team#milestone-maintainers)'
-    - name: release-managers
-      description: '[Release Managers](https://kubernetes.io/releases/release-managers/)'
-    - name: release-team
-      description: Members of the current Release Team and subproject owners
-    - name: release-team-leads
-      description: Release Team Leads for the current Kubernetes release cycle
     - name: sig-release
       description: SIG Release Members
     - name: sig-release-admins
@@ -2001,6 +1996,17 @@ sigs:
       The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
     contact:
       slack: release-management
+      mailing_list: https://groups.google.com/a/kubernetes.io/g/release-managers
+      private_mailing_list: https://groups.google.com/a/kubernetes.io/g/release-managers-private
+      teams:
+      - name: build-admins
+      - name: publishing-bot-admins
+      - name: publishing-bot-maintainers
+      - name: release-engineering
+      - name: release-managers
+        description: '[Release Managers](https://kubernetes.io/releases/release-managers/)'
+      - name: repo-infra-admins
+      - name: repo-infra-maintainers
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/bom/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/downloadkubernetes/master/OWNERS
@@ -2015,6 +2021,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/OWNERS
     - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS
     - https://raw.githubusercontent.com/kubernetes/website/main/content/en/releases/OWNERS
     - https://raw.githubusercontent.com/kubernetes/website/main/data/releases/OWNERS
@@ -2030,6 +2037,14 @@ sigs:
   - name: Release Team
     description: |
       The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
+    contact:
+      mailing_list: https://groups.google.com/a/kubernetes.io/g/release-team
+      teams:
+      - name: ci-signal
+      - name: release-team
+        description: Members of the current Release Team and subproject owners
+      - name: release-team-leads
+        description: Release Team Leads for the current Kubernetes release cycle
     owners:
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
   - name: SIG Release Process Documentation
@@ -2037,13 +2052,6 @@ sigs:
       Documents and processes related to SIG Release
     owners:
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
-  - name: kubernetes/repo-infra
-    description: |
-      Creates and maintains tools and templates for Kubernetes org repositories.
-      Includes bazel tooling for managing dependencies for kubernetes/kubernetes
-      and kubernetes/test-infra.
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
 - dir: sig-scalability
   name: Scalability
   mission_statement: >


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Part of SIG Release Annual Report 2021: https://github.com/kubernetes/community/issues/6377

/assign @saschagrunert @dims 
/cc @kubernetes/sig-release-leads 

---

Fixes based on https://github.com/dims/maintainers/tree/be0c97550f21065e2383500c23479945b750b369

Before:

```console
❯ time maintainers audit sig-release --kubernetes-directory ~/prj/k8s/kubernetes
WARN: GOPATH not setRunning script : 01-25-2022 13:14:47

>>>> Processing sig [sig-release/Release]
OPTIONAL: missing 'private_mailing_list' in contact

>>>> Processing subproject Release Engineering under sig-release
WARNING: missing 'mailing_list' in contact
OPTIONAL: missing 'private_mailing_list' in contact
OPTIONAL: missing 'teams' in contact

>>>> Processing owners files for sig-release/Release Engineering

>>>> Processing subproject Release Team under sig-release
WARNING: missing 'contact' key

>>>> Processing owners files for sig-release/Release Team
WARNING: missing 'meetings' key

>>>> Processing subproject SIG Release Process Documentation under sig-release
WARNING: missing 'contact' key

>>>> Processing owners files for sig-release/SIG Release Process Documentation
WARNING: missing 'meetings' key

>>>> Processing subproject kubernetes/repo-infra under sig-release
WARNING: missing 'contact' key

>>>> Processing owners files for sig-release/kubernetes/repo-infra
WARNING: missing 'meetings' key

>>>> Processing github id(s)
```

<details>

```console
>>>> Processing owners files
INFO: unable to classify LICENSES/OWNERS
INFO: unable to classify OWNERS
INFO: unable to classify api/OWNERS
INFO: unable to classify build/OWNERS
INFO: unable to classify build/pause/OWNERS
INFO: unable to classify cluster/addons/addon-manager/OWNERS
INFO: unable to classify cluster/addons/calico-policy-controller/OWNERS
INFO: unable to classify cluster/addons/cluster-loadbalancing/OWNERS
INFO: unable to classify cluster/addons/dashboard/OWNERS
INFO: unable to classify cluster/addons/dns-horizontal-autoscaler/OWNERS
INFO: unable to classify cluster/addons/dns/OWNERS
INFO: unable to classify cluster/addons/ip-masq-agent/OWNERS
INFO: unable to classify cluster/addons/kube-proxy/OWNERS
INFO: unable to classify cluster/addons/metadata-proxy/OWNERS
INFO: unable to classify cluster/addons/node-problem-detector/OWNERS
INFO: unable to classify cluster/addons/volumesnapshots/OWNERS
INFO: unable to classify cluster/gce/gci/OWNERS
INFO: unable to classify cluster/gce/manifests/OWNERS
INFO: unable to classify cluster/gce/windows/OWNERS
INFO: unable to classify cluster/images/OWNERS
INFO: unable to classify cmd/OWNERS
INFO: unable to classify cmd/dependencycheck/OWNERS
INFO: unable to classify cmd/dependencyverifier/OWNERS
INFO: unable to classify cmd/importverifier/OWNERS
INFO: unable to classify cmd/preferredimports/OWNERS
INFO: unable to classify cmd/yamlfmt/OWNERS
INFO: unable to classify hack/OWNERS
INFO: unable to classify pkg/OWNERS
INFO: unable to classify pkg/api/OWNERS
INFO: unable to classify pkg/api/persistentvolume/OWNERS
INFO: unable to classify pkg/api/persistentvolumeclaim/OWNERS
INFO: unable to classify pkg/api/pod/OWNERS
INFO: unable to classify pkg/api/service/OWNERS
INFO: unable to classify pkg/api/testing/OWNERS
INFO: unable to classify pkg/api/v1/OWNERS
INFO: unable to classify pkg/apis/OWNERS
INFO: unable to classify pkg/apis/autoscaling/OWNERS
INFO: unable to classify pkg/apis/core/install/OWNERS
INFO: unable to classify pkg/apis/core/validation/OWNERS
INFO: unable to classify pkg/client/OWNERS
INFO: unable to classify pkg/client/testdata/OWNERS
INFO: unable to classify pkg/controller/apis/config/OWNERS
INFO: unable to classify pkg/controller/cronjob/config/OWNERS
INFO: unable to classify pkg/controller/daemon/config/OWNERS
INFO: unable to classify pkg/controller/deployment/config/OWNERS
INFO: unable to classify pkg/controller/endpoint/config/OWNERS
INFO: unable to classify pkg/controller/garbagecollector/config/OWNERS
INFO: unable to classify pkg/controller/job/config/OWNERS
INFO: unable to classify pkg/controller/namespace/config/OWNERS
INFO: unable to classify pkg/controller/nodeipam/config/OWNERS
INFO: unable to classify pkg/controller/nodeipam/ipam/OWNERS
INFO: unable to classify pkg/controller/nodelifecycle/OWNERS
INFO: unable to classify pkg/controller/nodelifecycle/config/OWNERS
INFO: unable to classify pkg/controller/podautoscaler/config/OWNERS
INFO: unable to classify pkg/controller/podgc/OWNERS
INFO: unable to classify pkg/controller/podgc/config/OWNERS
INFO: unable to classify pkg/controller/replicaset/config/OWNERS
INFO: unable to classify pkg/controller/replication/config/OWNERS
INFO: unable to classify pkg/controller/resourcequota/config/OWNERS
INFO: unable to classify pkg/controller/statefulset/config/OWNERS
INFO: unable to classify pkg/controller/ttlafterfinished/config/OWNERS
INFO: unable to classify pkg/controller/volume/attachdetach/OWNERS
INFO: unable to classify pkg/controller/volume/ephemeral/OWNERS
INFO: unable to classify pkg/controller/volume/expand/OWNERS
INFO: unable to classify pkg/controller/volume/persistentvolume/OWNERS
INFO: unable to classify pkg/controlplane/storageversionhashdata/OWNERS
INFO: unable to classify pkg/credentialprovider/OWNERS
INFO: unable to classify pkg/credentialprovider/aws/OWNERS
INFO: unable to classify pkg/credentialprovider/azure/OWNERS
INFO: unable to classify pkg/credentialprovider/gcp/OWNERS
INFO: unable to classify pkg/features/OWNERS
INFO: unable to classify pkg/kubelet/cm/cpumanager/OWNERS
INFO: unable to classify pkg/kubelet/cm/cpuset/OWNERS
INFO: unable to classify pkg/kubelet/cm/devicemanager/OWNERS
INFO: unable to classify pkg/kubelet/cm/topologymanager/OWNERS
INFO: unable to classify pkg/kubelet/cri/remote/OWNERS
INFO: unable to classify pkg/kubelet/metrics/OWNERS
INFO: unable to classify pkg/kubelet/pluginmanager/OWNERS
INFO: unable to classify pkg/kubelet/server/OWNERS
INFO: unable to classify pkg/kubelet/stats/OWNERS
INFO: unable to classify pkg/kubelet/volumemanager/OWNERS
INFO: unable to classify pkg/quota/v1/evaluator/OWNERS
INFO: unable to classify pkg/quota/v1/install/OWNERS
INFO: unable to classify pkg/registry/OWNERS
INFO: unable to classify pkg/registry/autoscaling/OWNERS
INFO: unable to classify pkg/registry/core/OWNERS
INFO: unable to classify pkg/registry/events/OWNERS
INFO: unable to classify pkg/registry/registrytest/OWNERS
INFO: unable to classify pkg/registry/storage/OWNERS
INFO: unable to classify pkg/routes/OWNERS
INFO: unable to classify pkg/util/goroutinemap/OWNERS
INFO: unable to classify pkg/volume/awsebs/OWNERS
INFO: unable to classify pkg/volume/azure_file/OWNERS
INFO: unable to classify pkg/volume/azuredd/OWNERS
INFO: unable to classify pkg/volume/cephfs/OWNERS
INFO: unable to classify pkg/volume/cinder/OWNERS
INFO: unable to classify pkg/volume/configmap/OWNERS
INFO: unable to classify pkg/volume/downwardapi/OWNERS
INFO: unable to classify pkg/volume/emptydir/OWNERS
INFO: unable to classify pkg/volume/fc/OWNERS
INFO: unable to classify pkg/volume/flexvolume/OWNERS
INFO: unable to classify pkg/volume/flocker/OWNERS
INFO: unable to classify pkg/volume/gcepd/OWNERS
INFO: unable to classify pkg/volume/git_repo/OWNERS
INFO: unable to classify pkg/volume/glusterfs/OWNERS
INFO: unable to classify pkg/volume/hostpath/OWNERS
INFO: unable to classify pkg/volume/iscsi/OWNERS
INFO: unable to classify pkg/volume/local/OWNERS
INFO: unable to classify pkg/volume/nfs/OWNERS
INFO: unable to classify pkg/volume/portworx/OWNERS
INFO: unable to classify pkg/volume/quobyte/OWNERS
INFO: unable to classify pkg/volume/rbd/OWNERS
INFO: unable to classify pkg/volume/secret/OWNERS
INFO: unable to classify pkg/volume/util/nestedpendingoperations/OWNERS
INFO: unable to classify pkg/volume/util/operationexecutor/OWNERS
INFO: unable to classify pkg/volume/util/subpath/OWNERS
INFO: unable to classify pkg/volume/vsphere_volume/OWNERS
INFO: unable to classify plugin/OWNERS
INFO: unable to classify plugin/pkg/admission/OWNERS
INFO: unable to classify plugin/pkg/admission/eventratelimit/apis/eventratelimit/OWNERS
INFO: unable to classify plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/OWNERS
INFO: unable to classify plugin/pkg/admission/runtimeclass/OWNERS
INFO: unable to classify plugin/pkg/admission/storage/persistentvolume/label/OWNERS
INFO: unable to classify staging/src/k8s.io/api/autoscaling/OWNERS
INFO: unable to classify staging/src/k8s.io/api/networking/OWNERS
INFO: unable to classify staging/src/k8s.io/apiextensions-apiserver/pkg/apis/OWNERS
INFO: unable to classify staging/src/k8s.io/apiextensions-apiserver/pkg/features/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/api/errors/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/api/meta/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/api/resource/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/apis/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/util/mergepatch/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/third_party/forked/golang/json/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/apis/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/filters/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/metrics/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/request/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/testing/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/features/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/quota/v1/generic/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/server/filters/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/server/mux/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/server/options/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/server/routes/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/etcd3/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/storagebackend/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/testing/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storageversion/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/rest/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/tools/cache/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/tools/leaderelection/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/tools/metrics/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/transport/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/util/retry/OWNERS
INFO: unable to classify staging/src/k8s.io/cloud-provider/controllers/route/OWNERS
INFO: unable to classify staging/src/k8s.io/cloud-provider/controllers/service/config/OWNERS
INFO: unable to classify staging/src/k8s.io/cluster-bootstrap/token/OWNERS
INFO: unable to classify staging/src/k8s.io/code-generator/cmd/client-gen/OWNERS
INFO: unable to classify staging/src/k8s.io/code-generator/cmd/go-to-protobuf/OWNERS
INFO: unable to classify staging/src/k8s.io/controller-manager/config/OWNERS
INFO: unable to classify staging/src/k8s.io/controller-manager/pkg/features/OWNERS
INFO: unable to classify staging/src/k8s.io/kube-aggregator/pkg/apis/OWNERS
INFO: unable to classify staging/src/k8s.io/kube-controller-manager/OWNERS
INFO: unable to classify staging/src/k8s.io/kube-controller-manager/config/OWNERS
INFO: unable to classify staging/src/k8s.io/kubectl/pkg/explain/OWNERS
INFO: unable to classify staging/src/k8s.io/kubectl/pkg/util/openapi/OWNERS
INFO: unable to classify staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/aws/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/azure/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/gce/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/openstack/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/vsphere/OWNERS
INFO: unable to classify test/e2e/framework/providers/vsphere/OWNERS
INFO: unable to classify test/e2e/network/netpol/OWNERS
INFO: unable to classify test/e2e/testing-manifests/storage-csi/OWNERS
INFO: unable to classify test/e2e_node/jenkins/OWNERS
INFO: unable to classify test/images/OWNERS
INFO: unable to classify test/images/agnhost/OWNERS
INFO: unable to classify test/images/apparmor-loader/OWNERS
INFO: unable to classify test/images/busybox/OWNERS
INFO: unable to classify test/images/cuda-vector-add-old/OWNERS
INFO: unable to classify test/images/cuda-vector-add/OWNERS
INFO: unable to classify test/images/echoserver/OWNERS
INFO: unable to classify test/images/jessie-dnsutils/OWNERS
INFO: unable to classify test/images/kitten/OWNERS
INFO: unable to classify test/images/metadata-concealment/OWNERS
INFO: unable to classify test/images/nautilus/OWNERS
INFO: unable to classify test/images/nonewprivs/OWNERS
INFO: unable to classify test/images/nonroot/OWNERS
INFO: unable to classify test/images/redis/OWNERS
INFO: unable to classify test/images/regression-issue-74839/OWNERS
INFO: unable to classify test/images/sample-apiserver/OWNERS
INFO: unable to classify test/images/volume/OWNERS
INFO: unable to classify test/integration/apiserver/OWNERS
INFO: unable to classify test/integration/dryrun/OWNERS
INFO: unable to classify test/integration/etcd/OWNERS
INFO: unable to classify test/typecheck/OWNERS
INFO: unable to classify test/utils/image/OWNERS
INFO: unable to classify third_party/forked/shell2junit/OWNERS
WARNING: file CHANGELOG/OWNERS should be in one of ["sig-release"] based on labels/aliases
WARNING: file build/build-image/OWNERS should be in one of ["sig-release"] based on labels/aliases
WARNING: file staging/publishing/OWNERS should be in one of ["sig-release"] based on labels/aliases
WARNING: file staging/src/k8s.io/component-base/version/OWNERS should be in one of ["sig-api-machinery" "sig-release"] based on labels/aliases
WARNING: file test/conformance/image/OWNERS should be in one of ["sig-release" "sig-testing"] based on labels/aliases
Done.
maintainers audit sig-release --kubernetes-directory ~/prj/k8s/kubernetes  0.19s user 1.27s system 29% cpu 4.906 total
```

</details>

After:

```console
❯ time maintainers audit sig-release --kubernetes-directory ~/prj/k8s/kubernetes
WARN: GOPATH not setRunning script : 01-25-2022 15:04:35

>>>> Processing sig [sig-release/Release]

>>>> Processing subproject Release Engineering under sig-release

>>>> Processing owners files for sig-release/Release Engineering
WARNING: needs an alias as approver/reviewer reflecting sig-release - https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/OWNERS
WARNING: needs an alias as approver/reviewer reflecting sig-release - https://raw.githubusercontent.com/kubernetes/kubernetes/master/build/build-image/OWNERS
WARNING: needs an alias as approver/reviewer reflecting sig-release - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/OWNERS

>>>> Processing subproject Release Team under sig-release
WARNING: missing 'slack' in contact
OPTIONAL: missing 'private_mailing_list' in contact

>>>> Processing owners files for sig-release/Release Team
WARNING: missing 'meetings' key

>>>> Processing subproject SIG Release Process Documentation under sig-release
WARNING: missing 'contact' key

>>>> Processing owners files for sig-release/SIG Release Process Documentation
WARNING: missing 'meetings' key

>>>> Processing github id(s)
```

<details>

```console
>>>> Processing owners files
ERROR: file staging/src/k8s.io/component-base/version/OWNERS should be in ["sig-api-machinery" "sig-release"] based on labels/aliases but is in ["sig-api-machinery"]
ERROR: file test/conformance/image/OWNERS should be in ["sig-release" "sig-testing"] based on labels/aliases but is in ["sig-architecture"]
INFO: unable to classify LICENSES/OWNERS
INFO: unable to classify OWNERS
INFO: unable to classify api/OWNERS
INFO: unable to classify build/OWNERS
INFO: unable to classify build/pause/OWNERS
INFO: unable to classify cluster/addons/addon-manager/OWNERS
INFO: unable to classify cluster/addons/calico-policy-controller/OWNERS
INFO: unable to classify cluster/addons/cluster-loadbalancing/OWNERS
INFO: unable to classify cluster/addons/dashboard/OWNERS
INFO: unable to classify cluster/addons/dns-horizontal-autoscaler/OWNERS
INFO: unable to classify cluster/addons/dns/OWNERS
INFO: unable to classify cluster/addons/ip-masq-agent/OWNERS
INFO: unable to classify cluster/addons/kube-proxy/OWNERS
INFO: unable to classify cluster/addons/metadata-proxy/OWNERS
INFO: unable to classify cluster/addons/node-problem-detector/OWNERS
INFO: unable to classify cluster/addons/volumesnapshots/OWNERS
INFO: unable to classify cluster/gce/gci/OWNERS
INFO: unable to classify cluster/gce/manifests/OWNERS
INFO: unable to classify cluster/gce/windows/OWNERS
INFO: unable to classify cluster/images/OWNERS
INFO: unable to classify cmd/OWNERS
INFO: unable to classify cmd/dependencycheck/OWNERS
INFO: unable to classify cmd/dependencyverifier/OWNERS
INFO: unable to classify cmd/importverifier/OWNERS
INFO: unable to classify cmd/preferredimports/OWNERS
INFO: unable to classify cmd/yamlfmt/OWNERS
INFO: unable to classify hack/OWNERS
INFO: unable to classify pkg/OWNERS
INFO: unable to classify pkg/api/OWNERS
INFO: unable to classify pkg/api/persistentvolume/OWNERS
INFO: unable to classify pkg/api/persistentvolumeclaim/OWNERS
INFO: unable to classify pkg/api/pod/OWNERS
INFO: unable to classify pkg/api/service/OWNERS
INFO: unable to classify pkg/api/testing/OWNERS
INFO: unable to classify pkg/api/v1/OWNERS
INFO: unable to classify pkg/apis/OWNERS
INFO: unable to classify pkg/apis/autoscaling/OWNERS
INFO: unable to classify pkg/apis/core/install/OWNERS
INFO: unable to classify pkg/apis/core/validation/OWNERS
INFO: unable to classify pkg/client/OWNERS
INFO: unable to classify pkg/client/testdata/OWNERS
INFO: unable to classify pkg/controller/apis/config/OWNERS
INFO: unable to classify pkg/controller/cronjob/config/OWNERS
INFO: unable to classify pkg/controller/daemon/config/OWNERS
INFO: unable to classify pkg/controller/deployment/config/OWNERS
INFO: unable to classify pkg/controller/endpoint/config/OWNERS
INFO: unable to classify pkg/controller/garbagecollector/config/OWNERS
INFO: unable to classify pkg/controller/job/config/OWNERS
INFO: unable to classify pkg/controller/namespace/config/OWNERS
INFO: unable to classify pkg/controller/nodeipam/config/OWNERS
INFO: unable to classify pkg/controller/nodeipam/ipam/OWNERS
INFO: unable to classify pkg/controller/nodelifecycle/OWNERS
INFO: unable to classify pkg/controller/nodelifecycle/config/OWNERS
INFO: unable to classify pkg/controller/podautoscaler/config/OWNERS
INFO: unable to classify pkg/controller/podgc/OWNERS
INFO: unable to classify pkg/controller/podgc/config/OWNERS
INFO: unable to classify pkg/controller/replicaset/config/OWNERS
INFO: unable to classify pkg/controller/replication/config/OWNERS
INFO: unable to classify pkg/controller/resourcequota/config/OWNERS
INFO: unable to classify pkg/controller/statefulset/config/OWNERS
INFO: unable to classify pkg/controller/ttlafterfinished/config/OWNERS
INFO: unable to classify pkg/controller/volume/attachdetach/OWNERS
INFO: unable to classify pkg/controller/volume/ephemeral/OWNERS
INFO: unable to classify pkg/controller/volume/expand/OWNERS
INFO: unable to classify pkg/controller/volume/persistentvolume/OWNERS
INFO: unable to classify pkg/controlplane/storageversionhashdata/OWNERS
INFO: unable to classify pkg/credentialprovider/OWNERS
INFO: unable to classify pkg/credentialprovider/aws/OWNERS
INFO: unable to classify pkg/credentialprovider/azure/OWNERS
INFO: unable to classify pkg/credentialprovider/gcp/OWNERS
INFO: unable to classify pkg/features/OWNERS
INFO: unable to classify pkg/kubelet/cm/cpumanager/OWNERS
INFO: unable to classify pkg/kubelet/cm/cpuset/OWNERS
INFO: unable to classify pkg/kubelet/cm/devicemanager/OWNERS
INFO: unable to classify pkg/kubelet/cm/topologymanager/OWNERS
INFO: unable to classify pkg/kubelet/cri/remote/OWNERS
INFO: unable to classify pkg/kubelet/metrics/OWNERS
INFO: unable to classify pkg/kubelet/pluginmanager/OWNERS
INFO: unable to classify pkg/kubelet/server/OWNERS
INFO: unable to classify pkg/kubelet/stats/OWNERS
INFO: unable to classify pkg/kubelet/volumemanager/OWNERS
INFO: unable to classify pkg/quota/v1/evaluator/OWNERS
INFO: unable to classify pkg/quota/v1/install/OWNERS
INFO: unable to classify pkg/registry/OWNERS
INFO: unable to classify pkg/registry/autoscaling/OWNERS
INFO: unable to classify pkg/registry/core/OWNERS
INFO: unable to classify pkg/registry/events/OWNERS
INFO: unable to classify pkg/registry/registrytest/OWNERS
INFO: unable to classify pkg/registry/storage/OWNERS
INFO: unable to classify pkg/routes/OWNERS
INFO: unable to classify pkg/util/goroutinemap/OWNERS
INFO: unable to classify pkg/volume/awsebs/OWNERS
INFO: unable to classify pkg/volume/azure_file/OWNERS
INFO: unable to classify pkg/volume/azuredd/OWNERS
INFO: unable to classify pkg/volume/cephfs/OWNERS
INFO: unable to classify pkg/volume/cinder/OWNERS
INFO: unable to classify pkg/volume/configmap/OWNERS
INFO: unable to classify pkg/volume/downwardapi/OWNERS
INFO: unable to classify pkg/volume/emptydir/OWNERS
INFO: unable to classify pkg/volume/fc/OWNERS
INFO: unable to classify pkg/volume/flexvolume/OWNERS
INFO: unable to classify pkg/volume/flocker/OWNERS
INFO: unable to classify pkg/volume/gcepd/OWNERS
INFO: unable to classify pkg/volume/git_repo/OWNERS
INFO: unable to classify pkg/volume/glusterfs/OWNERS
INFO: unable to classify pkg/volume/hostpath/OWNERS
INFO: unable to classify pkg/volume/iscsi/OWNERS
INFO: unable to classify pkg/volume/local/OWNERS
INFO: unable to classify pkg/volume/nfs/OWNERS
INFO: unable to classify pkg/volume/portworx/OWNERS
INFO: unable to classify pkg/volume/quobyte/OWNERS
INFO: unable to classify pkg/volume/rbd/OWNERS
INFO: unable to classify pkg/volume/secret/OWNERS
INFO: unable to classify pkg/volume/util/nestedpendingoperations/OWNERS
INFO: unable to classify pkg/volume/util/operationexecutor/OWNERS
INFO: unable to classify pkg/volume/util/subpath/OWNERS
INFO: unable to classify pkg/volume/vsphere_volume/OWNERS
INFO: unable to classify plugin/OWNERS
INFO: unable to classify plugin/pkg/admission/OWNERS
INFO: unable to classify plugin/pkg/admission/eventratelimit/apis/eventratelimit/OWNERS
INFO: unable to classify plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/OWNERS
INFO: unable to classify plugin/pkg/admission/runtimeclass/OWNERS
INFO: unable to classify plugin/pkg/admission/storage/persistentvolume/label/OWNERS
INFO: unable to classify staging/src/k8s.io/api/autoscaling/OWNERS
INFO: unable to classify staging/src/k8s.io/api/networking/OWNERS
INFO: unable to classify staging/src/k8s.io/apiextensions-apiserver/pkg/apis/OWNERS
INFO: unable to classify staging/src/k8s.io/apiextensions-apiserver/pkg/features/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/api/errors/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/api/meta/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/api/resource/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/apis/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/util/mergepatch/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/OWNERS
INFO: unable to classify staging/src/k8s.io/apimachinery/third_party/forked/golang/json/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/apis/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/filters/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/metrics/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/request/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/endpoints/testing/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/features/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/quota/v1/generic/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/registry/rest/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/server/filters/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/server/mux/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/server/options/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/server/routes/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/etcd3/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/storagebackend/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storage/testing/OWNERS
INFO: unable to classify staging/src/k8s.io/apiserver/pkg/storageversion/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/rest/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/tools/cache/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/tools/leaderelection/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/tools/metrics/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/transport/OWNERS
INFO: unable to classify staging/src/k8s.io/client-go/util/retry/OWNERS
INFO: unable to classify staging/src/k8s.io/cloud-provider/controllers/route/OWNERS
INFO: unable to classify staging/src/k8s.io/cloud-provider/controllers/service/config/OWNERS
INFO: unable to classify staging/src/k8s.io/cluster-bootstrap/token/OWNERS
INFO: unable to classify staging/src/k8s.io/code-generator/cmd/client-gen/OWNERS
INFO: unable to classify staging/src/k8s.io/code-generator/cmd/go-to-protobuf/OWNERS
INFO: unable to classify staging/src/k8s.io/controller-manager/config/OWNERS
INFO: unable to classify staging/src/k8s.io/controller-manager/pkg/features/OWNERS
INFO: unable to classify staging/src/k8s.io/kube-aggregator/pkg/apis/OWNERS
INFO: unable to classify staging/src/k8s.io/kube-controller-manager/OWNERS
INFO: unable to classify staging/src/k8s.io/kube-controller-manager/config/OWNERS
INFO: unable to classify staging/src/k8s.io/kubectl/pkg/explain/OWNERS
INFO: unable to classify staging/src/k8s.io/kubectl/pkg/util/openapi/OWNERS
INFO: unable to classify staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/aws/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/azure/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/gce/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/openstack/OWNERS
INFO: unable to classify staging/src/k8s.io/legacy-cloud-providers/vsphere/OWNERS
INFO: unable to classify test/e2e/framework/providers/vsphere/OWNERS
INFO: unable to classify test/e2e/network/netpol/OWNERS
INFO: unable to classify test/e2e/testing-manifests/storage-csi/OWNERS
INFO: unable to classify test/e2e_node/jenkins/OWNERS
INFO: unable to classify test/images/OWNERS
INFO: unable to classify test/images/agnhost/OWNERS
INFO: unable to classify test/images/apparmor-loader/OWNERS
INFO: unable to classify test/images/busybox/OWNERS
INFO: unable to classify test/images/cuda-vector-add-old/OWNERS
INFO: unable to classify test/images/cuda-vector-add/OWNERS
INFO: unable to classify test/images/echoserver/OWNERS
INFO: unable to classify test/images/jessie-dnsutils/OWNERS
INFO: unable to classify test/images/kitten/OWNERS
INFO: unable to classify test/images/metadata-concealment/OWNERS
INFO: unable to classify test/images/nautilus/OWNERS
INFO: unable to classify test/images/nonewprivs/OWNERS
INFO: unable to classify test/images/nonroot/OWNERS
INFO: unable to classify test/images/redis/OWNERS
INFO: unable to classify test/images/regression-issue-74839/OWNERS
INFO: unable to classify test/images/sample-apiserver/OWNERS
INFO: unable to classify test/images/volume/OWNERS
INFO: unable to classify test/integration/apiserver/OWNERS
INFO: unable to classify test/integration/dryrun/OWNERS
INFO: unable to classify test/integration/etcd/OWNERS
INFO: unable to classify test/typecheck/OWNERS
INFO: unable to classify test/utils/image/OWNERS
INFO: unable to classify third_party/forked/shell2junit/OWNERS
Done.
maintainers audit sig-release --kubernetes-directory ~/prj/k8s/kubernetes  0.17s user 0.84s system 23% cpu 4.324 total
```

</details>