### PR TITLE
Cross-link SIG and WG readmes

### DIFF
--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -68,6 +68,17 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 - Steering Committee Liaison: {{.Contact.Liaison.Name}} (**[@{{.Contact.Liaison.GitHub}}](https://github.com/{{.Contact.Liaison.GitHub}})**)
 {{- end }}
 
+{{- if .ReportingWGs }}
+
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-{{.Label}}:
+
+{{- range .ReportingWGs }}
+* [WG {{.}}](/{{.DirName}})
+{{- end }}
+{{ end }}
+
 {{- if .Subprojects }}
 
 ## Subprojects
@@ -114,3 +125,4 @@ The following [subprojects][subproject-definition] are owned by sig-{{.Label}}:
 {{- end }}
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups

--- a/generator/wg_readme.tmpl
+++ b/generator/wg_readme.tmpl
@@ -8,7 +8,7 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{- if .StakeholderSIGs }}
 ## Stakeholder SIGs
 {{- range .StakeholderSIGs }}
-* SIG {{.}}
+* [SIG {{.}}](/{{.DirName}})
 {{- end }}
 {{ end }}
 {{ if .Meetings -}}

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -49,6 +49,14 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-api-machinery-test-failures](https://github.com/orgs/kubernetes/teams/sig-api-machinery-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Davanum Srinivas (**[@dims](https://github.com/dims)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-api-machinery:
+* [WG API Expression](/wg-api-expression)
+* [WG Multitenancy](/wg-multitenancy)
+* [WG Structured Logging](/wg-structured-logging)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-api-machinery:
@@ -139,6 +147,7 @@ The following [subprojects][subproject-definition] are owned by sig-api-machiner
   - [kubernetes-sigs/yaml](https://github.com/kubernetes-sigs/yaml/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 ## Additional links
 

--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -46,6 +46,12 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-apps-test-failures](https://github.com/orgs/kubernetes/teams/sig-apps-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-apps:
+* [WG Data Protection](/wg-data-protection)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-apps:
@@ -94,6 +100,7 @@ The core workloads API, which is composed of the CronJob, DaemonSet, Deployment,
   - [kubernetes/kubernetes/test/integration/deployment](https://github.com/kubernetes/kubernetes/blob/master/test/integration/deployment/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Goals

--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -53,6 +53,15 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-architecture-test-failures](https://github.com/orgs/kubernetes/teams/sig-architecture-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-architecture:
+* [WG API Expression](/wg-api-expression)
+* [WG Policy](/wg-policy)
+* [WG Reliability](/wg-reliability)
+* [WG Structured Logging](/wg-structured-logging)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-architecture:
@@ -99,6 +108,7 @@ The following [subprojects][subproject-definition] are owned by sig-architecture
   - Slack: [#prod-readiness](https://kubernetes.slack.com/messages/prod-readiness)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 # Details about SIG-Architecture sub-projects

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -60,6 +60,13 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-auth-test-failures](https://github.com/orgs/kubernetes/teams/sig-auth-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-auth:
+* [WG Multitenancy](/wg-multitenancy)
+* [WG Policy](/wg-policy)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-auth:
@@ -160,6 +167,7 @@ Infrastructure implementing Kubernetes service account based workload identity.
   - [kubernetes/kubernetes/plugin/pkg/admission/serviceaccount](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/serviceaccount/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -60,6 +60,7 @@ The following [subprojects][subproject-definition] are owned by sig-autoscaling:
   - [kubernetes/autoscaler](https://github.com/kubernetes/autoscaler/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 ## Concerns
 * autoscaling of clusters,

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -108,6 +108,7 @@ Hybrid command-line/UI development experience for cloud-native development
   - Slack: [#kustomize](https://kubernetes.slack.com/messages/kustomize)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -47,6 +47,12 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-cloud-providers-misc](https://github.com/orgs/kubernetes/teams/sig-cloud-providers-misc) - General Discussion
 - Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-cloud-provider:
+* [WG Structured Logging](/wg-structured-logging)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-cloud-provider:
@@ -135,6 +141,7 @@ The following [subprojects][subproject-definition] are owned by sig-cloud-provid
     - [Meeting recordings](https://www.youtube.com/playlist?list=PLutJyDdkKQIpOT4bOfuO3MEMHvU1tRqyR).
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -47,6 +47,12 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-cluster-lifecycle](https://github.com/orgs/kubernetes/teams/sig-cluster-lifecycle) - Notify group
 - Steering Committee Liaison: Davanum Srinivas (**[@dims](https://github.com/dims)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-cluster-lifecycle:
+* [WG Reliability](/wg-reliability)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-cluster-lifecycle:
@@ -181,6 +187,7 @@ The following [subprojects][subproject-definition] are owned by sig-cluster-life
     - [Meeting notes and Agenda](https://docs.google.com/document/d/1jhfmL1gsgN39uCEgz5pW9tnIotFgHhxq2yfMK3KYE4w/edit).
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -129,6 +129,7 @@ Creates and maintains tools and automation for Kubernetes Slack.
   - Slack: [#slack-infra](https://kubernetes.slack.com/messages/slack-infra)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Relevant Presentations

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -92,6 +92,7 @@ The following [subprojects][subproject-definition] are owned by sig-docs:
   - [kubernetes/website](https://github.com/kubernetes/website/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 * Discuss documentation and docs issues for kubernetes.io

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -49,6 +49,12 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-instrumentation-members](https://github.com/orgs/kubernetes/teams/sig-instrumentation-members) - SIG Membership Roster
 - Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-instrumentation:
+* [WG Structured Logging](/wg-structured-logging)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-instrumentation:
@@ -93,6 +99,7 @@ Organization of SIG Instrumentation subprojects
   - [kubernetes/kubernetes/staging/src/k8s.io/component-base/logs](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/logs/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-k8s-infra/README.md
+++ b/sig-k8s-infra/README.md
@@ -96,6 +96,7 @@ Experimental project for OCI distribution
     - [Meeting recordings](http://bit.ly/sig-k8s-infra-playlist).
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -44,6 +44,13 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-mutlicluster-proposals](https://github.com/orgs/kubernetes/teams/sig-mutlicluster-proposals) - Design Proposals
 - Steering Committee Liaison: Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-multicluster:
+* [WG IoT Edge](/wg-iot-edge)
+* [WG Policy](/wg-policy)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-multicluster:
@@ -64,6 +71,7 @@ The following [subprojects][subproject-definition] are owned by sig-multicluster
   - [kubernetes-sigs/work-api](https://github.com/kubernetes-sigs/work-api/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 ## Subprojects
 

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -50,6 +50,15 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-network-test-failures](https://github.com/orgs/kubernetes/teams/sig-network-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-network:
+* [WG IoT Edge](/wg-iot-edge)
+* [WG Multitenancy](/wg-multitenancy)
+* [WG Policy](/wg-policy)
+* [WG Structured Logging](/wg-structured-logging)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-network:
@@ -98,6 +107,7 @@ The following [subprojects][subproject-definition] are owned by sig-network:
   - [kubernetes/kubernetes/pkg/kubelet/network](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 ## Areas of Responsibility
 

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -41,6 +41,14 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-node-test-failures](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-node:
+* [WG Multitenancy](/wg-multitenancy)
+* [WG Policy](/wg-policy)
+* [WG Structured Logging](/wg-structured-logging)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-node:
@@ -76,6 +84,7 @@ The following [subprojects][subproject-definition] are owned by sig-node:
   - Slack: [#security-profiles-operator](https://kubernetes.slack.com/messages/security-profiles-operator)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 ## Goals
 

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -53,6 +53,12 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-release-leads](https://github.com/orgs/kubernetes/teams/sig-release-leads) - Chairs, Technical Leads, and Program Managers for SIG Release
 - Steering Committee Liaison: Davanum Srinivas (**[@dims](https://github.com/dims)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-release:
+* [WG Reliability](/wg-reliability)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-release:
@@ -107,6 +113,7 @@ Documents and processes related to SIG Release
   - [kubernetes/sig-release](https://github.com/kubernetes/sig-release/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 ---
 

--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -50,6 +50,12 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-scalability-test-failures](https://github.com/orgs/kubernetes/teams/sig-scalability-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-scalability:
+* [WG Reliability](/wg-reliability)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-scalability:
@@ -82,6 +88,7 @@ The following [subprojects][subproject-definition] are owned by sig-scalability:
   - [kubernetes/perf-tests/clusterloader2](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 # Scalability Regression - Contact Points
 

--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -53,6 +53,14 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-scheduling-test-failures](https://github.com/orgs/kubernetes/teams/sig-scheduling-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-scheduling:
+* [WG Multitenancy](/wg-multitenancy)
+* [WG Policy](/wg-policy)
+* [WG Structured Logging](/wg-structured-logging)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-scheduling:
@@ -80,6 +88,7 @@ The following [subprojects][subproject-definition] are owned by sig-scheduling:
   - [kubernetes-sigs/scheduler-plugins](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -62,6 +62,7 @@ SIG Security discussions, documents, processes and other artifacts
   - Slack: [#sig-security](https://kubernetes.slack.com/messages/sig-security)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-service-catalog/README.md
+++ b/sig-service-catalog/README.md
@@ -63,6 +63,7 @@ The following [subprojects][subproject-definition] are owned by sig-service-cata
   - [kubernetes-sigs/service-catalog](https://github.com/kubernetes-sigs/service-catalog/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -51,6 +51,15 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-storage-test-failures](https://github.com/orgs/kubernetes/teams/sig-storage-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Paris Pittman (**[@parispittman](https://github.com/parispittman)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-storage:
+* [WG Data Protection](/wg-data-protection)
+* [WG Multitenancy](/wg-multitenancy)
+* [WG Policy](/wg-policy)
+* [WG Structured Logging](/wg-structured-logging)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-storage:
@@ -120,6 +129,7 @@ The following [subprojects][subproject-definition] are owned by sig-storage:
   - [kubernetes/kubernetes/pkg/volume](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Details

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -49,6 +49,12 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-testing-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-testing-pr-reviews) - PR Reviews
 - Steering Committee Liaison: Paris Pittman (**[@parispittman](https://github.com/parispittman)**)
 
+## Working Groups
+
+The following [working groups][working-group-definition] are sponsored by sig-testing:
+* [WG Reliability](/wg-reliability)
+
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-testing:
@@ -97,6 +103,7 @@ Miscellaneous tools and configuration to run the testing infrastructure for the 
   - [kubernetes/kubernetes/test](https://github.com/kubernetes/kubernetes/blob/master/test/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 ## Presentations

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -47,6 +47,7 @@ The following [subprojects][subproject-definition] are owned by sig-ui:
   - [kubernetes/dashboard](https://github.com/kubernetes/dashboard/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-usability/README.md
+++ b/sig-usability/README.md
@@ -53,6 +53,7 @@ The following [subprojects][subproject-definition] are owned by sig-usability:
   - [kubernetes-sigs/sig-usability](https://github.com/kubernetes-sigs/sig-usability/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -71,6 +71,7 @@ The following [subprojects][subproject-definition] are owned by sig-windows:
   - [kubernetes-sigs/sig-windows-tools](https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
 ## Getting Started
 

--- a/wg-api-expression/README.md
+++ b/wg-api-expression/README.md
@@ -12,8 +12,8 @@ Enable API authors to better serve API consumers, by improving and documenting a
 [See full Mission Statement](https://docs.google.com/document/d/1XYbQXfge2qKM9psksfC5XZnW8hybtLqL1EcJLU4JwKg).
 
 ## Stakeholder SIGs
-* SIG API Machinery
-* SIG Architecture
+* [SIG API Machinery](/sig-api-machinery)
+* [SIG Architecture](/sig-architecture)
 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-api-expression) for the group will typically add invites for the following meetings to your calendar.*

--- a/wg-data-protection/README.md
+++ b/wg-data-protection/README.md
@@ -14,8 +14,8 @@ This [work-in-progress doc](https://docs.google.com/document/d/1yHbW0hxHehQzdaL7
 The [charter](charter.md) defines the scope and governance of the Data Protection Working Group.
 
 ## Stakeholder SIGs
-* SIG Apps
-* SIG Storage
+* [SIG Apps](/sig-apps)
+* [SIG Storage](/sig-storage)
 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-data-protection) for the group will typically add invites for the following meetings to your calendar.*

--- a/wg-iot-edge/README.md
+++ b/wg-iot-edge/README.md
@@ -11,8 +11,8 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 A Working Group dedicated to discussing, designing and documenting using Kubernetes for developing and deploying IoT and Edge specific applications
 
 ## Stakeholder SIGs
-* SIG Multicluster
-* SIG Network
+* [SIG Multicluster](/sig-multicluster)
+* [SIG Network](/sig-network)
 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge) for the group will typically add invites for the following meetings to your calendar.*

--- a/wg-multitenancy/README.md
+++ b/wg-multitenancy/README.md
@@ -11,12 +11,12 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 Define the models of multitenancy that Kubernetes will support. Discuss and execute upon any remaining work that needs to be done to support these models. Create conformance tests that will prove that these models can be built and used in production environments.
 
 ## Stakeholder SIGs
-* SIG API Machinery
-* SIG Auth
-* SIG Network
-* SIG Node
-* SIG Scheduling
-* SIG Storage
+* [SIG API Machinery](/sig-api-machinery)
+* [SIG Auth](/sig-auth)
+* [SIG Network](/sig-network)
+* [SIG Node](/sig-node)
+* [SIG Scheduling](/sig-scheduling)
+* [SIG Storage](/sig-storage)
 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy) for the group will typically add invites for the following meetings to your calendar.*

--- a/wg-policy/README.md
+++ b/wg-policy/README.md
@@ -11,13 +11,13 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 Provide an overall architecture that describes both the current policy related implementations as well as future policy related proposals in Kubernetes. Through a collaborative method, we want to present both dev and end user a universal view of policy architecture in Kubernetes.
 
 ## Stakeholder SIGs
-* SIG Architecture
-* SIG Auth
-* SIG Multicluster
-* SIG Network
-* SIG Node
-* SIG Scheduling
-* SIG Storage
+* [SIG Architecture](/sig-architecture)
+* [SIG Auth](/sig-auth)
+* [SIG Multicluster](/sig-multicluster)
+* [SIG Network](/sig-network)
+* [SIG Node](/sig-node)
+* [SIG Scheduling](/sig-scheduling)
+* [SIG Storage](/sig-storage)
 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-policy) for the group will typically add invites for the following meetings to your calendar.*

--- a/wg-reliability/README.md
+++ b/wg-reliability/README.md
@@ -13,11 +13,11 @@ Allow users to safely use Kubernetes for managing production workloads by ensuri
 The [charter](charter.md) defines the scope and governance of the Reliability Working Group.
 
 ## Stakeholder SIGs
-* SIG Architecture
-* SIG Cluster Lifecycle
-* SIG Release
-* SIG Scalability
-* SIG Testing
+* [SIG Architecture](/sig-architecture)
+* [SIG Cluster Lifecycle](/sig-cluster-lifecycle)
+* [SIG Release](/sig-release)
+* [SIG Scalability](/sig-scalability)
+* [SIG Testing](/sig-testing)
 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-reliability) for the group will typically add invites for the following meetings to your calendar.*

--- a/wg-structured-logging/README.md
+++ b/wg-structured-logging/README.md
@@ -13,14 +13,14 @@ Modernize logging in Kubernetes core components, allowing users to efficiently c
 The [charter](charter.md) defines the scope and governance of the Structured Logging Working Group.
 
 ## Stakeholder SIGs
-* SIG API Machinery
-* SIG Architecture
-* SIG Cloud Provider
-* SIG Instrumentation
-* SIG Network
-* SIG Node
-* SIG Scheduling
-* SIG Storage
+* [SIG API Machinery](/sig-api-machinery)
+* [SIG Architecture](/sig-architecture)
+* [SIG Cloud Provider](/sig-cloud-provider)
+* [SIG Instrumentation](/sig-instrumentation)
+* [SIG Network](/sig-network)
+* [SIG Node](/sig-node)
+* [SIG Scheduling](/sig-scheduling)
+* [SIG Storage](/sig-storage)
 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-structured-logging) for the group will typically add invites for the following meetings to your calendar.*


### PR DESCRIPTION
I realized while looking at annual report stuff that we don't cross-link WGs and SIGs

This surfaces the SIG/WG relationship in both directions, and has the benefit of poking a SIG readme if a WG adds/removes them as a stakeholder

