### PR TITLE
Add CAPI operator slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -56,6 +56,7 @@ channels:
   - name: cluster-api-kubevirt
   - name: cluster-api-nested
   - name: cluster-api-openstack
+  - name: cluster-api-operator
   - name: cluster-api-packet
   - name: cluster-api-vsphere
   - name: cn-dev


### PR DESCRIPTION
This PR adds a slack channel for Cluster API operator subproject https://github.com/kubernetes-sigs/cluster-api-operator