### PR TITLE
Add note about new Survey channel.

### DIFF
--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -84,12 +84,16 @@ in the purpose or pinned docs of that channel.
 - `#kubernetes-contributors` - Questions and discourse around upstream
   contributions and development to kubernetes.
 - `#kubernetes-careers` - Job openings for positions working with/on/around
-  Kubernetes. Postings
+  Kubernetes. This is the only channel where job postings are permitted. Postings
   must include:
   - A link to the posting or job description.
   - The business name that will employ the Kubernetes hire.
   - The location of the role or if remote is OK.
-
+- `#surveys` - third-party surveys, posted by vendors, recruiters, and researchers.
+  Ecosystem members may post relevant surveys here.  They may *not* post them in
+  any other channel; only surveys authored by official Kubernetes teams may be
+  shared in other channels.
+  
 
 ### Escalating and/or Reporting a Problem
 


### PR DESCRIPTION
This adds a doc for the new "#surveys" channel.  

Once this is merged, the new channel (and new policy) will be announced on Slack.

/sig contributor-experience
/area slack-management
/assign @coderanger @markyjackson-taulia 