### PR TITLE
channels: add cluster-api-cloudstack slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -47,6 +47,7 @@ channels:
   - name: cluster-api-aws-alerts
   - name: cluster-api-azure
   - name: cluster-api-baremetal
+  - name: cluster-api-cloudstack
   - name: cluster-api-digitalocean
   - name: cluster-api-docker
     archived: true


### PR DESCRIPTION
This proposes to add a new cluster-api-cloudstack Slack channel for use of community building, participation and discussion around CAPI provider for Apache CloudStack (http://cloudstack.apache.org/), an opensource IaaS cloud computing platform. This is under the cluster-api sub-project of k8s cluster-lifecycle SIG. We're in process of proposing and donating this provider to the SIG.