### PR TITLE
Add SIG Docs CONTRIBUTING.md

### DIFF
--- a/sig-docs/CONTRIBUTING.md
+++ b/sig-docs/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to SIG Docs
+
+SIG Docs focuses on creating, maintaining, and publishing documentation for the Kubernetes project
+in the kubernetes.io [website](https://kubernetes.io), 
+[blog](https://kubernetes.io/blog), 
+and API [e.g. API reference for v1.23](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/) 
+& [CLI](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands) 
+reference documentation.
+
+For more details on SIG Docs' scope of work, what's in-scope, and what's out-of-scope, see the 
+[SIG Docs charter](https://github.com/kubernetes/community/blob/master/sig-docs/charter.md).
+
+## Getting started
+
+Anyone can contribute with a pull request to the [kubernetes/website](https://github.com/kubernetes/website) GitHub repository or open an issue to [kubernetes/website](https://github.com/kubernetes/website).
+
+Before opening a pull request, contributors must sign the [CNCF Contributor License Agreement](https://github.com/kubernetes/community/blob/master/CLA.md).
+
+Contributors should be familiar with the following:
+- [kubernetes/website repo](https://github.com/kubernetes/website)
+- [Reference docs repo](https://github.com/kubernetes-sigs/reference-docs))
+- [Hugo static site generator](https://gohugo.io/)
+- [Documentation content guide](https://kubernetes.io/docs/contribute/style/content-guide/)
+  - [What's allowed](https://kubernetes.io/docs/contribute/style/content-guide/#what-s-allowed)
+    - [Third-party content](https://kubernetes.io/docs/contribute/style/content-guide/#third-party-content)
+- [Documentation style guide](https://kubernetes.io/docs/contribute/style/style-guide/)
+- [Submitting a blog or case study](https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/)
+
+More information can be found on the [contribute page](https://kubernetes.io/docs/contribute/) 
+and on the [documentation style overview page](https://kubernetes.io/docs/contribute/style/).
+
+## Pull request process
+
+The pull request process for the kubernetes.io website is documented on the
+[Open a pull request](https://kubernetes.io/docs/contribute/new-content/open-a-pr/) page.
+
+Anyone can review pull requests and the review process is outlined in the 
+[Reviewing pull requests](https://kubernetes.io/docs/contribute/review/reviewing-prs/) page.
+
+## Questions about contributing
+Feel free to ask any questions in the [#sig-docs](https://kubernetes.slack.com/messages/sig-docs) 
+Slack channel or in a 
+[SIG Docs meeting](https://github.com/kubernetes/community/tree/master/sig-docs#meetings).


### PR DESCRIPTION
This PR adds a CONTRIBUTING.md to k/community/sig-docs per [sig-governance.md](https://git.k8s.io/community/committee-steering/governance/sig-governance.md)

> Ensure contributing instructions (CONTRIBUTING.md) are defined in the SIGs folder located in the Kubernetes/community repo if the groups contributor steps and experience are different or more in-depth than the documentation listed in the general [contributor guide](https://github.com/kubernetes/community/blob/master/contributors/guide/README.md) and [devel](https://github.com/kubernetes/community/blob/master/contributors/devel/README.md) folder.

/cc @divya-mohan0209 @jimangel @natalisucks 