### PR TITLE
SIG Charter Update: Instrumentation (tracing, non-retired projects)

### DIFF
--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -8,7 +8,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 --->
 # Instrumentation Special Interest Group
 
-Covers best practices for cluster observability through metrics, logging, and events across all Kubernetes components and development of relevant components such as Heapster and kube-state-metrics. Coordinates metric requirements of different SIGs for other components through finding common APIs.
+Covers best practices for cluster observability through metrics, logging, events, and traces across all Kubernetes components and development of relevant components such as klog and kube-state-metrics. Coordinates metric requirements of different SIGs for other components through finding common APIs.
 
 The [charter](charter.md) defines the scope and governance of the Instrumentation Special Interest Group.
 

--- a/sig-instrumentation/charter.md
+++ b/sig-instrumentation/charter.md
@@ -5,9 +5,9 @@ the Roles and Organization Management outlined in [sig-governance].
 
 ## Scope
 
-Owns best practices for cluster observability through metrics and logging
-across all Kubernetes components and development of components required for all
-Kubernetes clusters (eg. heapster, metrics-server).
+Owns best practices for cluster observability through metrics, logging, events,
+and traces across all Kubernetes components and development of components
+required for all Kubernetes clusters (eg. klog, kube-state-metrics).
 
 ### In scope
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1459,9 +1459,9 @@ sigs:
 - dir: sig-instrumentation
   name: Instrumentation
   mission_statement: >
-    Covers best practices for cluster observability through metrics, logging, and
-    events across all Kubernetes components and development of relevant components
-    such as Heapster and kube-state-metrics. Coordinates metric requirements of different
+    Covers best practices for cluster observability through metrics, logging, events,
+    and traces across all Kubernetes components and development of relevant components
+    such as klog and kube-state-metrics. Coordinates metric requirements of different
     SIGs for other components through finding common APIs.
 
   charter_link: charter.md


### PR DESCRIPTION
This is a small change to our charter/summary to reflect our current projects and responsibilities.

This scope update adds tracing and removes references to the deprecated project Heapster, replacing it with klog.

I also made sure the projects in charter.md and README.md matched.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

/sig instrumentation
/committee steering
since this is a charter update that covers scope (although we have defacto been covering this scope since [tracing was added](https://github.com/kubernetes/enhancements/issues/647))

As discussed amongst SIG Instrumentation leads when preparing our annual report.
/cc @logicalhan @dashpole @dgrisonnet 