### PR TITLE
Add recommendation to use Informers to SLO guidance

### DIFF
--- a/sig-scalability/slos/slos.md
+++ b/sig-scalability/slos/slos.md
@@ -89,6 +89,8 @@ In order to meet SLOs, you have to use extensibility features "wisely".
 The more precise formulation is to-be-defined, but this includes things like:
 - webhooks have to provide high availability and low latency
 - CRDs and CRs have to be kept within thresholds
+- Applications running in the cluster should use Informers where applicable (rather than making repeated 
+  LIST calls to the API Server). Most [officially-supported client libraries](https://kubernetes.io/docs/reference/using-api/client-libraries/#officially-supported-kubernetes-client-libraries) offer Informers.
 - ...
 
 ## Kubernetes SLIs/SLOs


### PR DESCRIPTION
If an app running in the cluster needs a constantly up-to-date
list of objects, and it does so by making repeated LIST calls,
that can add very significant load to etcd and the API server, 
to the point that SLOs are not met. That is exactly the problem
that Informers are designed to solve.

As of early 2022, the Haskel and Python libraries are the only
officially-supported libraries that do not yet include Informers.

