### PR TITLE
Update communication guide to match style guidelines

### DIFF
--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -1,61 +1,35 @@
 ---
 title: "Slack Guidelines"
 description: |
-  The policies, procedures, and escalation mechanisms for the Slack platform,
+  These are the policies, procedures, and escalation mechanisms for the Slack platform,
   such as requesting channels, tokens, and how to report inappropriate content.
 ---
 
-<!-- omit in toc -->
-# Slack Guidelines
-
 Slack serves as the main communication platform for the Kubernetes community
-outside of the mailing lists. It’s important that conversations stays on topic
-in each channel, and that everyone abides by the [Code of Conduct][coc]. There
-are over 100,000 members who should all expect to have a positive experience.
+outside of the mailing lists. It's important that conversations stay on topic in
+each channel, and that everyone abides by the [Code of Conduct][coc]. There are
+over 150,000 members who should all expect to have a positive experience. You
+are a part of building and keeping a positive community.
 
-Chat is searchable and public. Do not make comments that you would not say on a
-video recording or in another public space. Please be courteous to others.
-
-- [Code of Conduct](#code-of-conduct)
-- [Admins](#admins)
-- [General Communication Guidelines](#general-communication-guidelines)
-  - [Workspace Channel History](#workspace-channel-history)
-  - [DM (Direct Message) Conversations](#dm-direct-message-conversations)
-  - [Specific Channel Rules](#specific-channel-rules)
-  - [Escalating and/or Reporting a Problem](#escalating-andor-reporting-a-problem)
-- [Should you have a channel on the Kubernetes Slack?](#should-you-have-a-channel-on-the-kubernetes-slack)
-- [Requesting a Channel](#requesting-a-channel)
-  - [Delegating Channel Ownership](#delegating-channel-ownership)
-- [Requesting a User Group](#requesting-a-user-group)
-- [Requesting a Bot, Token, or Webhook](#requesting-a-bot-token-or-webhook)
-- [Moderation](#moderation)
-  - [Admin Expectations and Guidelines](#admin-expectations-and-guidelines)
-  - [Sending Messages to the Channel](#sending-messages-to-the-channel)
-  - [Processing Slack Requests](#processing-slack-requests)
-    - [Processing Channel Requests](#processing-channel-requests)
-    - [Processing User Group Requests](#processing-user-group-requests)
-    - [Processing Bot, Token, or Webhook Requests](#processing-bot-token-or-webhook-requests)
-  - [Inactivating Accounts](#inactivating-accounts)
-
+Chat is searchable and public. It's best not to make comments that you would not
+say on a video recording or in another public space. Please be courteous to
+others.
 
 ## Code of Conduct
 
 Kubernetes adheres to the [Kubernetes Code of Conduct][coc] throughout the
 project, and includes all communication mediums.
 
-
 ## Admins
 
-- Check the [centralized list of administrators][admins] for contact information.
+-   Check the [centralized list of administrators][admins] for contact information.
 
-Slack Admins will have listed that they are a Slack admin in their Slack profile,
-along with their specific timezone.
+Slack Admins will have listed that they are a Slack admin in their Slack
+profile, along with their specific timezone.
 
 To connect: please reach out in the `#slack-admins` channel, mention an admin
-directly in the `#slack-admins` channel when you have a question, or DM (Direct
-Message) one privately.
-
----
+directly in the `#slack-admins` channel when you have a question, or DM (direct
+message) one privately.
 
 ## General Communication Guidelines
 
@@ -64,36 +38,31 @@ Message) one privately.
 The Kubernetes Slack Workspace is archived and made available when the
 administrators have time. There is no explicit interval.
 
-[Slack Archive Download]
+[Slack Archive Download][]
 
 ### DM (Direct Message) Conversations
 
 Please do not engage in proprietary company specific conversations in the
 Kubernetes Slack instance. This workspace is meant for conversations related to
 Kubernetes open source topics and community. Proprietary conversations should
-occur in your company Slack and/or communication platforms.  As with all
+occur in your company Slack and/or communication platforms. As with all
 communication, please be mindful of appropriateness, professionalism, and
 applicability to the Kubernetes community.
-
 
 ### Specific Channel Rules
 
 Some channels have specific rules or guidelines. If they do, they will be listed
 in the purpose or pinned docs of that channel.
 
-- `#kubernetes-contributors` - Questions and discourse around upstream
-  contributions and development to kubernetes.
-- `#kubernetes-careers` - Job openings for positions working with/on/around
-  Kubernetes. This is the only channel where job postings are permitted. Postings
-  must include:
-  - A link to the posting or job description.
-  - The business name that will employ the Kubernetes hire.
-  - The location of the role or if remote is OK.
-- `#surveys` - third-party surveys, posted by vendors, recruiters, and researchers.
-  Ecosystem members may post relevant surveys here.  They may *not* post them in
-  any other channel; only surveys authored by official Kubernetes teams may be
-  shared in other channels.
-  
+-   `#kubernetes-contributors` - Questions and discourse around upstream
+    contributions and development to kubernetes.
+-   `#kubernetes-careers` - Job openings for positions working with/on/around
+    Kubernetes. Postings must include:
+    -   A link to the posting or job description.
+    -   The business name that will employ the Kubernetes hire.
+    -   The location of the role or if remote is OK.
+-   `#surveys` - Cloud native community wide surveys. Posts must be ecosystem
+    related.
 
 ### Escalating and/or Reporting a Problem
 
@@ -102,27 +71,25 @@ accessed by clicking on "More actions", the "**...**" to the right of a message,
 and selecting **Report message**.
 
 This will open a new dialog prompt where you may describe the problem. When
-done, it will send the reported message and your comments to **BOTH** the Slack
-admins and [Code of Conduct Committee (CoCC)][cocc].
+done, it will send the reported message and your comments to **BOTH** the
+[Slack admins][admins] and [Code of Conduct Committee (CoCC)][].
 
 A Slack admin or CoCC member will work to resolve the issue or reach out for
 more information.
 
 If the issue has not been responded to in a timely manner, Join the
-`#slack-admins` channel and alert the admins to the current issue. Many Slack
+#slack-admins channel and alert the admins to the current issue. Many Slack
 admins watch the channel and should respond to you shortly.
 
 As a last resort, or if the issue is private, contact one of the admins in the
 [closest timezone][admins] via DM directly and describe the situation. If the
 issue can be documented, please take a screenshot to include in your message.
 
-**What if you have a problem with an admin?**
+#### What if you have a problem with an admin?
 
-Send a DM to another [listed admin][admins] and describe the situation. If it’s
+Send a DM to another [listed admin][admins] and describe the situation. If it's
 a [code of conduct][coc] issue, please send an email to <conduct@kubernetes.io>
-and describe the situation.
-
----
+and describe the situation. 
 
 ## Should you have a channel on the Kubernetes Slack?
 
@@ -131,189 +98,199 @@ Kubernetes project. However it is useful for developers and users to have a
 strong ecosystem of channels for related things. Here are some guidelines for
 determining if you should request a channel:
 
-- The channel MUST be Kubernetes related in some way.
-  - Related cloud native projects might be more appropriate on the [CNCF Slack].
-- The project MUST be open source. 
-  - If you are open sourcing a project DO THAT FIRST, we cannot accommodate every
-    organization's open sourcing launch plans.
-  - The purpose of Slack is to organize an existing community, not seed new ones.
-  - Moderators look at contributor activity, adoption and community consensus
-    around a project, otherwise Slack becomes a vehicle for promotion instead of
-    promulgation.
-  - Establishing and maintaining a Slack channel should be an inflection point
-    in a project's adoption.
-  - Requesting a channel means maintaining it on behalf of the project filing
-    the issue, you will be expected to participate and foster a healthy
-    discourse.
-- Channels around commercial services built on OSS projects are allowed.
-  - Users love the value of being able to collaborate around various services.
-  - Keep it classy, on the Kubernetes Slack we're all on the same team.
-- The channel MUST be public.
-  - In order to ensure all channels adhere to our Code of Conduct, we heavily
-    restrict private channels.
-  - We do allow `#...-dev` channels for established projects where a single
-    project channel is too noisy, but please don't create both at the start.
-  - If you need private discussion areas for security-sensitive topics, a
-    project-specific Slack or the [CNCF Slack] may be a better fit.
-- Ask in #slack-admins or file an issue if you're unsure, it never hurts to ask.
+-   The channel MUST be Kubernetes related in some way.
+    -   Related cloud native projects might be more appropriate on the 
+        [CNCF Slack][].
+-   The project MUST be open source.
+    -   Open Source a project BEFORE requesting a channel. We cannot accommodate
+        every organization's open sourcing launch plans.
+    -   The purpose of Slack is to organize an existing community, not seed new
+        ones.
+    -   Moderators look at contributor activity, adoption and community
+        consensus around a project, otherwise Slack becomes a vehicle for
+        promotion instead of promulgation.
+    -   Establishment and maintenance of a Slack channel should be an inflection
+        point in a project's adoption.
+    -   Requesting a channel means maintaining it on behalf of the project
+        filing the issue. You will be expected to participate and foster a
+        healthy discourse.
+-   Channels around commercial services built on OSS projects are allowed.
+    -   Users love the value of being able to collaborate around various
+        services.
+    -   Keep it classy, on the Kubernetes Slack we're all on the same team.
+-   The channel MUST be public.
+    -   In order to ensure all channels adhere to our Code of Conduct, we
+        heavily restrict private channels.
+    -   We do allow `#...-dev` channels for established projects where a single
+        project channel is too noisy, but please don't create both at the
+        start.
+    -   If you need private discussion areas for security-sensitive topics, a
+        project-specific Slack or the [CNCF Slack][] may be a better fit.
+-   Ask in `#slack-admins` or file an issue if you're unsure It never hurts to
+    ask.
 
 ## Requesting a Channel
 
-Channels and User Groups are managed by [Tempelis], a tool that enables external
-management of Slack.
+Channels and User Groups are managed by [Tempelis][], a tool that enables
+external management of Slack.
 
-To add a channel, open a Pull Request (PR) updating the [slack-config].
-- Add the channel to [channels.yaml] following the [Channel Documentation].
-  - Channel names must be 21 characters or less in length (Slack limit).
-  - Typical channel naming conventions follow:
-    - `#kubernetes-foo`
-    - `#sig-foo`
-    - `#meetup-foo`
-    - `#location-user`
-    - `#projectname`
-- In the PR comments, include some details regarding the purpose of the Channel.
-  - Channels should be dedicated to [SIGs, WGs, UGs][sig-list], sub-projects,
-    community topics, or related Kubernetes programs/projects.
-  - Linking to resources such as the PR adding the subproject will speed in the
-    validation and processing of the channel creation request.
-  - Channels are **NOT**:
-    - Company specific; cloud providers are ok with product names as the channel.
-      Discourse will be about Kubernetes-related topics and not proprietary
-      information of the provider.
-    - Private channels with the exception of: code of conduct matters, mentoring,
-      security/vulnerabilities, github management, or steering committee.
-  - Special accommodations will be made where necessary.
+To add a channel, open a Pull Request (PR) updating the [slack-config][].
+
+-   Add the channel to 'channels.yaml' following the [Channel Documentation][]
+    -   Channel names must be 21 characters or less in length, limited by Slack
+        design.
+    -   Channels must not share the same name with a Slack user or user group.
+    -   Typical channel naming conventions follow:
+        -   `#kubernetes-foo`
+        -   `#sig-foo`
+        -   `#meetup-foo`
+        -   `#location-user`
+        -   `#projectname`
+-   In the PR comments, include some details regarding the purpose of the
+    Channel.
+    -   Channels should be dedicated to [SIGs, WGs, UGs][sig-list], sub-projects,
+        community topics, or related Kubernetes programs/projects.
+    -   Linking to resources such as the PR adding the subproject will speed in
+        the validation and processing of the channel creation request.
+    -   Channels are NOT
+        -   **Company specific**; cloud providers are ok with product names as
+            the channel. Discourse will be about Kubernetes-related topics and
+            not proprietary information of the provider.
+        -   **Private channels** with the exception of: code of conduct matters,
+            mentoring, security/vulnerabilities, github management, or
+            steering committee.
+    -   Special accommodations will be made where necessary.
 
 After you submit your request the Slack Admins will review and follow-up with
-any questions in the PR itself. Once it is signed off and merged, the Channel
+any questions in the PR itself. Once it is signed off and merged, the channel
 will be created.
 
-For further information, see the [Slack Config Documentation].
-
+For further information, see the [Slack Config Documentation][].
 
 ### Delegating Channel Ownership
 
-Channel management can be delegated to other groups enabling SIG leads or other
-members to govern certain sets channels. This by-passes the need for a Slack
+Channel management can be delegated to other groups, enabling SIG leads or other
+members to govern certain sets of channels. This bypasses the need for a Slack
 Admins to sign-off on all requests and passes the responsibility to the most
 relevant group.
 
-To delegate channel ownership, open a Pull Request (PR) updating the
-[slack-config].
-- Create a sub-directory under the [slack-config] for your sig or group.
-- Update [restrictions.yaml] with an entry targeting yaml config files in the
-  sub-directory you created along with one or more regular expressions that
-  match the channel names that should be delegated.
-  - **Example Restrictions Entry:**
-    ```yaml
-    restrictions:
-    - path: "sig-foo/*.yaml"          # path to channel config
-      channels:
-      - "^kubernetes-foo-[a-z]{1,3}$" # channel regexp - example match: kubernetes-foo-bar
-      - "^foo-[a-zA-Z]+$"             # channel regexp - example match: foo-awesomechannel
-    ```
-- Create an [`OWNERS`] file in the sub-directory adding the appropriate
-  reviewers and approvers for the desired channels.
-- In the directory create one or more channel configs following the
-  [Channel Documentation].
-  - **Example Channel Config:**
-    ```yaml
-    channels:
-    - name: kubernetes-foo-bar # regexp: "^kubernetes-foo-[a-z]{1,3}$"
-    - name: foo-users          # regexp: "^foo-[a-zA-Z]+$"
-    - name: foo-dev            # regexp: "^foo-[a-zA-Z]+$"
-    ```
+To delegate channel ownership - Open a Pull Request (PR) updating the
+[slack-config][].
+
+-   Create a sub-directory under the [slack-config][] for your sig or group.
+-   Update restrictions.yaml with an entry targeting yaml config files in the
+    sub-directory you created along with one or more regular expressions that
+    match the channel names that should be delegated.
+    -   **Example Restrictions Entry:**
+        ```yaml
+        restrictions:
+        - path: "sig-foo/*.yaml"          # path to channel config
+          channels:
+          - "^kubernetes-foo-[a-z]{1,3}$" # channel regexp - example match: kubernetes-foo-bar
+          - "^foo-[a-zA-Z]+$"             # channel regexp - example match: foo-awesomechannel
+        ```
+-   Create an [OWNERS][] file in the sub-directory adding the appropriate
+    reviewers and approvers for the desired channels.
+-   In the directory create one or more channel configs following the Channel
+    Documentation
+    -   **Example Channel Config:**
+        ```yaml
+        channels:
+        - name: kubernetes-foo-bar # regexp: "^kubernetes-foo-[a-z]{1,3}$"
+        - name: foo-users          # regexp: "^foo-[a-zA-Z]+$"
+        - name: foo-dev            # regexp: "^foo-[a-zA-Z]+$"
+        ```
+
 After you submit your PR and the Slack Admins sign off on the update, it will be
 merged and the group will be able to fully self-manage their own channels.
 
-For further information, see the [Slack Config Documentation].
+For further information, see the 
+[Slack Config Documentation][Channel Documentation].
 
 ## Requesting a User Group
 
-Channels and User Groups are managed by [Tempelis], a tool that enables external
-management of Slack.
+Channels and User Groups are managed by [Tempelis][], a tool that enables
+external management of Slack.
 
-To add a User Group, open a Pull Request (PR) updating the [slack-config].
-- Add the [users] to [users.yaml]. **NOTE:** This **must** be a mapping of their
-  GitHub ID to their Slack Member ID.
-  - To get a person's Slack Member ID, view their profile. Then click on the
-    "**...**" and select **Copy member ID**. It will be a  9 character string of
+To add a User Group, open a Pull Request (PR) updating the [slack-config][].
+
+-   Add the users to users.yaml. **NOTE:** This must be a mapping of their
+    GitHub ID to their Slack Member ID. 
+-   To get a person's Slack Member ID, view their profile. Then click on the
+    "**...**" and select **Copy member ID**. It will be a 9 character string of
     uppercase letters and numbers (example: `U1H63D8SZ`).
-- Update [usergroups.yaml] Follow the guidelines for creating a User Group in
-  the Slack Config [User Group Documentation].
-- In the PR comments, include details on the User Group and `/cc` the members
-  you are adding so that they may sign off and accept being added to the group.
+-   Update [usergroups.yaml][] Follow the guidelines for creating a User Group
+    in the Slack Config [User Group Documentation][].
+-   In the PR comments, include details on the User Group and `/cc` the members
+    you are adding so that they may sign off and accept being added to the
+    group.
 
 After you submit your request, the Slack Admins will review and follow-up with
 any questions in the PR itself. Once it is signed off by the members being added
 and the Slack Admins, it will be merged, and the User Group will be created.
 
-For further information, see the [Slack Config Documentation].
-
+For further information, see the 
+[Slack Config Documentation][Channel Documentation].
 
 ## Requesting a Bot, Token, or Webhook
 
 **READ BEFORE SUBMITTING A REQUEST**
 
-Bots, tokens, and webhooks are reviewed on a case-by-case basis with most
-requests being rejected due to security, privacy, and usability concerns. Bots
+Bots, tokens, and webhooks are reviewed on a case-by-case basis **with most
+requests being rejected due to security, privacy, and usability concerns**. Bots
 and the like tend to make a lot of noise in channels. The Kubernetes Slack
-instance has over 50,000 members and it is the role of the Slack admins to
+instance has over 145,000 members and it is the role of the Slack admins to
 ensure everyone has a great experience.
 
 Typically approved requests include: GitHub, CNCF requests, or other
 tools/platforms used to aid in the management of Slack itself.
 
-- Create a [GitHub Issue] using the Slack Request template.
-- In the description, describe the request, its intended purpose and benefit to
-  the community. Supplying links to supporting content such as a document
-  outlining what OAuth scopes that are requested, and why are
-  **STRONGLY ENCOURAGED**.
+-   Create a [GitHub Issue][] using the Slack Request template.
+-   In the description, describe the request, its intended purpose and benefit
+    to the community. Supplying links to supporting content such as a document
+    outlining what OAuth scopes that are requested and why are **STRONGLY
+    ENCOURAGED**.
 
-After you submit your request the Slack admins will review and follow-up with
+After you submit your request, the Slack admins will review and follow-up with
 any questions in the issue. If consensus can be reached among the admins, the
 request will be approved and follow-up communication on implementation will be
 discussed in Slack itself.
-
----
 
 ## Moderation
 
 ### Admin Expectations and Guidelines
 
-Admins should adhere to the general Kubernetes project [moderation guidelines].
+Admins should adhere to the general Kubernetes project 
+[moderation guidelines][].
 
 Additionally, admins should ensure they have 2-factor auth enabled for their
 account and mention they are a Slack admin in the "What I do" portion of their
-profile. This message should also include the timezone they are representing.
+profile. This message should also include the time zone they are representing.
 
 Be mindful of how you handle communication during stressful interactions.
 Administrators act as direct representatives of the community, and need to
 maintain a very high level of professionalism at all times. If you feel too
-involved in the situation to maintain impartiality or professionalism, that’s
-a great time to enlist the help of another admin.
+involved in the situation to maintain impartiality or professionalism, that's a
+great time to enlist the help of another admin.
 
 Try to take any situations that involve upset or angry members to DM or video
 chat. Please document these interactions for other Slack admins to review.
 
 Content will be removed if it violates code of conduct or is a sales pitch.
 Admins will take a screenshot of such behavior in order to document the
-situation. The community takes such violations extremely seriously, and the
+situation. **The community takes such violations extremely seriously**, and the
 admins are empowered to handle it swiftly.
-
 
 ### Sending Messages to the Channel
 
 `@all`, `@here` and `@channel` should be used rarely. Members will receive
-notifications from these commands. Remember Kubernetes is a global project -
-please be kind.
-
+notifications from these commands. Remember Kubernetes is a global
+project---please be kind.
 
 ### Processing Slack Requests
 
 Admins are tasked with processing requests for channels and other things such as
-bots, tokens or webhook.
-
+bots, tokens or webhooks. Please see the processes outlined below.
 
 #### Processing Channel Requests
 
@@ -322,12 +299,12 @@ Kubernetes community. Typically channels should be dedicated to SIGs, WGs, UGs,
 sub-projects, community topics, and other things related to Kubernetes programs
 and projects.
 
-For Kubernetes project centric requests, validate them against the [sig-list],
-or request a link to a related issue/PR, or mailing list discussion for the
-requested Channel.
+For Kubernetes project centric requests, validate them against the
+[sig-list][SIGs, WGs, UGs], or request a link to a related issue/PR, or mailing
+list discussion for the requested Channel.
 
 Small external projects are encouraged to use the channel of the SIG, WG, or UG
-most relevant to them. Other things such as programming language specific
+most relevant to them. Other things such as programming language-specific
 channels are discouraged and should in turn be steered to `#kubernetes-client`
 or communication avenues commonly used by their specific language.
 
@@ -336,12 +313,15 @@ In general, use your best judgment.
 Once two Slack admins have reviewed and agreed to sponsor the channel, they will
 sign off on the Channel Request PR. Once merged, the channel will be created.
 
-Channels managed by [Tempelis] will automatically have [default messages pinned].
-For any manually provisioned channels, such as private channels, add the below
-message and pin it.
+Channels managed by [Tempelis][] will automatically have default messages
+pinned. For any manually-provisioned channels, such as private channels, add the
+below message and pin it.
+
 ```
-This channel abides to the Kubernetes Code of Conduct - http://git.k8s.io/community/code-of-conduct.md
-Contact conduct@kubernetes.io or an admin in the #slack-admins channel if there is a problem.
+This channel abides to the Kubernetes Code of Conduct -
+http://git.k8s.io/community/code-of-conduct.md
+Contact conduct@kubernetes.io or an admin in the #slack-admins channel if there
+is a problem.
 ```
 
 #### Processing User Group Requests
@@ -353,73 +333,70 @@ are a useful alias, but can also easily be spammed or abused.
 Before signing off on a User Group PR request, ensure all members of the User
 Group have signed off acknowledging they will be added to the group.
 
-After all the User Group members have accepted being added to the group, and two
+After all the User Group members have accepted being added to the group and two
 Slack Admins have signed off on the request, the PR will be merged. Once merged,
 the User Group will be created.
-
 
 #### Processing Bot, Token, or Webhook Requests
 
 Requests should first be evaluated for their relevance to the project. Typically
-approved requests are related to: GitHub, the CNCF, or other tools/platforms
+approved requests are related to: GitHub, the CNCF, or other tools and platforms
 used to aid in the management of Slack. Requests outside of this scope should be
 heavily scrutinized and reviewed for **ANY** potential security, privacy, or
 usability concerns.
 
-It is best to err on the side of not allowing a Bot, Token or Webhook request
-than allowing one.
+It is best to err on the side of not allowing a bot, token, or webhook request
+rather than allowing one.
 
-If consensus among the admins can be reached regarding the request; an admin
-should assign the issue to themselves, and reach out to the request contact
-regarding next steps.
-
+If the admins come to consensus and agree to the request, an admin should assign
+the issue to themselves and reach out to the request contact regarding next
+steps.
 
 ### Inactivating Accounts
 
 For the reasons listed below, admins may inactivate individual Slack accounts.
-Due to Slack’s framework, it does not allow for an account to be banned or
-suspended in the traditional sense, merely inactivated. See [Slack’s policy on
-inactivated accounts] for more information.
+Due to Slack's framework, it does not allow for an account to be banned or
+suspended in the traditional sense, merely inactivated. 
+See [Slack's policy on inactivated accounts][] for more information.
 
-- Spreading spam content in DMs and/or channels.
-- Not adhering to the code of conduct set forth in DMs and/or channels.
-- Overtly selling products, related or unrelated to Kubernetes.
+#### Reasons to inactivate an account
+
+-   Spreading spam content in DMs and/or channels.
+-   Not adhering to the code of conduct set forth in DMs and/or channels.
+-   Overtly selling products, related or unrelated to Kubernetes.
 
 **BE CAREFUL**
 
-To inactivate a user, and optionally remove their content (spam). First, double
-check you have the correct user by verifying their Slack Member ID. Spammers may
-try and fake or assume the identity of another user.
+To inactivate a user, and optionally remove their content (spam):
 
-Once verified, find a message from the offending user. Then select
-"**More actions**", the "**...**" to the right of a message from the offending user.
-Then select "**Report message**".
+-   First, double check you have the correct user by verifying their Slack
+    Member ID.
+-   Spammers may try and fake or assume the identity of another user.
 
-This will open a contextually aware prompt only available to Slack Admins with
-the options to deactivate the user and remove all content from them over the 
+Once verified, find a message from the offending user. Then select **More
+actions**, the "**...**" to the right of a message from the offending user. Then
+select **Report message**.
+
+This will open a contextually-aware prompt only available to Slack Admins with
+the options to deactivate the user and remove all content from them over the
 past "X" minutes/hours.
 
-Report any actions taken to the other slack admins, and if needed the
+Report any actions taken to the other slack admins, and if needed the 
 [Code of Conduct Committee][cocc].
 
-[coc]: /code-of-conduct.md
-[admins]: ./moderators.md#Slack
-[Slack Archive Download]: https://drive.google.com/drive/folders/1Xnkwsxis3tu0pT7rwp-crRq4IciZ5b1o?usp=sharing
-[cocc]: /committee-code-of-conduct/README.md
-[GitHub Issue]: https://github.com/kubernetes/community/issues/new/choose
-[sig-list]: /sig-list.md
-[tempelis]: http://sigs.k8s.io/slack-infra/tempelis
-[slack-config]: ./slack-config/
-[Channel Documentation]: ./slack-config/README.md#channels
-[channels.yaml]: ./slack-config/channels.yaml
-[restrictions.yaml]: ./slack-config/restrictions.yaml
-[`owners`]: /contributors/guide/owners.md
-[users]: ./slack-config/README.md#users
-[users.yaml]: ./slack-config/users.yaml
-[usergroups.yaml]: ./slack-config/usergroups.yaml
-[User Group Documentation]: ./slack-config/README.md#usergroups
-[Slack Config Documentation]: ./slack-config/README.md
-[default message pinned]: ./slack-config/template.yaml
-[Slack’s policy on inactivated accounts]: https://get.Slack.help/hc/en-us/articles/204475027-Deactivate-a-member-s-account
-[moderation guidelines]: ./moderation.md
-[CNCF Slack]: https://slack.cncf.io/
+  [Code of Conduct]: /code-of-conduct.md
+  [admins]: ./moderators.md#Slack
+  [Slack Archive Download]: https://drive.google.com/drive/folders/1Xnkwsxis3tu0pT7rwp-crRq4IciZ5b1o?usp=sharing
+  [cocc]: /committee-code-of-conduct/README.md
+  [CNCF Slack]: https://slack.cncf.io/
+  [Tempelis]: http://sigs.k8s.io/slack-infra/tempelis
+  [slack-config]: ./slack-config/
+  [Channel Documentation]: ./slack-config/README.md
+  [sig-list]: https://www.kubernetes.dev/community/community-groups
+  [Slack Config Documentation]: ./slack-config/README.md
+  [OWNERS]: /contributors/guide/owners
+  [usergroups.yaml]: ./slack-config/usergroups.yaml
+  [User Group Documentation]: ./slack-config/README.md#usergroups
+  [GitHub Issue]: https://github.com/kubernetes/community/issues/new/choose
+  [moderation guidelines]: ./moderation.md
+  [Slack's policy on inactivated accounts]: https://get.slack.help/hc/en-us/articles/204475027-Deactivate-a-member-s-account

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -72,7 +72,7 @@ and selecting **Report message**.
 
 This will open a new dialog prompt where you may describe the problem. When
 done, it will send the reported message and your comments to **BOTH** the
-[Slack admins][admins] and [Code of Conduct Committee (CoCC)][].
+[Slack admins][admins] and [Code of Conduct Committee (CoCC)][cocc].
 
 A Slack admin or CoCC member will work to resolve the issue or reach out for
 more information.
@@ -300,7 +300,7 @@ sub-projects, community topics, and other things related to Kubernetes programs
 and projects.
 
 For Kubernetes project centric requests, validate them against the
-[sig-list][SIGs, WGs, UGs], or request a link to a related issue/PR, or mailing
+[sig-list], or request a link to a related issue/PR, or mailing
 list discussion for the requested Channel.
 
 Small external projects are encouraged to use the channel of the SIG, WG, or UG
@@ -384,7 +384,7 @@ past "X" minutes/hours.
 Report any actions taken to the other slack admins, and if needed the 
 [Code of Conduct Committee][cocc].
 
-  [Code of Conduct]: /code-of-conduct.md
+  [coc]: /code-of-conduct.md
   [admins]: ./moderators.md#Slack
   [Slack Archive Download]: https://drive.google.com/drive/folders/1Xnkwsxis3tu0pT7rwp-crRq4IciZ5b1o?usp=sharing
   [cocc]: /committee-code-of-conduct/README.md

--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -4,57 +4,36 @@ description: |
   Policies, procedures and best practices for managing Zoom.
 ---
 
-<!-- omit in toc -->
-# Zoom guidelines
-
-Zoom is the main video communication platform for Kubernetes.
-It is used for running the [community meeting], [SIG/WG meetings],
-[Office Hours], [Meet Our Contributors] and many other Kubernetes online events.
-Since the Zoom meetings are open to the general public, a Zoom host or co-host
-has to moderate a meeting in all senses of the word from starting and stopping
-the meeting, to acting on [Kubernetes code of conduct] issues.
+Zoom is the main video communication platform for Kubernetes. It is used for
+running the [community meeting][], [SIG/WG meetings][], [Office Hours][], 
+[Meet Our Contributors][] and many other Kubernetes online events. Since the Zoom
+meetings are open to the general public, a Zoom host or co-host has to moderate
+a meeting in all senses of the word, from starting and stopping the meeting to
+acting on [Kubernetes code of conduct][] issues.
 
 These guidelines are meant as a tool to help Kubernetes members manage their
 Zoom resources.
 
-Check the main [moderation] page for more information on other tools and general
-moderation guidelines.
-
-
-- [Code of conduct](#code-of-conduct)
-- [Zoom license management](#zoom-license-management)
-  - [Obtaining a Zoom license](#obtaining-a-zoom-license)
-- [Setting up your meeting and moderation](#setting-up-your-meeting-and-moderation)
-  - [Moderation](#moderation)
-    - [Related moderation documentation](#related-moderation-documentation)
-  - [Escalating and/Reporting a Problem](#escalating-andreporting-a-problem)
-- [Meeting recordings](#meeting-recordings)
-- [Screen sharing guidelines and recommendations](#screen-sharing-guidelines-and-recommendations)
-- [Audio/Video quality recommendations](#audiovideo-quality-recommendations)
-  - [Recommended hardware to have](#recommended-hardware-to-have)
-  - [Hardware we don't recommend](#hardware-we-dont-recommend)
-  - [Pro-tips](#pro-tips)
+Check the main [moderation][] page for more information on other tools
+and general moderation guidelines.
 
 
 ## Code of conduct
 
-The Kubernetes project adheres to the [Kubernetes Code of Conduct] throughout all
-platforms and includes all communication mediums.
-
+The Kubernetes project adheres to the [Kubernetes Code of Conduct][]
+throughout all platforms and includes all communication mediums.
 
 ## Zoom license management
 
-Zoom licenses are managed by the [CNCF Service Desk] through the [Zoom Admins]
-listed in the [centralized list of administrators].
-
+Zoom licenses are managed by the [CNCF Service Desk][] through the
+[Zoom Admins][] listed in the  [centralized list of administrators][].
 
 ### Obtaining a Zoom license
 
 Ensure that all SIG/WG leads, chairs, and any other necessary trusted owners
-have access to the `k-sig-<foo>-leads@googlegroups.com` account as described
-in the [sig creation procedure]. Once done, contact one of the [Zoom Admins]
-to obtain a Zoom licence.
-
+have access to the `k-sig-<foo>-leads@googlegroups.com` account as described in
+the [sig creation procedure][]. Once done, contact one of the [Zoom Admins][] to
+obtain a Zoom license.
 
 ## Setting up your meeting and moderation
 
@@ -63,37 +42,40 @@ and others who would intentionally attempt to disrupt your Zoom call.
 
 To create a meeting with **moderation** enabled, ensure the following:
 
-- Have the [latest version] of the Zoom client installed.
-- Be logged in as the leads account associated with the meeting **OR** use the
-  [host key] to "claim host".
-- Configure a meeting setup through the "Meeting" menu in the leads Zoom account.
-  **NOTE:** Do **NOT** use the "Personal Meeting ID". This will create an
-  "ad-hoc" meeting that is time-bounded and without moderation capability.
+-   Have the [latest version][] of the Zoom client installed.
+-   Be logged in as the leads account associated with the meeting **OR** use the
+    [host key][] to "claim host".
+-   Configure a meeting setup through the "Meeting" menu in the leads Zoom
+    account. **NOTE:** Do **NOT** use the "Personal Meeting ID". This will
+    create an "ad-hoc" meeting that is time-bounded and without moderation
+    capability.
+-   Set the password to the meeting to "77777"
 
 After the meeting has started:
 
-- Assign a co-host to help with moderation. It should never be your note taker
-  unless it's a very small group.
-- Turn **off** screen sharing for everyone and indicate only host. If you have
-  others that need to share their screen, the host can enable that on the fly.
-  (via the `^` menu next to **Share Screen**)
+-   Assign a co-host to help with moderation. It should never be your note taker
+    unless it's a very small group.
+-   Turn **off** screen sharing for everyone and indicate "only host". If you
+    have others that need to share their screen, the host can enable that on
+    the fly. (via the `^` menu next to **Share Screen**)
 
 ### Moderation
 
 If you're dealing with a troll or bad actor:
 
-- Put the troll or bad actor on **hold**. The participant will be put into a
-  "[waiting room]" and will not be able to participate in the call until the host
-  removes the hold.
-  - **NOTE:** Depending on your client version this will be called
-    "**Put in Waiting Room**" instead of on **hold**.
-- Remove the participant. Please be cautious when testing or using this feature,
-  as it is **permanent**. They will never be able to come back into that meeting
-  ID on that particular device. Do **not** joke around with this feature; it's
-  better to put the attendee on "hold" first and then remove.
-- After an action has been taken, use the **lock meeting** feature so that no
-  one else can come into the meeting. If that fails, end the call immediately,
-  and contact the [Zoom Admins] to report the issue.
+-   Put the troll or bad actor on **hold**. The participant will be put into a
+    [waiting room][] and will not be able to participate in the call until the
+    host removes the hold.
+    -   **NOTE:** Depending on your client version this will be called "**Put in
+        Waiting Room**" instead of on **hold**.
+-   Remove the participant. Please be cautious when testing or using this
+    feature, as it is **permanent**. They will never be able to come back into
+    that meeting ID on that particular device. Do **not** joke around with
+    this feature; it's better to put the attendee on "hold" first and then
+    remove.
+-   After an action has been taken, use the **lock meeting** feature so that no
+    one else can come into the meeting. If that fails, end the call
+    immediately, and contact the [Zoom Admins][] to report the issue.
 
 **NOTE:** You can find these actions when clicking on the **more** or **"..."**
 options after scrolling over the participants name/information.
@@ -101,58 +83,53 @@ options after scrolling over the participants name/information.
 Hosts **must** be comfortable with how to use these moderation tools and the
 Zoom settings in general. Make sure whoever is running your meeting is equipped
 with the right knowledge and skills. If you have any questions or concerns,
-reach out to the [Zoom Admins] and they will be able to provide further guidance
-and training.
-
+reach out to the [Zoom Admins][] and they will be able to provide further
+guidance and training.
 
 #### Related moderation documentation
 
-- Zoom has [documentation on how to use their moderation tools].
-- Members of the _leads@_ group have access to an extensive
-  [best practices doc] with screenshots going over the community Zoom best
-  practices.
+-   Zoom has [documentation on how to use their moderation tools][].
+-   Members of the _leads@_ group have access to an extensive 
+    [best practices doc][] with screenshots going over the community Zoom best
+    practices.
 
+### Escalating and Reporting a Problem
 
-### Escalating and/Reporting a Problem
-
-Issues that cannot be handle via normal moderation, or with the assistance of the
-[Zoom Admins] should be escalated to the Kubernetes [Code of Conduct Committee]
-at conduct@kubernetes.io.
+Issues that cannot be handled via normal moderation, or with the assistance of
+the [Zoom Admins][] should be escalated to the Kubernetes 
+[Code of Conduct Committee][] at conduct@kubernetes.io.
 
 To contact the admin group in Slack, ping `@zoom-admins` in the `#sig-contribex`
 Slack channel.
 
-
 ## Meeting recordings
 
 Chairs and TLs are responsible for posting all update meetings to their playlist
-on YouTube. [Please follow this guideline for more details].
+on YouTube. [Please follow this guideline for more details][].
 
 If a violation has been addressed by a host and it has been recorded by Zoom,
-the video should be edited before being posted on the [Kubernetes channel].
+the video should be edited before being posted on the [Kubernetes channel][].
 
-Contact [SIG Contributor Experience] if you need help to edit a video before
-posting it to the public.
-
+Contact [SIG Contributor Experience][] if you need help to edit a video
+before posting it to the public.
 
 ## Screen sharing guidelines and recommendations
 
-Zoom has a [documentation on how to use their screen sharing feature]:
+Zoom has [documentation on how to use their screen sharing feature][].
 
 Recommendations:
 
-- Turn off notification to prevent any interference.
-- Close all sensitive documents and unrelated programs before sharing the screen
-  eg. Emails.
-- Test your presentation before hand to make sure everything goes smoothly.
-- Keep your desktop clean. Make sure there is no offensive or/and distracting
-  background.
-
+-   Turn off notification to prevent any interference.
+-   Close all sensitive documents and unrelated programs before sharing the
+    screen. Email notifications are distracting!
+-   Test your presentation beforehand to make sure everything goes smoothly.
+-   Keep your computer background desktop clean. Make sure there are no offensive
+    or distracting visuals.
 
 ## Audio/Video quality recommendations
 
 While video conferencing has been a real boon to productivity there are still
-[lots of things that can go wrong] during a conference video call.
+[lots of things that can go wrong][] during a conference video call.
 
 There are some things that are just plain out of your control, but there are
 some things that you can control. Here are some tips if you're just getting into
@@ -160,81 +137,80 @@ remote meetings. Keep in mind that sometimes things just break. These are not
 hard rules, more of a set of loose guidelines on how to tip the odds in your
 favor.
 
-
 ### Recommended hardware to have
 
-- **A dedicated microphone** - This is the number one upgrade you can do. Sound
-  is one of those things that can immediately change the quality of your call.
-  If you plan on being here for the long haul, something like a [Blue Yeti] will
-  work great due to the simplicity of using USB audio and having a hardware
-  mute button. Consider a [pop filter] as well if necessary.
-- **A Video Camera** - A bad image can be worked around if the audio is good.
-  Certain models have noise cancelling dual-microphones, which are a great
-  backup for a dedicated microphone or if you are travelling.
-- **A decent set of headphones** - Personal preference, these cut down on the
-  audio feedback when in larger meetings.
+-   **A dedicated microphone** - This is the number one upgrade you can do.
+    Sound is one of those things that can immediately change the quality of
+    your call. If you plan on being here for the long haul, something like a
+    [Blue Yeti][] will work great due to the simplicity of using USB
+    audio and having a hardware mute button. Consider a [pop filter][]
+    as well if necessary.
+-   **A Video Camera** - A bad image can be worked around if the audio is good.
+    Certain models have noise canceling dual-microphones, which are a great
+    backup for a dedicated microphone or if you are traveling.
+-   **A decent set of headphones** - These cut down on the audio feedback when
+    in larger meetings.
 
 What about an integrated headset and microphone? This totally depends on the
 type. We recommend testing it with a friend or asking around for recommendations
 for which models work best.
 
-
 ### Hardware we don't recommend
 
-- **Earbuds**. Generally speaking they are not ideal, and while they might sound
-  fine to you when 50 people are on a call the ambient noise adds up. Some
-  people join with earbuds and it sounds excellent, others join and it sounds
-  terrible. Practicing with someone ahead of time can help you determine how
-  well your earbuds work.
+-   **Earbuds** - These are not ideal, and while they might sound fine to you,
+    when 50 people are on a call the ambient noise adds up. Some people join
+    with earbuds and it sounds excellent, others join and it sounds
+    terrible. Practicing with someone ahead of time can help you determine how
+    well your earbuds work.
 
 ### Pro-tips
 
-- [Join on muted audio and video] in order to prevent noise to those already in
-  a call.
-- If you don't have anything to say at that moment, **MUTE**. This is a common
-  problem. You can help out a teammate by mentioning it on Zoom chat or asking
-  them to mute on the call itself. The meeting co-host can help with muting
-  noisly attendees before it becomes too disruptive. Don't feel bad if this
-  happens to you, it's a common occurrence.
-- Try to find a quiet meeting place to join from; some coworking spaces and
-  coffee shops have a ton of ambient noise that won't be obvious to you but
-  will be to other people in the meeting. When presenting to large groups
-  consider delegating to another person who is in a quieter environment.
-- Using your computer's built in microphone and speakers might work in a pinch,
-  but in general won't work as well as a dedicated headset/microphone.
-- Consider using visual signals to agree to points so that you don't have to
-  mute/unmute often during a call. This can be an especially useful technique
-  when people are asking for lazy consensus. A simple thumbs up can go a long
-  way!
-- It is common for people to step on each other when there's an audio delay,
-  and both parties are trying to communicate something. Don't worry, just
-  remember to try and pause before speaking, or consider raising your hand
-  (if your video is on) to help the host determine who should speak first.
+-   [Join on muted audio and video][] in order to prevent noise to those
+    already in a call.
+-   If you don't have anything to say at that moment, **MUTE**. This is a common
+    problem. You can help out a teammate by mentioning it on Zoom chat or
+    asking them to mute on the call itself. The meeting co-host can help with
+    muting noisy attendees before it becomes too disruptive. Don't feel bad if
+    this happens to you, it's a common occurrence.
+-   Try to find a quiet meeting place to join from; some coworking spaces and
+    coffee shops have a ton of ambient noise that won't be obvious to you but
+    will be to other people in the meeting. When presenting to large groups
+    consider delegating to another person who is in a quieter environment.
+-   Using your computer's built-in microphone and speakers might work in a
+    pinch, but in general won't work as well as a dedicated
+    headset/microphone.
+-   Consider using visual signals to agree to points so that you don't have to
+    mute/unmute often during a call. This can be an especially useful
+    technique when people are asking for lazy consensus. A simple thumbs up
+    can go a long way!
+-   It is common for people to step on each other when there's an audio delay,
+    and both parties are trying to communicate something. Don't worry, just
+    remember to try and pause before speaking, or consider raising your hand
+    (if your video is on) to help the host determine who should speak first.
 
 Thanks for making Kubernetes meetings work great!
 
-
-[community meeting]: /events/community-meeting.md
-[SIG/WG meetings]: /sig-list.md
-[Office Hours]: /events/office-hours.md
-[Meet Our Contributors]: /mentoring/programs/meet-our-contributors.md
-[moderation]: ./moderation.md
-[zoom admins]: /communication/moderators.md#zoom
-[host key]: https://support.zoom.us/hc/en-us/articles/205172555-Host-Key
-[CNCF Service Desk]: https://github.com/cncf/servicedesk
-[Kubernetes Code of Conduct]: /code-of-conduct.md
-[code of conduct committee]: /committee-code-of-conduct/README.md
-[SIG Creation procedure]: /sig-wg-lifecycle.md#communicate
-[latest version]: https://zoom.us/download
-[documentation on how to use their moderation tools]: https://support.zoom.us/hc/en-us/articles/201362603-Host-Controls-in-a-Meeting
-[best practices doc]: https://docs.google.com/document/d/1fudC_diqhN2TdclGKnQ4Omu4mwom83kYbZ5uzVRI07w/edit?usp=sharing
-[Kubernetes channel]: https://www.youtube.com/c/kubernetescommunity
-[SIG Contributor Experience]: /sig-contributor-experience
-[Please follow this guideline for more details]: ./youtube/youtube-guidelines.md
-[centralized list of administrators]: ./moderators.md
-[documentation on how to use their screen sharing feature]: https://support.zoom.us/hc/en-us/articles/201362153-How-Do-I-Share-My-Screen
-[lots of things that can go wrong]: https://www.youtube.com/watch?v=JMOOG7rWTPg
-[Blue Yeti]: https://www.bluedesigns.com/products/yeti/
-[pop filter]: https://en.wikipedia.org/wiki/Pop_filter
-[Join on muted audio and video]: https://support.zoom.us/hc/en-us/articles/203024649-Video-Or-Microphone-Off-By-Attendee
-[waiting room]: https://support.zoom.us/hc/en-us/articles/115000332726-Waiting-Room
+  [community meeting]: /events/community-meeting
+  [SIG/WG meetings]: /sig-list.md
+  [Office Hours]: /events/office-hours
+  [Meet Our Contributors]: /mentoring/programs/meet-our-contributors.md
+  [Kubernetes code of conduct]: /code-of-conduct.md
+  [moderation]: ./moderation.md
+  [CNCF Service Desk]: https://github.com/cncf/servicedesk
+  [Zoom Admins]: ./moderators.md#zoom
+  [centralized list of administrators]: ./moderators.md
+  [sig creation procedure]: /sig-wg-lifecycle.md#communicate
+  [latest version]: https://zoom.us/download
+  [host key]: https://support.zoom.us/hc/en-us/articles/205172555-Host-Key
+  [waiting room]: https://support.zoom.us/hc/en-us/articles/115000332726-Waiting-Room
+  [documentation on how to use their moderation tools]: https://support.zoom.us/hc/en-us/articles/201362603-Host-Controls-in-a-Meeting
+  [best practices doc]: https://docs.google.com/document/d/1fudC_diqhN2TdclGKnQ4Omu4mwom83kYbZ5uzVRI07w/edit?usp=sharing
+  [Code of Conduct Committee]: /committee-code-of-conduct/README.md
+  [Please follow this guideline for more details]: ./youtube/youtube-guidelines.md
+  [Kubernetes channel]: https://www.youtube.com/c/kubernetescommunity
+  [SIG Contributor Experience]: /sig-contributor-experience
+  [documentation on how to use their screen sharing feature]: https://support.zoom.us/hc/en-us/articles/201362153-How-Do-I-Share-My-Screen
+  [lots of things that can go wrong]: https://www.youtube.com/watch?v=JMOOG7rWTPg
+  [Blue Yeti]: https://www.bluedesigns.com/products/yeti/
+  [pop filter]: https://en.wikipedia.org/wiki/Pop_filter
+  [Join on muted audio and video]: https://support.zoom.us/hc/en-us/articles/203024649-Video-Or-Microphone-Off-By-Attendee


### PR DESCRIPTION
Update the Zoom and Slack communication guides to match style guidelines. This also includes a few updates, grammar fixes, and modifications from the community.

Co-authored-by: Aaron Epperson <aaron@aaronepperson.com>

-------

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #