### PR TITLE
Repair broken link for first contributions

### DIFF
--- a/contributors/guide/first-contribution.md
+++ b/contributors/guide/first-contribution.md
@@ -30,7 +30,7 @@ Here are some things you can do today to get started contributing:
 * Help triage issues
 
 If the above suggestions don't appeal to you, you can browse the 
-[Community Issues] to see who is looking for help. Those interested 
+[issues labeled as a good first issue] to see who is looking for help. Those interested 
 in contributing without writing code can also find ideas in the 
 [Non-Code Contributions Guide].
 

--- a/contributors/guide/first-contribution.md
+++ b/contributors/guide/first-contribution.md
@@ -127,7 +127,7 @@ subrepository. For example, a documentation issue should be opened in
 [kubernetes/website]. Make sure to adhere to the prompted submission guidelines 
 while opening an issue. Check the [issue triage guide] for more information.
 
-[Community Issues]: https://github.com/kubernetes/community/issues
+[issues labeled as a good first issue]: https://go.k8s.io/good-first-issue
 [k8s-ci-robot]: https://github.com/k8s-ci-robot
 [Non-Code Contributions Guide]: ./non-code-contributions.md
 [multiple repositories]: https://github.com/kubernetes/

--- a/contributors/guide/first-contribution.md
+++ b/contributors/guide/first-contribution.md
@@ -30,7 +30,7 @@ Here are some things you can do today to get started contributing:
 * Help triage issues
 
 If the above suggestions don't appeal to you, you can browse the 
-[Contributor Role Board] to see who is looking for help. Those interested 
+[Community Issues] to see who is looking for help. Those interested 
 in contributing without writing code can also find ideas in the 
 [Non-Code Contributions Guide].
 
@@ -127,7 +127,7 @@ subrepository. For example, a documentation issue should be opened in
 [kubernetes/website]. Make sure to adhere to the prompted submission guidelines 
 while opening an issue. Check the [issue triage guide] for more information.
 
-[Contributor Role Board]: https://discuss.kubernetes.io/c/contributors/role-board
+[Community Issues]: https://github.com/kubernetes/community/issues
 [k8s-ci-robot]: https://github.com/k8s-ci-robot
 [Non-Code Contributions Guide]: ./non-code-contributions.md
 [multiple repositories]: https://github.com/kubernetes/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

The link to "Contributor Role Board" in the https://www.kubernetes.dev/docs/guide/first-contribution/ page is broken.  The PR updates it to the good first issue link.

Fixes #6493

