### PR TITLE
Add licensing guidance to the org owners guidance

### DIFF
--- a/github-management/org-owners-guide.md
+++ b/github-management/org-owners-guide.md
@@ -47,6 +47,21 @@ code in.
 It is easier to start new code in a Kubernetes organization than it is to
 transfer in existing code.
 
+## Licensing Guidance
+
+Section 11 of the [CNCF Charter] provides guidance on how to license code and
+documentation owned by the CNCF projects. However, it doesn't explicitly cover
+situations where a repo may have mixed content (such as repos that contain both
+code and documentation living alongside each other).
+
+For clarity, here is the guidance for Kubernetes GitHub organizations:
+- If a repo contains only code, it should be licensed under the
+  [Apache License, Version 2.0].
+- If a repo contains only documentation, it should be licensed under the
+  [Creative Commons Attribution 4.0 International License].
+- If a repo contains both code and documentation, it should be licensed under
+  the [Apache License, Version 2.0].
+
 ## Team Guidance
 
 ### Nomenclature
@@ -230,3 +245,6 @@ https://help.github.com/articles/archiving-a-github-repository/
 [kubernetes-template-project]: https://github.com/kubernetes/kubernetes-template-project
 [SIG Repository]: /github-management/kubernetes-repositories.md##sig-repositories
 [template repo]: https://help.github.com/en/articles/creating-a-repository-from-a-template
+[CNCF Charter]: https://github.com/cncf/foundation/blob/main/charter.md
+[Apache License, Version 2.0]: https://www.apache.org/licenses/LICENSE-2.0
+[Creative Commons Attribution 4.0 International License]: https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
This adds specific guidance to the org owners guide on how to licence mixed context repos under Kubernetes organizations.