### PR TITLE
sig-release: add release-team-shadow-stats repo

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -100,6 +100,7 @@ The Release Engineering subproject is responsible for the [process/procedures](h
 ### Release Team
 The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
 - **Owners:**
+  - [kubernetes-sigs/release-team-shadow-stats](https://github.com/kubernetes-sigs/release-team-shadow-stats/blob/main/OWNERS)
   - [kubernetes/sig-release/release-team](https://github.com/kubernetes/sig-release/blob/master/release-team/OWNERS)
 - **Contact:**
   - [Mailing List](https://groups.google.com/a/kubernetes.io/g/release-team)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2122,6 +2122,7 @@ sigs:
       - name: release-team-leads
         description: Release Team Leads for the current Kubernetes release cycle
     owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/release-team-shadow-stats/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
   - name: SIG Release Process Documentation
     description: |


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/3259

/assign @saschagrunert 
cc @leonardpahlke 

/hold
need lgtm from at least one sig release lead