### PR TITLE
sig-node: add ci-testing subproject

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -53,6 +53,13 @@ The following [working groups][working-group-definition] are sponsored by sig-no
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-node:
+### ci-testing
+- **Owners:**
+  - [kubernetes/kubernetes/test/e2e_node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/OWNERS)
+  - [kubernetes/test-infra/config/jobs/kubernetes/sig-node](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/OWNERS)
+  - [kubernetes/test-infra/jobs/e2e_node](https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/OWNERS)
+- **Contact:**
+  - [Mailing List](https://groups.google.com/g/kubernetes-sig-node-test-failures)
 ### cri-api
 - **Owners:**
   - [kubernetes/cri-api](https://github.com/kubernetes/cri-api/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1975,6 +1975,13 @@ sigs:
       github: tpepper
       name: Tim Pepper
   subprojects:
+  - name: ci-testing
+    contact:
+      mailing_list: https://groups.google.com/g/kubernetes-sig-node-test-failures
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e_node/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-node/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/OWNERS
   - name: cri-api
     owners:
     - https://raw.githubusercontent.com/kubernetes/cri-api/master/OWNERS


### PR DESCRIPTION
While drafting the sig annual report I noticed that we were missing documentation for the ci-testing subproject that originated in [May 2020](https://kubernetes.io/blog/2022/02/16/sig-node-ci-subproject-celebrates/).

This adds them to sigs.yaml and regenerates the node readme. I think this should be a representative example of the code that is nominally owned by the subproject.

/cc @ehashman @SergeyKanzhelev 
(as the subproject leads)
/cc @derekwaynecarr
(as a sig-node lead)