### PR TITLE
Add sig-security-assessments sub-project

### DIFF
--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -38,6 +38,12 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-security:
+### security-assessments
+Security focussed Assessments of Kubernetes Sub-projects
+- **Owners:**
+  - [kubernetes/sig-security/sig-security-assessments](https://github.com/kubernetes/sig-security/blob/main/sig-security-assessments/OWNERS)
+- **Contact:**
+  - Slack: [#sig-security-assess-capi](https://kubernetes.slack.com/messages/sig-security-assess-capi)
 ### security-audit
 Third Party Security Audit
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2343,6 +2343,12 @@ sigs:
       github: parispittman
       name: Paris Pittman
   subprojects:
+  - name: security-assessments
+    description: Security focussed Assessments of Kubernetes Sub-projects
+    contact:
+      slack: sig-security-assess-capi
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/sig-security/main/sig-security-assessments/OWNERS
   - name: security-audit
     description: Third Party Security Audit
     owners:


### PR DESCRIPTION
Sub-project has now been identified: https://github.com/kubernetes/sig-security/pull/48
