### PR TITLE
Add a new `sro` channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -403,6 +403,7 @@ channels:
   - name: spark-operator
   - name: spinnaker
   - name: sre
+  - name: sro
   - name: steering-committee
   - name: submariner
   - name: surveys


### PR DESCRIPTION
This PR adds a new `#sro` channel for the [Special Resource Operator](https://github.com/kubernetes-sigs/special-resource-operator).
This was requested by multiple members at [SRO's community meeking](https://docs.google.com/document/d/1b-wFATh2A0Pm1P3k11lniSeRP4q74rUa1fTvmk_ZdWY/edit#).