### PR TITLE
Add rukpak-dev channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -345,6 +345,7 @@ channels:
   - name: reddit-mods
   - name: rktnetes
   - name: ro-users
+  - name: rukpak-dev
   - name: ru-users
   - name: scaleway-k8s
   - name: schemahero


### PR DESCRIPTION
This PR adds new Kubernetes Slack channel: rukpak-dev

[RukPak](https://github.com/operator-framework/rukpak) is a new project under the CNCF Operator Framework project and already has contributors from the community.

We want to encourage the community to participate more in the development of rukpak, so we would like to move our communication to open slack channels.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>