### PR TITLE
Add CAPI Oracle Cloud Infrastructure (OCI) slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -56,6 +56,7 @@ channels:
   - name: cluster-api-kubemark
   - name: cluster-api-kubevirt
   - name: cluster-api-nested
+  - name: cluster-api-oci
   - name: cluster-api-openstack
   - name: cluster-api-operator
   - name: cluster-api-packet


### PR DESCRIPTION
This PR adds a slack channel for Cluster API Oracle Cloud Infrastructure (OCI) provider https://github.com/oracle/cluster-api-provider-oci


**Which issue(s) this PR fixes**:
No open issues related to this PR
