### PR TITLE
Removing Matt Broberg from ContribComms

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -32,7 +32,6 @@ usergroups:
       - Debanitrkl
       - Jason
       - kaslin
-      - mbbroberg
       - paris
       - PurneswarPrasad
       - rajula96reddy


### PR DESCRIPTION
Removing Matt Broberg from the contributor comms slack group, as he has stepped away from the group for now.
