### PR TITLE
Fix identifier link in api-conventions.md

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -111,7 +111,7 @@ its sole use. When choosing a group name, we recommend selecting a subdomain
 your group or organization owns, such as "widget.mycompany.com".
 
 Version strings should match
-[DNS_LABEL](https://git.k8s.io/design-proposals-archive/architecture/identifiers.md)
+[DNS_LABEL](https://github.com/kubernetes/design-proposals-archive/blob/main/architecture/identifiers.md)
 format.
 
 


### PR DESCRIPTION
* Fixes a broken link in the API conventions documentation following past archival

/sig architecture

Fixes #6566
