### PR TITLE
Add Zarf slack channels: #zarf and #zarf-dev

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -471,3 +471,5 @@ channels:
   - name: windows-containerd
   - name: workshop-chat
   - name: yaml-overlay-tool
+  - name: zarf
+  - name: zarf-dev


### PR DESCRIPTION
Zarf is open-source air gap software delivery tool that focuses on enabling declarative deployments for various K8s distros in air-gapped and limited-connectivity environments.  I am requesting a channel for user support (zarf) and a dev channel (zarf-dev) for open-source collaboration.

Git repo: https://github.com/defenseunicorns/zarf/
Related Zarf Issue: https://github.com/defenseunicorns/zarf/issues/424