### PR TITLE
how to get rid of invalid-commit-message label.

### DIFF
--- a/contributors/guide/pull-requests.md
+++ b/contributors/guide/pull-requests.md
@@ -466,6 +466,14 @@ will continually do so each time the PR is updated.
 
 
 <!-- omit in toc -->
+#### Update a PR with `do-not-merge/invalid-commit-message` label.
+
+If you accidentally used `closes #NNNN` or @-mention, you need to rewrite the git history
+of your branch to remove the `do-not-merge/invalid-commit-message` label. 
+See [Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
+
+
+<!-- omit in toc -->
 ### Use the commit message body to explain the _what_ and _why_ of the commit
 
 Commits and their commit messages are the _"permanent record"_ of the changes


### PR DESCRIPTION
Relates: https://github.com/kubernetes/community/issues/6576

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

