### PR TITLE
Add Nabarun and Arnaud to GitHub Admin Team

### DIFF
--- a/github-management/OWNERS
+++ b/github-management/OWNERS
@@ -2,13 +2,13 @@
 
 approvers:
   - cblecker
-  - spiffxp
-
-reviewers:
-  - fejta
-  - idvoretskyi
   - mrbobbytables
   - nikhita
+
+reviewers:
+  - ameukam
+  - idvoretskyi
+  - palnabarun
 
 labels:
   - sig/contributor-experience

--- a/github-management/README.md
+++ b/github-management/README.md
@@ -27,10 +27,10 @@ we have a GitHub Administration team that is responsible for carrying out the
 various tasks.
 
 This team (**[@kubernetes/owners](https://github.com/orgs/kubernetes/teams/owners)**) is as follows:
-* Aaron Crickenberger (**[@spiffxp](https://github.com/spiffxp)**, US Pacific)
+* Arnaud Meukam (**[@ameukam](https://github.com/ameukam)**, Central European Time)
 * Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**, US Eastern)
 * Christoph Blecker (**[@cblecker](https://github.com/cblecker)**, CA Pacific)
-* Erick Fejta (**[@fejta](https://github.com/fejta)**, US Pacific)
+* Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**, Indian Standard Time)
 * Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**, Indian Standard Time)
 * Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**, UA Eastern European)
 


### PR DESCRIPTION
Ref: [sig contribex thread](https://groups.google.com/g/kubernetes-sig-contribex/c/O26DCoCdMYQ/m/GwkkzX-2AQAJ) for the nomination.

Lazy consensus achieved.

/hold

/committee steering
/cc @kubernetes/steering-committee 
need majority of steering committee to lgtm this change

/assign @cblecker @mrbobbytables 
currently active gh admins (Ihor is temporarily unavailable)
Can you also +1 here?

/assign @palnabarun @ameukam 
Can you confirm that you are interested in joining the GitHub Admin Team and accept the security embargo policy?
