### PR TITLE
Removes vagrant reference in running-locally doc

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -156,7 +156,7 @@ change the service-cluster-ip-range flag to something else.
 
 ### I cannot create a replication controller with replica size greater than 1!  What gives?
 
-You are running a single node setup.  This has the limitation of only supporting a single replica of a given pod.  If you are interested in running with larger replica sizes, we encourage you to try the local vagrant setup or one of the cloud providers.
+You are running a single node setup.  This has the limitation of only supporting a single replica of a given pod.  If you are interested in running with larger replica sizes, we encourage you to try Kind or one of the cloud providers.
 
 ### I changed Kubernetes code, how do I run it?
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

As referenced in #4497, Vagrant is no longer supported, so this removes the reference to Vagrant in the `running-locally.md` doc and replaces it with Kind (as suggested in the referenced PR).

