### PR TITLE
sig-node: add content to annual-report-2021

### DIFF
--- a/sig-node/annual-report-2021.md
+++ b/sig-node/annual-report-2021.md
@@ -4,14 +4,14 @@
 
 1. What work did the SIG do this year that should be highlighted?
 
-   -
-   -
+   - The CI testing subgroup crossed its two year threshold and managed to bring stability to the Kubelet Serial tests (and majority of other suites).
+   - Deprecation of Dockershim
    -
 
 2. What initiatives are you working on that aren't being tracked in KEPs?
 
-   -
-   -
+   - CI/Testability improvements
+   - Overall testability and stability improvements
    -
 
 3. KEP work in 2021 (1.x, 1.y, 1.z):
@@ -21,6 +21,8 @@ In future, this will be generated from kubernetes/enhancements kep.yaml files
 1. with SIG as owning-sig or in participating-sigs
 2. listing 1.x, 1.y, or 1.z in milestones or in latest-milestone
 -->
+
+**TODO** (help-wanted, if anyone can generate these before I get to it)
 
    - Stable
      - [$kep-number - $title](https://git.k8s.io/community/$link/README.md) - $milestone.stable
@@ -39,96 +41,101 @@ In future, this will be generated from kubernetes/enhancements kep.yaml files
 1. What areas and/or subprojects does your group need the most help with?
    Any areas with 2 or fewer OWNERs? (link to more details)
 
-   -
-   -
-   -
+   - **TODO** Feedback wanted
 
 2. What metrics/community health stats does your group care about and/or measure?
 
-   -
-   -
-   -
+   - Incoming vs Completed PRs get a readout during every community meeting with
+     approximated tracking of trends.
 
 3. Does your [CONTRIBUTING.md] help **new** contributors engage with your group specifically by pointing
    to activities or programs that provide useful context or allow easy participation?
 
-   -
+   - The Node CONTRIBUTING.md has some useful documentation for new contributors, such
+     as the [Getting Started](https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#getting-started)
+     section. We need to make some improvements to talk about how we work and provide
+     more guidance. That work is tracked in [kubernetes/community/6611](https://github.com/kubernetes/community/issues/6611). 
 
 4. If your group has special training, requirements for reviewers/approvers, or processes beyond the general [contributor guide],
    does your [CONTRIBUTING.md] document those to help **existing** contributors grow throughout the [contributor ladder]?
 
-   -
+   - We have additional requirements that are not currently documented publicly.
+     The work to move those to community documentation is tracked in [kubernetes/community/6612](https://github.com/kubernetes/community/issues/6612).
 
 5. Does the group have contributors from multiple companies/affiliations?
 
-   -
+   - We have contributors from a wide range of companies including Google,
+     RedHat, VMware, Intel, and Nvidia. Sig Leads are from Google and RedHat.
 
 6. Are there ways end users/companies can contribute that they currently are not?
    If one of those ways is more full time support, what would they work on and why?
 
-   -
-   -
+   - sig-node today struggles to accept new features or changes in a way that
+     allows us to ship with confidence. The sig needs contributors to help pay
+     down technical debt in tests, test infrastucture, and overall
+     maintainability of the codebase.
+   - If a full time maintainer joined the sig, there would be an array of
+     projects that in practice take full time commitment to do well:
+       - Ensuring that test-grid is green and following up when tests fail or
+         flakiness changes.
+       - Paying down technical debt throughout the kubelet through adding or
+         improving tests, and aiding with refactors and rewrites.
+       - Introducing new forms of testing to find and fix latent bugs in the
+         kubelet and improving our confidence in changes.
 
 ## Membership
 
-- Primary slack channel member count:
-- Primary mailing list member count:
-- Primary meeting attendee count (estimated, if needed):
-- Primary meeting participant count (estimated, if needed):
-- Unique reviewers for SIG-owned packages: <!-- in future, this will be generated from OWNERS files referenced from subprojects, expanded with OWNERS_ALIASES files -->
-- Unique approvers for SIG-owned packages: <!-- in future, this will be generated from OWNERS files referenced from subprojects, expanded with OWNERS_ALIASES files -->
+- Primary slack channel member count: 3141
+- Primary mailing list member count: 725
+- Primary meeting attendee count (estimated, if needed): ~15-30
+- Primary meeting participant count (estimated, if needed): ~10
+- Unique reviewers for SIG-owned packages: 
+- Unique approvers for SIG-owned packages: 7 top level approvers
 
 Include any other ways you measure group membership
 
 ## Subprojects
 
-<!--
-In future, this will be generated from delta of sigs.yaml from $YYYY-01-01 to $YYYY-12-31
-Manually visible via `git diff HEAD@{$YYYY-01-01} HEAD@{$YYYY-12-31} -- $sig-id/README.md`
--->
+New in 2021: None
 
-New in $YYYY:
-- [$subproject-name](https://git.k8s.io/community/$sig-id#$subproject-name)
--
-
-Retired in $YYYY:
-- [$subproject-name](https://git.k8s.io/community/$sig-id#$subproject-name)
--
+Retired in 2021: None
 
 Continuing:
-- [$subproject-name](https://git.k8s.io/community/$sig-id#$subproject-name)
+
+- [cri-api](https://git.k8s.io/community/sig-node#cri-api)
+- [cri-tools](https://git.k8s.io/community/sig-node#cri-tools)
+- [ci-testing](https://git.k8s.io/community/sig-node#ci-testing)
+- [kubelet](https://git.k8s.io/community/sig-node#kubelet)
+- [node-api](https://git.k8s.io/community/sig-node#node-api)
+- [node-feature-discovery](https://git.k8s.io/community/sig-node#node-feature-discovery)
+- [node-problem-detector](https://git.k8s.io/community/sig-node#node-problem-detector)
 -
+[noderesourcetopology-api](https://git.k8s.io/community/sig-node#$noderesourcetopology-api)
+- [security-profiles-operator](https://git.k8s.io/community/sig-node#security-profiles-operator)
 
 ## Working groups
 
-<!--
-In future, this will be generated from delta of sigs.yaml from $YYYY-01-01 to $YYYY-12-31
-Manually visible via `git diff HEAD@{$YYYY-01-01} HEAD@{$YYYY-12-31} -- $sig-id/README.md`
--->
+New in 2021:
+- [wg-policy](https://git.k8s.io/community/wg-policy/) ([2021 report](https://git.k8s.io/community/wg-policy/annual-report-2021.md))
+- [wg-structured-logging](https://git.k8s.io/community/wg-structured-logging/) ([2021 report](https://git.k8s.io/community/wg-structured-logging/annual-report-2021.md))
 
-New in $YYYY:
-- [$wg-name](https://git.k8s.io/community/$wg-id/) ([$YYYY report](https://git.k8s.io/community/$wg-id/annual-report-$YYYY.md))
--
-
-Retired in $YYYY:
-- [$wg-name](https://git.k8s.io/community/$wg-id/) ([$YYYY report](https://git.k8s.io/community/$wg-id/annual-report-$YYYY.md))
--
+Retired in 2021: None
 
 Continuing:
-- [$wg-name](https://git.k8s.io/community/$wg-id/) ([$YYYY report](https://git.k8s.io/community/$wg-id/annual-report-$YYYY.md))
+- [wg-multitenancy](https://git.k8s.io/community/wg-multitenancy/) ([2021 report](https://git.k8s.io/community/wg-multitenancy/annual-report-2021.md))
 -
 
 ## Operational
 
 Operational tasks in [sig-governance.md]:
 
-- [ ] [README.md] reviewed for accuracy and updated if needed
-- [ ] [CONTRIBUTING.md] reviewed for accuracy and updated if needed
+- [x] [README.md] reviewed for accuracy and updated if needed
+- [x] [CONTRIBUTING.md] reviewed for accuracy and updated if needed
       (or created if missing and your contributor steps and experience are different or more
       in-depth than the documentation listed in the general [contributor guide] and [devel] folder.)
-- [ ] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
-- [ ] SIG leaders (chairs, tech leads, and subproject owners) in [sigs.yaml] are accurate and active, and updated if needed
-- [ ] Meeting notes and recordings for 2021 are linked from [README.md] and updated/uploaded if needed
+- [x] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
+- [x] SIG leaders (chairs, tech leads, and subproject owners) in [sigs.yaml] are accurate and active, and updated if needed
+- [x] Meeting notes and recordings for 2021 are linked from [README.md] and updated/uploaded if needed
 - [ ] Did you have community-wide updates in 2021 (e.g. community meetings, kubecon, or kubernetes-dev@ emails)? Links to email, slides, or recordings:
       -
       -


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #6376 

Related PRs: https://github.com/kubernetes/community/pull/6510

Related Issues: #6611 #6612 

/sig node
/kind documentation

AI: Identify other areas of the sig to highlight:
/assign @SergeyKanzhelev

Sig Leads:
/assign @dchen1107 @derekwaynecarr 