### PR TITLE
Fix Indenting of Note for API Conventions Doc

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -128,7 +128,7 @@ lists should support filtering by fields (see
 
    Examples: `PodList`, `ServiceList`, `NodeList`.
 
-Note that`kubectl` and other tools sometimes output collections of resources
+   Note that`kubectl` and other tools sometimes output collections of resources
 as `kind: List`. Keep in mind that `kind: List` is not part of the Kubernetes API; it is
 exposing an implementation detail from client-side code in those tools, used to
 handle groups of mixed resources.


### PR DESCRIPTION
The indenting of the note was off making it hard to see what the note was associated with, and also making it harder to discover point 3 in the list.