### PR TITLE
Fix the link to scalability tests

### DIFF
--- a/sig-scalability/charter.md
+++ b/sig-scalability/charter.md
@@ -28,7 +28,7 @@ Kubernetes.
   - [Cluster loader](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2)
   - [Kubemark](https://github.com/kubernetes/kubernetes/tree/master/cmd/kubemark)
 - Scalability and performance tests:
-  - [Tests](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/scalability/)
+  - [Tests](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2/testing/)
   - [Jobs running those](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/sig-scalability)
 
 #### Cross-cutting and Externally Facing Processes


### PR DESCRIPTION
Fixes #6646

The test has been removed in https://github.com/kubernetes/kubernetes/pull/83322. The link here is taken from that PR.
Also, the OWNERS file link (kubernetes/kubernetes/test/e2e/scalability) is broken: https://github.com/kubernetes/community/tree/master/sig-scalability#subprojects
I'd like to update this too, is https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/OWNERS a new one?