### PR TITLE
Update Go version to 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-IMAGE_NAME=golang:1.12
-export GO111MODULE=on
+IMAGE_NAME=golang:1.18
 export GOPROXY?=https://proxy.golang.org
 
 default: \
@@ -12,7 +11,7 @@ generate:
 	go run ./generator/app.go
 
 generate-dockerized:
-	docker run --rm -e WHAT -e GO111MODULE -e GOPROXY -v $(shell pwd):/go/src/app:Z $(IMAGE_NAME) make -C /go/src/app generate
+	docker run --rm -e WHAT -e GOPROXY -v $(shell pwd):/go/src/app:Z $(IMAGE_NAME) make -C /go/src/app generate
 
 verify:
 	@hack/verify.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/community
 
-go 1.15
+go 1.18
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
`GO111MODULE` isn't required to set anymore and this might fix this issue: https://github.com/kubernetes/test-infra/blob/f7e21a3c18f4f4bbc7ee170675ed53e4544a0632/config/jobs/kubernetes/community/community-presubmit.yaml#L14-L15