### PR TITLE
Add Streaming Runtime channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -409,13 +409,13 @@ channels:
   - name: spinnaker
   - name: sre
   - name: steering-committee
-  - name: streaming-runtime
   - name: submariner
   - name: surveys
   - name: summit-staff
   - name: suse-caasp
   - name: talk-proposals
   - name: tanzu-community-edition
+  - name: tanzu-streaming-runtimes
   - name: terraform-providers
   - name: test-failures
   - name: tilt

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -409,6 +409,7 @@ channels:
   - name: spinnaker
   - name: sre
   - name: steering-committee
+  - name: streaming-runtime
   - name: submariner
   - name: surveys
   - name: summit-staff


### PR DESCRIPTION
Hi admins, 

I am working on a Streaming Runtime on top of Kubernetes. I would like to create a space (slack channel) where people can ask questions and involve themselves in this project. 

Git Repo: https://github.com/vmware-tanzu/streaming-runtimes
Docs: https://vmware-tanzu.github.io/streaming-runtimes/

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
