### PR TITLE
Adding new release version 1.24 and associated go version 1.18

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -284,7 +284,8 @@ different versions of Kubernetes.
 | 1.17 - 1.18    | 1.13.15     |
 | 1.19 - 1.20    | 1.15.5      |
 | 1.21 - 1.22    | 1.16.7      |
-| 1.23+          | 1.17        |
+| 1.23           | 1.17        |
+| 1.24+          | 1.18        |
 
 ##### A Note on Changing Go Versions
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

This change updates to the new go version for Kubernetes 1.24 as it has been updated to 1.18.
