### PR TITLE
Add terranetes channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -416,6 +416,7 @@ channels:
   - name: talk-proposals
   - name: tanzu-community-edition
   - name: terraform-providers
+  - name: terranetes
   - name: test-failures
   - name: tilt
   - name: tn-users


### PR DESCRIPTION
Terranetes enables application developers to self-serve cloud resources with minimal user input using Helm packages. You can either choose from our list of packages available on [artifacthub.io](https://artifacthub.io/packages/search?ts_query_web=appvia) or adopt our pattern and use [tf2helm](https://github.com/appvia/tf2helm) to build out your own packages. The solution leverages [Terraform](https://www.terraform.io/) and [Helm](https://helm.sh/) to create a Kubernetes Custom Resource Definition (CRD) Object watched and understood by a [terraform controller](https://github.com/appvia/terraform-controller) which then triggers a workflow that applies a referenced Terraform module.

Kubernetes / Community Projects:
-  [terraform controller](https://github.com/appvia/terraform-controller)
- [tf2helm](https://github.com/appvia/tf2helm)