### PR TITLE
slack config: add Capsule channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -27,6 +27,7 @@ channels:
     archived: true
   - name: brigade
   - name: camptocamp-devops-stack
+  - name: capsule
   - name: cartographer
   - name: cdk
   - name: cert-manager


### PR DESCRIPTION
Hi, I'd like to propose a Slack channel for [Capsule](https://capsule.clastix.io/docs/).

Capsule implements a multi-tenant and policy-based environment in your Kubernetes cluster. It is designed as a micro-services-based ecosystem with the minimalist approach, leveraging only on upstream Kubernetes.
Currently is the soft multi-tenancy solution that [Clastix](https://clastix.io/) provides.

- [Capsule](https://github.com/clastix/capsule/)
- [Capsule Community](https://github.com/clastix/capsule-community)

We would like to make growing the community on the Kubernetes workspace, in order to make it easier the access to the cloud native community and be present also for other cloud native projects, on the same workspace.

For example we contributed to other cloud native proejcts like Kubespray and Falco.

Thank you!