### PR TITLE
slack config: add Kamaji channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -169,6 +169,7 @@ channels:
   - name: k8s-release
     archived: true
   - name: k8spin
+  - name: kamaji
   - name: kapitan
   - name: kcp-prototype
   - name: keda


### PR DESCRIPTION
Hi, I'd like to propose a Slack channel for [Kamaji](https://github.com/clastix/kamaji).

Kamaji is a tool aimed to build and operate a Managed Kubernetes Service with a fraction of the operational burden. With Kamaji, you can deploy and operate hundreds of Kubernetes clusters as a hyper-scale cloud provider.

- [Kamaji](https://github.com/clastix/kamaji)

Currently is the solution for hard multi-tenancy provided by [Clastix](https://clastix.io).

We are working to create a community around it as the project is in the development stage. It has been released just 6 days ago.
At the same time we would like to share solutions and get feedbacks from the cloud native community, so I think that the Kubernetes workspace would be the right one. 