### PR TITLE
Add evented-pleg Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -98,6 +98,7 @@ channels:
   - name: es-users
   - name: etcd
   - name: etcdadm
+  - name: evented-pleg
   - name: events
   - name: external-dns
   - name: external-secrets


### PR DESCRIPTION
Adding a new channel for communication around sig node's project Evented PLEG. 

See [Evented PLEG doc](https://docs.google.com/document/d/1GfWDoKAYiaXApxayXmPl9bcK5ewyiimFDJ966r28TUE/edit#).
