### PR TITLE
Write generate errors to stderr

### DIFF
--- a/generator/app.go
+++ b/generator/app.go
@@ -702,7 +702,7 @@ func main() {
 	errs := ctx.Validate()
 	if len(errs) != 0 {
 		for _, err := range errs {
-			fmt.Printf("ERROR: %s\n", err.Error())
+			fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

the verify job redirects stdout to /dev/null:

https://github.com/kubernetes/community/blob/d8990155422b34cd1354be6074110e4c0bd74c16/hack/verify-generated-docs.sh#L33-L34

that means a validation error encountered (e.g. https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/community/6598/pull-community-verify/1529966618602377216) was printed to stdout, so it was invisible