### PR TITLE
Remove `LappleApple` from SIG Release user group

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -57,7 +57,6 @@ usergroups:
       - jeremyrickard # SIG Release Technical Lead / 1.23 Release Team EA
       - Jesse Butler # 1.24 Release Team Lead Shadow
       - justaugustus # SIG Release Chair
-      - LappleApple # SIG Release Program Manager
       - mkorbi # 1.24 Release Team Lead Shadow
       - puerco # SIG Release Technical Lead
       - saschagrunert # SIG Release Chair
@@ -77,7 +76,6 @@ usergroups:
       - cpanato # SIG Release Technical Lead
       - jeremyrickard # SIG Release Technical Lead
       - justaugustus # SIG Release Chair
-      - LappleApple # SIG Release Program Manager
       - puerco # SIG Release Technical Lead
       - saschagrunert # SIG Release Chair
 


### PR DESCRIPTION
Lauri has stepped back from SIG Release some time ago. This cleanup should reflect the current state of the SIG. :sob: 

cc @kubernetes/sig-release-leads 

Refers to https://github.com/kubernetes/org/pull/3450, https://github.com/kubernetes/k8s.io/pull/3789