### PR TITLE
group-mentee-guide broken link fix

### DIFF
--- a/mentoring/programs/group-mentee-guide.md
+++ b/mentoring/programs/group-mentee-guide.md
@@ -85,4 +85,4 @@ guidance as a founding member of this program!
 [community membership requirements doc]: /community-membership.md
 [SIG List]: /sig-list.md
 [Code Review Expectations]: /contributors/guide/expectations.md
-[Collaboration on k8s]: /contributors/guide/collab.md
+[Collaboration on k8s]: /contributors/guide/contributing.md


### PR DESCRIPTION
Signed-off-by: AugustasV <reg1nt1z@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes broken url in group-mentee-guide.md file
