### PR TITLE
updated homebrew path (macos SIP compatible) and jq install

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -155,14 +155,14 @@ system. [Follow these directions to install the tools](https://ryanparman.com/po
 In particular, this command installs the necessary packages:
 
 ```sh
-brew install coreutils ed findutils gawk gnu-sed gnu-tar grep make
+brew install coreutils ed findutils gawk gnu-sed gnu-tar grep make jq
 ```
 
 You will want to include this block or something similar at the end of
 your `.bashrc` or shell init script:
 
 ```sh
-GNUBINS="$(find /usr/local/opt -type d -follow -name gnubin -print)"
+GNUBINS="$(find /opt/homebrew/opt -type d -follow -name gnubin -print)"
 
 for bindir in ${GNUBINS[@]}
 do


### PR DESCRIPTION
the patch in this PR updates the installation instructions to install jq at the same time as the batch homebrew installations occur, as well as update the homebrew install location in the find command suggested for bashrc / zshrc addition to a modern install location that takes macos SIP filesystem restrictions into consideration.