### PR TITLE
Retire sig-service-catalog slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -400,6 +400,7 @@ channels:
   - name: sig-scheduling
   # sig-security* channels are defined in sig-security/
   - name: sig-service-catalog
+    archived: true
   # sig-testing channels are defined in sig-testing/
   - name: sig-ui
   - name: sig-usability


### PR DESCRIPTION
SIG Service Catalog has been retired, and all projects archived.

Moving ahead to archive the channel 👍 

