### PR TITLE
rename cdk -> canonical-kubernetes

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -27,9 +27,10 @@ channels:
     archived: true
   - name: brigade
   - name: camptocamp-devops-stack
+  - name: canonical-kubernetes
+    id: CG1V2CAMB
   - name: capsule
   - name: cartographer
-  - name: cdk
   - name: cert-manager
   - name: cert-manager-aws-privateca-issuer
   - name: cert-manager-dev


### PR DESCRIPTION
Canonical Distribution of Kubernetes (cdk) has evolved to include both MicroK8s and Charmed Kubernetes. I'd like to rename this channel so it's more obvious that we're supporting all Canonical k8s offerings here.