### PR TITLE
Remove subproject creation exception

### DIFF
--- a/sig-api-machinery/charter.md
+++ b/sig-api-machinery/charter.md
@@ -49,23 +49,6 @@ Technical leads seeded by legacy SIG chairs from existing subproject owners
 
 N/A
 
-### Deviations from [sig-governance]
-
-#### Sub-project Repo Creation
-
-The following individuals may approve kubernetes-sigs repo creation requests to be owned by any api-machinery
-sub-projects:
-
-- @cheftako
-- @sttts
-
-The following individuals may approve kubernetes-sigs repo creation requests to be owned by specific api-machinery
-sub-projects:
-
-- server-sdk
-  - @pwittrock
-
-
 ### Subproject Creation
 
 SIG delegates subproject approval to Technical Leads. See [Subproject creation - Option 1.]


### PR DESCRIPTION
AFAIK there is no longer a need to create subprojects at a rate that would burden the TLs, and since several of the people listed have switched focus, I think we should remove this section all together.

/assign @fedebongio @deads2k 

cc @cheftako @pwittrock @sttts in case one of you disagrees. (I'm happy to put this clause back in the future if it becomes necessary again)
