### PR TITLE
Add #kubewarden-dev slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -249,6 +249,7 @@ channels:
   - name: kubespray-dev
   - name: kubevirt-dev
   - name: kubewarden
+  - name: kubewarden-dev
   - name: kubicorn
   - name: kudo
   - name: kurl


### PR DESCRIPTION
The Kubewarden team would like to move all the development discussions
to the Kubernetes slack instance so that the whole community can
participate while keeping the user focused discussions into the
`#kubewarden` channel.

Website: https://kubewarden.io
