### PR TITLE
Add TestGrid channel under sig-testing

### DIFF
--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -56,6 +56,7 @@ restrictions:
       - "^sig-testing"
       - "^kind"
       - "^prow"
+      - "^testgrid"
       - "^testing"
     usergroups:
       - "^test-infra-oncall$"

--- a/communication/slack-config/sig-testing/config.yaml
+++ b/communication/slack-config/sig-testing/config.yaml
@@ -3,6 +3,7 @@ channels:
   - name: prow
   - name: prow-alerts
   - name: sig-testing
+  - name: testgrid
   - name: testing-commons
     archived: true
   - name: testing-ops


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Adds a "TestGrid" channel for users and developers of our test visualization system, https://testgrid.k8s.io/

TestGrid is being continuously developed, and having an open, central place to discuss features, make announcements, and collaborate would be ideal. The general "sig-testing" channel doesn't quite fit for all of these users.
