### PR TITLE
Add requirement for minimum bash version for running unit tests

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -322,6 +322,10 @@ this permanent, add this to your `.bashrc` or login script:
 export PATH="$GOPATH/src/k8s.io/kubernetes/third_party/etcd:${PATH}"
 ```
 
+##### BASH version requirement
+
+To successfully run unit tests in Kubernetes, you will need bash version installed to be >4.3.
+
 Once you have installed all required software, you can proceed to the
 [Building Kubernetes](#building-kubernetes) section to test if it all works properly.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Haven't found an issue created yet but ran into an issue on master where `make test` command was failing and it wasn't evident from errors whats the issue. After poking around I figured minimum bash version required is >4.3 and couldn't find this info anywhere in the docs.
