### PR TITLE
Remove link to deleted Google Slide deck

### DIFF
--- a/icons/README.md
+++ b/icons/README.md
@@ -92,10 +92,6 @@ There is 2 types of icons
 #### Exposed Pod with 3 replicas
 ![](./docs/k8s-exposed-pod.png)
 
-### Slide Deck
-
-[Kubernetes_Icons_GSlide](https://docs.google.com/presentation/d/15h_MHjR2fzXIiGZniUdHok_FP07u1L8MAX5cN1r0j4U/edit)
-
 ## License
 The Kubernetes Icons Set is licensed under a choice of either Apache-2.0
 or CC-BY-4.0 (Creative Commons Attribution 4.0 International). The


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

As per the discussion in #6527, the linked Google Slides deck does not exist. This pull request removes the link and reference to it in the documentation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6527
