### PR TITLE
Add africa-dev channel for dedicated k8s mentorship

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -2,6 +2,7 @@
 # This includes archived channels, which are marked with `archived: true`.
 
 channels:
+  - name: africa-dev
   - name: airflow-operator
   - name: akri
   - name: aks-engine-users


### PR DESCRIPTION
Addresses issue #6729

This is a request for a public slack channel for African contributorsof Kubernetes for easy communication and mentoring of new African devs to the Kubernetes community.

Cc @somtochiama 