### PR TITLE
Fix markdown links to be compatible with contributor-site

### DIFF
--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -38,7 +38,7 @@ message) one privately.
 The Kubernetes Slack Workspace is archived and made available when the
 administrators have time. There is no explicit interval.
 
-[Slack Archive Download][]
+[Slack Archive Download]
 
 ### DM (Direct Message) Conversations
 
@@ -100,7 +100,7 @@ determining if you should request a channel:
 
 -   The channel MUST be Kubernetes related in some way.
     -   Related cloud native projects might be more appropriate on the 
-        [CNCF Slack][].
+        [CNCF Slack].
 -   The project MUST be open source.
     -   Open Source a project BEFORE requesting a channel. We cannot accommodate
         every organization's open sourcing launch plans.
@@ -125,18 +125,18 @@ determining if you should request a channel:
         project channel is too noisy, but please don't create both at the
         start.
     -   If you need private discussion areas for security-sensitive topics, a
-        project-specific Slack or the [CNCF Slack][] may be a better fit.
+        project-specific Slack or the [CNCF Slack] may be a better fit.
 -   Ask in `#slack-admins` or file an issue if you're unsure It never hurts to
     ask.
 
 ## Requesting a Channel
 
-Channels and User Groups are managed by [Tempelis][], a tool that enables
+Channels and User Groups are managed by [Tempelis], a tool that enables
 external management of Slack.
 
-To add a channel, open a Pull Request (PR) updating the [slack-config][].
+To add a channel, open a Pull Request (PR) updating the [slack-config].
 
--   Add the channel to 'channels.yaml' following the [Channel Documentation][]
+-   Add the channel to 'channels.yaml' following the [Channel Documentation]
     -   Channel names must be 21 characters or less in length, limited by Slack
         design.
     -   Channels must not share the same name with a Slack user or user group.
@@ -167,7 +167,7 @@ There are two approvals needed. `/lgtm` and `/approve`. Once one moderator give 
 and add the `/approve` command as well as `/hold cancel`, which will remove the hold on the PR.
 Once it is signed off and merged, the channel will be created.
 
-For further information, see the [Slack Config Documentation][].
+For further information, see the [Slack Config Documentation].
 
 ### Delegating Channel Ownership
 
@@ -177,9 +177,9 @@ Admins to sign-off on all requests and passes the responsibility to the most
 relevant group.
 
 To delegate channel ownership - Open a Pull Request (PR) updating the
-[slack-config][].
+[slack-config].
 
--   Create a sub-directory under the [slack-config][] for your sig or group.
+-   Create a sub-directory under the [slack-config] for your sig or group.
 -   Update restrictions.yaml with an entry targeting yaml config files in the
     sub-directory you created along with one or more regular expressions that
     match the channel names that should be delegated.
@@ -191,7 +191,7 @@ To delegate channel ownership - Open a Pull Request (PR) updating the
           - "^kubernetes-foo-[a-z]{1,3}$" # channel regexp - example match: kubernetes-foo-bar
           - "^foo-[a-zA-Z]+$"             # channel regexp - example match: foo-awesomechannel
         ```
--   Create an [OWNERS][] file in the sub-directory adding the appropriate
+-   Create an [OWNERS] file in the sub-directory adding the appropriate
     reviewers and approvers for the desired channels.
 -   In the directory create one or more channel configs following the Channel
     Documentation
@@ -211,18 +211,18 @@ For further information, see the
 
 ## Requesting a User Group
 
-Channels and User Groups are managed by [Tempelis][], a tool that enables
+Channels and User Groups are managed by [Tempelis], a tool that enables
 external management of Slack.
 
-To add a User Group, open a Pull Request (PR) updating the [slack-config][].
+To add a User Group, open a Pull Request (PR) updating the [slack-config].
 
 -   Add the users to users.yaml. **NOTE:** This must be a mapping of their
     GitHub ID to their Slack Member ID. 
 -   To get a person's Slack Member ID, view their profile. Then click on the
     "**...**" and select **Copy member ID**. It will be a 9 character string of
     uppercase letters and numbers (example: `U1H63D8SZ`).
--   Update [usergroups.yaml][] Follow the guidelines for creating a User Group
-    in the Slack Config [User Group Documentation][].
+-   Update [usergroups.yaml] Follow the guidelines for creating a User Group
+    in the Slack Config [User Group Documentation].
 -   In the PR comments, include details on the User Group and `/cc` the members
     you are adding so that they may sign off and accept being added to the
     group.
@@ -247,7 +247,7 @@ ensure everyone has a great experience.
 Typically approved requests include: GitHub, CNCF requests, or other
 tools/platforms used to aid in the management of Slack itself.
 
--   Create a [GitHub Issue][] using the Slack Request template.
+-   Create a [GitHub Issue] using the Slack Request template.
 -   In the description, describe the request, its intended purpose and benefit
     to the community. Supplying links to supporting content such as a document
     outlining what OAuth scopes that are requested and why are **STRONGLY
@@ -263,7 +263,7 @@ discussed in Slack itself.
 ### Admin Expectations and Guidelines
 
 Admins should adhere to the general Kubernetes project 
-[moderation guidelines][].
+[moderation guidelines].
 
 Additionally, admins should ensure they have 2-factor auth enabled for their
 account and mention they are a Slack admin in the "What I do" portion of their
@@ -315,7 +315,7 @@ In general, use your best judgment.
 Once two Slack admins have reviewed and agreed to sponsor the channel, they will
 sign off on the Channel Request PR. Once merged, the channel will be created.
 
-Channels managed by [Tempelis][] will automatically have default messages
+Channels managed by [Tempelis] will automatically have default messages
 pinned. For any manually-provisioned channels, such as private channels, add the
 below message and pin it.
 
@@ -359,7 +359,7 @@ steps.
 For the reasons listed below, admins may inactivate individual Slack accounts.
 Due to Slack's framework, it does not allow for an account to be banned or
 suspended in the traditional sense, merely inactivated. 
-See [Slack's policy on inactivated accounts][] for more information.
+See [Slack's policy on inactivated accounts] for more information.
 
 #### Reasons to inactivate an account
 

--- a/communication/youtube/youtube-guidelines.md
+++ b/communication/youtube/youtube-guidelines.md
@@ -21,15 +21,15 @@ and includes all communications such as YouTube.
 
 ## Meeting Playlists
 
-The [Kubernetes YouTube Channel][] has separate playlists for each SIG, WG, UG
+The [Kubernetes YouTube Channel] has separate playlists for each SIG, WG, UG
 meeting recordings, as well as recordings of other recurring events such as the
-Kubernetes [community meeting][], [Office Hours][], [Meet our Contributors][]
+Kubernetes [community meeting], [Office Hours], [Meet our Contributors]
 and others.
 
-[Subprojects][], in addition to SIGs, WGs, UGs may request their own playlists
+[Subprojects], in addition to SIGs, WGs, UGs may request their own playlists
 to better target their contributors and increase general discoverability.
 
-To better serve the community, [collaboration][] has been enabled to share the
+To better serve the community, [collaboration] has been enabled to share the
 management of the playlists. Anyone with the appropriate link to the particular
 playlist can upload videos *to that particular playlist* (links & playlists are
 one-to-one).
@@ -41,9 +41,9 @@ Hours, will be shared with the appropriate point(s) of contact.
 ### Uploading Guidelines for Collaborators
 
 **NOTE:** If you're using a Google Workspace account (formerly known as G Suite)
-you may need to [update the permissions in your YouTube settings][]. If you have
-any questions, reach out to the [YouTube admins][] or
-[SIG Contributor Experience][]. You may need to reach out to someone at your
+you may need to [update the permissions in your YouTube settings]. If you have
+any questions, reach out to the [YouTube admins] or
+[SIG Contributor Experience]. You may need to reach out to someone at your
 organization if you do not have access to Google Workspace Admin permissions.
 
 **NOTE:** Both public and private steering meeting recordings should be made
@@ -103,7 +103,7 @@ our governance documents.
 ### Moderator Expectations and Guidelines
 
 Moderators should adhere to the general Kubernetes project
-[moderation guidelines][].
+[moderation guidelines].
 
 Moderation responsibilities for YouTube admins is minimal and is centered around
 checking and removing any potential comments that would violate the
@@ -112,7 +112,7 @@ checking and removing any potential comments that would violate the
 
 ### Trimming and Editing Recordings
 
-YouTube admins are asked to help [trim][] and [edit][] recordings that come into
+YouTube admins are asked to help [trim] and [edit] recordings that come into
 the video queue.
 
 #### Examples:
@@ -149,7 +149,7 @@ the steps outlined below.
     you or reset it to a new one.
 -   Kubernetes YouTube admin permissions
 -   A correctly set up recurring meeting with a start and end time (this is
-    important) - check [Zoom guidelines][] for more details
+    important) - check [Zoom guidelines] for more details
 
 **Steps:**
 
@@ -166,13 +166,13 @@ the steps outlined below.
 
 The following SIGs and groups are currently running splain.io:
 
--   [SIG Auth][]
--   [SIG Contributor Experience][]
--   [SIG Docs][]
--   [SIG Network][]
--   [SIG Release][]
--   [Steering Committee][]
--   [WG Data Protection][]
+-   [SIG Auth]
+-   [SIG Contributor Experience]
+-   [SIG Docs]
+-   [SIG Network]
+-   [SIG Release]
+-   [Steering Committee]
+-   [WG Data Protection]
 -   The main Zoom admin account which holds Meet Our Contributors and others (if
     you log in to splain using this account, all of the other accounts will be
     logged here)
@@ -214,9 +214,9 @@ to hear from you.
 ### Streaming Events
 
 YouTube admins with a system capable of streaming may be asked to stream public
-Kubernetes Community events such as the weekly [Community Meeting][], 
-[Office Hours][], [Meet our Contributors][], or other publicly streamed
-events. For detailed information about streaming, see our [Streaming Config][].
+Kubernetes Community events such as the weekly [Community Meeting], 
+[Office Hours], [Meet our Contributors], or other publicly streamed
+events. For detailed information about streaming, see our [Streaming Config].
 
 ### Migrating Content
 
@@ -225,7 +225,7 @@ be useful to grab content from other channels. It is currently NOT POSSIBLE to
 move content from one YouTube channel to another, so the content must be
 downloaded and then reuploaded to the Kubernetes channel.
 
-1.  Download [youtube-dl][], which makes it easier to bulk download videos.
+1.  Download [youtube-dl], which makes it easier to bulk download videos.
 2.  Download the channel or playlist with: `youtube-dl <url>`
 3.  Clean up the filenames as they are used to generate new titles. Do this
     locally since it is easier than doing it per video in the YouTube web UI.

--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -5,34 +5,34 @@ description: |
 ---
 
 Zoom is the main video communication platform for Kubernetes. It is used for
-running the [community meeting][], [SIG/WG meetings][], [Office Hours][], 
-[Meet Our Contributors][] and many other Kubernetes online events. Since the Zoom
+running the [community meeting], [SIG/WG meetings], [Office Hours], 
+[Meet Our Contributors] and many other Kubernetes online events. Since the Zoom
 meetings are open to the general public, a Zoom host or co-host has to moderate
 a meeting in all senses of the word, from starting and stopping the meeting to
-acting on [Kubernetes code of conduct][] issues.
+acting on [Kubernetes code of conduct] issues.
 
 These guidelines are meant as a tool to help Kubernetes members manage their
 Zoom resources.
 
-Check the main [moderation][] page for more information on other tools
+Check the main [moderation] page for more information on other tools
 and general moderation guidelines.
 
 
 ## Code of conduct
 
-The Kubernetes project adheres to the [Kubernetes Code of Conduct][]
+The Kubernetes project adheres to the [Kubernetes Code of Conduct]
 throughout all platforms and includes all communication mediums.
 
 ## Zoom license management
 
-Zoom licenses are managed by the [CNCF Service Desk][] through the
-[Zoom Admins][] listed in the  [centralized list of administrators][].
+Zoom licenses are managed by the [CNCF Service Desk] through the
+[Zoom Admins] listed in the  [centralized list of administrators].
 
 ### Obtaining a Zoom license
 
 Ensure that all SIG/WG leads, chairs, and any other necessary trusted owners
 have access to the `k-sig-<foo>-leads@googlegroups.com` account as described in
-the [sig creation procedure][]. Once done, contact one of the [Zoom Admins][] to
+the [sig creation procedure]. Once done, contact one of the [Zoom Admins] to
 obtain a Zoom license.
 
 ## Setting up your meeting and moderation
@@ -42,9 +42,9 @@ and others who would intentionally attempt to disrupt your Zoom call.
 
 To create a meeting with **moderation** enabled, ensure the following:
 
--   Have the [latest version][] of the Zoom client installed.
+-   Have the [latest version] of the Zoom client installed.
 -   Be logged in as the leads account associated with the meeting **OR** use the
-    [host key][] to "claim host".
+    [host key] to "claim host".
 -   Configure a meeting setup through the "Meeting" menu in the leads Zoom
     account. **NOTE:** Do **NOT** use the "Personal Meeting ID". This will
     create an "ad-hoc" meeting that is time-bounded and without moderation
@@ -64,7 +64,7 @@ After the meeting has started:
 If you're dealing with a troll or bad actor:
 
 -   Put the troll or bad actor on **hold**. The participant will be put into a
-    [waiting room][] and will not be able to participate in the call until the
+    [waiting room] and will not be able to participate in the call until the
     host removes the hold.
     -   **NOTE:** Depending on your client version this will be called "**Put in
         Waiting Room**" instead of on **hold**.
@@ -75,7 +75,7 @@ If you're dealing with a troll or bad actor:
     remove.
 -   After an action has been taken, use the **lock meeting** feature so that no
     one else can come into the meeting. If that fails, end the call
-    immediately, and contact the [Zoom Admins][] to report the issue.
+    immediately, and contact the [Zoom Admins] to report the issue.
 
 **NOTE:** You can find these actions when clicking on the **more** or **"..."**
 options after scrolling over the participants name/information.
@@ -83,21 +83,21 @@ options after scrolling over the participants name/information.
 Hosts **must** be comfortable with how to use these moderation tools and the
 Zoom settings in general. Make sure whoever is running your meeting is equipped
 with the right knowledge and skills. If you have any questions or concerns,
-reach out to the [Zoom Admins][] and they will be able to provide further
+reach out to the [Zoom Admins] and they will be able to provide further
 guidance and training.
 
 #### Related moderation documentation
 
--   Zoom has [documentation on how to use their moderation tools][].
+-   Zoom has [documentation on how to use their moderation tools].
 -   Members of the _leads@_ group have access to an extensive 
-    [best practices doc][] with screenshots going over the community Zoom best
+    [best practices doc] with screenshots going over the community Zoom best
     practices.
 
 ### Escalating and Reporting a Problem
 
 Issues that cannot be handled via normal moderation, or with the assistance of
-the [Zoom Admins][] should be escalated to the Kubernetes 
-[Code of Conduct Committee][] at conduct@kubernetes.io.
+the [Zoom Admins] should be escalated to the Kubernetes 
+[Code of Conduct Committee] at conduct@kubernetes.io.
 
 To contact the admin group in Slack, ping `@zoom-admins` in the `#sig-contribex`
 Slack channel.
@@ -105,17 +105,17 @@ Slack channel.
 ## Meeting recordings
 
 Chairs and TLs are responsible for posting all update meetings to their playlist
-on YouTube. [Please follow this guideline for more details][].
+on YouTube. [Please follow this guideline for more details].
 
 If a violation has been addressed by a host and it has been recorded by Zoom,
-the video should be edited before being posted on the [Kubernetes channel][].
+the video should be edited before being posted on the [Kubernetes channel].
 
-Contact [SIG Contributor Experience][] if you need help to edit a video
+Contact [SIG Contributor Experience] if you need help to edit a video
 before posting it to the public.
 
 ## Screen sharing guidelines and recommendations
 
-Zoom has [documentation on how to use their screen sharing feature][].
+Zoom has [documentation on how to use their screen sharing feature].
 
 Recommendations:
 
@@ -129,7 +129,7 @@ Recommendations:
 ## Audio/Video quality recommendations
 
 While video conferencing has been a real boon to productivity there are still
-[lots of things that can go wrong][] during a conference video call.
+[lots of things that can go wrong] during a conference video call.
 
 There are some things that are just plain out of your control, but there are
 some things that you can control. Here are some tips if you're just getting into
@@ -142,8 +142,8 @@ favor.
 -   **A dedicated microphone** - This is the number one upgrade you can do.
     Sound is one of those things that can immediately change the quality of
     your call. If you plan on being here for the long haul, something like a
-    [Blue Yeti][] will work great due to the simplicity of using USB
-    audio and having a hardware mute button. Consider a [pop filter][]
+    [Blue Yeti] will work great due to the simplicity of using USB
+    audio and having a hardware mute button. Consider a [pop filter]
     as well if necessary.
 -   **A Video Camera** - A bad image can be worked around if the audio is good.
     Certain models have noise canceling dual-microphones, which are a great
@@ -165,7 +165,7 @@ for which models work best.
 
 ### Pro-tips
 
--   [Join on muted audio and video][] in order to prevent noise to those
+-   [Join on muted audio and video] in order to prevent noise to those
     already in a call.
 -   If you don't have anything to say at that moment, **MUTE**. This is a common
     problem. You can help out a teammate by mentioning it on Zoom chat or

--- a/contributors/guide/release-notes.md
+++ b/contributors/guide/release-notes.md
@@ -73,7 +73,7 @@ Here are some pull requests with examples of exemplary release notes:
 - https://github.com/kubernetes/kubernetes/pull/97252
 - https://github.com/kubernetes/kubernetes/pull/105517
 
-For more tips on writing good release notes, check out the [Release Notes Handbook][].
+For more tips on writing good release notes, check out the [Release Notes Handbook].
 
 ## Applying a Release Note
 


### PR DESCRIPTION
While the trailing brackets [] are markdown compatible they break the links with the contributor-site link generator when the content is ingested. The contributor-site script that does the ingestion needs to be updated, but removing them is a short term solution to fix the site.
