### PR TITLE
Add channel for Elections Subproject.

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -388,6 +388,7 @@ channels:
   - name: sig-contribex
   - name: sig-contribex-meetings
   - name: sig-contribex-comms
+  - name: sig-contribex-elections
   - name: sig-contribex-triage
     archived: true
   # sig-docs* channels are defined in sig-docs/


### PR DESCRIPTION
Add new channel for Contribex Elections Subproject.

We considered other mechanisms for keeping in touch with subproject contributors, but they weren't working.  As such, we need this channel in order to coordinate among Subproject contributors.

This is purposefully separate from the #election-officers channel, since that one is closed & private and only allows the current EOs to join so that they can discuss detailed election matters.  The new channel, to develop the subproject, will be open for everyone working on long-term election goals.

/sig contributor-experience
/area elections