### PR TITLE
Modify voter eligibility to include all of sigs.yaml

### DIFF
--- a/elections/steering/2022/README.md
+++ b/elections/steering/2022/README.md
@@ -79,6 +79,9 @@ Eligibility for voting in 2021 is defined as:
   Contributions include GitHub events like creating issues, creating PRs,
   reviewing PRs, commenting on issues, etc. For full details see
   [the SQL query used by devstats for developer activity counts][devstats-sql].
+  
+* Any contributor directly named in [SIGs.yaml], regardless of contribution count,
+  except for contributors listed as "emeritus".
 
 * People who have submitted the [voter exception form] and are accepted by
   the election committee.
@@ -307,3 +310,4 @@ Nominees may be found in the [election app].
 [voter exception form]: https://elections.k8s.io/app/elections/steering---2022/exception
 [public Steering Committee Meeting]: https://github.com/kubernetes/steering/#meetings
 [Eligible voters]: https://github.com/kubernetes/community/tree/master/elections/steering/2021#eligibility
+[SIGs.yaml]: https://github.com/kubernetes/community/blob/master/sigs.yaml


### PR DESCRIPTION
Per discussion in [Steering 226](https://github.com/kubernetes/steering/issues/226), this is one of two possible PRs, which automatically includes anyone listed in SIGs.yaml as eligible to vote, regardless of number of contributions.

This is an exclusive alternative to PR #6756, for decision by the Steering Committee between the alternatives.

/sig contributor-experience
/area elections