### PR TITLE
Move Contributor Awards recipients from README.md to separate files and add 2021 award recipients

### DIFF
--- a/events/awards/README.md
+++ b/events/awards/README.md
@@ -1,89 +1,16 @@
 # Kubernetes Contributor Awards
 
-Every year the Kubernetes Contributor Community select awardees for outstanding contributions to the project
+Every year, the Kubernetes Contributor Community recognizes and awards their peers for
+outstanding contributions to the project for the year.
+These awards are handed out during the end-of-year Contributor Summit.
 
-# 2020 
+## [Playbook][playbook]
 
-### SIG API Machinery
+## Contributor Award Recipients
 
-- Haowei Cai	
-- Chao Xu
+- [2021 Contributor Award Recipients][2021-awards-recipients]
+- [2020 Contributor Award Recipients][2020-awards-recipients]
 
-### SIG Architecture
-
-- Hippie Hacker
-- Michelle Au
-- Dawn Chen
-- Paris Pittman
-
-### SIG Authentication
-
-- Shihang Zhang
-
-### SIG CLI
-
-- Yao Zhou
-- Brian Pursely
-- Syam Sundar Kirubakaran
-
-### SIG Cloud Provider 
-
-- Cici Huang
-
-### SIG Contributor Experience
-
-- Matthew Broberg
-- Kaslin Fields
-- Noah Kantrowitz
-- Rajula Vineet Reddy
-
-### SIG Cluster Lifecycle
-
-- Ciprian Hacman
-- John Gardiner Myers
-- Ole Markus
-
-## SIG Documentation
-
-- Tim Bannister
-- Qiming Teng
-- Zachary Sarah Corleissen
-
-### SIG Instrumentation
-
-- Hongcai Ren
-- Lili Cosic
-- Marek Siarkowicz
-
-### SIG Network
-
-- Antonio Ojea
-- Jay Vyas
-
-### SIG Release
-
-- Joyce Kung
-- Daniel Mangum
-
-### SIG Scheduling
-
-- Aldo Culquicondor
-
-### SIG Storage
-
-- Patrick Ohly
-
-### SIG Testing
-
-- Antonio Ojea
-- Daniel Magnum
-
-### SIG Usability
-
-- Gaby Moreno Cesar
-- Carl J Pearson
-- Josie Pynadath
-
-### SIG Windows
-
-- James Sturtevant
+[playbook]: ./README.md
+[2021-awards-recipients]: ./award-recipients/2021-award-recipients.md
+[2020-awards-recipients]: ./award-recipients/2020-award-recipients.md

--- a/events/awards/award-recipients/2020-award-recipients.md
+++ b/events/awards/award-recipients/2020-award-recipients.md
@@ -1,0 +1,91 @@
+# Kubernetes Contributor Awards
+
+Every year the Kubernetes Contributor Community select awardees for outstanding contributions to the project
+
+# 2020 
+
+By Special Interest Group (SIG)
+
+#### API Machinery
+
+- Haowei Cai
+- Chao Xu
+
+#### Architecture
+
+- Hippie Hacker
+- Michelle Au
+- Dawn Chen
+- Paris Pittman
+
+#### Authentication
+
+- Shihang Zhang
+
+#### CLI
+
+- Yao Zhou
+- Brian Pursely
+- Syam Sundar Kirubakaran
+
+#### Cloud Provider 
+
+- Cici Huang
+
+#### Contributor Experience
+
+- Matthew Broberg
+- Kaslin Fields
+- Noah Kantrowitz
+- Rajula Vineet Reddy
+
+#### Cluster Lifecycle
+
+- Ciprian Hacman
+- John Gardiner Myers
+- Ole Markus
+
+#### Documentation
+
+- Tim Bannister
+- Qiming Teng
+- Zachary Sarah Corleissen
+
+#### Instrumentation
+
+- Hongcai Ren
+- Lili Cosic
+- Marek Siarkowicz
+
+#### Network
+
+- Antonio Ojea
+- Jay Vyas
+
+#### Release
+
+- Joyce Kung
+- Daniel Mangum
+
+#### Scheduling
+
+- Aldo Culquicondor
+
+#### Storage
+
+- Patrick Ohly
+
+#### Testing
+
+- Antonio Ojea
+- Daniel Magnum
+
+#### Usability
+
+- Gaby Moreno Cesar
+- Carl J Pearson
+- Josie Pynadath
+
+#### Windows
+
+- James Sturtevant

--- a/events/awards/award-recipients/2021-award-recipients.md
+++ b/events/awards/award-recipients/2021-award-recipients.md
@@ -1,0 +1,179 @@
+# Kubernetes Contributor Awards
+
+Every year the Kubernetes Contributor Community select awardees for outstanding contributions to the project
+
+# 2021
+
+By Special Interest Group (SIG) with listed message/nomination reason
+
+#### API Machinery
+
+*Han Kang, @logicalhan*  
+For their continued contributions related to the overlap with SIG Instrumentation.
+
+*Antoine Pelisse*  
+For their long term effort and leadership on server-side-apply and the related wg-api-expression. 
+
+#### Apps
+
+*Aldo Culquicondor*  
+For improving the jobs controller, expanding its functionality
+
+#### Architecture
+
+*Riaan Kleinhans*  
+Conformance Work
+
+*Madhav Jivrajani*  
+KEP Reading Club  
+
+*Kirsten Garrison, @kikisdeliveryservice*  
+Enhancements Subproject
+
+*Elana Hashman, @ehashdn*  
+Production Readiness Reviews 
+
+#### Autoscaling
+
+*Wayne, @wangyysde*  
+Promoting the HPA v2 API to GA after being in beta for more than 3 years.
+
+#### CLI
+
+*Natasha Sarkar*  
+Maintaining Kustomize
+
+*Paco Xu*  
+Holding down the APAC timezone for SIG-CLI by triaging and organization issues.
+
+*Chok Yip Lau*  
+Shipped backlogged bug fixes and features requested by the community.
+
+#### Cluster-lifecycle
+
+*Cecile Robert-Michon*  
+Long time Cluster API leader, maintainer, and active contributor 
+  
+*Paco Xu*  
+Great contributor in the kubeadm sub-project, helping in multiple areas and onboarding new contributors
+
+#### Contributor-experience
+
+*Josh Berkus, @jberkus  
+Paris Pittman, @parispittman*  
+Thank you both for being a rock, and always willing to step up and help with the works that needs doing <3
+
+#### Docs
+
+*Natali Vlatko, @natalisucks*  
+Helping to shape the localization subproject efforts
+  
+*Arsh Sharma, @RinkiyaKeDad*  
+Helping to form the new contributor ambassador role
+
+#### Instrumentation
+
+*Damien Grisonnet*  
+Work on core Kubernetes metrics, triage, bringing great ideas to SIG discussions, and thorough, detailed reviews.
+  
+*Patrick Ohly*  
+Stepping up to assist with the structured logging migration and adopting, coordinating, and completing an instrumental amount of work.
+
+#### Multicluster
+
+*Laura Lorenz*  
+Outstanding contributions pushing the ClusterProperty and Multicluster services projects forward with cross SIG collaboration.
+
+#### Network
+
+*Antonio Ojea, @aojea*  
+For always volunteering for the dirtiest jobs and demonstrating an exemplary leadership attitude.
+  
+*Kal Henidak*    
+For keeping an eye on the ideal future, and trying hard to make it happen one step at a time.
+
+#### Node
+
+*Elana Hashman, @ehashdn*
+Driving broad community participation, improving and sustaining the health of SIG Node CI, helping new contributors.
+  
+*Sergey Kanzhelev, @sergeykanzhelev*
+Driving broad community participation, improving and sustaining the health of SIG Node CI, helping new contributors.
+  
+*Mrunal Patel, @mrunalp*
+New maintainer in the SIG Node kubelet sub-project and coordinating release feature goals.
+
+#### Release
+*Karen Chu* 
+For stepping up to be the 1.23 communications lead, reaching all deadlines in the 1.23 release cycle, and mentoring shadows that could succeed as communications lead in 1.24 and beyond.
+  
+*Jesse Butler*
+For stepping up to be the 1.22 communications lead as a first time shadow and stepping up to be the 1.23 docs lead without release docs experience, reorienting the incoming communication lead, and for being a great mentor.
+  
+*Nabarun Pal*
+For being a huge impact in SIG Release as the lead for the 1.21 release, as a release manager associate, as a branch manager shadow for the 1.23 release, for bringing the CI Signal tool into a Kubernetes community repository, and for being willing to contribute to the success of the project and the SIG.
+  
+*Rey Lejano*
+For being a consistent contributor to SIG Release for some time across many releases and roles. When the 1.23 Release came around, he volunteered to lead the release when we were unable to identify a release lead.
+
+
+#### Scalability
+*Wojciech Tyczyński*
+Outstanding cross-SIG work working on P&F and Efficient watch resumption which required cross-SIG collaboration and were large contributions to multiple Kubernetes releases.
+
+#### Security
+
+*Savitha Raghunathan, @coffeeartgirl*
+*Pushkar Joglekar, @PuDiJoglekar*
+Building a welcoming, encouraging community for new and experienced contributors, for being great examples on how we help each other grow, for seeing what needs to be done and putting in the work to do it while bringing others along.
+
+#### Scheduling
+*Mike Dame*  
+Leading the descheduler project, leading the refactoring effort to cut unneeded dependencies, for designing and implementing a new simplified scheduler plugin configuration API.
+
+
+#### Storage
+
+*Hemant Kumar, @gnufied*
+Working on difficult bugs, long-standing reliability issues such as uncertain mounts, and slow mounts due to recursive fsgroup and fixing issues in order to move the volume expansion feature to GA 
+
+*Jiawei Wang*
+Driving the CSI migration effort that has been ongoing for several releases and hosting meetings and working with maintainers across many cloud providers to move in-tree volume plugins to out-of-tree CSI drivers.
+
+#### Testing
+
+*Arnaud Meukam, @ameukam*  
+k8s-infra prow and migrating scalability jobs
+  
+*Chao Dai*   
+Automating prow updates
+  
+*Claudiu Belu*    
+Migrating Kubernetes to k8s.gcr.io/e2e-test-images
+
+
+#### UI
+
+*Sebastian Florek  
+Marcin Maciaszczyk*  
+Both of their efforts maintaining Kubernetes Dashboard for over five years and keeping the Kubernetes Dashboard project healthy and secure
+
+#### Usability
+
+*Cleopatra Enjeck*  
+Helping SIG Usability operationalize how the SIG weighs feedback in the jobs-to-be-done study and helping the SIG make progress in analyzing the results of the study
+  
+*Josie Pynadath*   
+Interviewing and collecting results for SIG Usability’s study 
+  
+*Carl J. Pearson, @carljpearson*     
+Creating and presenting a framework on how to “code” results from the jobs-to-be-done study that enables new contributors
+
+
+#### Windows
+
+*Ravi Gudimetla*     
+Established and runs the weekly SIG Windows CI/Triage meeting and for cross-SIG collaboration to get a new OS field added to Pod specs (alpha in v1.23) which will help solve many SIG Windows related issues such as being able to enforce OS specific policies during admission time.  
+  
+*Amim Knabben, @ak_ndb*    
+Improving the developer experience for Windows related changes in Kubernetes which eases the on-ramp of developers to be involved with SIG Windows.


### PR DESCRIPTION
As we have more Contributor Awards, instead of adding award recipients to the README.md, I suggest moving the award recipients from the README.md and into separate files by year.

This PR suggests the following changes:
- move the 2020 Contributor Award recipients from README.md to its own file in a new awards dir
- add the 2021 Contributor Award recipients
- Update README.md with links to the playbook and awards recipient files

