### PR TITLE
Update sigs.yaml to rename special-resource-operator

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -69,6 +69,9 @@ The following [subprojects][subproject-definition] are owned by sig-node:
 ### cri-tools
 - **Owners:**
   - [kubernetes-sigs/cri-tools](https://github.com/kubernetes-sigs/cri-tools/blob/master/OWNERS)
+### kernel-module-management
+- **Owners:**
+  - [kubernetes-sigs/kernel-module-management](https://github.com/kubernetes-sigs/kernel-module-management/blob/main/OWNERS)
 ### kubelet
 - **Owners:**
   - [kubernetes/kubernetes/cmd/kubelet](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/OWNERS)
@@ -94,9 +97,6 @@ The following [subprojects][subproject-definition] are owned by sig-node:
   - [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#security-profiles-operator](https://kubernetes.slack.com/messages/security-profiles-operator)
-### special-resource-operator
-- **Owners:**
-  - [kubernetes-sigs/special-resource-operator](https://github.com/kubernetes-sigs/special-resource-operator/blob/main/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 [working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2082,6 +2082,9 @@ sigs:
   - name: cri-tools
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cri-tools/master/OWNERS
+  - name: kernel-module-management
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kernel-module-management/main/OWNERS
   - name: kubelet
     owners:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubelet/OWNERS
@@ -2107,9 +2110,6 @@ sigs:
       slack: security-profiles-operator
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/master/OWNERS
-  - name: special-resource-operator
-    owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/special-resource-operator/main/OWNERS
 - dir: sig-release
   name: Release
   mission_statement: >


### PR DESCRIPTION
Update sigs.yaml and sig-node docs to rename special-resource-operator to kernel-module-management to match repo rename

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#3587](https://github.com/kubernetes/org/issues/3587)
