### PR TITLE
sig-windows: add windows-operational-readiness repo

### DIFF
--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -59,6 +59,9 @@ The following [subprojects][subproject-definition] are owned by sig-windows:
 ### windows-gmsa
 - **Owners:**
   - [kubernetes-sigs/windows-gmsa](https://github.com/kubernetes-sigs/windows-gmsa/blob/master/OWNERS)
+### windows-operational-readiness
+- **Owners:**
+  - [kubernetes-sigs/windows-operational-readiness](https://github.com/kubernetes-sigs/windows-operational-readiness/blob/main/OWNERS)
 ### windows-samples
 - **Owners:**
   - [kubernetes-sigs/sig-windows-samples](https://github.com/kubernetes-sigs/sig-windows-samples/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2878,6 +2878,9 @@ sigs:
   - name: windows-gmsa
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/windows-gmsa/master/OWNERS
+  - name: windows-operational-readiness
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/windows-operational-readiness/main/OWNERS
   - name: windows-samples
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-samples/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/3585

/assign @jayunit100 
cc @iXinqi @knabben 

/hold
for lgtm from a sig-windows lead