### PR TITLE
Rename the SRO channel to KMM.

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -401,9 +401,10 @@ channels:
   - name: sig-network
   - name: sig-node
   - name: sig-node-bug-scrub
+  - name: sig-node-kmm
+    id: C037RE58RED
   - name: sig-node-rkt
     archived: true
-  - name: sig-node-sro
   - name: sig-node-swap
   - name: sig-scalability
   - name: sig-scheduling


### PR DESCRIPTION
This rename follows the repo rename in https://github.com/kubernetes/org/issues/3587.