### PR TITLE
slack-config: create "dra" channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -90,6 +90,7 @@ channels:
   - name: digitalocean-k8s
   - name: distroless
   - name: diversity
+  - name: dra
   - name: draft-dev
   - name: draft-users
   - name: eks


### PR DESCRIPTION
"dra" stands for dynamic resource allocation, a KEP that got accepted for
Kubernetes 1.25:
https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3063-dynamic-resource-allocation#readme

It is a complex feature that is owned by SIG Node, SIG Scheduling and various
others. Significant discussions are expected not just while we develop this
feature, but also while third-party developers and users start to make use of
the functionality. It is similar to CSI (owned by SIG Storage) in that regard
which also has its own #csi channel.

Discussing it in either of these SIG's channels would miss relevant people and
may cause additional noise for those who are not interested in details of this
new feature. We also considered other means of communication (CNCF #tag-runtime
Slack channel, private Teams chat) but none of those are really suitable.
