### PR TITLE
Updated the security-profile-operator reference

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -94,7 +94,7 @@ The following [subprojects][subproject-definition] are owned by sig-node:
   - [kubernetes/noderesourcetopology-api](https://github.com/kubernetes/noderesourcetopology-api/blob/master/OWNERS)
 ### security-profiles-operator
 - **Owners:**
-  - [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator/blob/master/OWNERS)
+  - [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/OWNERS)
 - **Contact:**
   - Slack: [#security-profiles-operator](https://kubernetes.slack.com/messages/security-profiles-operator)
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2109,7 +2109,7 @@ sigs:
     contact:
       slack: security-profiles-operator
     owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/main/OWNERS
 - dir: sig-release
   name: Release
   mission_statement: >


### PR DESCRIPTION
This PR does a minor update in the link to the OWNERS of sub-project security-profile-operator that is referenced under SIG node README page.