### PR TITLE
Clarify CoCC & SRC addition to include the full year.

### DIFF
--- a/elections/steering/2022/README.md
+++ b/elections/steering/2022/README.md
@@ -81,7 +81,8 @@ Eligibility for voting in 2022 is defined as:
   [the SQL query used by devstats for developer activity counts][devstats-sql].
   
 * Full members of the Code of Conduct Committee (CoCC) and Security Response Committee
-  (SRC), as listed in [SIGs.yaml], regardless of contribution count.
+  (SRC), as listed in [SIGs.yaml], at any time between August 2021 and August 2022, 
+  regardless of contribution count.
 
 * People who have submitted the [voter exception form] and are accepted by
   the election committee.


### PR DESCRIPTION
Attention @kubernetes/steering-committee:

This answers a question that the current Election Officers have due to the CoCC being selected shortly before the election begins.  Under this clarification, people who are or were on the CoCC or SRC at any time during the "contribution year" are automatically eligible to vote.  Otherwise, we'd have ended up with a situation where folks who served in the CoCC from July 2021-July2022 would not be eligible.

@coderanger @kaslin @dims 