### PR TITLE
slack-config/sig-release: Add release-packages-poc channel

### DIFF
--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -8,3 +8,4 @@ channels:
   - name: release-management
     id: CJH2GBF7Y
   - name: release-notes
+  - name: release-packages-poc


### PR DESCRIPTION
Adds #release-obs-poc Slack channel for collaboration with SUSE folks around an OBS-based PoC of building k8s DEB/RPM packaging to avoid adding noise to the #sig-release channel

**Which issue(s) this PR fixes**:
Fixes #6811 
