### PR TITLE
api-conventions: fix leftover merge conflict mark

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -1995,4 +1995,3 @@ need human evaluation to decide.  For example, Service `clusterIP` is highly
 coupled to the rest of Service and most instances use it.  But it also is
 strictly optional and has an increasingly complicated schema of related fields.
 An argument could be made for either path.
->>>>>>> 49012588 (Loosen the meaning of status in API conventions)


### PR DESCRIPTION
This seems to be a leftover.

