### PR TITLE
Replacing "go get" with "go install" on CFSSL installation

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -50,7 +50,7 @@ The [CFSSL](https://cfssl.org/) binaries (cfssl, cfssljson) must be installed an
 The easiest way to get it is to run these shell commands:
 
 ```sh
-go get -u github.com/cloudflare/cfssl/cmd/...
+go install github.com/cloudflare/cfssl/cmd/...@latest
 PATH=$PATH:$GOPATH/bin
 ```
 


### PR DESCRIPTION
When trying to install CFSSL with the current command it failed because the command is note updated:
```
root@main:/home/cyber# go get -u github.com/cloudflare/cfssl/cmd/...
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecat                                                                                                                                                             ion
        or run 'go help get' or 'go help install'.
```
The new command is `go install github.com/cloudflare/cfssl/cmd/...@latest`:
```
root@main:/home/cyber# go install github.com/cloudflare/cfssl/cmd/...@latest
go: downloading github.com/lib/pq v1.10.1
go: downloading github.com/go-sql-driver/mysql v1.6.0
go: downloading github.com/mattn/go-sqlite3 v1.14.7
go: downloading github.com/prometheus/client_golang v1.10.0
go: downloading github.com/jmoiron/sqlx v1.3.3
go: downloading github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46
go: downloading github.com/google/certificate-transparency-go v1.1.2-0.20210511102531-373a877eec92
go: downloading golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503
go: downloading github.com/cloudflare/redoctober v0.0.0-20201013214028-99c99a8e7544
go: downloading github.com/zmap/zcrypto v0.0.0-20210511125630-18f1e0152cfc
go: downloading github.com/zmap/zlint/v3 v3.1.0
go: downloading golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/golang/protobuf v1.5.2
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/cespare/xxhash v1.1.0
go: downloading github.com/prometheus/common v0.24.0
go: downloading github.com/prometheus/procfs v0.6.0
go: downloading google.golang.org/protobuf v1.26.0
go: downloading github.com/golang/glog v0.0.0-20210429001901-424d2337a529
go: downloading github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
go: downloading golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
go: downloading github.com/getsentry/raven-go v0.2.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading github.com/weppos/publicsuffix-go v0.15.1-0.20210511084619-b1f36a2d6c0b
go: downloading golang.org/x/text v0.3.6
go: downloading github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
go: downloading github.com/pkg/errors v0.9.1

```


