### PR TITLE
PRR Freeze docs

### DIFF
--- a/sig-architecture/production-readiness.md
+++ b/sig-architecture/production-readiness.md
@@ -20,6 +20,10 @@ As of 1.21, PRRs are now blocking. PRR _approval_ is required for the enhancemen
 to be part of the release. This means that any KEPs targeting the release for any
 stage will require production readiness approval by the *Enhancements Freeze Date*.
 
+Introduced in 1.23, *Product Readiness Freeze* happens a week before *Enhancements Freeze Date*. All KEPs must be opted in by this date to help PRR reviewers provision their workload. 
+KEPs opted in after the *Product Readiness Freeze* are at risk
+of not being reviewed by the PRR team, depending on bandwidth.
+
 Note that some of the questions in the [KEP template] should be answered in both
 the KEP's README.md and the `kep.yaml`, in order to support automated checks on
 the PRR. The template points out these as needed.

--- a/sig-architecture/production-readiness.md
+++ b/sig-architecture/production-readiness.md
@@ -20,9 +20,11 @@ As of 1.21, PRRs are now blocking. PRR _approval_ is required for the enhancemen
 to be part of the release. This means that any KEPs targeting the release for any
 stage will require production readiness approval by the *Enhancements Freeze Date*.
 
-Introduced in 1.23, *Product Readiness Freeze* happens a week before *Enhancements Freeze Date*. All KEPs must be opted in by this date to help PRR reviewers provision their workload. 
-KEPs opted in after the *Product Readiness Freeze* are at risk
-of not being reviewed by the PRR team, depending on bandwidth.
+Introduced in 1.23, *Product Readiness Freeze* happens a week before *Enhancements 
+Freeze Date*. All KEPs must be opted in by this date to help PRR reviewers provision 
+their workload. KEPs opted in after the *Product Readiness Freeze* are at risk of not 
+being reviewed by the PRR team, depending on bandwidth. KEP owners can file an 
+[Exception request](https://github.com/kubernetes/sig-release/blob/master/releases/EXCEPTIONS.md) if the PRR has not been completed post Enhancements Freeze.
 
 Note that some of the questions in the [KEP template] should be answered in both
 the KEP's README.md and the `kep.yaml`, in order to support automated checks on


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/2011 to better communicate PRR Freeze.

Added:
- Risks of not opting in by PRR freeze which is not having a PRR done. This is to prevent the surge of last minute opt-in.
- Exception request process available for KEPs that didn't have PRR done by Enhancements Freeze. This has been the practice for past releases in my understanding, so just documenting it.

PRR reviewers - please let me know if this all sounds good