### PR TITLE
slack sig-node: add users and dra-dev group

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -404,13 +404,7 @@ channels:
   - name: sig-multicluster
   - name: sig-network
   - name: sig-network-multi-network
-  - name: sig-node
-  - name: sig-node-bug-scrub
-  - name: sig-node-kmm
-    id: C037RE58RED
-  - name: sig-node-rkt
-    archived: true
-  - name: sig-node-swap
+  # sig-node channels are defined in sig-node/
   - name: sig-scalability
   - name: sig-scheduling
   # sig-security* channels are defined in sig-security/

--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -27,6 +27,11 @@ restrictions:
   - path: "sig-network/*.yaml"
     channels:
       - "^sig-network-.*$"
+  - path: "sig-node/*.yaml"
+    channels:
+      - "^sig-node"
+    usergroups:
+      - "^dra-dev$"
   - path: "sig-release/*.yaml"
     channels:
       - "^sig-release$"

--- a/communication/slack-config/sig-node/OWNERS
+++ b/communication/slack-config/sig-node/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-node-leads
+approvers:
+  - sig-node-leads
+labels:
+  - sig/node

--- a/communication/slack-config/sig-node/config.yaml
+++ b/communication/slack-config/sig-node/config.yaml
@@ -1,0 +1,8 @@
+channels:
+  - name: sig-node
+  - name: sig-node-bug-scrub
+  - name: sig-node-kmm
+    id: C037RE58RED
+  - name: sig-node-rkt
+    archived: true
+  - name: sig-node-swap

--- a/communication/slack-config/sig-node/usergroups.yaml
+++ b/communication/slack-config/sig-node/usergroups.yaml
@@ -1,0 +1,17 @@
+# This file contains a list of all Slack User Groups that are managed by SIG Node.
+
+usergroups:
+  - name: dra-dev
+    long_name: dynamic resource allocation developers
+    description: Developers working on or with the dynamic resource allocation KEP.
+    channels:
+      - sig-node
+    members:
+      # Entries are GitHub handles. They must be listed under ../users.yaml.
+      # Sorted alphabetically!
+      - bart0sh
+      - byako
+      - elezar
+      - klihub
+      - klueska # subproject owner
+      - pohly # subproject owner

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -11,16 +11,18 @@ users:
   anjaltelang: U028B09KZ5X
   ankeesler: UBAA1KQ4A
   annajung: U8SLB1P2Q
-  AvineshTripathi: U029U44P26B
   aravindputrevu: U1G27SDU6
   asmacdo: UNVH7RY9J
   Atharva-Shinde: U028J67T478
+  AvineshTripathi: U029U44P26B
   bai: U4XAULHL3
   Bart Farrell: U01DZM7PJDT
+  bart0sh: U8VJC20R3
   benjaminapetersen: U0217E7EXV4
   bhumijgupta: U022JUBM3B4
   briandealwis: UAZKM38JV
   bubblemelon: U7K9C643G
+  byako: U03GZBD4J4C
   calebamiles: U1ZDD4CUR
   camilamacedo86: UJDM393EH
   castrojo: U1W1Q6PRQ
@@ -41,6 +43,7 @@ users:
   dims: U0Y7A2MME
   divya-mohan0209: UV4J7K97Z
   dougm: U8GG20UE9
+  elezar: ULV21K3CH
   enj: U2T4CVDTJ
   erismaster: U0162FJ79LY
   estroz: UKSEANEC9
@@ -84,6 +87,8 @@ users:
   katharine: UBTBNJ6GL
   katcosgrove: U01GDERGEHF
   kikisdeliveryservice: U9HFFRFT2
+  klihub: U9856A799
+  klueska: UF3ARH55Y
   Kunal Kushwaha: UQ14U3NAY
   LappleApple: U011C07244F
   leonardpahlke: U029NBZFV97
@@ -118,6 +123,7 @@ users:
   pensu91: U44FHF81G
   phenixblue: UB4UVLEAK
   pnbrown: U011JJTQVGF
+  pohly: U91901TMF
   prietyc123: U01D4MBLM52
   puerco: ULGHLJ7TP
   PurneswarPrasad: U027CFKVAB0


### PR DESCRIPTION
This is for pinging the right set of people when posting on a channel like #sig-node or #sig-scheduling that they might not actively follow.
