### PR TITLE
Add 2019 contributor award recipients to k/community

### DIFF
--- a/events/awards/README.md
+++ b/events/awards/README.md
@@ -10,7 +10,9 @@ These awards are handed out during the end-of-year Contributor Summit.
 
 - [2021 Contributor Award Recipients][2021-awards-recipients]
 - [2020 Contributor Award Recipients][2020-awards-recipients]
+- [2019 Contributor Award Recipients][2019-awards-recipients]
 
 [playbook]: ./README.md
 [2021-awards-recipients]: ./award-recipients/2021-award-recipients.md
 [2020-awards-recipients]: ./award-recipients/2020-award-recipients.md
+[2019-awards-recipients]: ./award-recipients/2019-award-recipients.md

--- a/events/awards/award-recipients/2019-award-recipients.md
+++ b/events/awards/award-recipients/2019-award-recipients.md
@@ -1,0 +1,35 @@
+# Kubernetes Contributor Awards
+
+Every year the Kubernetes Contributor Community select awardees for outstanding contributions to the project
+
+# 2019
+
+By Special Interest Group (SIG)
+
+#### Cloud Provider
+
+- Lubomir Ivanov
+
+#### Instrumentation
+
+- Han Kang
+
+#### Release
+
+- Katharine Berry
+
+#### Scheduling
+
+- Huang Wei
+
+#### Storage
+
+- Michelle Au
+
+#### Windows
+
+- Jordan Liggitt
+
+#### WG Multitenancy
+
+- Ryan Bezdicek


### PR DESCRIPTION
This PR adds the 2019 contributor award recipients to k/community/events/awards
Source of 2019 contributor award recipients is https://www.kubernetes.dev/community/awards/2019/