### PR TITLE
Update channels.yaml

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -19,7 +19,6 @@ channels:
     archived: true
   - name: argentina
   - name: arm64
-  - name: armory-k8s
   - name: aus-nz-dev
   - name: aus-nz-users
   - name: awesome-kubernetes
@@ -453,6 +452,7 @@ channels:
   - name: ug-big-data
     id: C0ELB338T
   - name: ug-vmware
+  - name: ug-armory
   - name: undistro
   - name: vcluster
   - name: velero-dev

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -19,6 +19,7 @@ channels:
     archived: true
   - name: argentina
   - name: arm64
+  - name: armory-k8s
   - name: aus-nz-dev
   - name: aus-nz-users
   - name: awesome-kubernetes

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -449,10 +449,10 @@ channels:
   - name: traefik
   - name: travis-ci
   - name: tw-users
+  - name: ug-armory
   - name: ug-big-data
     id: C0ELB338T
   - name: ug-vmware
-  - name: ug-armory
   - name: undistro
   - name: vcluster
   - name: velero-dev


### PR DESCRIPTION
Added ‘Armory k8s’ slack channel for our users to discuss issues around advanced deployments to Kubernetes. Armory is a commercial Open Source company originally built around OSS Spinnaker. Our newest deployment offering is a Kubernetes-specific deployment service, which is why we would like to get a slack channel on the Kubernetes.io slack server as well.

Purpose:
For discussion about advanced deployments to all forms of Kubernetes using Armory Continuous Deployment

Links to Armory's products for Kubernetes:
https://www.armory.io/products/scale-agent-for-spinnaker-kubernetes/ (Based on OSS Spinnaker, extends it's ability to scale to large numbers of Kubernetes clusters)
https://www.armory.io/products/continuous-deployment-self-hosted/ (Based on OSS Spinnaker, supports Kubernetes + additional targets))
https://www.armory.io/products/continuous-deployment-as-a-service/ (not based on Spinnaker, only deploys to Kubernetes)
