### PR TITLE
Add new devfile-devs user group

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -208,3 +208,19 @@ usergroups:
       - robshelly
       - vladimirmukhin
       - wurbanski
+
+  - name: devfile-devs
+    long_name: Devfile Development Team
+    description: Active developers of Devfile on #devfile
+    channels:
+      - devfile
+    members:
+      - elsony
+      - johnmcollier
+      - kim-tsao
+      - maysunfaisal
+      - michael-valdron
+      - mike-hoang
+      - rtaniwa
+      - schultzp2020
+      - yangcao77

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -44,6 +44,7 @@ users:
   divya-mohan0209: UV4J7K97Z
   dougm: U8GG20UE9
   elezar: ULV21K3CH
+  elsony: UCW8323KL
   enj: U2T4CVDTJ
   erismaster: U0162FJ79LY
   estroz: UKSEANEC9
@@ -79,6 +80,7 @@ users:
   joelanford: U1R6NQD8W
   joelsmith: U5SLG8T8F
   johnbelamaric: U246A1A0N
+  johnmcollier: UCVS4TNMQ
   jonasrosland: U0A4G34S2
   jrsapi: U0DS2L6E8
   justaugustus: U0E0E78AK
@@ -87,6 +89,7 @@ users:
   katharine: UBTBNJ6GL
   katcosgrove: U01GDERGEHF
   kikisdeliveryservice: U9HFFRFT2
+  kim-tsao: U02U1LDH4T1
   klihub: U9856A799
   klueska: UF3ARH55Y
   Kunal Kushwaha: UQ14U3NAY
@@ -100,10 +103,13 @@ users:
   markyjackson-taulia: U19TKJ64E
   MarlonGamez: U016N1XK06R
   mattmoyer: U0DRP8H42
+  maysunfaisal: U01DEHK2YUB
   mbbroberg: U18JTHMDY
   micahhausler: U1WJ1BZA5
+  michael-valdron: U03LXKVS0SX
   microwavables: UAF606ESE
   mik-dass: UCUULSG1W
+  mike-hoang: U03PDV4LS1Z
   ming-qiu: U02JVSL5550
   mkorbi: UEBLUUA0P
   mohammedzee1000: U3PFFE8CD
@@ -135,11 +141,13 @@ users:
   rm3l: U034AQUV7PB
   rnapoles-rh: U01KDAMSWJD
   robshelly: U01LL4P09SR
+  rtaniwa: U03K27HLHKN
   salaxander: UDHV1RXB2
   sammy: U8NJFL023
   sandipanpanda: U02A47HJ517
   saschagrunert: U53SUDBD4
   savitharaghunathan: UC8U2V3BM
+  schultzp2020: U030K8UQA2G
   scott-seago: UHGD79E78
   sethmccombs: U92LLUZ8A
   shamus: US7EUUBK8
@@ -166,5 +174,6 @@ users:
   wurbanski: URX7CMK97
   xmudrii: U4Q2TNGVD
   xun-jiang: U02J0QC1VKJ
+  yangcao77: U01D1VCNJQ3
   yinw: UMVD1GDCY
   zubron: U7G0KNS86


### PR DESCRIPTION
Signed-off-by: Kim Tsao <ktsao@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
N/A

We would like to add a new user group `devfile-devs` so our core team can be directly notified on our `#devfile` channel
