### PR TITLE
Update instructions to install cfssl

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -50,7 +50,7 @@ The [CFSSL](https://cfssl.org/) binaries (cfssl, cfssljson) must be installed an
 The easiest way to get it is to run these shell commands:
 
 ```sh
-go get -u github.com/cloudflare/cfssl/cmd/...
+go install github.com/cloudflare/cfssl/cmd/...@latest
 PATH=$PATH:$GOPATH/bin
 ```
 


### PR DESCRIPTION
go get does not work anymore, please see https://github.com/kubernetes/kubernetes/issues/111351 for the error.

So we switch to go install as documented in cfssl repository:
https://github.com/cloudflare/cfssl/#installation

/kind cleanup

Use the newer "go install" variant as we are above go 1.18

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
