### PR TITLE
Add official Oracle Cloud Infrastructure OCI provider channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -353,6 +353,7 @@ channels:
   - name: prometheus
   - name: prometheus-operator
   - name: prometheus-operator-dev
+  - name: provider-oci
   - name: pt_br-users
   - name: purelb-users
   - name: raksh


### PR DESCRIPTION
This PR adds a slack channel for Oracle Cloud Infrastructure (OCI) provider - https://github.com/oracle/oci-cloud-controller-manager. It includes cloud-controller-manager, CSI driver, volume provisioner open source implementation of Oracle Cloud Infrastructure Cloud Provider. 

**Which issue(s) this PR fixes**:
No open issues related to this PR
