### PR TITLE
Add official Nutanix CAPI Provider Slack Channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -61,6 +61,7 @@ channels:
   - name: cluster-api-kubemark
   - name: cluster-api-kubevirt
   - name: cluster-api-nested
+  - name: cluster-api-nutanix
   - name: cluster-api-oci
   - name: cluster-api-openstack
   - name: cluster-api-operator


### PR DESCRIPTION
This PR adds a slack channel for The Nutanix CAPI Provider (CAPX) - https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix


**Which issue(s) this PR fixes**:
NONE
