### PR TITLE
Update subteams in the release team

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -105,12 +105,12 @@ The Kubernetes Release Team is responsible for the day-to-day work required to s
 - **Contact:**
   - [Mailing List](https://groups.google.com/a/kubernetes.io/g/release-team)
   - GitHub Teams:
+    - [@kubernetes/release-ci-signal](https://github.com/orgs/kubernetes/teams/release-ci-signal)
+    - [@kubernetes/release-team](https://github.com/orgs/kubernetes/teams/release-team) - Members of the current Release Team and subproject owners
     - [@kubernetes/release-team-bug-triage](https://github.com/orgs/kubernetes/teams/release-team-bug-triage)
     - [@kubernetes/release-team-comms](https://github.com/orgs/kubernetes/teams/release-team-comms)
     - [@kubernetes/release-team-docs](https://github.com/orgs/kubernetes/teams/release-team-docs)
     - [@kubernetes/release-team-enhancements](https://github.com/orgs/kubernetes/teams/release-team-enhancements)
-    - [@kubernetes/release-ci-signal](https://github.com/orgs/kubernetes/teams/release-ci-signal)
-    - [@kubernetes/release-team](https://github.com/orgs/kubernetes/teams/release-team) - Members of the current Release Team and subproject owners
     - [@kubernetes/release-team-leads](https://github.com/orgs/kubernetes/teams/release-team-leads) - Release Team Leads for the current Kubernetes release cycle
     - [@kubernetes/release-team-release-notes](https://github.com/orgs/kubernetes/teams/release-team-release-notes)
 ### SIG Release Process Documentation

--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -105,9 +105,14 @@ The Kubernetes Release Team is responsible for the day-to-day work required to s
 - **Contact:**
   - [Mailing List](https://groups.google.com/a/kubernetes.io/g/release-team)
   - GitHub Teams:
-    - [@kubernetes/ci-signal](https://github.com/orgs/kubernetes/teams/ci-signal)
+    - [@kubernetes/release-team-bug-triage](https://github.com/orgs/kubernetes/teams/release-team-bug-triage)
+    - [@kubernetes/release-team-comms](https://github.com/orgs/kubernetes/teams/release-team-comms)
+    - [@kubernetes/release-team-docs](https://github.com/orgs/kubernetes/teams/release-team-docs)
+    - [@kubernetes/release-team-enhancements](https://github.com/orgs/kubernetes/teams/release-team-enhancements)
+    - [@kubernetes/release-ci-signal](https://github.com/orgs/kubernetes/teams/release-ci-signal)
     - [@kubernetes/release-team](https://github.com/orgs/kubernetes/teams/release-team) - Members of the current Release Team and subproject owners
     - [@kubernetes/release-team-leads](https://github.com/orgs/kubernetes/teams/release-team-leads) - Release Team Leads for the current Kubernetes release cycle
+    - [@kubernetes/release-team-release-notes](https://github.com/orgs/kubernetes/teams/release-team-release-notes)
 ### SIG Release Process Documentation
 Documents and processes related to SIG Release
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2244,16 +2244,16 @@ sigs:
     contact:
       mailing_list: https://groups.google.com/a/kubernetes.io/g/release-team
       teams:
+      - name: release-ci-signal
+      - name: release-team
+        description: Members of the current Release Team and subproject owners
       - name: release-team-bug-triage
       - name: release-team-comms
       - name: release-team-docs
       - name: release-team-enhancements
-      - name: release-ci-signal
-      - name: release-team-release-notes
-      - name: release-team
-        description: Members of the current Release Team and subproject owners
       - name: release-team-leads
         description: Release Team Leads for the current Kubernetes release cycle
+      - name: release-team-release-notes
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/release-team-shadow-stats/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2244,7 +2244,12 @@ sigs:
     contact:
       mailing_list: https://groups.google.com/a/kubernetes.io/g/release-team
       teams:
-      - name: ci-signal
+      - name: release-team-bug-triage
+      - name: release-team-comms
+      - name: release-team-docs
+      - name: release-team-enhancements
+      - name: release-ci-signal
+      - name: release-team-release-notes
       - name: release-team
         description: Members of the current Release Team and subproject owners
       - name: release-team-leads


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

**Which issue(s) this PR fixes**:

None

ref: PR to rename the ci signal team https://github.com/kubernetes/org/pull/3738

/cc @palnabarun @reylejano @Nivedita-coder 
cc @kubernetes/sig-release-leads 
