### PR TITLE
sig-auth: Add sig-auth-tools repo

### DIFF
--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -168,6 +168,10 @@ Infrastructure implementing Kubernetes service account based workload identity.
   - [kubernetes/kubernetes/pkg/kubelet/token](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/token/OWNERS)
   - [kubernetes/kubernetes/pkg/serviceaccount](https://github.com/kubernetes/kubernetes/blob/master/pkg/serviceaccount/OWNERS)
   - [kubernetes/kubernetes/plugin/pkg/admission/serviceaccount](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/serviceaccount/OWNERS)
+### sig-auth-tools
+Tooling to automate the SIG Auth project boards
+- **Owners:**
+  - [kubernetes-sigs/sig-auth-tools](https://github.com/kubernetes-sigs/sig-auth-tools/blob/main/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 [working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -565,6 +565,11 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/token/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/serviceaccount/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/serviceaccount/OWNERS
+  - name: sig-auth-tools
+    description: |
+      Tooling to automate the SIG Auth project boards
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/sig-auth-tools/main/OWNERS
 - dir: sig-autoscaling
   name: Autoscaling
   mission_statement: >


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/3688

@enj should this be a new subproject? or is there another that would be better?

