### PR TITLE
add external-secrets-dev channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -109,6 +109,7 @@ channels:
   - name: events
   - name: external-dns
   - name: external-secrets
+  - name: external-secrets-dev
   - name: falco
   - name: fiaas
   - name: finops


### PR DESCRIPTION
Which issue(s) this PR fixes:

This PR adds a new Slack channel called #external-secrets-dev to be used by the maintainers and contributors of the external-secrets CNCF project (external-secrets.io). It will be used to coordinate development communication amongst maintainers and contributors leaving `#external-secrets` to be user and broader community focused.

- [x] i'm aware of the limitations of Kubernetes slack in regards to slack apps and development integrations