### PR TITLE
Update files in k/community/contributor-comms to reflect name change

### DIFF
--- a/communication/contributor-comms/CHARTER.md
+++ b/communication/contributor-comms/CHARTER.md
@@ -36,4 +36,4 @@ Things change, priorities get optimized, life happens. Having an easy on and off
 
 In the case where no shadow is available, other Marketing Council team members have the responsibility to cover the role. Concerns for time or ability to cover work can be escalated to advisors and SIG Contributor Experience leads as necessary.
 
-[Marketing Council](/communication/marketing-team/role-handbooks/council.md)
+[Marketing Council](/communication/contributor-comms/role-handbooks/council.md)

--- a/communication/contributor-comms/role-handbooks/Social-Media.md
+++ b/communication/contributor-comms/role-handbooks/Social-Media.md
@@ -24,9 +24,9 @@ Team members: 1-3 hour per week.
 
 ## General Expectations
 
-- Rules for social posts and more can be found in [social guidelines](https://github.com/kubernetes/community/blob/master/communication/marketing-team/storytelling-resources/social-guidelines.md)
+- Rules for social posts and more can be found in [social guidelines](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/storytelling-resources/social-guidelines.md)
 - Be welcoming, be yourself
-- Understanding, communicating, and setting/adjusting [social guidelines](https://github.com/kubernetes/community/blob/master/communication/marketing-team/storytelling-resources/social-guidelines.md)
+- Understanding, communicating, and setting/adjusting [social guidelines](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/storytelling-resources/social-guidelines.md)
 - Coordinating work to create tweets, ensuring tweet requests are fulfilled
 - Working with other Contributor Comms leads, such as the Event Coordinator Lead, on social media tasks
 - Approving tweet PRs on [kubernetes-sigs/contributor-tweets](https://github.com/kubernetes-sigs/contributor-tweets)

--- a/communication/contributor-comms/role-handbooks/council.md
+++ b/communication/contributor-comms/role-handbooks/council.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Marketing Council is made up of multiple individuals working to bring multiple functions together to ensure Kubernetes contributors have a wealth of robust content and communications. The Marketing Council act as joint leaders to the Upstream Marketing team and its key responsibilities to the entire Kubernetes contributor base.
+The Marketing Council is made up of multiple individuals working to bring multiple functions together to ensure Kubernetes contributors have a wealth of robust content and communications. The Marketing Council act as joint leaders to the Contributor Comms team and its key responsibilities to the entire Kubernetes contributor base.
 
 #### How It Works
 
@@ -47,7 +47,7 @@ Responsibilities are categorized by the division of contribution among Marketing
   - Contributors
 - Working with the liaison team members to manage communications and workflows between the groups
 - Create new liaison positions as needed to coordinate key initiatives across the Kubernetes community
-- Audit the experience of engaging with the Upstream Marketing team and propose opportunities for improvement
+- Audit the experience of engaging with the Contributor Comms team and propose opportunities for improvement
 
 ### Minimum Skills and Requirements
 
@@ -60,7 +60,7 @@ Skills:
 Requirements:
 
 - Member of the [Kubernetes GitHub Org]
-- [Reviewer] in the marketing team folder
+- [Reviewer] in the contributor-comms folder
 - Shadowed under a lead in any role on the team for 6 months total (could be a combination of roles during that time period)
 
 #### Expected Time Investment

--- a/communication/contributor-comms/role-handbooks/storytellers.md
+++ b/communication/contributor-comms/role-handbooks/storytellers.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Upstream Marketing depends on great storytelling to get the message out about our amazing community.
+Contributor Comms depends on great storytelling to get the message out about our amazing community.
 
 It's no secret that governance and technical documentation can be kind of on the boring side. And that's ok–it's not always there for entertainment purposes. It is about providing valuable information and getting you where you need to go. But that said, an important message can be lost without an entertaining messenger. 
 
@@ -10,11 +10,11 @@ In this role, Storytellers are here to help Kubernetes contributors hear the lat
 
 ## Workflow ⚡️
 
-Storytelling is welcome in any medium that can be supported by the Upstream Marketing team. This includes but is not limited to written word–as outlined in [blogging guidelines]–or through video following our [YouTube guidelines]. 
+Storytelling is welcome in any medium that can be supported by the Contributor Comms team. This includes but is not limited to written word–as outlined in [blogging guidelines]–or through video following our [YouTube guidelines]. 
 
 Storytellers are constantly building new ways to share, and these resources are gathered in the [storytelling resources folder]. 
 
-### Upstream Marketing Process
+### Contributor Comms Process
 
 #### Idea Paths
 
@@ -22,7 +22,7 @@ There are multiple ways to successfully contribute a Kubernetes blog post. Here 
 
 **To start:** 
 
-* Open a [Contributor Comms Requests issue](https://github.com/kubernetes/community/issues) to share your blog idea, or attend an [Upstream Marketing team](https://github.com/kubernetes/community/tree/master/communication/marketing-team) meeting to discuss it ahead of time
+* Open a [Contributor Comms Requests issue](https://github.com/kubernetes/community/issues) to share your blog idea, or attend an [Contributor Comms team](https://github.com/kubernetes/community/tree/master/communication/contributor-comms) meeting to discuss it ahead of time
 
 **To write:**
 
@@ -30,17 +30,17 @@ There are multiple ways to successfully contribute a Kubernetes blog post. Here 
   * A draft can be written in:
     * Google Docs or
     * Markdown (and shared via [Gist](https://gist.github.com/) or [HackMD](https://hackmd.io/))
-* Connect with a storyteller -- if you reach out to Upstream Marketing, you will be paired with someone to help you through writing, editing, and getting your article published
+* Connect with a storyteller -- if you reach out to Contributor Comms, you will be paired with someone to help you through writing, editing, and getting your article published
   * Discussion happens via GitHub issue or through working group meetings
-* This includes working with Upstream Marketing team to polish, and format your blog post
-  * There is not a single canonical format for documents, but we do have [guidelines for effective articles](https://github.com/kubernetes/community/blob/master/communication/marketing-team/blog-guidelines.md#how-to-write-an-effective-blog)
+* This includes working with Contributor Comms team to polish, and format your blog post
+  * There is not a single canonical format for documents, but we do have [guidelines for effective articles](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/blog-guidelines.md#how-to-write-an-effective-blog)
   * There are further technical considerations by the [Blog team](https://github.com/kubernetes/community/blob/4026287dc3a2d16762353b62ca2fe4b80682960a/sig-docs/blog-subproject/README.md#submit-a-post)
 
 When it's ready, submit the blog post: 
 
 * Go to the `kubernetes/website` repository
 * Open a PR with your added blog post
-  * If you need help with this process, Upstream Marketing will look to pair you with someone for PR and shepherd it through the review cycle
+  * If you need help with this process, Contributor Comms will look to pair you with someone for PR and shepherd it through the review cycle
 
 Or if you already have everything you think you need you can:
 
@@ -72,7 +72,7 @@ Anyone is welcome to contribute when they have time. The core expectation of sto
 If you would like to be listed as a member of the team, here are the expectations:
 
 1. Be prepared to write one blog a quarter and participate in edits to other articles. The time commitment is typically 5-10 hours per quarter depending on the number of blog posts in the review queue.
-2. Storytellers are expected to attend at least one upstream marketing team meeting a month or check-in to remain active.
+2. Storytellers are expected to attend at least one Contributor Comms meeting a month or check-in to remain active.
 3. Remain non-partial: if you receive a request to write about a project, an individual, or a group of people from your employer, you should ask an impartial blogger to write it.
 4. As with all contribution to Kubernetes, adhere to the [code of conduct](/code-of-conduct.md), values, and principles of the project.
 

--- a/communication/contributor-comms/storytelling-resources/blog-guidelines.md
+++ b/communication/contributor-comms/storytelling-resources/blog-guidelines.md
@@ -1,6 +1,6 @@
-# Upstream Marketing Blog Guidelines
+# Contributor Comms Blog Guidelines
 
-This initiative falls under the [Upstream Marketing Charter](./CHARTER.md).
+This initiative falls under the [Contributor Comms Charter](./CHARTER.md).
 
 We are looking for Kubernetes-curious community members who are **interested in writing** and **care about getting the word out** to our huge community of users, developers, and contributors of all types. Here's how to get involved.
 
@@ -55,7 +55,7 @@ Anyone is welcome to contribute when they have time.
 If you would like to be listed as a member of the team, here are the expectations:
 
 1. Be prepared to write one blog a quarter and participate in edits to other articles. The time commitment is typically 5-10 hours per quarter depending on the number of blog posts in the review queue.
-2. Bloggers are expected to attend at least one upstream marketing team meeting a month or check-in to remain active.
+2. Bloggers are expected to attend at least one Contributor Comms team meeting a month or check-in to remain active.
 3. Remain non-partial: if you receive a request to write about a project, an individual, or a group of people from your employer, you should ask an impartial blogger to write it.
 4. As with all contribution to Kubernetes, adhere to the [code of conduct](/code-of-conduct.md), values, and principles of the project.
 

--- a/communication/contributor-comms/storytelling-resources/social-guidelines.md
+++ b/communication/contributor-comms/storytelling-resources/social-guidelines.md
@@ -4,7 +4,7 @@
 
 ## General guidelines
 
-All messaging must be consistent with the values and principles of the project and the [ethos/vision of the team](/communication/marketing-team/CHARTER.md#ethosvision). Messaging should be positive and uplifting. Be aware that sarcasm and/or jokes are generally hard to read over a medium such as social media.
+All messaging must be consistent with the values and principles of the project and the [ethos/vision of the team](/communication/contributor-comms/CHARTER.md#ethosvision). Messaging should be positive and uplifting. Be aware that sarcasm and/or jokes are generally hard to read over a medium such as social media.
 
 Original messages should come out of this teams' accounts at least twice a week (if not more). However, there should be no more than three tweets per hour (including retweets). Retweets, likes, and responses are unlimited, but they should be used thoughtfully to encourage inclusive and kind participation. Use scheduling software as needed to space out messages. All messages should serve a purpose: have an action and/or thumbnail image ("click link for details," "register today," etc. are example actions). Never include photos, user handles, or other personally identifiable information without explicit permission.
 


### PR DESCRIPTION
Related to issue https://github.com/kubernetes/community/issues/6641
Follow-up to PR https://github.com/kubernetes/community/pull/6911

This PR changes files in k/community/contributor-comms in the following manner:
  - to fix links for the dir name change from k/community/marketing-team to k/community/contributor-comms
  - to reflect the name change of Upstream Marketing to Contributor Comms

/cc @kaslin @chris-short 