### PR TITLE
Make slack-guidelines links explicit

### DIFF
--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -386,19 +386,19 @@ past "X" minutes/hours.
 Report any actions taken to the other slack admins, and if needed the 
 [Code of Conduct Committee][cocc].
 
-  [coc]: /code-of-conduct.md
-  [admins]: ./moderators.md#Slack
+  [coc]: https://github.com/kubernetes/community/blob/master/code-of-conduct.md
+  [admins]: https://github.com/kubernetes/community/blob/master/communication/moderators.md#Slack
   [Slack Archive Download]: https://drive.google.com/drive/folders/1Xnkwsxis3tu0pT7rwp-crRq4IciZ5b1o?usp=sharing
-  [cocc]: /committee-code-of-conduct/README.md
+  [cocc]: https://github.com/kubernetes/community/blob/master/committee-code-of-conduct/README.md
   [CNCF Slack]: https://slack.cncf.io/
   [Tempelis]: http://sigs.k8s.io/slack-infra/tempelis
-  [slack-config]: ./slack-config/
-  [Channel Documentation]: ./slack-config/README.md
+  [slack-config]: https://github.com/kubernetes/community/tree/master/communication/slack-config
+  [Channel Documentation]: https://github.com/kubernetes/community/tree/master/communication/slack-config/README.md
   [sig-list]: https://www.kubernetes.dev/community/community-groups
-  [Slack Config Documentation]: ./slack-config/README.md
-  [OWNERS]: /contributors/guide/owners
-  [usergroups.yaml]: ./slack-config/usergroups.yaml
-  [User Group Documentation]: ./slack-config/README.md#usergroups
+  [Slack Config Documentation]: https://github.com/kubernetes/community/tree/master/communication/slack-config/README.md
+  [OWNERS]: https://github.com/kubernetes/community/blob/master/contributors/guide/OWNERS
+  [usergroups.yaml]: https://github.com/kubernetes/community/tree/master/communication/slack-config/usergroups.yaml
+  [User Group Documentation]: https://github.com/kubernetes/community/tree/master/communication/slack-config/README.md#usergroups
   [GitHub Issue]: https://github.com/kubernetes/community/issues/new/choose
-  [moderation guidelines]: ./moderation.md
+  [moderation guidelines]: https://github.com/kubernetes/community/tree/master/communication/moderation.md
   [Slack's policy on inactivated accounts]: https://get.slack.help/hc/en-us/articles/204475027-Deactivate-a-member-s-account


### PR DESCRIPTION
This doc is imported into the kubernetes.dev site to pull together community docs from various locations. This works great for avoiding duplication, but brings an implicit requirement that the links in the doc can no longer be relative.

To avoid getting 404 links on kubernetes.dev, this updates all of the links in `slack-guidelines.md` to be their full explicit path on GitHub.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6934 
