### PR TITLE
Replace deprecated make generated_files

### DIFF
--- a/contributors/devel/sig-architecture/api_changes.md
+++ b/contributors/devel/sig-architecture/api_changes.md
@@ -679,15 +679,15 @@ Once all the necessary manually written conversions are added, you need to
 regenerate auto-generated ones. To regenerate them run:
 
 ```sh
-make clean && make generated_files
+make clean && hack/update-codegen.sh
 ```
 
 `make clean` is important, otherwise the generated files might be stale, because
 the build system uses custom cache.
 
-`make all` will invoke `make generated_files` as well.
+`make all` will invoke `hack/update-codegen.sh` as well.
 
-The `make generated_files` will also regenerate the `zz_generated.deepcopy.go`,
+The `hack/update-codegen.sh` will also regenerate the `zz_generated.deepcopy.go`,
 `zz_generated.defaults.go`, and `api/openapi-spec/swagger.json`.
 
 If regeneration is somehow not possible due to compile errors, the easiest


### PR DESCRIPTION
Running `make generated_files` shows :  

```
% make clean && make generated_files
+++ [1020 19:54:43] Verifying Prerequisites....
'make generated_files' is deprecated.  Please use hack/update-codegen.sh instead.
make: *** [Makefile:314 : generated_files] Erreur 1
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
