### PR TITLE
channels: Add kube-operating-systems-dev

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -223,6 +223,7 @@ channels:
     archived: true
   - name: kube-monkey
   - name: kube-oidc-proxy
+  - name: kube-operating-systems-dev
   - name: kube-router
   - name: kube-score
   - name: kube-spawn


### PR DESCRIPTION
channels: Add kube-operating-systems-dev

This is intended to be a cross-distro/cross-os channel for
cooperation and questions between developers/maintainers of
Kubernetes-native and Kubernetes-adjacent operating systems.

On topic are things like system provisioning, Kube-native APIs
for operating system configuration and management, sharing
image-based update ideas and code, etc.

For example: Talos Linux, Fedora/RHEL CoreOS, Flatcar, etc.

This thread got some interest:
https://twitter.com/cgwalters/status/1583122147756556288
and I'm hoping we can move some conversation here.
