### PR TITLE
slack-config: rename ko-project to ko-build

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -191,7 +191,8 @@ channels:
   - name: kcna-exam-prep
   - name: klog
   - name: knative
-  - name: ko-project
+  - name: ko-build
+    id: C01T7DTP65S
   - name: kompose
   - name: kong
   - name: konveyor


### PR DESCRIPTION
The `#ko-project` channel would like to rename to `#ko-build`.

This matches the project's new GitHub org (https://github.com/ko-build) and website (https://ko.build) and main command (`ko build`).