### PR TITLE
Add #podman-desktop to the Kubernetes slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -358,6 +358,7 @@ channels:
   - name: pharmer
   - name: pinniped
   - name: pl-users
+  - name: podman-desktop
   - name: pr-reviews
   - name: prometheus
   - name: prometheus-operator

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -180,6 +180,16 @@ usergroups:
       - jonasrosland
       - pnbrown
 
+  - name: podman-desktop-devs
+    long_name: Podman Desktop Dev Team
+    description: Active developers of Podman Desktop on #podman-desktop
+    channels:
+      - podman-desktop
+    members:
+      - cdrage
+      - benoitf
+      - vzhukovs
+
   - name: steering-members
     long_name: Kubernetes Steering Committee
     description: Members of the Kubernetes Steering Committee

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -20,6 +20,7 @@ users:
   bart0sh: U8VJC20R3
   benjaminapetersen: U0217E7EXV4
   bentheelder: U1P7T516X
+  benoitf: UCQC3DNUA
   bhumijgupta: U022JUBM3B4
   briandealwis: UAZKM38JV
   bubblemelon: U7K9C643G
@@ -171,6 +172,7 @@ users:
   varshaprasad96: UK59YP2DA
   Verolop: U7NNE57PU
   vladimirmukhin: UHVSCSD4G
+  vzhukovs: U030TR1FG85
   wilsonehusin: U0100068GF2
   wurbanski: URX7CMK97
   xmudrii: U4Q2TNGVD


### PR DESCRIPTION
Add #podman-desktop to the Kubernetes slack

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
N/A

**Overview:**

Hey all!

We're a dev team that focuses on creating a GUI interface
for "Podman" which is an open source project.

Podman Desktop implements Kubernetes heavily as you can create a
container, change it to a pod, and then deploy to Kubernetes. All with
open source tools.

Under-the-hood it is podman (open source) as well as the kubernetes
Node.JS library.

We have first class support for Kubernetes and wish to
be part of the Kubernetes slack for all community communication.

Our future intentions of the project is the implementation of Docker
Compose to Kubernetes tools such as Kompose
(https://github.com/kubernetes/kompose), which I'm a core maintainer of.

We have a ROADMAP to add more Kubernetes features
(https://github.com/orgs/containers/projects/2), specifically: https://github.com/containers/podman-desktop/issues/29

**Purpose of the channel:**

Over the past year, we've been using Discord. Our motivation to join the
Kubernetes Slack is because all of us are already on it! We all already
have accounts and are active in other channels.

**Criteria:**

I Believe we fit all the critera as we're:

* An open source project
* Kubernetes-specific with first class support
* Not product focused or proprietary

**Chatroom requested:**

#podman-desktop

**About the team:**

* Charlie Drage (cdrage): Maintainer of http://github.com/kubernetes/kompose which already has a Kubernetes #kompose channel

* Florent Benoit (benoitf): Contributor and active maintainer in the
https://github.com/containers

* Vladyslav Zhukovskyi (vzhukovs): Contributor and active maintainer of
  https://github.com/containers

**Other:**

* We understand and acknowledge the Kubernetes Code of Conduct
* Hi from Kubecon (was there yesterday!)

Many thanks and let us know if you need anything else!

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
