### PR TITLE
typo in generate-devstats-repo-sql.yaml 

### DIFF
--- a/hack/generate-devstats-repo-sql.py
+++ b/hack/generate-devstats-repo-sql.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """
-Output devstats repo_groups.sql based on subproject defintions in sigs.yaml
+Output devstats repo_groups.sql based on subproject definitions in sigs.yaml
 
 This is likely missing a few repos because:
     - some repos lack an owner (eg: kubernetes/kubernetes)


### PR DESCRIPTION
spelling fix on 'defintions' in the first block of comments in generate-devstats-repo-sql.yaml

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
