### PR TITLE
Adjust guidance on generics to include v1.24

### DIFF
--- a/sig-architecture/generics.md
+++ b/sig-architecture/generics.md
@@ -1,9 +1,9 @@
 # Background
 
-In general, Kubernetes has not restricted using new Go features, we've quickly
+In general, Kubernetes has not restricted using new Go features. We've quickly
 adopted new standard library types and methods and will continue to do so.
 
-Generally the latest stable go release is in use on the main development branch.
+Generally the latest stable Go release is in use on the main development branch.
 This includes all of the staging libraries (client-go etc.) that originate in the
 main [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repository.
 
@@ -14,19 +14,21 @@ Now that v1.24.0 is out, use of generics should be allowed.
 
 # Generics Policy
 
-Generics may be used in Kubernetes starting in v1.25, with the following restrictions 
-applying only until v1.24 is [out of support][version-support]:
+Generics may be used in Kubernetes starting in v1.24, with the following restrictions
+applying only until v1.23 is [out of support][version-support]:
 
 - Generics should **not** be used in Kubernetes libraries used across multiple Kubernetes
-versions, that is the non "staged" libraries like:
+  versions, that is the non "staged" libraries like:
   - [k8s.io/utils](https://github.com/kubernetes/utils)
   - [sigs.k8s.io/yaml](https://github.com/kubernetes-sigs/yaml)
   - [k8s.io/klog](https://github.com/kubernetes/klog)
   - etc.
 
-- Generics should be **avoided** when writing Kubernetes bug fixes that are likely to be backported, to streamline cherry-picking to older release branches.
+- Generics should be **avoided** when writing Kubernetes bug fixes that are
+  likely to be backported to v1.23 or older, to streamline cherry-picking to
+  those release branches which predate Go 1.18.
 
-These restrictions should be considered lifted when v1.24 is out of support.
+These restrictions should be considered lifted when v1.23 is out of support.
 
 ## Recommendations for Reviewers
 


### PR DESCRIPTION
Kubernetes v1.24 is built on Go 1.18, and will not revert to Go 1.17 at this point.  Ergo, it should be allowed to use Go generics as soon as 1.24 is the oldest supported release.

cc @dims
cc @BenTheElder 
cc @liggitt 

/sig architecture