### PR TITLE
Add resource-management subproject to sig-node

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -89,8 +89,9 @@ The following [subprojects][subproject-definition] are owned by sig-node:
   - [kubernetes/test-infra/config/jobs/kubernetes/node-problem-detector](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/node-problem-detector/OWNERS)
 - **Contact:**
   - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
-### noderesourcetopology-api
+### resource-management
 - **Owners:**
+  - [kubernetes/kubernetes/staging/src/k8s.io/dynamic-resource-allocation](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/dynamic-resource-allocation/OWNERS)
   - [kubernetes/noderesourcetopology-api](https://github.com/kubernetes/noderesourcetopology-api/blob/master/OWNERS)
 ### security-profiles-operator
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2148,8 +2148,9 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/node-problem-detector/OWNERS
-  - name: noderesourcetopology-api
+  - name: resource-management
     owners:
+    - https://raw.githubusercontent.com/kubernetes/dynamic-resource-allocation/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/noderesourcetopology-api/master/OWNERS
   - name: security-profiles-operator
     contact:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2150,7 +2150,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/node-problem-detector/OWNERS
   - name: resource-management
     owners:
-    - https://raw.githubusercontent.com/kubernetes/dynamic-resource-allocation/master/OWNERS
+    - https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/dynamic-resource-allocation/OWNERS
     - https://raw.githubusercontent.com/kubernetes/noderesourcetopology-api/master/OWNERS
   - name: security-profiles-operator
     contact:


### PR DESCRIPTION
Add resource-management subproject to sig-node

As part of this, add `dynamic-resource-management` staging repo as part of this subproject as well as absorb the (previously) standalone subproject for `noderesourcetopology-api` into this new subproject.

/cc @derekwaynecarr 
/cc @swatisehgal 
/cc @pohly 