### PR TITLE
Document the k8s-stable4 version marker

### DIFF
--- a/contributors/devel/sig-release/kubernetes-versions.md
+++ b/contributors/devel/sig-release/kubernetes-versions.md
@@ -328,6 +328,7 @@ The following generic markers are available:
 - `k8s-stable1`
 - `k8s-stable2`
 - `k8s-stable3`
+- `k8s-stable4`
 
 Generic markers reference cross builds generated via the `ci-kubernetes-build`
 jobs, which run approximately every hour.
@@ -400,6 +401,7 @@ We publish a set of additional generic version markers:
 - `k8s-stable1`
 - `k8s-stable2`
 - `k8s-stable3`
+- `k8s-stable4`
 
 Depending on the point in the release cycle, the meaning of these markers can
 change.


### PR DESCRIPTION
Part of the conversation in https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669065861073859, https://github.com/kubernetes/sig-release/issues/850:

We're now publishing the `k8s-stable4` version marker so this PR documents it.

Relevant to https://github.com/kubernetes/sig-release/issues/2094

/assign @justaugustus @jeremyrickard @cici37
cc: https://github.com/orgs/kubernetes/teams/release-engineering