### PR TITLE
Update the references under sig-node

### DIFF
--- a/contributors/devel/sig-node/cherry-picks.md
+++ b/contributors/devel/sig-node/cherry-picks.md
@@ -24,7 +24,7 @@ cherry-picked to previous releases must be [triaged], prioritized, LGTM'd, and
 approved by the deadline.
 
 [patch releases]: https://github.com/kubernetes/sig-release/blob/master/release-engineering/versioning.md#patch-releases
-[target dates]: https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md#upcoming-monthly-releases
+[target dates]: https://kubernetes.io/releases/patch-releases/#upcoming-monthly-releases
 [triaged]: triage.md
 
 ## Monthly cherry-pick process

--- a/contributors/devel/sig-node/container-runtime-interface.md
+++ b/contributors/devel/sig-node/container-runtime-interface.md
@@ -5,7 +5,7 @@
 CRI (_Container Runtime Interface_) consists of a
 specifications/requirements (to-be-added),
 [protobuf API](https://git.k8s.io/kubernetes/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.proto),
-and [libraries](https://git.k8s.io/kubernetes/pkg/kubelet/server/streaming)
+and [libraries](https://git.k8s.io/kubernetes/pkg/kubelet/cri/streaming)
 for container runtimes to integrate with kubelet on a node. The CRI API is
 currently in Alpha, and the CRI-Docker integration is used by default as of
 Kubernetes 1.7+.

--- a/contributors/devel/sig-node/e2e-node-tests.md
+++ b/contributors/devel/sig-node/e2e-node-tests.md
@@ -192,7 +192,7 @@ However, image configuration files select test cases based on the `tests` field.
 
 See https://github.com/kubernetes/test-infra/blob/4572dc3bf92e70f572e55e7ac1be643bdf6b2566/jobs/e2e_node/benchmark-config.yaml#L22-23 for an example configuration. 
 
-If the [Prow e2e job configuration](https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/image-config.yaml) does **not** specify the `tests` field, FOCUS and SKIP will run as expected.
+If the [Prow e2e job configuration](https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/containerd/image-config.yaml) does **not** specify the `tests` field, FOCUS and SKIP will run as expected.
 
 # Additional test options for both remote and local execution
 
@@ -307,7 +307,7 @@ For example,
     /test pull-kubernetes-node-e2e
     flake due to #12345
 
-The PR builder runs tests against the images listed in [image-config.yaml](https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/image-config.yaml).
+The PR builder runs tests against the images listed in [image-config.yaml](https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/containerd/image-config.yaml).
 
 Other [node e2e Prow jobs](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/sig-node)
 run against different images depending on the configuration chosen in the

--- a/contributors/devel/sig-node/triage.md
+++ b/contributors/devel/sig-node/triage.md
@@ -141,8 +141,8 @@ After 30d more, they will be marked as rotten, and then closed automatically.
 Reviewers should feel free to close stale PRs (4+ months of no changes) with a
 note that the author can reopen when they are ready to work on it.
 
-[tests are failing]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md#troubleshooting-a-failure
-[flake]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/flaky-tests.md
+[tests are failing]: /contributors/devel/sig-testing/testing.md#troubleshooting-a-failure
+[flake]: /contributors/devel/sig-testing/flaky-tests.md
 
 ## Waiting on Reviewer
 

--- a/contributors/devel/sig-node/triage.md
+++ b/contributors/devel/sig-node/triage.md
@@ -141,8 +141,8 @@ After 30d more, they will be marked as rotten, and then closed automatically.
 Reviewers should feel free to close stale PRs (4+ months of no changes) with a
 note that the author can reopen when they are ready to work on it.
 
-[tests are failing]: contributors/devel/sig-testing/testing.md#troubleshooting-a-failure
-[flake]: contributors/devel/sig-testing/flaky-tests.md
+[tests are failing]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md#troubleshooting-a-failure
+[flake]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/flaky-tests.md
 
 ## Waiting on Reviewer
 


### PR DESCRIPTION
This PR updates the references in [sig-node](https://github.com/kubernetes/community/tree/master/contributors/devel/sig-node) under the contributors development area