### PR TITLE
Add cluster api cloud director slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -54,6 +54,7 @@ channels:
   - name: cluster-api-aws-alerts
   - name: cluster-api-azure
   - name: cluster-api-baremetal
+  - name: cluster-api-cloud-director
   - name: cluster-api-cloudstack
   - name: cluster-api-digitalocean
   - name: cluster-api-docker


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

The purpose of the PR is to create a slack channel for the project https://github.com/vmware/cluster-api-provider-cloud-director
 - The project implements cluster-api (https://github.com/kubernetes-sigs/cluster-api) for VMWare cloud director platform.

**Which issue(s) this PR fixes**:

Fixes #
