### PR TITLE
Update required go version

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -285,7 +285,8 @@ different versions of Kubernetes.
 | 1.19 - 1.20    | 1.15.5      |
 | 1.21 - 1.22    | 1.16.7      |
 | 1.23           | 1.17        |
-| 1.24+          | 1.18        |
+| 1.24           | 1.18        |
+| 1.25+          | 1.19        |
 
 ##### A Note on Changing Go Versions
 


### PR DESCRIPTION
Today we had k8s upstream training[1] in Japan, and we found this table is not updated at this time.
The pull request[2] updated the go version to 1.19 in Kubernetes v1.25 development.
This updates the table to catch that.

[1]: https://www.okinawaopendays.com/session-dec14-training
[2]: https://github.com/kubernetes/kubernetes/pull/111679