### PR TITLE
Update slack approvers to match current team

### DIFF
--- a/communication/slack-config/OWNERS
+++ b/communication/slack-config/OWNERS
@@ -2,18 +2,19 @@
 
 # These are the primary slack moderators.
 approvers:
-  - katharine
-  - castrojo
   - jeefy
   - mrbobbytables
   - alejandrox1
-  - jdumars
   - coderanger
-  - idvoretskyi
-  - idealhack
   - munnerz
   - DylanGraham
+  - jberkus
 emeritus_approvers:
   - parispitmann
+  - idvoretskyi
+  - katharine
+  - castrojo
+  - jdumars
+  - idealhack
 labels:
   - area/slack-management


### PR DESCRIPTION
Moved multiple former slack admins to emeritus.

Added myself as OWNER; while this is redundant right now because of root-level ownership, it won't always be.

Please comment if there are additional slack admins I should be adding.