### PR TITLE
sig-cloud-provider: add aws-file-cache-csi-driver repo

### DIFF
--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -92,6 +92,7 @@ The following [subprojects][subproject-definition] are owned by sig-cloud-provid
   - [kubernetes-sigs/aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/OWNERS)
   - [kubernetes-sigs/aws-efs-csi-driver](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/OWNERS)
   - [kubernetes-sigs/aws-encryption-provider](https://github.com/kubernetes-sigs/aws-encryption-provider/blob/master/OWNERS)
+  - [kubernetes-sigs/aws-file-cache-csi-driver](https://github.com/kubernetes-sigs/aws-file-cache-csi-driver/blob/main/OWNERS)
   - [kubernetes-sigs/aws-fsx-csi-driver](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/blob/master/OWNERS)
   - [kubernetes-sigs/aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/OWNERS)
   - [kubernetes-sigs/provider-aws-test-infra](https://github.com/kubernetes-sigs/provider-aws-test-infra/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -870,6 +870,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/aws-encryption-provider/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/aws-file-cache-csi-driver/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/aws-fsx-csi-driver/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/aws-iam-authenticator/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/provider-aws-test-infra/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/3866

/assign @nckturner 

/hold
for lgtm from sig-cloud-provider lead