### PR TITLE
Correct reference link formatting

### DIFF
--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -386,19 +386,19 @@ past "X" minutes/hours.
 Report any actions taken to the other slack admins, and if needed the 
 [Code of Conduct Committee][cocc].
 
-  [coc]: /code-of-conduct.md
-  [admins]: ./moderators.md#Slack
-  [Slack Archive Download]: https://drive.google.com/drive/folders/1Xnkwsxis3tu0pT7rwp-crRq4IciZ5b1o?usp=sharing
-  [cocc]: /committee-code-of-conduct/README.md
-  [CNCF Slack]: https://slack.cncf.io/
-  [Tempelis]: http://sigs.k8s.io/slack-infra/tempelis
-  [slack-config]: ./slack-config/
-  [Channel Documentation]: ./slack-config/README.md
-  [sig-list]: https://www.kubernetes.dev/community/community-groups
-  [Slack Config Documentation]: ./slack-config/README.md
-  [OWNERS]: /contributors/guide/owners
-  [usergroups.yaml]: ./slack-config/usergroups.yaml
-  [User Group Documentation]: ./slack-config/README.md#usergroups
-  [GitHub Issue]: https://github.com/kubernetes/community/issues/new/choose
-  [moderation guidelines]: ./moderation.md
-  [Slack's policy on inactivated accounts]: https://get.slack.help/hc/en-us/articles/204475027-Deactivate-a-member-s-account
+[coc]: /code-of-conduct.md
+[admins]: ./moderators.md#Slack
+[Slack Archive Download]: https://drive.google.com/drive/folders/1Xnkwsxis3tu0pT7rwp-crRq4IciZ5b1o?usp=sharing
+[cocc]: /committee-code-of-conduct/README.md
+[CNCF Slack]: https://slack.cncf.io/
+[Tempelis]: http://sigs.k8s.io/slack-infra/tempelis
+[slack-config]: ./slack-config/
+[Channel Documentation]: ./slack-config/README.md
+[sig-list]: https://www.kubernetes.dev/community/community-groups
+[Slack Config Documentation]: ./slack-config/README.md
+[OWNERS]: /contributors/guide/OWNERS
+[usergroups.yaml]: ./slack-config/usergroups.yaml
+[User Group Documentation]: ./slack-config/README.md#usergroups
+[GitHub Issue]: https://github.com/kubernetes/community/issues/new/choose
+[moderation guidelines]: ./moderation.md
+[Slack's policy on inactivated accounts]: https://get.slack.help/hc/en-us/articles/204475027-Deactivate-a-member-s-account

--- a/communication/youtube/youtube-guidelines.md
+++ b/communication/youtube/youtube-guidelines.md
@@ -236,26 +236,26 @@ downloaded and then reuploaded to the Kubernetes channel.
     generate thumbnails and process the videos.
 7.  Once videos are finalized, set the playlist to Public to publish them.
 
-  [coc]: /code-of-conduct.md
-  [admins]: /communication/moderators.md
-  [Kubernetes YouTube Channel]: https://www.youtube.com/channel/UCZ2bu0qutTOM0tHYa_jkIwg
-  [community meeting]: /events/community-meeting.md
-  [Office Hours]: /events/office-hours.md
-  [Meet our Contributors]: /events/meet-our-contributors.md
-  [Subprojects]: /governance.md#subprojects
-  [collaboration]: https://support.google.com/youtube/answer/6109639
-  [update the permissions in your YouTube settings]: https://support.google.com/a/answer/6212415
-  [YouTube admins]: /communication/moderators.md#YouTube-Channel
-  [SIG Contributor Experience]: /sig-contributor-experience/README.md
-  [moderation guidelines]: /communication/moderation.md
-  [trim]: https://support.google.com/youtube/answer/9057455?hl=en
-  [edit]: https://support.google.com/youtube/topic/9257530?hl=en&ref_topic=9257610
-  [Zoom guidelines]: /communication/zoom-guidelines.md
-  [SIG Auth]: /sig-auth/README.md
-  [SIG Docs]: /sig-docs/README.md
-  [SIG Network]: /sig-network/README.md
-  [SIG Release]: /sig-release/README.md
-  [Steering Committee]: /committee-steering/governance/README.md
-  [WG Data Protection]: /wg-data-protection/README.md
-  [Streaming Config]: /communication/youtube/streaming-config.md
-  [youtube-dl]: https://ytdl-org.github.io/youtube-dl/index.html
+[coc]: /code-of-conduct.md
+[admins]: /communication/moderators.md
+[Kubernetes YouTube Channel]: https://www.youtube.com/channel/UCZ2bu0qutTOM0tHYa_jkIwg
+[community meeting]: /events/community-meeting.md
+[Office Hours]: /events/office-hours.md
+[Meet our Contributors]: /events/meet-our-contributors.md
+[Subprojects]: /governance.md#subprojects
+[collaboration]: https://support.google.com/youtube/answer/6109639
+[update the permissions in your YouTube settings]: https://support.google.com/a/answer/6212415
+[YouTube admins]: /communication/moderators.md#YouTube-Channel
+[SIG Contributor Experience]: /sig-contributor-experience/README.md
+[moderation guidelines]: /communication/moderation.md
+[trim]: https://support.google.com/youtube/answer/9057455?hl=en
+[edit]: https://support.google.com/youtube/topic/9257530?hl=en&ref_topic=9257610
+[Zoom guidelines]: /communication/zoom-guidelines.md
+[SIG Auth]: /sig-auth/README.md
+[SIG Docs]: /sig-docs/README.md
+[SIG Network]: /sig-network/README.md
+[SIG Release]: /sig-release/README.md
+[Steering Committee]: /committee-steering/governance/README.md
+[WG Data Protection]: /wg-data-protection/README.md
+[Streaming Config]: /communication/youtube/streaming-config.md
+[youtube-dl]: https://ytdl-org.github.io/youtube-dl/index.html

--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -190,27 +190,27 @@ for which models work best.
 
 Thanks for making Kubernetes meetings work great!
 
-  [community meeting]: /events/community-meeting
-  [SIG/WG meetings]: /sig-list.md
-  [Office Hours]: /events/office-hours
-  [Meet Our Contributors]: /mentoring/programs/meet-our-contributors.md
-  [Kubernetes code of conduct]: /code-of-conduct.md
-  [moderation]: ./moderation.md
-  [CNCF Service Desk]: https://github.com/cncf/servicedesk
-  [Zoom Admins]: ./moderators.md#zoom
-  [centralized list of administrators]: ./moderators.md
-  [sig creation procedure]: /sig-wg-lifecycle.md#communicate
-  [latest version]: https://zoom.us/download
-  [host key]: https://support.zoom.us/hc/en-us/articles/205172555-Host-Key
-  [waiting room]: https://support.zoom.us/hc/en-us/articles/115000332726-Waiting-Room
-  [documentation on how to use their moderation tools]: https://support.zoom.us/hc/en-us/articles/201362603-Host-Controls-in-a-Meeting
-  [best practices doc]: https://docs.google.com/document/d/1fudC_diqhN2TdclGKnQ4Omu4mwom83kYbZ5uzVRI07w/edit?usp=sharing
-  [Code of Conduct Committee]: /committee-code-of-conduct/README.md
-  [Please follow this guideline for more details]: ./youtube/youtube-guidelines.md
-  [Kubernetes channel]: https://www.youtube.com/c/kubernetescommunity
-  [SIG Contributor Experience]: /sig-contributor-experience
-  [documentation on how to use their screen sharing feature]: https://support.zoom.us/hc/en-us/articles/201362153-How-Do-I-Share-My-Screen
-  [lots of things that can go wrong]: https://www.youtube.com/watch?v=JMOOG7rWTPg
-  [Blue Yeti]: https://www.bluedesigns.com/products/yeti/
-  [pop filter]: https://en.wikipedia.org/wiki/Pop_filter
-  [Join on muted audio and video]: https://support.zoom.us/hc/en-us/articles/203024649-Video-Or-Microphone-Off-By-Attendee
+[community meeting]: /events/community-meeting
+[SIG/WG meetings]: /sig-list.md
+[Office Hours]: /events/office-hours
+[Meet Our Contributors]: /mentoring/programs/meet-our-contributors.md
+[Kubernetes code of conduct]: /code-of-conduct.md
+[moderation]: ./moderation.md
+[CNCF Service Desk]: https://github.com/cncf/servicedesk
+[Zoom Admins]: ./moderators.md#zoom
+[centralized list of administrators]: ./moderators.md
+[sig creation procedure]: /sig-wg-lifecycle.md#communicate
+[latest version]: https://zoom.us/download
+[host key]: https://support.zoom.us/hc/en-us/articles/205172555-Host-Key
+[waiting room]: https://support.zoom.us/hc/en-us/articles/115000332726-Waiting-Room
+[documentation on how to use their moderation tools]: https://support.zoom.us/hc/en-us/articles/201362603-Host-Controls-in-a-Meeting
+[best practices doc]: https://docs.google.com/document/d/1fudC_diqhN2TdclGKnQ4Omu4mwom83kYbZ5uzVRI07w/edit?usp=sharing
+[Code of Conduct Committee]: /committee-code-of-conduct/README.md
+[Please follow this guideline for more details]: ./youtube/youtube-guidelines.md
+[Kubernetes channel]: https://www.youtube.com/c/kubernetescommunity
+[SIG Contributor Experience]: /sig-contributor-experience
+[documentation on how to use their screen sharing feature]: https://support.zoom.us/hc/en-us/articles/201362153-How-Do-I-Share-My-Screen
+[lots of things that can go wrong]: https://www.youtube.com/watch?v=JMOOG7rWTPg
+[Blue Yeti]: https://www.bluedesigns.com/products/yeti/
+[pop filter]: https://en.wikipedia.org/wiki/Pop_filter
+[Join on muted audio and video]: https://support.zoom.us/hc/en-us/articles/203024649-Video-Or-Microphone-Off-By-Attendee

--- a/events/2016/developer-summit-2016/KubDevSummitVoting.md
+++ b/events/2016/developer-summit-2016/KubDevSummitVoting.md
@@ -1,33 +1,31 @@
-###Kubernetes Developer's Summit Discussion Topics Voting
-###
-A voting poll for discussion topic proposals has been created, and the link to the poll can be found [here][poll]. 
+### Kubernetes Developer's Summit Discussion Topics Voting
 
-The poll will close on 10/07/16 at 23:59:59 PDT. 
+A voting poll for discussion topic proposals has been created, and the link to the poll can be found [here][poll].
+
+The poll will close on 10/07/16 at 23:59:59 PDT.
 
 #### How Does it Work?
-####
+
 The voting uses the Condorcet method, which relies on relative rankings to pick winners. You can read more about the Condorcet method and the voting service we're using on the [CIVS website][civs].
 
-There are 27 topics to choose from, and you will rank them from 1 (favorite) to 27 (least favorite). You can also mark "no opinion" on topics that you don't wish to include in the ranking. 
+There are 27 topics to choose from, and you will rank them from 1 (favorite) to 27 (least favorite). You can also mark "no opinion" on topics that you don't wish to include in the ranking.
 
-The poll on CIVS has just the topic titles for ease of viewing. For topic descriptions, please see this [spreadsheet][topics]. The topic order on the voting service should mirror the order on the spreadsheet. 
+The poll on CIVS has just the topic titles for ease of viewing. For topic descriptions, please see this [spreadsheet][topics]. The topic order on the voting service should mirror the order on the spreadsheet.
 
-You will note the message saying "*Only the 15 favorite choices will win the poll*". CIVS requires a number be selected for winners, and we have arbitrarily chosen 15. The final schedule may include more or less than 15 of the submitted topics. 
+You will note the message saying "*Only the 15 favorite choices will win the poll*". CIVS requires a number be selected for winners, and we have arbitrarily chosen 15. The final schedule may include more or less than 15 of the submitted topics.
 
-##### A Small Request 
-#####
+##### A Small Request
 
-In order to make the poll accessible via URL, it has to be made "public". This means than any unique IP address can vote, which can be easily exploited for multiple votes. 
+In order to make the poll accessible via URL, it has to be made "public". This means than any unique IP address can vote, which can be easily exploited for multiple votes.
 
 We fully expect the community to behave with sportsmanship and only vote once, and as such we almost didn't bring this concern up to begin with. However, we have chosen to explicitly address it, in order to reiterate the importance of everyone's voice receiving equal weight in a community-driven event.
 
 #### After the Poll
-####
+
 A schedule will be made from the winning topics with
 some editorial license, and the schedule will be announced to the group
 at least a week before the event.
 
-[//]: # (Reference Links)
-   [civs]: <http://civs.cs.cornell.edu/>
-   [poll]: <http://civs.cs.cornell.edu/cgi-bin/vote.pl?id=E_9ef4ac5e58c4cab1&akey=7cc2652f9715b525>
-   [topics]: <https://docs.google.com/spreadsheets/d/1bmp6uLG8H32MVz02-zsieeKKZDZITw-8B6UjOaNTXOA/edit?usp=sharing>
+[civs]: <http://civs.cs.cornell.edu/>
+[poll]: <http://civs.cs.cornell.edu/cgi-bin/vote.pl?id=E_9ef4ac5e58c4cab1&akey=7cc2652f9715b525>
+[topics]: <https://docs.google.com/spreadsheets/d/1bmp6uLG8H32MVz02-zsieeKKZDZITw-8B6UjOaNTXOA/edit?usp=sharing>

--- a/events/2016/developer-summit-2016/Kubernetes_Dev_Summit.md
+++ b/events/2016/developer-summit-2016/Kubernetes_Dev_Summit.md
@@ -1,12 +1,11 @@
 # Kubernetes Dev Summit
-# 
 
 ## Edit - Event Location
-##
+
 The event is on the 4th Floor of the *Union Street Tower* of the Sheraton Seattle Hotel. 
 
 # About the Event
-#
+
 The Kubernetes Developers' Summit provides an avenue for Kubernetes
 developers  to connect face to face and mindshare about future community
 development and community governance endeavors.
@@ -15,7 +14,7 @@ In some sense, the summit is a real-life extension of the community
 meetings and SIG meetings.
 
 ## Event Format
-## 
+
 The Dev Summit is a "loosely-structured [unconference][uncf]". Rather
 than speakers and presentations, we will have moderators/facilitators
 and discussion topics, alongside all-day completely unstructured
@@ -35,7 +34,7 @@ Then, there will be 2 smaller rooms for hacking / unstructured
 discussion all day.
 
 #### Who Should Go?
-#### 
+
 The target audience is the Kubernetes developer community. The group
 will be relatively small (~120-150 attendees), to improve communication
 and facilitate easier decision-making. The majority of the attendees
@@ -52,7 +51,7 @@ Please note that this Summit is not the right environment for people to
 involved initially.
 
 #### Call for Proposals
-#### 
+
 Proposals for discussion topics can be submitted through [this
 form][propfrm] by September 30, 23:59 PT. If you propose a session topic,
 please be prepared to attend and facilitate the session if it gets
@@ -71,7 +70,7 @@ some editorial license, and the schedule will be announced to the group
 at least a week before the event.
 
 ## When & Where?
-## 
+
 The Dev Summit will follow [Kubecon][kbc] on November 10th, 2016.
 Fortunately for those who attend Kubecon, the Dev Summit will be at the
 same venue, [the Sheraton Seattle Hotel][sher]. As of now, the day's
@@ -79,18 +78,17 @@ activities should run from breakfast being served at 8 AM to closing
 remarks ending around 3:30 PM, with an external happy hour to follow.
 
 ## Desired outcomes
-## 
+
 * Generate notes from the sessions to feed the project's documentation
 and knowledge base, and also to keep non-attendees plugged in 
 * Make (and document) recommendations and decisions for the near-term and
 mid-term future of the project 
 * Come up with upcoming action items, as well as leaders for those action items, for the various topics that we discuss
 
-[//]: # (Reference Links)
-   [uncf]: <https://en.wikipedia.org/wiki/Unconference>
-   [mtp]: <http://www.meetup.com/topics/kubernetes/all/>
-   [lotfrm]: <https://docs.google.com/forms/d/e/1FAIpQLSe8t6pvRjh1OeF6xrXKbXmzHGMhQ4c-MbZ6QUr9APJNjpgAzA/viewform>
-   [propfrm]: <https://docs.google.com/forms/d/e/1FAIpQLSf30x18OGCv_Und7qah4y5Zs3Z-0YoBCo964ZsmhtbxBjMzxA/viewform>
-   [civs]: <http://civs.cs.cornell.edu/>
-   [kbc]: <http://events.linuxfoundation.org/events/kubecon>
-   [sher]: <http://www.sheratonseattle.com/>
+[uncf]: <https://en.wikipedia.org/wiki/Unconference>
+[mtp]: <http://www.meetup.com/topics/kubernetes/all/>
+[lotfrm]: <https://docs.google.com/forms/d/e/1FAIpQLSe8t6pvRjh1OeF6xrXKbXmzHGMhQ4c-MbZ6QUr9APJNjpgAzA/viewform>
+[propfrm]: <https://docs.google.com/forms/d/e/1FAIpQLSf30x18OGCv_Und7qah4y5Zs3Z-0YoBCo964ZsmhtbxBjMzxA/viewform>
+[civs]: <http://civs.cs.cornell.edu/>
+[kbc]: <http://events.linuxfoundation.org/events/kubecon>
+[sher]: <http://www.sheratonseattle.com/>


### PR DESCRIPTION
When using reference links (`[a link to something][something]`) the link goes itself is referred to later in the file. This normally should be a line that starts with the reference name in brackets, followed by the actual link (`[something]: <link>`).

Many of these reference links in the repo have unnecessary leading spaces. While this renders OK, at least with GitHub's markdown rendering, it currently causes problems for sites like kubernetes.dev that pull in these docs and attempt to update the links so they are usable from a different rendered location.

While the script that does that import should probably be updated to be a little more robust, this addresses the immediate need of fixing these broken kubernetes.dev links by removing the leading whitespaces so they are properly recongized and updated.

Also some very minor cleanup in some older files. While these don't appear to be imported elsewhere, they were cleaned up to avoid the risk of any future copy/paste issues that could happen prior to the doc import script being updated to handle things correctly.

**Which issue(s) this PR fixes**:

Fixes #6934
