### PR TITLE
Use local-up-cluster.sh always as root

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -75,21 +75,13 @@ In a separate tab of your terminal, run the following:
 
 ```sh
 cd kubernetes
-./hack/local-up-cluster.sh
-```
-
-Since root access is sometimes needed to start/stop Kubernetes daemons, `./hack/local-up-cluster.sh` may need to be run as root. If it reports failures, try this instead:
-
-```sh
 sudo ./hack/local-up-cluster.sh
 ```
-
-This will build and start a lightweight local cluster, consisting of a master and a single node. Press Control+C to shut it down.
 
 **Note:** If you've already compiled the Kubernetes components, you can avoid rebuilding them with the `-O` flag.
 
 ```sh
-./hack/local-up-cluster.sh -O
+sudo ./hack/local-up-cluster.sh -O
 ```
 
 You can use the `./cluster/kubectl.sh` script to interact with the local cluster. `./hack/local-up-cluster.sh` will
@@ -163,7 +155,7 @@ You are running a single node setup.  This has the limitation of only supporting
 ```sh
 cd kubernetes
 make
-./hack/local-up-cluster.sh
+sudo ./hack/local-up-cluster.sh
 ```
 
 ### kubectl claims to start a container but `get pods` and `docker ps` don't show it.


### PR DESCRIPTION
This change fixes some permission errors in local running mode. `./hack/local-up-cluster.sh` creates a file with the wrong owner, and it fails for the second run. To avoid various permission issues it would be nice to run the script always as `root`.

```
.rw------- root  root  1.5 MB Mon Jan 16 11:36:40 2023 kube-apiserver-audit.log
```

Next time API manager fails

```
E0116 11:37:23.023960   12336 run.go:74] "command failed" err="ensureLogFile: open /tmp/kube-apiserver-audit.log: permission denied"
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/115016

