### PR TITLE
Fix 2023 GB election bios

### DIFF
--- a/elections/steering/2023-GB/candidate-cblecker.md
+++ b/elections/steering/2023-GB/candidate-cblecker.md
@@ -2,3 +2,5 @@
 name: Christoph Blecker
 ID: cblecker
 -------------------------------------------------------------
+
+name: Christoph Blecker

--- a/elections/steering/2023-GB/candidate-justaugustus.md
+++ b/elections/steering/2023-GB/candidate-justaugustus.md
@@ -2,3 +2,5 @@
 name: Stephen Augustus
 ID: justaugustus
 -------------------------------------------------------------
+
+name: Stephen Augustus

--- a/elections/steering/2023-GB/election.yaml
+++ b/elections/steering/2023-GB/election.yaml
@@ -1,6 +1,6 @@
 name: 2023 Kubernetes CNCF Governing Board Election
 organization: Kubernetes
-start_datetime: 2023-01-20 00:00:01
+start_datetime: 2023-01-19 00:00:01
 end_datetime: 2022-01-22 11:59:59
 no_winners: 1
 allow_no_opinion: False
@@ -10,4 +10,4 @@ election_officers:
   - jberkus
 eligibility: Eligibility is limited to the [current Steering Committee Members](https://github.com/kubernetes/steering/tree/c0e6eafa131bb5918bd24653233568a44439497f#members)
 exception_description: No exception requests accepted for the GB election.
-exception_due: 2023-01-20 00:00:01
+exception_due: 2023-01-19 00:00:01


### PR DESCRIPTION
Elekto errors out with an empty profile.
Repeated candidate name.

also bumped start date to today to test.

/assign @jberkus 