### PR TITLE
Remove community meeting requirements from governance docs

### DIFF
--- a/committee-steering/governance/README.md
+++ b/committee-steering/governance/README.md
@@ -43,7 +43,7 @@ As part of this we will define roles for the [OARP] process (Owners, Approvers, 
   If more substantial changes are desired it is advisable to socialize those before drafting a PR.
     - The steering committee will be looking to ensure the scope of the SIG as represented in the charter is reasonable (and within the scope of Kubernetes) and that processes are fair.
 - For large changes alert the rest of the Kubernetes community (Participants) as the scope of the changes becomes clear.
-  Sending mail to [dev@kubernetes.io] and/or announcing at the community meeting are a good ways to do this.
+  Sending mail to [dev@kubernetes.io] and (optionally) announcing it in the #kubernetes-contributors slack channel.
 
 If there are questions about this process please reach out to the steering committee at [steering@kubernetes.io].
 

--- a/committee-steering/governance/annual-reports.md
+++ b/committee-steering/governance/annual-reports.md
@@ -201,7 +201,7 @@ Operational tasks in [sig-governance.md]:
 [ ] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
 [ ] SIG leaders (chairs, tech leads, and subproject owners) in [sigs.yaml] are accurate and active, and updated if needed
 [ ] Meeting notes and recordings for $YYYY are linked from [README.md] and updated/uploaded if needed
-[ ] Did you have community-wide updates in $YYYY (e.g. community meetings, kubecon, or kubernetes-dev@ emails)? Links to email, slides, or recordings:
+[ ] Did you have community-wide updates in $YYYY (e.g. kubecon, or kubernetes-dev@ emails)? Links to email, slides, or recordings:
     - 
     - 
 

--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -16,9 +16,6 @@ repo
 [Kubernetes Community YouTube playlist]  
 - Report activity with the community via the dev@kubernetes.io mailing list at
 least once a year. 
-  - Each SIG is assigned an update during the [monthly community meeting]
-  throughout the year from sig-contributor-experience. The meeting host will publish the notes to the
-  kubernetes-dev mailing list with the update.  
   - This is separate from the [annual report]. 
 - Participate in release planning meetings and retrospectives, and burndown
 meetings, as needed
@@ -115,7 +112,6 @@ Subproject contributors (as applicable).
  groups like SIGs and the Steering Committee but *MAY* delegate the actual
  communication and creation of content to other contributors where
  appropriate  
-- *MUST* provide updates through the [monthly community meeting]
 - *MUST* present yearly [annual report] for the group but *SHOULD* get help with
 curation from other SIG participants
 
@@ -276,6 +272,5 @@ Issues impacting multiple subprojects in the SIG should be resolved by either:
 [Marketing Council]: /communication/marketing-team/role-handbooks/council.md
 [Events Lead]: /events/events-team/events-lead.md
 [PR Wrangler]: https://kubernetes.io/docs/contribute/participate/pr-wranglers/
-[monthly community meeting]: /events/community-meeting.md
 [Inclusive Open Source Community Orientation course]: https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/
 [technical-lead.md]: /contributors/chairs-and-techleads/technical-lead.md

--- a/governance.md
+++ b/governance.md
@@ -166,10 +166,9 @@ user groups are documented in [sigs.yaml].
 As you can see in the descriptions above, the project is robust with diverse
 groups of contributors and their varying degrees of expected communications.
 
-The annual community group health check will establish an opportunity for deeper
+The [annual community group health check] will establish an opportunity for deeper
  dialogue and broader communication across the chairs of each group and the
- Steering Committee. By including this reporting with the existing community
- meeting structure, we can focus on the goals outlined in the [Annual Report] doc.
+ Steering Committee.
 
 ## Cross-project Communication and Coordination
 
@@ -223,6 +222,5 @@ All contributors must sign the CNCF CLA, as described [here](CLA.md).
 [working group governance]: /committee-steering/governance/wg-governance.md
 [user group governance]: /committee-steering/governance/ug-governance.md
 [SIG Governance Requirements]: /committee-steering/governance/sig-governance-requirements.md
-[Annual Report]: /committee-steering/governance/annual-reports.md
-[monthly community meeting]: /events/community-meeting.md
+[annual community group health check]: /committee-steering/governance/annual-reports.md
 [KEP process]: https://github.com/kubernetes/enhancements/tree/master/keps#kubernetes-enhancement-proposals-keps


### PR DESCRIPTION
The community meeting has not been an effective means of communicating important information or updates for a few years now, and is no longer occurring on a regular cadence (and may be removed altogether soon in the future).

As such it should be removed as a community group governance requirement.

/committee steering
/assign @kubernetes/steering-committee 

/hold for comments