### PR TITLE
Clarify rules around having only two channels per external project

### DIFF
--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -114,6 +114,11 @@ determining if you should request a channel:
     -   Requesting a channel means maintaining it on behalf of the project
         filing the issue. You will be expected to participate and foster a
         healthy discourse.
+    -   External projects (ones not owned by a Kubernetes SIG) may have a 
+        maximum of two channels, usually `#project` or `#project-users`,
+        and `#project-dev`.
+    -   A second channel for a specific project will not be approved until the 
+        first channel demonstrates significant traffic.
 -   Channels around commercial services built on OSS projects are allowed.
     -   Users love the value of being able to collaborate around various
         services.
@@ -121,9 +126,6 @@ determining if you should request a channel:
 -   The channel MUST be public.
     -   In order to ensure all channels adhere to our Code of Conduct, we
         heavily restrict private channels.
-    -   We do allow `#...-dev` channels for established projects where a single
-        project channel is too noisy, but please don't create both at the
-        start.
     -   If you need private discussion areas for security-sensitive topics, a
         project-specific Slack or the [CNCF Slack] may be a better fit.
 -   Ask in `#slack-admins` or file an issue if you're unsure It never hurts to


### PR DESCRIPTION
We've always had the working rule that projects not owned by a SIG never get more than two channels (and only get one to start).  However, the explanation of that in the guidelines has been very unclear, leading to some argument.  This PR makes it explicitly clear.

/sig contributor-experience
/area slack
attn: @mrbobbytables @coderanger @markyjackson-taulia 
