### PR TITLE
FIX: Broken Link on Comms Role-hadbooks

### DIFF
--- a/communication/contributor-comms/role-handbooks/storytellers.md
+++ b/communication/contributor-comms/role-handbooks/storytellers.md
@@ -33,7 +33,7 @@ There are multiple ways to successfully contribute a Kubernetes blog post. Here 
 * Connect with a storyteller -- if you reach out to Contributor Comms, you will be paired with someone to help you through writing, editing, and getting your article published
   * Discussion happens via GitHub issue or through working group meetings
 * This includes working with Contributor Comms team to polish, and format your blog post
-  * There is not a single canonical format for documents, but we do have [guidelines for effective articles](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/blog-guidelines.md#how-to-write-an-effective-blog)
+  * There is not a single canonical format for documents, but we do have [guidelines for effective articles](https://github.com/kubernetes/community/tree/master/sig-docs/blog-subproject#blog-guidelines)
   * There are further technical considerations by the [Blog team](https://github.com/kubernetes/community/blob/4026287dc3a2d16762353b62ca2fe4b80682960a/sig-docs/blog-subproject/README.md#submit-a-post)
 
 When it's ready, submit the blog post: 


### PR DESCRIPTION
This PR **tends** to solve a couple of broken links found [here](https://github.com/kubernetes/community/tree/master/communication/contributor-comms/role-handbooks).

However, before merging the changes, we need to take a look at the last line of [this](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/storytellers.md#expectations) content. There's a broken link found here as well which is **not fixed**:

_There is no shadow roles for Storytellers. If Storytellers are interested in becoming a shadow they can read more about it in the [Marketing Council Handbook](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/council.md)._

As per the research, I found that no such file exists in the repo/has been modified. There can be either one thing which can be done to solve this:

1. **Remove the line itself**: _There is no shadow roles for Storytellers. If Storytellers are interested in becoming a shadow they can read more about it in the [Marketing Council Handbook](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/council.md)._

2. **Find the actual file itself**: Anyone would like to share their thoughts about this?