### PR TITLE
Fix k8s dev mailing list links

### DIFF
--- a/communication/best-practices.md
+++ b/communication/best-practices.md
@@ -94,7 +94,7 @@ procedure, see the Gmail help page on [Creating rules to filter your email].
 These suggestions come largely from an old [kubernetes-dev] mailing list [thread]
 on Gmail filters for Kubernetes.
 
-[kubernetes-dev]: https://groups.google.com/g/kubernetes-dev
+[kubernetes-dev]: https://groups.google.com/a/kubernetes.io/g/dev
 [thread]: https://groups.google.com/forum/#!topic/kubernetes-dev/5qU8irU7_tE/discussion
 
 <!-- shared links -->

--- a/contributors/chairs-and-techleads/leadership-changes.md
+++ b/contributors/chairs-and-techleads/leadership-changes.md
@@ -35,7 +35,7 @@ lazy consensus cannot be achieved, an election should be held.
 SIG Contributor Experience should be contacted to assist with the
 administration of the election.
 
-[kubernetes-dev]: https://groups.google.com/g/kubernetes-dev
+[kubernetes-dev]: https://groups.google.com/a/kubernetes.io/g/dev
 [steering-private]: steering-private@kubernetes.io
 [member]: /community-membership.md#member
 [`sigs.yaml`]: /sigs.yaml

--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -387,7 +387,7 @@ git push --force
 [Kubernetes Code Search]: https://cs.k8s.io/
 [@dims]: https://github.com/dims
 [calendar]: https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io
-[kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
+[kubernetes-dev]: https://groups.google.com/a/kubernetes.io/g/dev
 [slack channels]: http://slack.k8s.io/
 [Stack Overflow]: https://stackoverflow.com/questions/tagged/kubernetes
 [youtube channel]: https://www.youtube.com/c/KubernetesCommunity/


### PR DESCRIPTION
This pull request updates several docs to reflect that the historic google group https://groups.google.com/g/kubernetes-dev has been sunset and archived as of January 2022.

The new group is https://groups.google.com/a/kubernetes.io/g/dev.

This pull request only updates general docs and does not touch any references in meeting notes etc which should remain pointing to the old archived group.