### PR TITLE
clarify the term 'schedulable pod' in SLO document

### DIFF
--- a/sig-scalability/slos/pod_startup_latency.md
+++ b/sig-scalability/slos/pod_startup_latency.md
@@ -7,8 +7,9 @@
 | __Official__ | Startup latency of schedulable<sup>[1](#footnote1)</sup> stateless<sup>[2](#footnote2)</sup> pods, excluding time to pull images and run init containers, measured from pod creation timestamp to when all its containers are reported as started and observed via watch, measured as 99th percentile over last 5 minutes | In default Kubernetes installation, 99th percentile per cluster-day <= 5s |
 | __WIP__ | Startup latency of schedulable<sup>[1](#footnote1)</sup> stateful<sup>[3](#footnote3)</sup> pods, excluding time to pull images, run init containers, provision volumes (in delayed binding mode) and unmount/detach volumes (from previous pod if needed), measured from pod creation timestamp to when all its containers are reported as started and observed via watch, measured as 99th percentile over last 5 minutes | In default Kubernetes installation, 99th percentile per cluster-day <= X where X depends on storage provider |
 
-<a name="footnote1">[1\]</a>By schedulable pod we mean a pod that can be
-scheduled in the cluster without causing any preemption.
+<a name="footnote1">[1\]</a>By schedulable pod we mean a pod that has to be immediately
+(without actions from any other components) schedulable in the cluster without
+causing any preemption.
 
 <a name="footnote2">[2\]</a>A `stateless pod` is defined as a pod that doesn't
 mount volumes with sources other than secrets, config maps, downward API and


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/enhancements/pull/3739#discussion_r1094255726

With the introduction of [PodSchedulingReadiness](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/), between pod gets created and scheduled, there might be a new phase `SchedulingGated`, to claim it's not scheduling ready. And this is controlled by external components.

So this PR is updating the statement of 'schedulable pod' to avoid ambiguity on the related SLO.