### PR TITLE
Fixing wrong KUBE_DNS_NAME at running locally

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -177,7 +177,7 @@ To start the DNS service, you need to set the following variables:
 ```sh
 KUBE_ENABLE_CLUSTER_DNS=true
 KUBE_DNS_SERVER_IP="10.0.0.10"
-KUBE_DNS_DOMAIN="cluster.local"
+KUBE_DNS_NAME="cluster.local"
 ```
 
 To know more on DNS service you can check out the [docs](http://kubernetes.io/docs/admin/dns/).


### PR DESCRIPTION
I think the variable has been renamed at some point. `DNS_DOMAIN=${KUBE_DNS_NAME:-"cluster.local"}`

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
