### PR TITLE
Conduct: Add H1 2022 Transparency Report

### DIFF
--- a/committee-code-of-conduct/README.md
+++ b/committee-code-of-conduct/README.md
@@ -44,7 +44,7 @@ The members and their terms are as follows:
 ### Term ends on August 23, 2023
 
 - Jeremy Rickard (Microsoft)
-- Nabarun Pal (VMware)
+- Jason DeTiberus (Cisco)
 
 ### Term ends on August 17, 2024
 

--- a/committee-code-of-conduct/transparency-reports/2022-h1.md
+++ b/committee-code-of-conduct/transparency-reports/2022-h1.md
@@ -1,0 +1,44 @@
+# H1 2022 - Transparency Report
+This document is a log of all code of conduct incidents occurring in Kubernetes community spaces. Information is anonymized to protect those involved in incidents.
+
+### Terms used in these reports
+- **Incident report**: An incident report is a description of an action, event or public statement the reporter feels violates the Code of Conduct. For more information, see [Incident Reports](https://github.com/kubernetes/community/blob/master/committee-code-of-conduct/incident-process.md#incident-reports).  
+- **Conduct action**: A conduct action is any action (restorative or punitive) taken by the Code of Conduct Committee or another body empowered by them (such as a direct action by Slack admins). 
+
+## Kubernetes Code of Conduct Transparency Report for H1 2022
+**Data collection period**: January 1, 2022 - June 30, 2022
+
+**Incident report counts**
+
+| Received Via | This Period | Delta vs Prior Period |
+| -------- | -------- | -------- |
+| conduct@kubernetes.org    | 3     | -5     |
+| Slack admins | 61 | +5 |
+| GitHub admins | X<sup>1</sup> | X<sup>1</sup> |
+| Linux Foundation event staff | 5 | +4 |
+| Other avenues | N/A | N/A |
+
+**Total incidents reported**: 69
+
+---
+
+**Total conduct incidents** 
+Incident reports determined to be CoC violations and which resulted in conduct action
+
+
+| Action By | Restorative Action This Period | Delta vs Prior Period | Punitive Action This Period | Delta vs Prior Period |
+| -------- | -------- | -------- | -------- | -------- | 
+| Code of Conduct Committee     | 0     | -1     | 0 | N/A |
+| Slack Admins | 37 | +2 | 14 | +5 |
+| GitHub Admins | X<sup>1</sup> | X<sup>1</sup> | X<sup>1</sup> | X<sup>1</sup> |
+| Linux Foundation Staff | 4 | X<sup>2</sup> | 0 | X<sup>2</sup>
+| Other avenues | N/A | N/A | N/A | N/A |
+
+**Total incidents which resulted in conduct action**: 41
+
+---
+
+**Footnotes:**
+<sup>1</sup> Due to a full turnover of the code of conduct committee staff, the collection of data for this report was delayed. As such, the data rention window for GitHub had passed. In the future, we will take steps to prevent this from happening.
+
+<sup>2</sup> This data was not available in the previous transparency report, therefore there is no delta to report.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

Add the first transparency report for 2022 to the conduct directory. Also including a small update to the readme to reflect membership

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
