### PR TITLE
slack config: add Nauticus channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -330,6 +330,7 @@ channels:
   - name: multi-platform
   - name: mysql-operator
   - name: nais
+  - name: nauticus
   - name: navigator
     archived: true
   - name: ncw-staff


### PR DESCRIPTION
Hi, I'd like to propose a Slack channel for [Nauticus](https://nauticus.edixos.com/).

**Nauticus** is a Kubernetes space management controller. With Nauticus, you can easily create, update, and delete spaces within your Kubernetes cluster. Each space is a unique namespace with its own set of resources and quotas, making it ideal for multi-tenancy environments.

We believe that a Nauticus channel in the Kubernetes Slack community would foster greater collaboration and help to build a strong, supportive community around the project.

We would like to make growing the community on the Kubernetes workspace, in order to make it easier the access to the cloud native community and be present also for other cloud native projects, on the same workspace.

Thank you !

