### PR TITLE
Chairs responsibilities update

### DIFF
--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -90,7 +90,8 @@ Subproject contributors (as applicable).
 - *SHOULD* identify, track, and maintain the SIGs enhancements for current
   release and serve as point of contact for the release team, but *MAY* delegate
    to another Lead to fulfill these responsibilities
-- *MAY* delegate the creation of a SIG roadmap to other Leads
+- *MUST* ensure the SIG roadmap is shared regularly. *MAY* delegate the creation
+  of a SIG roadmap to other Leads
 - *MUST* organize a main group meeting and make sure [sigs.yaml] is up to date
 including subprojects and their meeting information but *SHOULD* delegate the
 need for subproject meetings to subproject owners  

--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -111,8 +111,6 @@ chairs/chairs in training
   staff and approve presented content but *MAY* delegate to other contributors
   to create material and present  
 - *MUST* ensure meetings are recorded and made available
-- *MUST* report activity with the community via k-dev mailing list at least
-once a quarter (slides, video from kubecon, etc)
 - *MUST* coordinate sponsored working group updates to the SIG and the wider
   community  
 - *MUST* coordinate communication and be a connector with other community

--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -119,6 +119,7 @@ chairs/chairs in training
  groups like SIGs and the Steering Committee but *MAY* delegate the actual
  communication and creation of content to other contributors where
  appropriate  
+- *SHOULD* help curate docs related to the SIG
 - *MUST* present yearly [annual report] for the group but *SHOULD* get help with
 curation from other SIG participants
 

--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -90,23 +90,23 @@ Subproject contributors (as applicable).
 - *SHOULD* identify, track, and maintain the SIGs enhancements for current
   release and serve as point of contact for the release team, but *MAY* delegate
    to another Lead to fulfill these responsibilities
-  - *MAY* delegate the creation of a SIG roadmap to other Leads
-  - *MUST* organize a main group meeting and make sure [sigs.yaml] is up to date
-  including subprojects and their meeting information but *SHOULD* delegate the
-  need for subproject meetings to subproject owners  
-  - *SHOULD* facilitate meetings but *MAY* delegate to other Leads or future
-  chairs/chairs in training
-  - *MUST* ensure there is a maintained CONTRIBUTING.md document in the
-  appropriate SIG folder if the contributor experience or on-boarding knowledge
-  is different than in the general [contributor guide]. *MAY* delegate to
-  contributors to create or update.
-  - *MUST* organize KubeCon/CloudNativeCon Intros and Deep Dives with CNCF Event
-   staff and approve presented content but *MAY* delegate to other contributors
-   to create material and present  
-  - *MUST* ensure meetings are recorded and made available
-  - *MUST* report activity with the community via k-dev mailing list at least
-  once a quarter (slides, video from kubecon, etc)
-  - *MUST* coordinate sponsored working group updates to the SIG and the wider
+- *MAY* delegate the creation of a SIG roadmap to other Leads
+- *MUST* organize a main group meeting and make sure [sigs.yaml] is up to date
+including subprojects and their meeting information but *SHOULD* delegate the
+need for subproject meetings to subproject owners  
+- *SHOULD* facilitate meetings but *MAY* delegate to other Leads or future
+chairs/chairs in training
+- *MUST* ensure there is a maintained CONTRIBUTING.md document in the
+appropriate SIG folder if the contributor experience or on-boarding knowledge
+is different than in the general [contributor guide]. *MAY* delegate to
+contributors to create or update.
+- *MUST* organize KubeCon/CloudNativeCon Intros and Deep Dives with CNCF Event
+  staff and approve presented content but *MAY* delegate to other contributors
+  to create material and present  
+- *MUST* ensure meetings are recorded and made available
+- *MUST* report activity with the community via k-dev mailing list at least
+once a quarter (slides, video from kubecon, etc)
+- *MUST* coordinate sponsored working group updates to the SIG and the wider
   community  
 - *MUST* coordinate communication and be a connector with other community
  groups like SIGs and the Steering Committee but *MAY* delegate the actual

--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -96,10 +96,16 @@ including subprojects and their meeting information but *SHOULD* delegate the
 need for subproject meetings to subproject owners  
 - *SHOULD* facilitate meetings but *MAY* delegate to other Leads or future
 chairs/chairs in training
-- *MUST* ensure there is a maintained CONTRIBUTING.md document in the
-appropriate SIG folder if the contributor experience or on-boarding knowledge
-is different than in the general [contributor guide]. *MAY* delegate to
-contributors to create or update.
+- *MUST* ensure the good contributors experience, *MAY* delegate those tasks
+  to contributors:
+  - *MUST* ensure there is a maintained CONTRIBUTING.md document in the
+    appropriate SIG folder if the contributor experience or on-boarding
+    knowledge is different than in the general [contributor guide]. 
+  - *MUST* curate "help wanted" and "good first issue" issues to simplify new
+    contributors experience
+  - *MUST* ensure up to date OWNERs files - elevate contributors and move people
+    to emeritus to improve review/approval cycle
+  - *SHOULD* define contributors ladder with clear requirements and progress tracking
 - *MUST* organize KubeCon/CloudNativeCon Intros and Deep Dives with CNCF Event
   staff and approve presented content but *MAY* delegate to other contributors
   to create material and present  

--- a/committee-steering/governance/sig-governance.md
+++ b/committee-steering/governance/sig-governance.md
@@ -92,6 +92,8 @@ Subproject contributors (as applicable).
    to another Lead to fulfill these responsibilities
 - *MUST* ensure the SIG roadmap is shared regularly. *MAY* delegate the creation
   of a SIG roadmap to other Leads
+- *MUST* watch for the active issues and PRs trends
+  and *SHOULD* coordinate triage, backlog grooming, assignments, and status checks
 - *MUST* organize a main group meeting and make sure [sigs.yaml] is up to date
 including subprojects and their meeting information but *SHOULD* delegate the
 need for subproject meetings to subproject owners  


### PR DESCRIPTION
Inspired by @thockin's PR: https://github.com/kubernetes/community/pull/7034

This PR is easiest to read commit-by commit:

1. Expand the responsibility about CHANGELOG maintenance to the contributors experience
2. Affirm that roadmap is a responsibility
3. Removed the quarterly updates to k-dev as I am not sure if this is even hapenning
4. Added issues and PRs trend watching as a responsibility
5. Note about docs

cc @kubernetes/steering-committee 