### PR TITLE
Add kcp-devs Slack user group

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -262,3 +262,21 @@ usergroups:
       - sbueringer
       - VibhorChinda
       - ykakarap
+
+  - name: kcp-devs
+    long_name: kcp Development Team
+    description: Active developers of kcp on #kcp-dev
+    members:
+      - csams
+      - davidfestal
+      - hardys
+      - jmprusi
+      - kylape
+      - ncdc
+      - nrb
+      - p0lyn0mial
+      - pweil-
+      - s-urbaniak
+      - stevekuznetsov
+      - sttts
+      - vincepri

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -41,8 +41,10 @@ users:
   cjcullen: U0ALJAVMF
   cji: U5YSRC21J
   cpanato: U8DFY4TTK
+  csams: U02B6A9GF55
   Dave Smith-Uchida: UDZDED8G2
   david-martin: ULMJ41U73
+  davidfestal: U014B06SVJ9
   Debanitrkl: U02149V23EU
   derekwaynecarr: U0A69N5GQ
   dharmit: U0APPPEKE
@@ -66,6 +68,7 @@ users:
   gsquared94: U0131C0PJBU
   guineveresaenger: U4H2QU3DW
   hackeramitkumar: U045992D532
+  hardys: UFMADFMS4
   hasheddan: ULLQEF30C
   Heba: UHE5TSU4W
   hoegaarden: U7VA4RZS9
@@ -87,6 +90,7 @@ users:
   jimangel: U4HSVFA5U
   jlbutler: U0122V3T932
   jmccormick2001: UMPLV0G0H
+  jmprusi: U014TN4HTPB
   jmrodri: U4KATPQ48
   joekr: U02MUT273GA
   Joel Barker: U014AHSTBPA
@@ -106,6 +110,7 @@ users:
   klihub: U9856A799
   klueska: UF3ARH55Y
   Kunal Kushwaha: UQ14U3NAY
+  kylape: UEUST4S22
   LappleApple: U011C07244F
   leonardpahlke: U029NBZFV97
   liggitt: U0BGPQ6DS
@@ -131,11 +136,14 @@ users:
   munnerz: U0EC03FTN
   nate-double-u: U01AWL6BD62
   nawazkh: U03HJN1C81W
+  ncdc: U0A4MJ62V
   nikhita: U2PQHGMLN
   nkubala: UA90QL2BE
+  nrb: U7S597E00
   nzoueidi: UBU72MWP2
   onlydole: U1DD4AZND
   oscr: U0183J37JUQ
+  p0lyn0mial: U1Q8CER5M
   pabloschuhmacher: U01AAGZ06KU
   palnabarun: UBH9NTMBM
   paris: U5SB22BBQ
@@ -148,6 +156,7 @@ users:
   prietyc123: U01D4MBLM52
   puerco: ULGHLJ7TP
   PurneswarPrasad: U027CFKVAB0
+  pweil-: U0AL6882X
   r-lawton: U019CNHR2E6
   rajula96reddy: U7K9EK1HC
   rashmigottipati: U013T1DD3PW
@@ -157,6 +166,7 @@ users:
   rnapoles-rh: U01KDAMSWJD
   robshelly: U01LL4P09SR
   rtaniwa: U03K27HLHKN
+  s-urbaniak: U0DT660QM
   sammy: U8NJFL023
   sandipanpanda: U02A47HJ517
   saschagrunert: U53SUDBD4
@@ -170,6 +180,8 @@ users:
   shubham-pampattiwar: U01QW84HBBN
   simplytunde: UAY1NBYHE
   Sladyn Nunes: UQ9J177Q8
+  stevekuznetsov: U0DUKNE6B
+  sttts: U0A2VFE8J
   Sujay Pillai: UBW3N1VGW
   sumitranr: UCQN13L9H
   swamymsft: UHU7ZNXH8
@@ -186,6 +198,7 @@ users:
   varshaprasad96: UK59YP2DA
   Verolop: U7NNE57PU
   VibhorChinda: U031EALE91D
+  vincepri: UCD11GCET
   vladimirmukhin: UHVSCSD4G
   vzhukovs: U030TR1FG85
   wilsonehusin: U0100068GF2


### PR DESCRIPTION
This creates a Slack user group called `kcp-devs` that contains folks actively developing kcp.

/cc csams davidfestal hardys jmprusi kylape nrb p0lyn0mial pweil- s-urbaniak stevekuznetsov sttts vincepri