### PR TITLE
Remove cluster addon for dashboard

### DIFF
--- a/sig-ui/charter.md
+++ b/sig-ui/charter.md
@@ -9,7 +9,6 @@ SIG-UI covers GUI-related aspects of the Kubernetes project. Efforts are centere
 #### Code, Binaries and Services
 
 - [Kubernetes Dashboard](https://github.com/kubernetes/dashboard)
-- [Dashboard Cluster Addon](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dashboard)
 - [Dashboard Metrics Scraper](https://github.com/kubernetes-sigs/dashboard-metrics-scraper)
 
 #### Cross-cutting and Externally Facing Processes


### PR DESCRIPTION
Dashboard cluster addon had been removed already.
https://github.com/kubernetes/kubernetes/pull/107481

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
