### PR TITLE
SIG-Autoscaling - Subproject Owners Cleanup

### DIFF
--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -53,17 +53,14 @@ The following [subprojects][subproject-definition] are owned by sig-autoscaling:
   - [kubernetes/autoscaler/addon-resizer](https://github.com/kubernetes/autoscaler/blob/master/addon-resizer/OWNERS)
 ### cluster-autoscaler
 - **Owners:**
-  - [kubernetes/autoscaler](https://github.com/kubernetes/autoscaler/blob/master/OWNERS)
+  - [kubernetes/autoscaler/cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/OWNERS)
 ### horizontal-pod-autoscaler
 - **Owners:**
   - [kubernetes/api/autoscaling](https://github.com/kubernetes/api/blob/master/autoscaling/OWNERS)
   - [kubernetes/kubernetes/pkg/controller/podautoscaler](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/podautoscaler/OWNERS)
-### scale-client
-- **Owners:**
-  - [kubernetes/client-go/scale](https://github.com/kubernetes/client-go/blob/master/scale/OWNERS)
 ### vertical-pod-autoscaler
 - **Owners:**
-  - [kubernetes/autoscaler](https://github.com/kubernetes/autoscaler/blob/master/OWNERS)
+  - [kubernetes/autoscaler/vertical-pod-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 [working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -623,17 +623,14 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
   - name: cluster-autoscaler
     owners:
-    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/cluster-autoscaler/OWNERS
   - name: horizontal-pod-autoscaler
     owners:
     - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
-  - name: scale-client
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/client-go/master/scale/OWNERS
   - name: vertical-pod-autoscaler
     owners:
-    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/vertical-pod-autoscaler/OWNERS
 - dir: sig-cli
   name: CLI
   mission_statement: >


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes up some of the SIG-Autoscaling subproject owner links to be more specific. Also removed scale client as an explicit subproject, as the SIG doesn't seem to have been actively involved in ownership of this for a long time now (it doesn't even have a [standalone OWNERS](https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/client-go/scale) file these days.)
