### PR TITLE
rename Packet to Equinix Metal in the README

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -179,7 +179,7 @@ Cluster API infrastructure provider for OpenStack
   - Slack: [#cluster-api-openstack](https://kubernetes.slack.com/messages/cluster-api-openstack)
   - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
 ### cluster-api-provider-packet
-Cluster API infrastructure provider for Packet
+Cluster API infrastructure provider for Equinix Metal
 - **Owners:**
   - [kubernetes-sigs/cluster-api-provider-packet](https://github.com/kubernetes-sigs/cluster-api-provider-packet/blob/master/OWNERS)
 - **Contact:**


### PR DESCRIPTION
Packet was acquired by Equinix in 2020. The provider still uses the cluster-api-provider-packet (CAPP) name, but the name of the service the provider operates against is Equinix Metal.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->


