### PR TITLE
Fix error anchor link of multiple-api-versions

### DIFF
--- a/contributors/devel/sig-architecture/api_changes.md
+++ b/contributors/devel/sig-architecture/api_changes.md
@@ -12,7 +12,7 @@ found at [API Conventions](api-conventions.md).
   - [Adding a field](#adding-a-field)
   - [Making a singular field plural](#making-a-singular-field-plural)
     - [Single-Dual ambiguity](#single-dual-ambiguity)
-  - [Multiple API versions](multiple-api-versions)
+  - [Multiple API versions](#multiple-api-versions)
 - [Backward compatibility gotchas](#backward-compatibility-gotchas)
 - [Incompatible API changes](#incompatible-api-changes)
 - [Changing versioned APIs](#changing-versioned-apis)
@@ -473,7 +473,7 @@ worked before the change.
   removed value as deprecated but allowed). For enumeration-like fields that expect to add
   new values in the future, such as `reason` fields, document that expectation clearly
   in the API field description in the first release the field is made available,
-  and describe how clients should treat an unknown value. Clients should treat such 
+  and describe how clients should treat an unknown value. Clients should treat such
   sets of values as potentially open-ended.
 
 * For [Unions](api-conventions.md#unions), sets of fields where at most one should
@@ -558,9 +558,9 @@ For types that need the generated
 [DeepCopyObject](https://github.com/kubernetes/kubernetes/commit/8dd0989b395b29b872e1f5e06934721863e4a210#diff-6318847735efb6fae447e7dbf198c8b2R3767)
 methods, usually only required by the top-level types like `Pod`, add this line
 to the comment
-([example](https://github.com/kubernetes/kubernetes/commit/39d95b9b065fffebe5b6f233d978fe1723722085#diff-ab819c2e7a94a3521aecf6b477f9b2a7R30)): 
+([example](https://github.com/kubernetes/kubernetes/commit/39d95b9b065fffebe5b6f233d978fe1723722085#diff-ab819c2e7a94a3521aecf6b477f9b2a7R30)):
 
-```golang 
+```golang
   // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 ```
 
@@ -693,7 +693,7 @@ The `make generated_files` will also regenerate the `zz_generated.deepcopy.go`,
 If regeneration is somehow not possible due to compile errors, the easiest
 workaround is to remove the files causing errors and rerun the command.
 
-## Generate Code 
+## Generate Code
 
 Apart from the `defaulter-gen`, `deepcopy-gen`, `conversion-gen` and
 `openapi-gen`, there are a few other generators:
@@ -997,7 +997,7 @@ cases, objects will be automatically converted to the new version; in other
 cases, a manual upgrade may be necessary; a manual upgrade may require downtime
 for anything relying on the new feature, and may require manual conversion of
 objects to the new version; when manual conversion is necessary, the project
-will provide documentation on the process 
+will provide documentation on the process
   - Cluster Reliability: since the feature has e2e tests, enabling the feature
 via a flag should not create new bugs in unrelated features; because the feature
 is new, it may have minor bugs
@@ -1090,7 +1090,7 @@ The preferred approach adds an alpha field to the existing object, and ensures i
     //
     // Add multiple dimensions to frobbers.
     Frobber2D utilfeature.Feature = "Frobber2D"
-    
+
     var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
       ...
       Frobber2D: {Default: false, PreRelease: utilfeature.Alpha},
@@ -1104,7 +1104,7 @@ The preferred approach adds an alpha field to the existing object, and ensures i
         * add the `// +optional` comment tag
         * ensure the field is entirely absent from API responses when empty (optional fields should be pointers, anyway)
     * include details about the alpha-level in the field description
-    
+
     ```go
     // API v6.
     type Frobber struct {
@@ -1130,16 +1130,16 @@ The recommended place to do this is in the REST storage strategy's PrepareForCre
     ```go
     func (frobberStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
       frobber := obj.(*api.Frobber)
-    
+
       if !utilfeature.DefaultFeatureGate.Enabled(features.Frobber2D) {
         frobber.Width = nil
       }
     }
-    
+
     func (frobberStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runtime.Object) {
       newFrobber := obj.(*api.Frobber)
       oldFrobber := old.(*api.Frobber)
-    
+
       if !utilfeature.DefaultFeatureGate.Enabled(features.Frobber2D) && oldFrobber.Width == nil {
         newFrobber.Width = nil
       }
@@ -1148,8 +1148,8 @@ The recommended place to do this is in the REST storage strategy's PrepareForCre
 
 4. To future-proof your API testing, when testing with feature gate on and off, ensure that the gate is deliberately set as desired. Don't assume that gate is off or on. As your feature
 progresses from `alpha` to `beta` and then `stable` the feature might be turned on or off by default across the entire code base. The below example
-provides some details 
- 
+provides some details
+
    ```go
    func TestAPI(t *testing.T){
     testCases:= []struct{
@@ -1162,7 +1162,7 @@ provides some details
        // ... test case ..
        },
    }
-   
+
    for _, testCase := range testCases{
      t.Run("..name...", func(t *testing.T){
       // run with gate on
@@ -1175,7 +1175,7 @@ provides some details
       // ... test gate-off testing logic logic ...
      })
    }
-   ``` 
+   ```
 
 5. In validation, validate the field if present:
 
@@ -1202,7 +1202,7 @@ In future Kubernetes versions:
       Height int32  `json:"height" protobuf:"varint,1,opt,name=height"`
       // param ...
       Param  string `json:"param" protobuf:"bytes,2,opt,name=param"`
-      
+
       // +k8s:deprecated=width,protobuf=3
     }
     ```
@@ -1265,7 +1265,7 @@ and graduating to beta and enabled by default in release 2.
     //
     // Allow OnTuesday restart policy in frobbers.
     FrobberRestartPolicyOnTuesday utilfeature.Feature = "FrobberRestartPolicyOnTuesday"
-    
+
     var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
       ...
       FrobberRestartPolicyOnTuesday: {Default: false, PreRelease: utilfeature.Alpha},
@@ -1275,7 +1275,7 @@ and graduating to beta and enabled by default in release 2.
 2. Update the documentation on the API type:
 
     * include details about the alpha-level in the field description
-    
+
     ```go
     type Frobber struct {
       // restartPolicy may be set to "Always" or "Never" (or "OnTuesday" if the alpha "FrobberRestartPolicyOnTuesday" feature is enabled).
@@ -1297,7 +1297,7 @@ The recommended place to do this is in the REST storage strategy's Validate/Vali
       frobber := obj.(*api.Frobber)
       return validation.ValidateFrobber(frobber, validationOptionsForFrobber(frobber, nil))
     }
-    
+
     func (frobberStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
       newFrobber := obj.(*api.Frobber)
       oldFrobber := old.(*api.Frobber)
@@ -1353,7 +1353,7 @@ The recommended place to do this is in the REST storage strategy's Validate/Vali
     //
     // Allow OnTuesday restart policy in frobbers.
     FrobberRestartPolicyOnTuesday utilfeature.Feature = "FrobberRestartPolicyOnTuesday"
-    
+
     var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
       ...
       FrobberRestartPolicyOnTuesday: {Default: true, PreRelease: utilfeature.Beta},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes the  error anchor link of chapter `Multiple API versions`
