### PR TITLE
Add channel for Atmosphere

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -19,6 +19,7 @@ channels:
     archived: true
   - name: argentina
   - name: arm64
+  - name: atmosphere
   - name: aus-nz-dev
   - name: aus-nz-users
   - name: awesome-kubernetes


### PR DESCRIPTION
This is a request for the [Atmosphere](https://github.com/vexxhost/atmosphere) project to get a channel in the Kubernetes Slack.

The project allows you to deploy a full Kubernetes control plane (using `kubeadm`), deploy an OpenStack cloud on top of it (using `openstack-helm`, which the community exists on the Kubernetes slack), leverage Rook to provide object storage and use the Cluster API for OpenStack to deploy Kubernetes clusters on top of that infrastructure.

The project is fully open sourced, there are several contributors from different organizations and with the increased volume of PRs, we wanted to have a space that new users can talk and ask about it, but also a space for existing developers to discuss the project.