### PR TITLE
docs: fix api convention concurrency control and consistency part typo

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -969,7 +969,7 @@ Kubernetes leverages the concept of *resource versions* to achieve optimistic
 concurrency. All Kubernetes resources have a "resourceVersion" field as part of
 their metadata. This resourceVersion is a string that identifies the internal
 version of an object that can be used by clients to determine when objects have
-changed. When a record is about to be updated, it's version is checked against a
+changed. When a record is about to be updated, its version is checked against a
 pre-saved value, and if it doesn't match, the update fails with a StatusConflict
 (HTTP status code 409).
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes a typo in the API convention `Concurrency Control and consistency` part.
