### PR TITLE
Updated the Marketing Council Handbook Link in the Storytellers.md file

### DIFF
--- a/communication/contributor-comms/role-handbooks/storytellers.md
+++ b/communication/contributor-comms/role-handbooks/storytellers.md
@@ -76,7 +76,7 @@ If you would like to be listed as a member of the team, here are the expectation
 3. Remain non-partial: if you receive a request to write about a project, an individual, or a group of people from your employer, you should ask an impartial blogger to write it.
 4. As with all contribution to Kubernetes, adhere to the [code of conduct](/code-of-conduct.md), values, and principles of the project.
 
-There is no shadow roles for Storytellers. If Storytellers are interested in becoming a shadow they can read more about it in the [Marketing Council Handbook].
+There are no shadow roles for Storytellers. If Storytellers are interested in becoming a shadow they can read more about the available leadership roles in the Contributor Comms [Role handbooks](https://github.com/kubernetes/community/tree/master/communication/contributor-comms/role-handbooks).
 
 [blogging guidelines]: ../storytelling-resources/blog-guidelines.md
 [YouTube guidelines]: /communication/youtube/youtube-guidelines.md


### PR DESCRIPTION
This PR seeks to resolve the issue of the broken link in the Storytellers.md file for the **Marketing Council Handbook**. The link had been leading to a 404 Error page, however, with this PR, it should now be functioning correctly.