### PR TITLE
Add Slack Channel for BPFD

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -30,6 +30,7 @@ channels:
   - name: bindings-discuss
   - name: bootkube
     archived: true
+  - name: bpfd
   - name: brigade
   - name: camptocamp-devops-stack
   - name: canonical-kubernetes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

This PR is a request for the [bpfd](https://bpfd.netlify.app/) project to receive a channel in the Kubernetes Slack Workspace. 

Bpfd allows users to easily deploy and manage [bpf programs within kubernetes clusters](https://bpfd.netlify.app/k8s-deployment/).  The project includes a [kubernetes operator](https://github.com/redhat-et/bpfd/tree/main/bpfd-operator) written using the operator SDK framework, and there are already [plans to integrate it with Blixt](https://github.com/Kong/blixt/issues/77) (a [soon to be](https://github.com/kubernetes/org/issues/3875) Kubernetes-sigs project).  

The project is [fully open source](https://github.com/redhat-et/bpfd#license). Due to increased interest from the kubernetes community we would like a  dedicated public channel for further upstream discussion around the future of bpf in kuberenetes and how that could work with bpfd.


