### PR TITLE
slack config: add jenkins-operator channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -167,6 +167,7 @@ channels:
   - name: it-users
   - name: java
   - name: jenkins-ci
+  - name: jenkins-operator
   - name: jenkins-x-dev
   - name: jenkins-x-user
   - name: jp-dev


### PR DESCRIPTION
Hi, I'd like to propose a Slack channel for the [jenkins kubernetes operator](https://github.com/jenkinsci/kubernetes-operator)

Like the name is already explain the Jenkins Operator is a k8s operator which manages operations for Jenkins on Kubernetes. It has been built with Immutability and declarative Configuration as Code in mind.

Our previous slack channel (in a separated slack instance) will be not available anymore because the company that initially developed the operator stepped down and we are moving to a community model to continue to support and develop the operator, that's why we need a new chat home and the kubernetes slack seems the perfect match :) 

Thanks in advance! 