### PR TITLE
stop suggesting depth=1, suggest filter=blob:none instead

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -59,10 +59,10 @@ PATH=$PATH:$GOPATH/bin
 In order to run kubernetes you must have the kubernetes code on the local machine. Cloning this repository is sufficient.
 
 ```sh
-git clone --depth=1 https://github.com/kubernetes/kubernetes.git
+git clone --filter=blob:none https://github.com/kubernetes/kubernetes.git
 ```
 
-The `--depth=1` parameter is optional and will ensure a smaller download.
+The `--filter=blob:none` parameter is optional and will ensure a smaller download.
 
 ## Starting the cluster
 


### PR DESCRIPTION
depth=1 will break git version info and break the build

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

https://github.com/kubernetes/kubernetes/issues/116716 may be related, see also https://github.com/kubernetes/test-infra/issues/26590