### PR TITLE
Add new slack channel for SIG-Docs Bulgarian localization (kubernetes-docs-bg)

### DIFF
--- a/communication/slack-config/sig-docs/docs-channels.yaml
+++ b/communication/slack-config/sig-docs/docs-channels.yaml
@@ -1,5 +1,6 @@
 channels:
   - name: kubernetes-docs-ar
+  - name: kubernetes-docs-bg
   - name: kubernetes-docs-bn
     id: CQ0TD298C
   - name: kubernetes-docs-de


### PR DESCRIPTION
Fixes #7183

This PR adds a new slack channel for SIG-Docs Bulgarian localization (`kubernetes-docs-bg`).

This request is based on https://github.com/kubernetes/community/issues/7183

