### PR TITLE
slack: add usergroup for Kubernetes GitHub Admins

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -281,3 +281,14 @@ usergroups:
       - stevekuznetsov
       - sttts
       - vincepri
+
+  - name: github-admins
+    long_name: Kubernetes GitHub Admins
+    description: Administrators of the Kubernetes GitHub organisations
+    members:
+      - ameukam
+      - cblecker
+      - idvoretskyi
+      - mrbobbytables
+      - nikhita
+      - palnabarun


### PR DESCRIPTION
/area github-management
/sig contributor-experience
/priority important-longterm

/cc @kubernetes/owners 