### PR TITLE
Add Self Assessments as a subproject to SIG Security

### DIFF
--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -38,6 +38,12 @@ The Chairs of the SIG run operations and processes governing the SIG.
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-security:
+### security-assessments
+Security self assessments for upstream projects
+- **Owners:**
+  - [kubernetes/sig-security/sig-security-assessments](https://github.com/kubernetes/sig-security/blob/main/sig-security-assessments/OWNERS)
+- **Contact:**
+  - Slack: [#sig-security-assessments](https://kubernetes.slack.com/messages/sig-security-assessments)
 ### security-audit
 Third Party Security Audit
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2556,6 +2556,12 @@ sigs:
       github: cpanato
       name: Carlos Tadeu Panato Jr.
   subprojects:
+  - name: security-assessments
+    description: Security self assessments for upstream projects
+    contact:
+      slack: sig-security-assessments
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/sig-security/main/sig-security-assessments/OWNERS
   - name: security-audit
     description: Third Party Security Audit
     owners:
@@ -2572,12 +2578,6 @@ sigs:
       slack: sig-security-tooling
     owners:
     - https://raw.githubusercontent.com/kubernetes/sig-security/main/sig-security-tooling/OWNERS
-  - name: security-assessments
-    description: Security self assessments for upstream projects
-    contact:
-      slack: sig-security-assessments
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/sig-security/main/sig-security-assessments/OWNERS  
   - name: sig-security
     description: SIG Security discussions, documents, processes and other artifacts
     contact:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2572,6 +2572,12 @@ sigs:
       slack: sig-security-tooling
     owners:
     - https://raw.githubusercontent.com/kubernetes/sig-security/main/sig-security-tooling/OWNERS
+  - name: security-assessments
+    description: Security self assessments for upstream projects
+    contact:
+      slack: sig-security-assessments
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/sig-security/main/sig-security-assessments/OWNERS  
   - name: sig-security
     description: SIG Security discussions, documents, processes and other artifacts
     contact:


### PR DESCRIPTION
Adding Self Assessments as a subproject to SIG Security

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
