### PR TITLE
use `--force-with-lease`

### DIFF
--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -230,7 +230,7 @@ To squash your commits, perform an [interactive rebase](https://git-scm.com/book
 4. Force push your changes to your remote branch:
 
   ```
-  git push --force
+  git push --force-with-lease
   ```
 
 For mass automated fixups such as automated doc formatting, use one or more


### PR DESCRIPTION
`--force-with-lease` is less dangerous:

from the docs:

> --force-with-lease alone, without specifying the details, will protect all remote refs that are going to be updated 
> by requiring their current value to be the same.

