### PR TITLE
Add log message style guidelines

### DIFF
--- a/contributors/devel/sig-instrumentation/logging.md
+++ b/contributors/devel/sig-instrumentation/logging.md
@@ -48,6 +48,16 @@ Example:
 klog.InfoS("Received HTTP request", "method", "GET", "URL", "/metrics", "latency", time.Second)
 ```
 
+### Message style guidelines
+
+Good practices when writing log messages are:
+
+- Start from a capital letter.
+- Do not end the message with a period.
+- Use active voice. Use complete sentences when there is an acting subject ("A could not do B") or omit the subject if the subject would be the program itself ("Could not do B").
+- Use past tense ("Could not delete B" instead of "Cannot delete B")
+- When referring to an object, state what type of object it is. ("Deleted pod" instead of "Deleted")
+
 ### What method to use?
 
 * `klog.ErrorS` - Errors should be used to indicate unexpected behaviours in code, like unexpected errors returned by subroutine function calls.


### PR DESCRIPTION
This is mentioned in [1], but since structured logging is now the norm (and soon contextual logging), I think this is a more appropriate and more permanent place for the style guide.

[1] https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

/sig instrumentation