### PR TITLE
Add cluster-api-k3s Slack Channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -62,6 +62,7 @@ channels:
     archived: true
   - name: cluster-api-gcp
   - name: cluster-api-ibmcloud
+  - name: cluster-api-k3s
   - name: cluster-api-kubemark
   - name: cluster-api-kubevirt
   - name: cluster-api-nested


### PR DESCRIPTION
This PR adds a slack channel for Cluster API k3s controlplane and bootstrap providers: https://github.com/cluster-api-provider-k3s/cluster-api-k3s.

As per discussion at https://github.com/cluster-api-provider-k3s/cluster-api-k3s/discussions/32.