### PR TITLE
Readme changes moving Jim Angel to Emeritus

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -39,7 +39,6 @@ The [charter](charter.md) defines the scope and governance of the Docs Special I
 The Chairs of the SIG run operations and processes governing the SIG.
 
 * Divya Mohan (**[@divya-mohan0209](https://github.com/divya-mohan0209)**), SUSE
-* Jim Angel (**[@jimangel](https://github.com/jimangel)**), Google
 * Natali Vlatko (**[@natalisucks](https://github.com/natalisucks)**), Wayfair
 * Rey Lejano (**[@reylejano](https://github.com/reylejano)**), SUSE
 
@@ -60,6 +59,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Jared Bhatti (**[@jaredbhatti](https://github.com/jaredbhatti)**)
 * Kaitlyn Barnard (**[@kbarnard10](https://github.com/kbarnard10)**)
 * Zach Corleissen (**[@zacharysarah](https://github.com/zacharysarah)**)
+* Jim Angel (**[@jimangel](https://github.com/jimangel)**)
 
 ## Contact
 - Slack: [#sig-docs](https://kubernetes.slack.com/messages/sig-docs)


### PR DESCRIPTION
Moving @jimangel to Emeritus ahead of the Annual Report for keeping the README for SIG Docs updated.

Reference: https://github.com/kubernetes/website/pull/38864

