### PR TITLE
add vpc-lattice-k8-community to slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -24,6 +24,7 @@ channels:
   - name: awesome-kubernetes
   - name: aws-authenticator
   - name: aws-controllers-k8s
+  - name: aws-gateway-api-controller
   - name: aws-vpc-cni
   - name: azure-service-operator
   - name: bazel


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
This PR adds a slack channel for AWS Gateway API Controller for VPC Lattice: https://github.com/aws/aws-application-networking-k8s.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
