### PR TITLE
CNCF + Summer of Code Mentoring Repo Link Detached - Fixed

### DIFF
--- a/mentoring/programs/google-summer-of-code.md
+++ b/mentoring/programs/google-summer-of-code.md
@@ -55,7 +55,7 @@ Or even better, volunteer for mentoring an intern during the work on your idea!
 
 Kubernetes has participated in Google Summer of Code in [2020](https://summerofcode.withgoogle.com/archive/2020/organizations/5861737481371648/), [2019](https://summerofcode.withgoogle.com/archive/2019/organizations/6034778267058176/), [2018](https://summerofcode.withgoogle.com/organizations/6453865516367872/) and [2017](https://summerofcode.withgoogle.com/archive/2017/organizations/6018829461225472/) as a part of CNCF and in [2015](https://www.google-melange.com/archive/gsoc/2015/orgs/kubernetes) as an independent organization.
 
-To get an idea about the projects, you can take a look at the list of project ideas published for GSoC at the [CNCF Mentoring repo](https://github.com/cncf/mentoring/tree/master/summerofcode).
+To get an idea about the projects, you can take a look at the list of project ideas published for GSoC at the [CNCF Mentoring repo](https://github.com/cncf/mentoring/tree/main/programs/summerofcode).
 
 ## Code of Conduct
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

The Past Participation section from the Mentoring Docs had to link a list of project ideas published for GSoC at the [CNCF Mentoring repo](https://github.com/kubernetes/community/blob/master/mentoring/programs/google-summer-of-code.md#past-participation). To get an idea about the projects, one can look at the list provided. Unfortunately, **the redirected link was found to be broken**. This contribution aims to fix the link, providing access to the list of project ideas. It is hoped that this contribution will be counted, as it is an effort to improve the accessibility of the project ideas. 

Furthermore, this ain't a major contribution, I am doing best to familiarize myself with Kubernetes. I appreciate your time and I hope this is a valid pull request. Hopefully soon will be able to contribute more significantly :)
