### PR TITLE
feat: add ebpf channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -103,6 +103,7 @@ channels:
   - name: draft-dev
   - name: draft-users
   - name: druid-operator
+  - name: ebpf
   - name: eks
   - name: elastickube
   - name: elk-charts


### PR DESCRIPTION
This PR adds a Slack channel for [ebpf](https://ebpf.io/) which is a burgeoning technology that enables running sandboxed programs in privileged contexts (such as an operating system kernel).

eBPF has been gaining prevalence in the Kubernetes SIGs community with projects such as [bpfd](https://github.com/kubernetes/community/pull/7172), [blixt](https://github.com/Kong/blixt/discussions/42) and with Kubernetes SIGs already having software that utilizes it such as [KPNG](https://github.com/kubernetes-sigs/kpng/tree/master/backends/ebpf).

The purpose of this channel will be general discussion and help for building and running eBPF programs on Kubernetes clusters as several of us in the SIG Network community are particularly trying to help grow this technology in the Kubernetes context and build a sub-community around it.