### PR TITLE
fix: Typo in sig-docs/blog-subproject README

### DIFF
--- a/sig-docs/blog-subproject/README.md
+++ b/sig-docs/blog-subproject/README.md
@@ -17,7 +17,7 @@ Regular Blog Meeting: Tuesdays at 18:30 UTC (biweekly). [Convert Your Timezone](
 
 ## Contact
 
-- Slack: [#kubernetes-docs-blog](https://kubernetes.slack.com/messages/CJDHVD54J)
+- Slack: [#sig-docs-blog](https://kubernetes.slack.com/messages/CJDHVD54J)
 - Mailing List: [blog@kubernetes.io](mailto:blog@kubernetes.io)
 - Open Community Issues/PRs: [`is:open repo:kubernetes/website label:area/blog`](https://github.com/issues?q=is%3Aopen+label%3Aarea%2Fblog+repo%3Akubernetes%2Fwebsite)
 - GitHub Teams: [@kubernetes/kubernetes-blog](https://github.com/orgs/kubernetes/teams/kubernetes-blog), [@kubernetes/kubernetes-blog-maintainers](https://github.com/orgs/kubernetes/teams/kubernetes-blog-maintainers)


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #7268 
