### PR TITLE
docs: Ask for cherry-picks to be made in order from newest to oldest releases

### DIFF
--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -76,7 +76,7 @@ patch release branches.
 
 ## Initiate a Cherry Pick
 
-Note: Before initiating a cherry-pick to a release branch, first make sure that the fix is available in every _newer_ release branch. (For example, if the 1.27 is the most recent release branch, then, before cherry-picking to 1.25, first make sure the fix is already in 1.26, and 1.27). This helps prevent regressions as the result of an upgrade to the next release.
+Note: Before initiating a cherry-pick to a release branch, make sure the fix is available in every _newer_ release branch. For example, if 1.27 is the most recent release branch, then, before cherry-picking to 1.25, make sure the fix is already in 1.26 and 1.27. This helps to prevent regressions as a result of an upgrade to the next release.
 
 - Run the [cherry pick script][cherry-pick-script]
 

--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -76,6 +76,8 @@ patch release branches.
 
 ## Initiate a Cherry Pick
 
+Note: Before initiating a cherry-pick to a release branch, first make sure that the fix is available in every _newer_ release branch. (For example, if the 1.27 is the most recent release branch, then, before cherry-picking to 1.25, first make sure the fix is already in 1.26, and 1.27). This helps prevent regressions as the result of an upgrade to the next release.
+
 - Run the [cherry pick script][cherry-pick-script]
 
   This example applies a master branch PR #98765 to the remote branch


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

I think it's worth adding this to the guidelines.

I made this as a result of [feedback](https://github.com/kubernetes/kubernetes/pull/117149#issuecomment-1507687032) to my own cherry-pick.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
