### PR TITLE
Annual Report 22

### DIFF
--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -142,8 +142,8 @@ This is a collection of presentations from our SIG members around contributing t
 
 This is the work we've done this past cycle and plan to work on in the future:
 
-- [Contributor Experience Community Update](https://youtu.be/J3O8fXTm3HE?t=148) (July 2020)
-  - [Slides](https://docs.google.com/presentation/d/1BS7liUs1WDSPnpNXIHRtRSKhGzK9usS5qzpry_9YU-I/edit?usp=sharing) 
+- [From Automation to Community: A Deep Dive Into SIG Contributor Experience](https://youtu.be/5Bs1bs6iFmY) (April 2023)
+  - [Slides](https://docs.google.com/presentation/d/1BNej12r_YN_0FSYgthPWvOqpcS53oiHS) 
 
 ## General Presentations
 
@@ -156,6 +156,9 @@ This is the work we've done this past cycle and plan to work on in the future:
 
 We give our SIG status at every KubeCon, here are our most current talks:
 
+- [From Automation to Community: A Deep Dive Into SIG Contributor Experience, Europe 2023](https://youtu.be/5Bs1bs6iFmY) - Madhav Jivrajani, Priyanka Saggu, Kaslin Fields
+- [SIG Contributor Experience Deep Dive, North America 2022](https://www.youtube.com/watch?v=C-k_h3vzWxE) - Nabarun Pal & Madhav Jivrajani, Marky Jackson, Kaslin Fields
+- [SIG Contributor Experience Deep Dive, Europe 2022](https://www.youtube.com/watch?v=hD6ZtmEIbEQ) - Alison Dowdney, Christoph Blecker, Bob Killen
 - [SIG Contributor Experience Deep Dive, North America 2021](https://youtu.be/QOiyWWFjG5Q) - Alison Dowdney, Christoph Blecker
 - [SIG Contributor Experience Deep Dive, Europe 2021](https://youtu.be/vPK3QmVOE4Y) - Bob Killen, Alison Dowdney, Christoph Blecker, Nikhita Raghunath
 - [Introdution to Contributor Experience 2020](https://youtu.be/VeCMQoNHFMU) - Bob Killen, Jorge Castro 

--- a/sig-contributor-experience/annual-report-2022.md
+++ b/sig-contributor-experience/annual-report-2022.md
@@ -1,77 +1,73 @@
 # 2022 Annual Report: SIG Contributor Experience
 
+The [Contributor Experience Special Interest Group](https://groups.google.com/forum/#!forum/kubernetes-sig-contribex) (SIG) is responsible for improving the experience of those who upstream contribute to the Kubernetes project. We do this by creating and maintaining programs and processes that promote community health and reduce project friction, while retiring those programs and processes that don't. Being conscientious of our contributor base is critical to scaling the project, growing the ecosystem, and helping the project succeed.
+
 ## Current initiatives
 
 1. What work did the SIG do this year that should be highlighted?
-
-   -
-   -
-   -
-
+    - Kubernetes Contributor Summits
+        - [Europe in Valencia](https://www.kubernetes.dev/events/2022/kcseu/)
+        - [North America in Detroit](https://www.kubernetes.dev/events/2022/kcsna/)
+    - Retired [Community meeting and Meet our Contributors](https://github.com/kubernetes/community/issues/7051)
+    - [Steering Committee Elections for the 2022 cycle](https://github.com/kubernetes/community/blob/master/elections/steering/2022/README.md)
+    - Leadership mentorship cohort for training new Chairs and Technical Leads for the SIG
+    - Ran group mentoring cohorts for SIG Apps and CLI
+    - [Launch of New Contributor Course](https://k8s.dev/course)
 2. What initiatives are you working on that aren't being tracked in KEPs?
-
-   -
-   -
-   -
-
-
-
+    - [Rollout of 1password](https://github.com/kubernetes/community/issues/6394)
+    - Migration of groups to kubernetes.io managed groups
+    - [Improved Zoom -> YouTube automation](https://github.com/kubernetes/community/issues/4175)
 3. KEP work in 2022 (v1.24, v1.25, v1.26):
-
+    - None
 
 ## Project health
 
 1. What areas and/or subprojects does your group need the most help with?
    Any areas with 2 or fewer OWNERs? (link to more details)
 
-   -
-   -
-   -
+    - Mentoring subproject needs a coordinator
+    - Contributor site needs Hugo expertise
 
 2. What metrics/community health stats does your group care about and/or measure?
 
-   -
-   -
-   -
+    - [Inactive Issues](https://k8s.devstats.cncf.io/d/73/inactive-issues-by-sig?orgId=1&var-sigs=%22contributor-experience%22&from=1641016800000&to=1672466400000) - ContribEx is a service oriented SIG; most items are tracked as issues.
+    - [Issues opened and closed by sig](https://k8s.devstats.cncf.io/d/39/issues-opened-closed-by-sig?orgId=1&var-period=d7&var-repo_name=kubernetes%2Fkubernetes&var-repo=kuberneteskubernetes&var-sig_name=contributor-experience&var-kind_name=All&from=1641016800000&to=1672466400000&viewPanel=3)
 
 3. Does your [CONTRIBUTING.md] help **new** contributors engage with your group specifically by pointing
    to activities or programs that provide useful context or allow easy participation?
 
-   -
+   - N/A
 
 4. If your group has special training, requirements for reviewers/approvers, or processes beyond the general [contributor guide],
    does your [CONTRIBUTING.md] document those to help **existing** contributors grow throughout the [contributor ladder]?
 
-   -
+   - N/A
 
 5. Does the group have contributors from multiple companies/affiliations?
 
-   -
+   - Yes - there are [25+ different organizations that participated during 2022](https://k8s.devstats.cncf.io/d/8/company-statistics-by-repository-group?orgId=1&var-period=d7&var-metric=contributions&var-repogroup_name=SIG%20Contributor%20Experience&var-repo_name=kubernetes%2Fkubernetes&var-companies=All&from=1641016800000&to=1672466400000&viewPanel=1)
 
 6. Are there ways end users/companies can contribute that they currently are not?
    If one of those ways is more full time support, what would they work on and why?
 
-   -
-   -
+   - SIG-ContribEx could use more help from people with project coordination experience, such as Project Managers. The [mentoring subproject](https://github.com/kubernetes/community/blob/master/mentoring/programs/group-mentoring.md) in particular is in need of a coordinator.
 
 ## Membership
 
-- Primary slack channel member count:
-- Primary mailing list member count:
-- Primary meeting attendee count (estimated, if needed):
-- Primary meeting participant count (estimated, if needed):
-- Unique reviewers for SIG-owned packages: <!-- in future, this will be generated from OWNERS files referenced from subprojects, expanded with OWNERS_ALIASES files -->
-- Unique approvers for SIG-owned packages: <!-- in future, this will be generated from OWNERS files referenced from subprojects, expanded with OWNERS_ALIASES files -->
+- Primary slack channel member count: 2,298
+- Primary mailing list member count: 411
+- Primary meeting attendee count: 10
+- Primary meeting participant count: 10
+- Unique reviewers for SIG-owned packages: 126
+- Unique approvers for SIG-owned packages: 131
 
 Include any other ways you measure group membership
 
 ## [Subprojects](https://git.k8s.io/community/sig-contributor-experience#subprojects)
 
-
-
 **New in 2022:**
 
-  - elections
+  - [elections](https://github.com/kubernetes/community/tree/master/elections)
 
 **Continuing:**
 
@@ -87,22 +83,23 @@ Include any other ways you measure group membership
 
 
 ## [Working groups](https://git.k8s.io/community/sig-contributor-experience#working-groups)
-
+  - N/A
 
 ## Operational
 
 Operational tasks in [sig-governance.md]:
 
-- [ ] [README.md] reviewed for accuracy and updated if needed
-- [ ] [CONTRIBUTING.md] reviewed for accuracy and updated if needed
+- [x] [README.md] reviewed for accuracy and updated if needed
+- [x] [CONTRIBUTING.md] reviewed for accuracy and updated if needed
       (or created if missing and your contributor steps and experience are different or more
       in-depth than the documentation listed in the general [contributor guide] and [devel] folder.)
-- [ ] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
-- [ ] SIG leaders (chairs, tech leads, and subproject owners) in [sigs.yaml] are accurate and active, and updated if needed
-- [ ] Meeting notes and recordings for 2022 are linked from [README.md] and updated/uploaded if needed
-- [ ] Did you have community-wide updates in 2022 (e.g. community meetings, kubecon, or kubernetes-dev@ emails)? Links to email, slides, or recordings:
-      -
-      -
+- [x] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
+- [x] SIG leaders (chairs, tech leads, and subproject owners) in [sigs.yaml] are accurate and active, and updated if needed
+- [x] Meeting notes and recordings for 2022 are linked from [README.md] and updated/uploaded if needed
+- [x] Did you have community-wide updates in 2022 (e.g. community meetings, kubecon, or kubernetes-dev@ emails)? Links to email, slides, or recordings:
+      - Link to KubeCon talks from 2022
+        - [KubeCon EU](https://www.youtube.com/watch?v=hD6ZtmEIbEQ)
+        - [KubeCon NA](https://www.youtube.com/watch?v=C-k_h3vzWxE)
 
 [CONTRIBUTING.md]: https://git.k8s.io/community/sig-contributor-experience/CONTRIBUTING.md
 [contributor ladder]: https://git.k8s.io/community/community-membership.md


### PR DESCRIPTION
Adding SIG-ContribEx Annual Report for 2022

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7105 
