### PR TITLE
lfx-mentorship repo detached

### DIFF
--- a/mentoring/programs/lfx-mentorship.md
+++ b/mentoring/programs/lfx-mentorship.md
@@ -4,4 +4,4 @@
 
 LFX Mentorship is actively used by the Cloud Native Computing Foundation as a mentorship platform across the CNCF projects.
 
-More details about the LFX Mentorship program you may find at the [CNCF Mentoring repo](https://github.com/cncf/mentoring/blob/master/lfx-mentorship/README.md).
+More details about the LFX Mentorship program you may find at the [CNCF Mentoring repo](https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md).


### PR DESCRIPTION
PR fixes broken link to CNCF mentorship Repository.

https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md