### PR TITLE
sig-scheduling: add kube-scheduler-wasm-extension repo

### DIFF
--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -83,6 +83,9 @@ The following [subprojects][subproject-definition] are owned by sig-scheduling:
 ### kube-scheduler-simulator
 - **Owners:**
   - [kubernetes-sigs/kube-scheduler-simulator](https://github.com/kubernetes-sigs/kube-scheduler-simulator/blob/master/OWNERS)
+### kube-scheduler-wasm-extension
+- **Owners:**
+  - [kubernetes-sigs/kube-scheduler-wasm-extension](https://github.com/kubernetes-sigs/kube-scheduler-wasm-extension/blob/main/OWNERS)
 ### kueue
 - **Owners:**
   - [kubernetes-sigs/kueue](https://github.com/kubernetes-sigs/kueue/blob/main/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2555,6 +2555,9 @@ sigs:
   - name: kube-scheduler-simulator
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kube-scheduler-simulator/master/OWNERS
+  - name: kube-scheduler-wasm-extension
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kube-scheduler-wasm-extension/main/OWNERS
   - name: kueue
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kueue/main/OWNERS


### PR DESCRIPTION
Fixes https://github.com/kubernetes/org/issues/4174

/assign @Huang-Wei @alculquicondor 

/hold
for lgtm from at least one sig-scheduling lead