### PR TITLE
Update e2e-tests-kubetest2.md with new source for Kubernetes releases

### DIFF
--- a/contributors/devel/sig-testing/e2e-tests-kubetest2.md
+++ b/contributors/devel/sig-testing/e2e-tests-kubetest2.md
@@ -195,11 +195,10 @@ kubetest2 gce --test ginkgo -- --test-package-version v1.18.0
 
 The argument to `--test-package-version` can be changed to specify
 some other test package version. To see available release names for
-this option, use this command:
+this option, visit https://github.com/kubernetes/kubernetes/releases.
 
-```sh
-gsutil ls gs://kubernetes-release/release/
-```
+Examples: v1.26.0-alpha.2, v1.26.0-beta.0, v1.26.1-rc.0, v1.26.5
+
 
 ### Testing against an existing cluster
 


### PR DESCRIPTION
This commit updates the 'e2e-tests-kubetest2.md' documentation. Instead of instructing users to use a `gsuti`l command to find release names, they are now directed to visit the Kubernetes GitHub releases page. This change removes the reliance on GCS as the release buckets will eventually be fully replaced with the community owned `dl.k8s.io` endpoint.

ref https://github.com/kubernetes/k8s.io/issues/2396