### PR TITLE
add eksctl channel in k8s slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -106,6 +106,7 @@ channels:
   - name: druid-operator
   - name: ebpf
   - name: eks
+  - name: eksctl
   - name: elastickube
   - name: elk-charts
     archived: true


### PR DESCRIPTION
This is a request for the [eksctl](https://eksctl.io/) project to have a channel in the Kubernetes Slack.

eksctl is a simple CLI tool for creating and managing clusters on EKS - AWS's managed Kubernetes service. The project is open source, and we want to move our Slack channel to Kubernetes Slack.
