### PR TITLE
Sig node contributing.md update

### DIFF
--- a/contributors/devel/sig-node/triage.md
+++ b/contributors/devel/sig-node/triage.md
@@ -12,7 +12,8 @@ CI-related PRs are tracked on the [CI subproject board].
 
 For help with the commands listed in the document below, review the [bot command documentation].
 
-[SIG Node Triage project board]: https://github.com/orgs/kubernetes/projects/49
+[SIG Node PR Triage project board]: https://github.com/orgs/kubernetes/projects/49
+[SIG Node Bugs Triage project board]: https://github.com/orgs/kubernetes/projects/59
 [CI subproject board]: https://github.com/orgs/kubernetes/projects/43
 [bot command documentation]: https://go.k8s.io/bot-commands
 

--- a/sig-node/CONTRIBUTING.md
+++ b/sig-node/CONTRIBUTING.md
@@ -16,7 +16,7 @@ SIG Node enhancements are available in the <https://github.com/kubernetes/enhanc
 
 **Code**:  
 
-For general code organization, read [contributors/devel/README.md](contributors/devel/README.md) for explaning things like
+For general code organization, read [contributors/devel/README.md](contributors/devel/README.md) for explaining things like
 `vendor/`, `staging`, etc.
 
 * Kubelet

--- a/sig-node/CONTRIBUTING.md
+++ b/sig-node/CONTRIBUTING.md
@@ -4,68 +4,96 @@ Welcome!
 
 ## For Kubernetes Contributions
 
-https://github.com/kubernetes/community/tree/master/contributors/guide#contributor-guide
+Read the [Kubernetes Contributor Guide](https://github.com/kubernetes/community/tree/master/contributors/guide#contributor-guide).
 
 If you aspire to grow scope in the SIG, please review the [SIG Node contributor ladder](./sig-node-contributor-ladder.md) for SIG specific guidance.
 
-### For Enhancements 
+### For Enhancements
 
-https://github.com/kubernetes/enhancements/tree/master/keps/sig-node
+SIG Node enhancements are available in the <https://github.com/kubernetes/enhancements/tree/master/keps/sig-node>.
 
 #### Helpful Links for Sig-Node
 
-Code:  
+**Code**:  
 
-https://github.com/kubernetes/kubernetes/tree/master/cmd/kubelet  
+For general code organization, read [contributors/devel/README.md](contributors/devel/README.md) for explaning things like
+`vendor/`, `staging`, etc.
 
-https://github.com/kubernetes/kubernetes/tree/master/pkg/kubelet  
+* Kubelet
+  * <https://github.com/kubernetes/kubernetes/tree/master/cmd/kubelet>
+  * <https://github.com/kubernetes/kubernetes/tree/master/pkg/kubelet>
+* Probe: <https://github.com/kubernetes/kubernetes/tree/master/pkg/probe>
+* NodeLifecycle: <https://github.com/kubernetes/kubernetes/tree/master/pkg/controller/nodelifecycle>
+* Node API: <https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/api/node>
+* CRI API: <https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/cri-api>
+* DRA:
+  * <https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/dynamic-resource-allocation>
+  * <https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/kubelet/pkg/apis/dra/>
+  * <https://github.com/kubernetes/kubernetes/tree/master/test/e2e/dra/>
+* E2E test:
+  * <https://github.com/kubernetes/kubernetes/tree/master/test/e2e/node/>
+  * <https://github.com/kubernetes/kubernetes/tree/master/test/e2e_node/>
+* CI (test-infra)
+  * [sig-node jobs](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/)
+  * [e2e_node jobs](<https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/>
+  * [sig-node test-grids](https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/sig-node/)
+  * [containerd test-grids](https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/containerd/)
 
-https://github.com/kubernetes/kubernetes/tree/master/pkg/probe  
+**Development Resources**:  
 
-Development Resources:  
+* <https://github.com/kubernetes/community/tree/master/contributors/devel#table-of-contents>
 
-https://github.com/kubernetes/community/tree/master/contributors/devel#table-of-contents
+There are two types of end-to-end tests in Kubernetes:
 
-Shared space / Sub projects:  
+* [Cluster end-to-end tests](https://git.k8s.io/community/contributors/devel/sig-testing/e2e-tests.md)
+* [Node end-to-end tests](https://git.k8s.io/community/contributors/devel/sig-node/e2e-node-tests.md)
 
-https://github.com/kubernetes/community/tree/master/contributors/devel/sig-node  
+**Shared space / Sub projects**:  
 
-https://github.com/kubernetes/community/tree/master/sig-node#subprojects
+* <https://github.com/kubernetes/community/tree/master/contributors/devel/sig-node>
+* <https://github.com/kubernetes/community/tree/master/sig-node#subprojects>
 
-Triage:
-https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/triage.md 
+**Triage**:
+
+* <https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/triage.md>
+
+**Test Grids**:
+
+* SIG Node overview: <https://testgrid.k8s.io/sig-node>
+* Release Blocking: <https://testgrid.k8s.io/sig-node-release-blocking>
+* Kubelet: <https://testgrid.k8s.io/sig-node-kubelet>
+* Containerd: <https://testgrid.k8s.io/sig-node-containerd>
 
 ## Getting Started
 
 Task #1 : Compile kubelet
-See tips in the root Makefile    
- 
-https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#building-kubernetes
+See tips in the root Makefile:
+
+* <https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#building-kubernetes>
 
 Task #2 : Run a single unit test  
 
-https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#unit-tests
+* <https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#unit-tests>
 
 Task #3 : Explore update/verify scripts  
 
 hack/update-gofmt.sh + hack/verify-gofmt.sh  
 
-https://github.com/kubernetes/kubernetes/blob/master/hack/update-gofmt.sh  
-
-https://github.com/kubernetes/kubernetes/blob/master/hack/verify-gofmt.sh
+* <https://github.com/kubernetes/kubernetes/blob/master/hack/update-gofmt.sh>
+* <https://github.com/kubernetes/kubernetes/blob/master/hack/verify-gofmt.sh>
 
 Task #4 : Explore dependencies  
 
 hack/pin-dependency.sh + hack/update-vendor.sh  
 
-https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/vendor.md
+* <https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/vendor.md>
 
 Task #5 : Using local-up-cluster script  
 
-https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md#starting-the-cluster  
+* <https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md#starting-the-cluster>
 
 Running a local cluster  
 
-https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md
-        
+* <https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md>
+
 Note: Task 5 requires Linux OS

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -13,7 +13,9 @@ SIG Node is responsible for the components that support the controlled interacti
 The [charter](charter.md) defines the scope and governance of the Node Special Interest Group.
 
 ## Meetings
+
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node) for the group will typically add invites for the following meetings to your calendar.*
+
 * Main SIG Meeting: [Tuesdays at 10:00 PT (Pacific Time)](https://zoom.us/j/4799874685) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG).
@@ -23,12 +25,14 @@ The [charter](charter.md) defines the scope and governance of the Node Special I
 ## Leadership
 
 ### Chairs
+
 The Chairs of the SIG run operations and processes governing the SIG.
 
 * Sergey Kanzhelev (**[@SergeyKanzhelev](https://github.com/SergeyKanzhelev)**), Google
 * Mrunal Patel (**[@mrunalp](https://github.com/mrunalp)**), Red Hat
 
 ### Technical Leads
+
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
@@ -37,88 +41,109 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Mrunal Patel (**[@mrunalp](https://github.com/mrunalp)**), Red Hat
 
 ## Contact
-- Slack: [#sig-node](https://kubernetes.slack.com/messages/sig-node)
-- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
-- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnode)
-- GitHub Teams:
-    - [@kubernetes/sig-node-api-reviews](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) - API Changes and Reviews
-    - [@kubernetes/sig-node-bugs](https://github.com/orgs/kubernetes/teams/sig-node-bugs) - Bug Triage and Troubleshooting
-    - [@kubernetes/sig-node-feature-requests](https://github.com/orgs/kubernetes/teams/sig-node-feature-requests) - Feature Requests
-    - [@kubernetes/sig-node-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) - PR Reviews
-    - [@kubernetes/sig-node-proposals](https://github.com/orgs/kubernetes/teams/sig-node-proposals) - Design Proposals
-    - [@kubernetes/sig-node-test-failures](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
+
+* Slack: [#sig-node](https://kubernetes.slack.com/messages/sig-node)
+* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
+* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnode)
+* GitHub Teams:
+  * [@kubernetes/sig-node-api-reviews](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) - API Changes and Reviews
+  * [@kubernetes/sig-node-bugs](https://github.com/orgs/kubernetes/teams/sig-node-bugs) - Bug Triage and Troubleshooting
+  * [@kubernetes/sig-node-feature-requests](https://github.com/orgs/kubernetes/teams/sig-node-feature-requests) - Feature Requests
+  * [@kubernetes/sig-node-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) - PR Reviews
+  * [@kubernetes/sig-node-proposals](https://github.com/orgs/kubernetes/teams/sig-node-proposals) - Design Proposals
+  * [@kubernetes/sig-node-test-failures](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) - Test Failures and Triage
+* Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 
 ## Working Groups
 
 The following [working groups][working-group-definition] are sponsored by sig-node:
+
 * [WG Batch](/wg-batch)
 * [WG Multitenancy](/wg-multitenancy)
 * [WG Policy](/wg-policy)
 * [WG Structured Logging](/wg-structured-logging)
 
-
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-node:
+
 ### ci-testing
-- **Owners:**
-  - [kubernetes/kubernetes/test/e2e/common](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/common/OWNERS)
-  - [kubernetes/kubernetes/test/e2e/common/node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/common/node/OWNERS)
-  - [kubernetes/kubernetes/test/e2e/node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node/OWNERS)
-  - [kubernetes/kubernetes/test/e2e_node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/OWNERS)
-  - [kubernetes/test-infra/config/jobs/kubernetes/sig-node](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/OWNERS)
-  - [kubernetes/test-infra/config/testgrids/kubernetes/sig-node](https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/sig-node/OWNERS)
-  - [kubernetes/test-infra/jobs/e2e_node](https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/OWNERS)
-- **Contact:**
-  - [Mailing List](https://groups.google.com/g/kubernetes-sig-node-test-failures)
+
+* **Owners:**
+  * [kubernetes/kubernetes/test/e2e/common](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/common/OWNERS)
+  * [kubernetes/kubernetes/test/e2e/common/node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/common/node/OWNERS)
+  * [kubernetes/kubernetes/test/e2e/node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node/OWNERS)
+  * [kubernetes/kubernetes/test/e2e_node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/OWNERS)
+  * [kubernetes/test-infra/config/jobs/kubernetes/sig-node](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/OWNERS)
+  * [kubernetes/test-infra/config/testgrids/kubernetes/sig-node](https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/sig-node/OWNERS)
+  * [kubernetes/test-infra/jobs/e2e_node](https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/OWNERS)
+* **Contact:**
+  * [Mailing List](https://groups.google.com/g/kubernetes-sig-node-test-failures)
+
 ### cri-api
-- **Owners:**
-  - [kubernetes/cri-api](https://github.com/kubernetes/cri-api/blob/master/OWNERS)
-  - [kubernetes/kubernetes/staging/src/k8s.io/cri-api](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/OWNERS)
-  - [kubernetes/kubernetes/staging/src/k8s.io/cri-api/pkg](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/pkg/OWNERS)
+
+* **Owners:**
+  * [kubernetes/cri-api](https://github.com/kubernetes/cri-api/blob/master/OWNERS)
+  * [kubernetes/kubernetes/staging/src/k8s.io/cri-api](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/OWNERS)
+  * [kubernetes/kubernetes/staging/src/k8s.io/cri-api/pkg](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/pkg/OWNERS)
+
 ### cri-tools
-- **Owners:**
-  - [kubernetes-sigs/cri-tools](https://github.com/kubernetes-sigs/cri-tools/blob/master/OWNERS)
+
+* **Owners:**
+  * [kubernetes-sigs/cri-tools](https://github.com/kubernetes-sigs/cri-tools/blob/master/OWNERS)
+
 ### kernel-module-management
-- **Owners:**
-  - [kubernetes-sigs/kernel-module-management](https://github.com/kubernetes-sigs/kernel-module-management/blob/main/OWNERS)
+
+* **Owners:**
+  * [kubernetes-sigs/kernel-module-management](https://github.com/kubernetes-sigs/kernel-module-management/blob/main/OWNERS)
+
 ### kubelet
-- **Owners:**
-  - [kubernetes/kubernetes/cmd/kubelet](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/OWNERS)
-  - [kubernetes/kubernetes/pkg/kubelet](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/OWNERS)
-  - [kubernetes/kubernetes/pkg/probe](https://github.com/kubernetes/kubernetes/blob/master/pkg/probe/OWNERS)
-  - [kubernetes/kubernetes/pkg/security/apparmor](https://github.com/kubernetes/kubernetes/blob/master/pkg/security/apparmor/OWNERS)
-  - [kubernetes/kubernetes/staging/src/k8s.io/component-helpers/node](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-helpers/node/OWNERS)
+
+* **Owners:**
+  * [kubernetes/kubernetes/cmd/kubelet](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/OWNERS)
+  * [kubernetes/kubernetes/pkg/kubelet](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/OWNERS)
+  * [kubernetes/kubernetes/pkg/probe](https://github.com/kubernetes/kubernetes/blob/master/pkg/probe/OWNERS)
+  * [kubernetes/kubernetes/pkg/security/apparmor](https://github.com/kubernetes/kubernetes/blob/master/pkg/security/apparmor/OWNERS)
+  * [kubernetes/kubernetes/staging/src/k8s.io/component-helpers/node](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-helpers/node/OWNERS)
+
 ### node-api
-- **Owners:**
-  - [kubernetes/api/node](https://github.com/kubernetes/api/blob/master/node/OWNERS)
-  - [kubernetes/kubernetes/staging/src/k8s.io/api/node](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/node/OWNERS)
+
+* **Owners:**
+  * [kubernetes/api/node](https://github.com/kubernetes/api/blob/master/node/OWNERS)
+  * [kubernetes/kubernetes/staging/src/k8s.io/api/node](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/node/OWNERS)
+
 ### node-feature-discovery
-- **Owners:**
-  - [kubernetes-sigs/node-feature-discovery-operator](https://github.com/kubernetes-sigs/node-feature-discovery-operator/blob/master/OWNERS)
-  - [kubernetes-sigs/node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/OWNERS)
+
+* **Owners:**
+  * [kubernetes-sigs/node-feature-discovery-operator](https://github.com/kubernetes-sigs/node-feature-discovery-operator/blob/master/OWNERS)
+  * [kubernetes-sigs/node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/OWNERS)
+
 ### node-problem-detector
-- **Owners:**
-  - [kubernetes/node-problem-detector](https://github.com/kubernetes/node-problem-detector/blob/master/OWNERS)
-  - [kubernetes/test-infra/config/jobs/kubernetes/node-problem-detector](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/node-problem-detector/OWNERS)
-- **Contact:**
-  - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
+
+* **Owners:**
+  * [kubernetes/node-problem-detector](https://github.com/kubernetes/node-problem-detector/blob/master/OWNERS)
+  * [kubernetes/test-infra/config/jobs/kubernetes/node-problem-detector](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/node-problem-detector/OWNERS)
+* **Contact:**
+  * Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
+
 ### resource-management
-- **Owners:**
-  - [kubernetes-sigs/dra-example-driver](https://github.com/kubernetes-sigs/dra-example-driver/blob/main/OWNERS)
-  - [kubernetes/kubernetes/pkg/controller/resourceclaim](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/resourceclaim/OWNERS)
-  - [kubernetes/kubernetes/pkg/scheduler/framework/plugins/dynamicresources](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/dynamicresources/OWNERS)
-  - [kubernetes/kubernetes/staging/src/k8s.io/dynamic-resource-allocation](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/dynamic-resource-allocation/OWNERS)
-  - [kubernetes/kubernetes/staging/src/k8s.io/kubelet/pkg/apis/dra](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/dra/OWNERS)
-  - [kubernetes/kubernetes/test/e2e/dra](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/dra/OWNERS)
-  - [kubernetes/kubernetes/test/e2e/testing-manifests/dra](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/dra/OWNERS)
-  - [kubernetes/noderesourcetopology-api](https://github.com/kubernetes/noderesourcetopology-api/blob/master/OWNERS)
+
+* **Owners:**
+  * [kubernetes-sigs/dra-example-driver](https://github.com/kubernetes-sigs/dra-example-driver/blob/main/OWNERS)
+  * [kubernetes/kubernetes/pkg/controller/resourceclaim](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/resourceclaim/OWNERS)
+  * [kubernetes/kubernetes/pkg/scheduler/framework/plugins/dynamicresources](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/dynamicresources/OWNERS)
+  * [kubernetes/kubernetes/staging/src/k8s.io/dynamic-resource-allocation](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/dynamic-resource-allocation/OWNERS)
+  * [kubernetes/kubernetes/staging/src/k8s.io/kubelet/pkg/apis/dra](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/dra/OWNERS)
+  * [kubernetes/kubernetes/test/e2e/dra](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/dra/OWNERS)
+  * [kubernetes/kubernetes/test/e2e/testing-manifests/dra](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/dra/OWNERS)
+  * [kubernetes/noderesourcetopology-api](https://github.com/kubernetes/noderesourcetopology-api/blob/master/OWNERS)
+
 ### security-profiles-operator
-- **Owners:**
-  - [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/OWNERS)
-- **Contact:**
-  - Slack: [#security-profiles-operator](https://kubernetes.slack.com/messages/security-profiles-operator)
+
+* **Owners:**
+  * [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/OWNERS)
+* **Contact:**
+  * Slack: [#security-profiles-operator](https://kubernetes.slack.com/messages/security-profiles-operator)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 [working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
@@ -127,21 +152,21 @@ The following [subprojects][subproject-definition] are owned by sig-node:
 
 The following topics fall under scope of this SIG.
 
-- Kubelet and its features
-- Pod API and Pod behaviors (with [sig-architecture](../sig-architecture))
-- Node API (with [sig-architecture](../sig-architecture))
-- Node controller
-- Node level performance and scalability (with [sig-scalability](../sig-scalability))
-- Node reliability (problem detection and remediation)
-- Node lifecycle management (with [sig-cluster-lifecycle](../sig-cluster-lifecycle))
-- Container runtimes
-- Device management
-- Image management
-- Node-level resource management (with [sig-scheduling](../sig-scheduling))
-- Hardware discovery
-- Issues related to node, pod, container monitoring (with [sig-instrumentation](../sig-instrumentation))
-- Node level security and Pod isolation (with [sig-auth](../sig-auth))
-- Host OS and/or kernel interactions (to a limited extent)
+* Kubelet and its features
+* Pod API and Pod behaviors (with [sig-architecture](../sig-architecture))
+* Node API (with [sig-architecture](../sig-architecture))
+* Node controller
+* Node level performance and scalability (with [sig-scalability](../sig-scalability))
+* Node reliability (problem detection and remediation)
+* Node lifecycle management (with [sig-cluster-lifecycle](../sig-cluster-lifecycle))
+* Container runtimes
+* Device management
+* Image management
+* Node-level resource management (with [sig-scheduling](../sig-scheduling))
+* Hardware discovery
+* Issues related to node, pod, container monitoring (with [sig-instrumentation](../sig-instrumentation))
+* Node level security and Pod isolation (with [sig-auth](../sig-auth))
+* Host OS and/or kernel interactions (to a limited extent)
 
 We also work closely with [sig-storage](../sig-storage) and [sig-network](../sig-network). As you can see, this is a very cross-functional team!
 <!-- END CUSTOM CONTENT -->

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -13,9 +13,7 @@ SIG Node is responsible for the components that support the controlled interacti
 The [charter](charter.md) defines the scope and governance of the Node Special Interest Group.
 
 ## Meetings
-
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node) for the group will typically add invites for the following meetings to your calendar.*
-
 * Main SIG Meeting: [Tuesdays at 10:00 PT (Pacific Time)](https://zoom.us/j/4799874685) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG).
@@ -25,14 +23,12 @@ The [charter](charter.md) defines the scope and governance of the Node Special I
 ## Leadership
 
 ### Chairs
-
 The Chairs of the SIG run operations and processes governing the SIG.
 
 * Sergey Kanzhelev (**[@SergeyKanzhelev](https://github.com/SergeyKanzhelev)**), Google
 * Mrunal Patel (**[@mrunalp](https://github.com/mrunalp)**), Red Hat
 
 ### Technical Leads
-
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
@@ -41,109 +37,88 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Mrunal Patel (**[@mrunalp](https://github.com/mrunalp)**), Red Hat
 
 ## Contact
-
-* Slack: [#sig-node](https://kubernetes.slack.com/messages/sig-node)
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
-* [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnode)
-* GitHub Teams:
-  * [@kubernetes/sig-node-api-reviews](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) - API Changes and Reviews
-  * [@kubernetes/sig-node-bugs](https://github.com/orgs/kubernetes/teams/sig-node-bugs) - Bug Triage and Troubleshooting
-  * [@kubernetes/sig-node-feature-requests](https://github.com/orgs/kubernetes/teams/sig-node-feature-requests) - Feature Requests
-  * [@kubernetes/sig-node-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) - PR Reviews
-  * [@kubernetes/sig-node-proposals](https://github.com/orgs/kubernetes/teams/sig-node-proposals) - Design Proposals
-  * [@kubernetes/sig-node-test-failures](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) - Test Failures and Triage
-* Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
+- Slack: [#sig-node](https://kubernetes.slack.com/messages/sig-node)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-node)
+- [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fnode)
+- GitHub Teams:
+    - [@kubernetes/sig-node-api-reviews](https://github.com/orgs/kubernetes/teams/sig-node-api-reviews) - API Changes and Reviews
+    - [@kubernetes/sig-node-bugs](https://github.com/orgs/kubernetes/teams/sig-node-bugs) - Bug Triage and Troubleshooting
+    - [@kubernetes/sig-node-feature-requests](https://github.com/orgs/kubernetes/teams/sig-node-feature-requests) - Feature Requests
+    - [@kubernetes/sig-node-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) - PR Reviews
+    - [@kubernetes/sig-node-proposals](https://github.com/orgs/kubernetes/teams/sig-node-proposals) - Design Proposals
+    - [@kubernetes/sig-node-test-failures](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) - Test Failures and Triage
+- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
 
 ## Working Groups
 
 The following [working groups][working-group-definition] are sponsored by sig-node:
-
 * [WG Batch](/wg-batch)
 * [WG Multitenancy](/wg-multitenancy)
 * [WG Policy](/wg-policy)
 * [WG Structured Logging](/wg-structured-logging)
 
+
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-node:
-
 ### ci-testing
-
-* **Owners:**
-  * [kubernetes/kubernetes/test/e2e/common](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/common/OWNERS)
-  * [kubernetes/kubernetes/test/e2e/common/node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/common/node/OWNERS)
-  * [kubernetes/kubernetes/test/e2e/node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node/OWNERS)
-  * [kubernetes/kubernetes/test/e2e_node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/OWNERS)
-  * [kubernetes/test-infra/config/jobs/kubernetes/sig-node](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/OWNERS)
-  * [kubernetes/test-infra/config/testgrids/kubernetes/sig-node](https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/sig-node/OWNERS)
-  * [kubernetes/test-infra/jobs/e2e_node](https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/OWNERS)
-* **Contact:**
-  * [Mailing List](https://groups.google.com/g/kubernetes-sig-node-test-failures)
-
+- **Owners:**
+  - [kubernetes/kubernetes/test/e2e/common](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/common/OWNERS)
+  - [kubernetes/kubernetes/test/e2e/common/node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/common/node/OWNERS)
+  - [kubernetes/kubernetes/test/e2e/node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node/OWNERS)
+  - [kubernetes/kubernetes/test/e2e_node](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/OWNERS)
+  - [kubernetes/test-infra/config/jobs/kubernetes/sig-node](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-node/OWNERS)
+  - [kubernetes/test-infra/config/testgrids/kubernetes/sig-node](https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/sig-node/OWNERS)
+  - [kubernetes/test-infra/jobs/e2e_node](https://github.com/kubernetes/test-infra/blob/master/jobs/e2e_node/OWNERS)
+- **Contact:**
+  - [Mailing List](https://groups.google.com/g/kubernetes-sig-node-test-failures)
 ### cri-api
-
-* **Owners:**
-  * [kubernetes/cri-api](https://github.com/kubernetes/cri-api/blob/master/OWNERS)
-  * [kubernetes/kubernetes/staging/src/k8s.io/cri-api](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/OWNERS)
-  * [kubernetes/kubernetes/staging/src/k8s.io/cri-api/pkg](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/pkg/OWNERS)
-
+- **Owners:**
+  - [kubernetes/cri-api](https://github.com/kubernetes/cri-api/blob/master/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/cri-api](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/cri-api/pkg](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/pkg/OWNERS)
 ### cri-tools
-
-* **Owners:**
-  * [kubernetes-sigs/cri-tools](https://github.com/kubernetes-sigs/cri-tools/blob/master/OWNERS)
-
+- **Owners:**
+  - [kubernetes-sigs/cri-tools](https://github.com/kubernetes-sigs/cri-tools/blob/master/OWNERS)
 ### kernel-module-management
-
-* **Owners:**
-  * [kubernetes-sigs/kernel-module-management](https://github.com/kubernetes-sigs/kernel-module-management/blob/main/OWNERS)
-
+- **Owners:**
+  - [kubernetes-sigs/kernel-module-management](https://github.com/kubernetes-sigs/kernel-module-management/blob/main/OWNERS)
 ### kubelet
-
-* **Owners:**
-  * [kubernetes/kubernetes/cmd/kubelet](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/OWNERS)
-  * [kubernetes/kubernetes/pkg/kubelet](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/OWNERS)
-  * [kubernetes/kubernetes/pkg/probe](https://github.com/kubernetes/kubernetes/blob/master/pkg/probe/OWNERS)
-  * [kubernetes/kubernetes/pkg/security/apparmor](https://github.com/kubernetes/kubernetes/blob/master/pkg/security/apparmor/OWNERS)
-  * [kubernetes/kubernetes/staging/src/k8s.io/component-helpers/node](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-helpers/node/OWNERS)
-
+- **Owners:**
+  - [kubernetes/kubernetes/cmd/kubelet](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/OWNERS)
+  - [kubernetes/kubernetes/pkg/kubelet](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/OWNERS)
+  - [kubernetes/kubernetes/pkg/probe](https://github.com/kubernetes/kubernetes/blob/master/pkg/probe/OWNERS)
+  - [kubernetes/kubernetes/pkg/security/apparmor](https://github.com/kubernetes/kubernetes/blob/master/pkg/security/apparmor/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/component-helpers/node](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-helpers/node/OWNERS)
 ### node-api
-
-* **Owners:**
-  * [kubernetes/api/node](https://github.com/kubernetes/api/blob/master/node/OWNERS)
-  * [kubernetes/kubernetes/staging/src/k8s.io/api/node](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/node/OWNERS)
-
+- **Owners:**
+  - [kubernetes/api/node](https://github.com/kubernetes/api/blob/master/node/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/api/node](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/node/OWNERS)
 ### node-feature-discovery
-
-* **Owners:**
-  * [kubernetes-sigs/node-feature-discovery-operator](https://github.com/kubernetes-sigs/node-feature-discovery-operator/blob/master/OWNERS)
-  * [kubernetes-sigs/node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/OWNERS)
-
+- **Owners:**
+  - [kubernetes-sigs/node-feature-discovery-operator](https://github.com/kubernetes-sigs/node-feature-discovery-operator/blob/master/OWNERS)
+  - [kubernetes-sigs/node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery/blob/master/OWNERS)
 ### node-problem-detector
-
-* **Owners:**
-  * [kubernetes/node-problem-detector](https://github.com/kubernetes/node-problem-detector/blob/master/OWNERS)
-  * [kubernetes/test-infra/config/jobs/kubernetes/node-problem-detector](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/node-problem-detector/OWNERS)
-* **Contact:**
-  * Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
-
+- **Owners:**
+  - [kubernetes/node-problem-detector](https://github.com/kubernetes/node-problem-detector/blob/master/OWNERS)
+  - [kubernetes/test-infra/config/jobs/kubernetes/node-problem-detector](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/node-problem-detector/OWNERS)
+- **Contact:**
+  - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
 ### resource-management
-
-* **Owners:**
-  * [kubernetes-sigs/dra-example-driver](https://github.com/kubernetes-sigs/dra-example-driver/blob/main/OWNERS)
-  * [kubernetes/kubernetes/pkg/controller/resourceclaim](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/resourceclaim/OWNERS)
-  * [kubernetes/kubernetes/pkg/scheduler/framework/plugins/dynamicresources](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/dynamicresources/OWNERS)
-  * [kubernetes/kubernetes/staging/src/k8s.io/dynamic-resource-allocation](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/dynamic-resource-allocation/OWNERS)
-  * [kubernetes/kubernetes/staging/src/k8s.io/kubelet/pkg/apis/dra](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/dra/OWNERS)
-  * [kubernetes/kubernetes/test/e2e/dra](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/dra/OWNERS)
-  * [kubernetes/kubernetes/test/e2e/testing-manifests/dra](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/dra/OWNERS)
-  * [kubernetes/noderesourcetopology-api](https://github.com/kubernetes/noderesourcetopology-api/blob/master/OWNERS)
-
+- **Owners:**
+  - [kubernetes-sigs/dra-example-driver](https://github.com/kubernetes-sigs/dra-example-driver/blob/main/OWNERS)
+  - [kubernetes/kubernetes/pkg/controller/resourceclaim](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/resourceclaim/OWNERS)
+  - [kubernetes/kubernetes/pkg/scheduler/framework/plugins/dynamicresources](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/dynamicresources/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/dynamic-resource-allocation](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/dynamic-resource-allocation/OWNERS)
+  - [kubernetes/kubernetes/staging/src/k8s.io/kubelet/pkg/apis/dra](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/dra/OWNERS)
+  - [kubernetes/kubernetes/test/e2e/dra](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/dra/OWNERS)
+  - [kubernetes/kubernetes/test/e2e/testing-manifests/dra](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/dra/OWNERS)
+  - [kubernetes/noderesourcetopology-api](https://github.com/kubernetes/noderesourcetopology-api/blob/master/OWNERS)
 ### security-profiles-operator
-
-* **Owners:**
-  * [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/OWNERS)
-* **Contact:**
-  * Slack: [#security-profiles-operator](https://kubernetes.slack.com/messages/security-profiles-operator)
+- **Owners:**
+  - [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/OWNERS)
+- **Contact:**
+  - Slack: [#security-profiles-operator](https://kubernetes.slack.com/messages/security-profiles-operator)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 [working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups

--- a/sig-node/annual-report-2021.md
+++ b/sig-node/annual-report-2021.md
@@ -1,0 +1,72 @@
+# SIG Node Annual Report 2021
+
+## Operational
+
+* How are you doing with operational tasks in
+[sig-governance.md](https://git.k8s.io/community/committee-steering/governance/sig-governance.md)?
+  * Is your README accurate? have a CONTRIBUTING.md file?
+    * Yes, [README.md](https://github.com/kubernetes/community/blob/master/sig-node/README.md) is accurate
+    * Opened [issue](https://github.com/kubernetes/community/issues/5600) to track completion CONTRIBUTING.md
+  * All subprojects correctly mapped and listed in [sigs.yaml](https://git.k8s.io/community/sig-list.md)?
+    * [Yes](https://github.com/kubernetes/community/tree/master/sig-node#subprojects)
+  * What’s your meeting culture? Large/small, active/quiet, learnings? Meeting notes up to date? Are you keeping
+  recordings up to date/trends in community members watching recordings?
+    * The SIG operates two recurring meetings.  The Regular SIG Meeting occurs weekly.  It focuses on top-level trends for the SIG, and provides a forum to discuss enhancements, blocked PRs, and release plans.  Each meeting has approximately 15-30 participants depending on the topic.  The meetings are relatively active.  The Chairs host the SIG meeting.  A member of the SIG reports on velocity metrics, and tries to draw attention to overall trends.  The agenda is open for members of the community to discuss an idea or enhancement.  Discussion may ensue for each topic.  SIG members that have participated in the SIG for an extended period will share historical context.  Recordings are up-to-date.  The Weekly CI meeting focuses on improving CI health and improving the number of SIG participants that have sufficient understanding of our test apparatus.  Each meeting has ~7 participants, but participation may improve with new scheduled time.  Each meeting focuses on supporting active triage and review of the project board.  [Recordings are kept up to date with regular SIG meetings](https://www.youtube.com/playlist?list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG).
+* How does the group get updates, reports, or feedback from subprojects? Are there any springing up or being
+retired? Are OWNERS.md files up to date in these areas?
+  * The regular SIG meetings provide a forum to discuss sub-projects closely tied to the Kubernetes release.  This includes cri-api, cri-tools, kubelet, and node-api.  A major focus in the SIG this year has been the graduation of existing features.  Other sub-projects get less frequent updates as development velocity has slowed as the project reached sufficient maturity.
+* Same question as above but for working groups.
+  * There is no regular interlock between working groups and the SIG.  SIG members based on interest and/ or desire may attend particular working group meetings.  The SIG did create a dedicated set of meetings to talk through particular areas like topology management for a limited period of time in order to provide room for discussion outside of the regular SIG meeting.  Once consensus was reached, those meetings ceased.  
+* When was your last monthly community-wide update? (provide link to deck and/or recording)
+  * Last presentation was on April 16, 2020:
+    * [Slides](https://docs.google.com/document/d/1VQDIAB0OqiSjIHI8AWMvSdceWhnz56jNpZrLs6o7NJY/edit#heading=h.di6sf3cdf3yr)
+
+## Membership
+
+* Are all listed SIG leaders (chairs, tech leads, and subproject owners) active?
+  * For the SIG leads yes.
+  * For subproject owners, likely there are some inactive maintainers, but it’s up to the subproject to prune their OWNERs files.
+  * For 2021, the SIG will look to audit the set of sponsored sub-projects to ensure OWNERs files are updated.
+* How do you measure membership? By mailing list members, OWNERs, or something else?
+  * Anyone can be considered a SIG member if they join the Zoom calls or general discussions regularly.
+* How does the group measure reviewer and approver bandwidth? Do you need help in any area now? What are you doing about it?
+  * The SIG identifies the set of items they wish to focus on each release.  A primary engineer and approver is identified up-front.  This provides a baseline understanding of responsibility and capacity going into the release.  As we near release milestones, we measure where we are relative to our planned goals and ensure attention is redirected where appropriate.
+  * The SIG suffered from atrophy in CI health and awareness.  Members of the SIG have developed a dedicated CI group to focus on health and train up new community members to assist.  The group started meeting in May 2020 with ~30 individuals volunteered to assist.  The group has created a large amount of learning materials, improved the CI health, and instituted project boards and triage processes.  The sub-group meets each week with ~7 regular attendees as the CI health has stabilized.
+  * The SIG has elevated 3 members to approver status for the kubelet sub-project in the past year.  It has shifted 2 members to emeritus status.  The SIG has members who have expressed interest and desire to grow their scope in particular parts, and we try to encourage that over a set of releases by focusing on particular sub-components.  We anticipate growing more approvers over the calendar year.
+* Is there a healthy onboarding and growth path for contributors in your SIG?
+What are some activities that the group does to encourage this? What programs are you participating in to grow contributors
+throughout the contributor ladder?
+  * The SIG identifies the set of items that we would like to tackle each release and clearly identifies the primary engineering owner and primary approver.  We try to pair new engineers with senior approvers to grow scope and comfort.  In the CI health meetings, we have established a project board to try and provide directional guidance on where and how to best contribute.
+* What programs do you participate in for new contributors?
+  * KubeCon updates with “how to get involved”, beginning at KubeCon EU 2021
+  * Improving documentation and process so new individuals can join, see e.g. [Node Project Board](https://github.com/orgs/kubernetes/projects/49), [Node PR Triage Guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/triage.md)
+  * Mentoring group for underrepresented individuals to become reviewers, first cohort (July-Dec. 2020) run by @dims and second cohort (Jan-Mar. 2021) run by @ehashman
+  * Next cohort leader/participants TBD  
+* Does the group have contributors from multiple companies/affiliations? Can end users/companies contribute in some way that
+they currently are not?
+  * The group has contributors from multiple companies/affiliations.
+  * [39 companies made 1+](https://k8s.devstats.cncf.io/d/8/company-statistics-by-repository-group?orgId=1&var-period=y&var-metric=contributions&var-repogroup_name=SIG%20Node&var-companies=All) contributions over the last year (70 if all activity is counted).
+  * Deprecating of dockershim is a big project that will require many end user to make a step to migrate and some companies who are not active on SIG Node, namely monitoring vendors, to help end users with this migration.
+
+## Current initiatives and project health
+
+* [x] Please include links to KEPs and other supporting information that will be beneficial to multiple types of community members.
+* What are initiatives that should be highlighted, lauded, shout out, that your group is proud of? Currently underway?
+What are some of the longer tail projects that your group is working on?
+  * Better tracking of [PRs setup](https://github.com/orgs/kubernetes/projects/49) and [Node PR Triage Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/triage.md) by @ehashaman
+  * cgroups v2
+  * [Graduating features](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#)
+  * Topology manager / device alignment
+* Year to date KEP work review: What’s now stable? Beta? Alpha? Road to alpha?
+  * The enumerated links list graduated KEPs for each of the related releases.
+  * 1.18: [GA-ed KEPs](https://github.com/kubernetes/enhancements/issues?q=is%3Aissue+milestone%3Av1.18+label%3Asig%2Fnode)
+  * 1.19: [GA-ed KEPs](https://github.com/kubernetes/enhancements/issues?q=is%3Aissue+milestone%3Av1.19+label%3Asig%2Fnode+)
+  * 1.20: [GA-ed KEPs](https://github.com/kubernetes/enhancements/issues?q=is%3Aissue+milestone%3Av1.20+label%3Asig%2Fnode+)
+* What areas and/or subprojects does the group need the most help with?
+  * The SIG could always use more help in sustaining CI.
+* What's the average open days of a PR and Issue in your group? / what metrics does your group care about and/or measure?
+  * Weekly sig meeting starts with an overview of how PRs were opened/reviewed/approved.
+  * The reporting is generally applicable to other SIGs and is based on following [template](https://docs.google.com/document/d/1JOXKBDgXmQzz8YQSYa7XYcfVteM79iMtvId1aQXC1e8/edit)
+  * The goal is to keep the reviews going so the numbers don’t spin out of control.  It also provides an overview of the week
+  as the scope of the SIG is large and it may be hard to keep up with all changes.
+  * [DevStats report](https://k8s.devstats.cncf.io/d/44/pr-time-to-approve-and-merge?orgId=1&var-period=y&var-repogroup_name=SIG%20Node&var-apichange=All&var-size_name=All&var-kind_name=All)


### PR DESCRIPTION
/sig node

**Which issue(s) this PR fixes**:

Fixes #7223

- [x] add back 2021 annual report (mistakenly removed)
- [x] update  contributing.md: 
- - [x] add code path for components and test-grid/job code pathes
- - [x] add e2e tests and e2e_node tests doc links
