### PR TITLE
github-management: add madhav as github admin

### DIFF
--- a/github-management/OWNERS
+++ b/github-management/OWNERS
@@ -4,11 +4,8 @@ approvers:
   - cblecker
   - mrbobbytables
   - nikhita
-
-reviewers:
-  - ameukam
-  - idvoretskyi
   - palnabarun
+  - MadhavJivrajani
 
 labels:
   - sig/contributor-experience

--- a/github-management/README.md
+++ b/github-management/README.md
@@ -27,12 +27,12 @@ we have a GitHub Administration team that is responsible for carrying out the
 various tasks.
 
 This team (**[@kubernetes/owners](https://github.com/orgs/kubernetes/teams/owners)**) is as follows:
-* Arnaud Meukam (**[@ameukam](https://github.com/ameukam)**, Central European Time)
 * Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**, US Eastern)
 * Christoph Blecker (**[@cblecker](https://github.com/cblecker)**, CA Pacific)
 * Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**, Indian Standard Time)
 * Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**, Indian Standard Time)
 * Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**, UA Eastern European)
+* Madhav Jivrajani (**[@MadhavJivrajani](https://github.com/MadhavJivrajani)**, Indian Standard Time)
 
 This team is responsible for holding Org Owner privileges over all the active
 Kubernetes orgs, and will take action in accordance with our polices and

--- a/github-management/README.md
+++ b/github-management/README.md
@@ -56,9 +56,7 @@ GitHub organization.
 They also have approval privileges for adding new members to the GitHub config.
 
 Our current coordinators are:
-* Arnaud Meukam (**[@ameukam](https://github.com/ameukam)**, Central European)
-* Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**, Indian Standard Time)
-* Savitha Raghunathan (**[@savitharaghunathan](https://github.com/savitharaghunathan)**, US Eastern)
+TBD
 
 ## Project Owned Organizations
 


### PR DESCRIPTION
Ref:

- [sig contribex thread](https://groups.google.com/g/kubernetes-sig-contribex/c/PtLSBDS2yms/m/oFpc3PqUAQAJ) for nomination
- @ameukam's [email](https://groups.google.com/a/kubernetes.io/g/steering/c/-ubWV0Daaxk/m/avoaWI7fAAAJ) to steering to step down 

Lazy consensus achieved.

/committee steering
/cc @kubernetes/steering-committee 
need majority of steering committee to lgtm this change

/assign @cblecker @mrbobbytables @palnabarun @idvoretskyi 
Can you also +1 here?

/assign @MadhavJivrajani 
Can you confirm that you are interested in joining the GitHub Admin Team and accept the security embargo policy?