### PR TITLE
Add official CAAPH Slack Channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -53,6 +53,7 @@ channels:
     archived: true
   - name: cluster-addons
   - name: cluster-api
+  - name: cluster-api-addon-helm
   - name: cluster-api-aws
   - name: cluster-api-aws-alerts
   - name: cluster-api-azure


### PR DESCRIPTION
This PR adds a slack channel for The Cluster API Add-on Provider for Helm (CAAPH) - https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm


**Which issue(s) this PR fixes**:
NONE
