### PR TITLE
Adding sig-docs-ru-owners to sig-docs/README.md

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -80,6 +80,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-docs-pl-owners](https://github.com/orgs/kubernetes/teams/sig-docs-pl-owners) - Polish language content
     - [@kubernetes/sig-docs-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-docs-pr-reviews) - Documentation PR reviews
     - [@kubernetes/sig-docs-pt-owners](https://github.com/orgs/kubernetes/teams/sig-docs-pt-owners) - Portuguese language content
+    - [@kubernetes/sig-docs-ru-owners](https://github.com/orgs/kubernetes/teams/sig-docs-ru-owners) - Russian language content
     - [@kubernetes/sig-docs-uk-owners](https://github.com/orgs/kubernetes/teams/sig-docs-uk-owners) - Ukrainian language content
     - [@kubernetes/sig-docs-zh-owners](https://github.com/orgs/kubernetes/teams/sig-docs-zh-owners) - Chinese language content
 - Steering Committee Liaison: Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1633,6 +1633,8 @@ sigs:
       description: Documentation PR reviews
     - name: sig-docs-pt-owners
       description: Portuguese language content
+    - name: sig-docs-ru-owners
+      description: Russian language content
     - name: sig-docs-uk-owners
       description: Ukrainian language content
     - name: sig-docs-zh-owners


### PR DESCRIPTION
The `sig-docs-ru-owners` GitHub team was not mentioned in the "Contact" list. However, it exists and operates, thus adding it.