### PR TITLE
Fix KubeCon video link

### DIFF
--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -117,7 +117,8 @@ Miscellaneous tools and configuration to run the testing infrastructure for the 
 | KubeCon EU 2019 - SIG Testing Deep Dive | TBD | [Video](https://www.youtube.com/watch?v=6m9frvTxK0o) | @BenTheElder, @munnerz |
 | KubeCon EU 2019 - Testing Your K8s Apps with Kind | TBD | [Video](https://www.youtube.com/watch?v=8KtmevMFfxA) | @BenTheElder, @munnerz | 
 | KubeCon NA 2019 - SIG Testing Intro | [Slides](https://static.sched.com/hosted_files/kccncna19/50/Sig-Testing%20Intro%20Presentation.pdf) | [Video](https://www.youtube.com/watch?v=ER1H9OPPYew) | @chases2, @fejta
-| KubeCon NA 2022 - SIG Testing: Intro And Updates | TBD | [Video](https://www.youtube.com/watch?v=CdKBl6CncHg) | @BenTheElder, @michelle192837, @chaodaiG, @aojea
+| KubeCon NA 2022 - SIG Testing: Intro And Updates | TBD | [Video](https://www.youtube.com/watch?v=K1m0RHE5uZo) | @BenTheElder, @michelle192837, @chaodaiG, @aojea
+
 
 
 <!-- END CUSTOM CONTENT -->


### PR DESCRIPTION
SIG Testing's README has a link to a recording of "KubeCon NA 2022 - SIG Testing: Intro And Updates", which currently goes to https://www.youtube.com/watch?v=CdKBl6CncHg. That's the wrong link though- although the first slide in that video says SIG Testing, it's actually a talk about SIG Security. 

Fixes by using the correct link.