### PR TITLE
sig-windows: Update meeting notes link

### DIFF
--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -16,7 +16,7 @@ The [charter](charter.md) defines the scope and governance of the Windows Specia
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-windows) for the group will typically add invites for the following meetings to your calendar.*
 * Backlog Refinement  / Bug Triage Meeting: [Thursdays at 12:30 Eastern Time (ET)](https://zoom.us/j/94389601840?pwd=MCs2SEJQWG0zUWpBS3Nod0ZNMmVXQT09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:30&tz=Eastern%20Time%20%28ET%29).
 * Regular SIG Meeting: [Tuesdays at 12:30 Eastern Time (ET)](https://zoom.us/j/96892680257?pwd=TVNyMzB4VVMwRGZnUkgzT1dnb2szZz09) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:30&tz=Eastern%20Time%20%28ET%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1aCcqSDBuXQ2gTbBg6QuGvLxCmzlSrAbTfflCTmo-960/).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4).
 * Weekly CI Meeting: [Tuesdays at 12:15 Eastern Time (ET)](https://zoom.us/j/96892680257?pwd=TVNyMzB4VVMwRGZnUkgzT1dnb2szZz09) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=12:15&tz=Eastern%20Time%20%28ET%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1j2XEKXNyGaSO0XZNkSQUliaT48ZQl6StLhrsVurJoco/edit#).

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3047,7 +3047,7 @@ sigs:
     tz: Eastern Time (ET)
     frequency: weekly
     url: https://zoom.us/j/96892680257?pwd=TVNyMzB4VVMwRGZnUkgzT1dnb2szZz09
-    archive_url: https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431
+    archive_url: https://docs.google.com/document/d/1aCcqSDBuXQ2gTbBg6QuGvLxCmzlSrAbTfflCTmo-960/
     recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4
   - description: Weekly CI Meeting
     day: Tuesday


### PR DESCRIPTION
The sig-windows meeting notes was causing rendering issues on some systems due to use of tables. To work around this, a new meeting note doc has been created with a link to the old notes which have now been archived.