### PR TITLE
Add SCS slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -401,7 +401,7 @@ channels:
   - name: ru-users
   - name: scaleway-k8s
   - name: schemahero
-  - name: scs
+  - name: sovereign-cloud-stack
   - name: se-users
   - name: sealed-secrets
   - name: security-profiles-operator

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -401,6 +401,7 @@ channels:
   - name: ru-users
   - name: scaleway-k8s
   - name: schemahero
+  - name: scs
   - name: se-users
   - name: sealed-secrets
   - name: security-profiles-operator


### PR DESCRIPTION
This PR adds a Slack channel for the [Sovereign Cloud Stack (SCS)](https://scs.community).
SCS is using and standardizing existing and proven Open Source components such as e.g. Kubernetes and does extend them where required.

As our community around container technologies keeps growing, we need a place for discussion which is close to the Kubernetes community.