### PR TITLE
Add the usergroup "cert-manager-maintainers"

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -307,6 +307,8 @@ usergroups:
       - cert-manager
     # To get that list, run the following:
     #  curl https://raw.githubusercontent.com/cert-manager/cert-manager/master/OWNERS | yq .approvers
+    # Note that you will then need to find your Slack User ID (look up in Stackoverflow)
+    # and copy it to the users.yaml file in this repository.
     members:
       - munnerz
       - joshvanl

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -298,4 +298,22 @@ usergroups:
       - mspreitz
       - ezra
       - paolo
-      
+
+  - name: cert-manager-maintainers
+    long_name: cert-manager Maintainers
+    description: The maintainers of the cert-manager project.
+    channels:
+      - cert-manager-dev
+      - cert-manager
+    # To get that list, run the following:
+    #  curl https://raw.githubusercontent.com/cert-manager/cert-manager/master/OWNERS | yq .approvers
+    members:
+      - munnerz
+      - joshvanl
+      - wallrj
+      - jakexks
+      - maelvls
+      - irbekrm
+      - sgtcodfish
+      - inteon
+

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -87,7 +87,10 @@ users:
   idvoretskyi: U0CBHE6GM
   ilya-zuyev: U018UF2G42F
   imran: U03K4862X7U
+  inteon: U03RG8315NW
+  irbekrm: UTX3WBNGZ
   IsaacPD: U01B0C1R9NZ
+  jakexks: U0AKBM9EC
   JamesLaverack: U9MK7274Y
   Jason: UB272379N
   jberkhahn: U7Q21LH2S
@@ -108,6 +111,7 @@ users:
   johnbelamaric: U246A1A0N
   johnmcollier: UCVS4TNMQ
   jonasrosland: U0A4G34S2
+  joshvanl: U9M09KHHQ
   jrsapi: U0DS2L6E8
   justaugustus: U0E0E78AK
   kadel: U0DE6E8JY
@@ -127,6 +131,7 @@ users:
   liggitt: U0BGPQ6DS
   listx: UFCU8S8P3
   lukehinds: UN2P2M4F4
+  maelvls: UKYB4CKNJ
   marc-obrien: UL51BRL9Y
   margocrawf: U01FWP2K74J
   markyjackson-taulia: U19TKJ64E
@@ -141,13 +146,13 @@ users:
   microwavables: UAF606ESE
   mik-dass: UCUULSG1W
   mike-hoang: U03PDV4LS1Z
-  mjlshen: UN08SUPPD
-  mspreitz: U0E40F05R
   ming-qiu: U02JVSL5550
+  mjlshen: UN08SUPPD
   mkorbi: UEBLUUA0P
   mohammedzee1000: U3PFFE8CD
   MonzElmasry: U018U96HYDQ
   mrbobbytables: U511ZSKHD
+  mspreitz: U0E40F05R
   munnerz: U0EC03FTN
   nate-double-u: U01AWL6BD62
   nawazkh: U03HJN1C81W
@@ -163,9 +168,9 @@ users:
   p0lyn0mial: U1Q8CER5M
   pabloschuhmacher: U01AAGZ06KU
   palnabarun: UBH9NTMBM
+  paolo: U01CGS609EY
   paris: U5SB22BBQ
   pb82: U019M8295AQ
-  paolo: U01CGS609EY
   pensu91: U44FHF81G
   phenixblue: UB4UVLEAK
   pnbrown: U011JJTQVGF
@@ -199,6 +204,7 @@ users:
   schultzp2020: U030K8UQA2G
   scott-seago: UHGD79E78
   sethmccombs: U92LLUZ8A
+  sgtcodfish: U01PQ8N3PM1
   shamus: US7EUUBK8
   shubham-pampattiwar: U01QW84HBBN
   simplytunde: UAY1NBYHE
@@ -226,6 +232,7 @@ users:
   vincepri: UCD11GCET
   vladimirmukhin: UHVSCSD4G
   vzhukovs: U030TR1FG85
+  wallrj: U1ZMERJF7
   willie-yao: U024EME7SQK
   wilsonehusin: U0100068GF2
   wurbanski: URX7CMK97


### PR DESCRIPTION
As detailed in #7360, we have 9 maintainers and we struggle with mentioning all of them each time we have a decision to make in the cert-manager-dev channel. 

I don't know if I have entered the correct Slack usernames. I have used the GitHub usernames from the approvers list:

```bash
curl https://raw.githubusercontent.com/cert-manager/cert-manager/master/OWNERS | yq .approvers
```

To find the Slack User IDs, I had to open Slack in my browser by going at https://kubernetes.slack.com and then I opened the Dev Tools (option+cmd+i) and then select the person's name with shift+cmd+c and look for "data-message-sender":

![slack-id](https://github.com/kubernetes/community/assets/2195781/7a972cb4-64b7-4dcc-bc8e-6a48cfedd499)


Closes https://github.com/kubernetes/community/issues/7360.
