### PR TITLE
docs: add hyperlink redirect to correct webpage

### DIFF
--- a/communication/contributor-comms/README.md
+++ b/communication/contributor-comms/README.md
@@ -11,7 +11,7 @@ To better inform the Kubernetes contributor community and highlight their work t
 | Subproject Lead | @kaslin, @chris-short | Shadow role is available. |
 | [Social Media Coordinator](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/Social-Media.md) |@kaslin | Shadow role is available. |
 | [Comms Tech Lead](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/Comms-Tech-Lead.md) | @Atharva-Shinde, @imnmo | @markarranz (shadow) |
-| [Comms Event Lead] | @AvineshTripathi | Shadow role is available. |
+| [Comms Event Lead](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/Comms-Events.md) | @AvineshTripathi | Shadow role is available. |
 | [Comms Blog Coordinator](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/blog-coordinator.md) | @fsmunoz |  Shadow role is available. |
 | [Storytellers] & other members | @hpopal11, @Atharva-Shinde | New to Contributor Comms? Add your name here! |
 | Emeritus | @parispittman, @mbbroberg |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This PR redirects the comms event lead text to it's markdown page as it happens with other texts in the table
