### PR TITLE
Add kuadrant channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -235,6 +235,7 @@ channels:
   - name: krew
   - name: krex
   - name: krustlet
+  - name: kuadrant
   - name: kube-aws
   - name: kube-bind
   - name: kube-deploy


### PR DESCRIPTION
Hi, We'd like to create a channel for our community
The project is open source, website at https://kuadrant.io/, source at https://github.com/Kuadrant
We do have an existing community, albeit on our own slack, but we're interested in moving it to the kubernetes slack for easier discovery and awareness.
At this time there is no commercial service built on it, but there will likely be soon. The contributors are primarily from Red Hat at this time.

Asked, with a provisional yes, in slack-admins as well https://kubernetes.slack.com/archives/C4M06S5HS/p1689175964952669

I might follow up with a usergroup for maintainers at a later time.

Thanks

fyi @maleck13 @jasonmadigan @thomasmaas @alexsnaps @guicassolato