### PR TITLE
add Operations Handbook to event team

### DIFF
--- a/events/events-team/README.md
+++ b/events/events-team/README.md
@@ -19,6 +19,7 @@ the logistical and operational pieces together.
 | Marketing Lead                              | [Marketing Handbook]                    |                                                     |
 | CNCF Events Manager                         | CNCF                    | CNCF will staff this                                |
 | Content Subteam                        | [Content Subteam Handbook]                    |                                                     |
+| Operations Lead                             | [Operations Handbook]                        |                                                     |
 | Accessibility, Inclusiveness, and Diversity | TODO                    |                                                     |   
 
 
@@ -47,6 +48,9 @@ The [Content Subteam Handbook] includes detailed handbooks for Content Coordinat
 ### Registration
 [registration handbook]
 
+### Day-Of Operations
+[Operations Handbook]
+
 # Out of scope
 
 We don't coordinate meetups. CNCF leads these efforts and their information can be found [here].
@@ -60,3 +64,4 @@ We don't coordinate meetups. CNCF leads these efforts and their information can 
 [Marketing Handbook]: ./marketing/README.md
 [Content Subteam Handbook]: ./content/README.md
 [Project Manager Handbook]: ./projectmanagement/README.md
+[Operations Handbook]: ./operations/README.md

--- a/events/events-team/operations/README.md
+++ b/events/events-team/operations/README.md
@@ -1,0 +1,94 @@
+# Operation Lead Handbook
+
+The Operations lead is responsible for day-of event management, supervision of event space, 
+schedule adherence, and delegation/management of room staff.
+
+- [Overview](#overview)
+- [Skills and Qualifications](#skills-and-qualifications)
+- [Activities](#activities)
+- [Room Duties](#room-duties)
+
+## Overview
+
+The Operations lead is responsible for all day-of duties, including room staffing.  
+They are the person who is at the event to make sure it runs smoothly, typically with very 
+little focus on attending sessions/content.  The majority of these duties are known, 
+but unassigned until a schedule framework has been finalized by the content lead.
+
+Time Commitment:
+
+- 1-2 hours per week, before the Schedule framework is finalized
+- 3-4 hours per week, after the Schedule framework is finalized
+- On-site: Approximately 2 hours for a site walkthrough, usually 1 day before the event, and supervisory duties for the entire event, not including the social.
+
+## Skills and Qualifications
+
+The Operations Lead must have been a shadow on the Operations team during a 
+previous contributor summit. The shadow is signing up to commit to lead a 
+future event within the next 12 months.
+
+- Demonstrate empathy
+- Good organizational skills
+- Be committed to a schedule running on time
+- Able to balance a time sheet for a team of volunteers
+- Have an eye for detail, to watch for problems
+- Be helpful!
+
+Shadows vs Volunteers:
+
+- Shadows intend to take over the duties of planning and running this 
+segment in the future. (1-2 shadows is ideal)
+- Volunteers are there to help with all the room staffing duties during the event, 
+but do not need to be involved with the Lead’s duties.  This may include leads and 
+shadows from other tasks, if they do not already have conflicting day-of duties.
+
+## Activities
+
+- Gather a team of room staff
+- Attend weekly meetings
+- Be aware of the room layout and needs, including which rooms will be recording, which need projectors, which need microphones, etc.
+- Be the keeper of any schedules and maps
+- Create the staffing spreadsheet
+	- [Example Sheet]
+	- Identify responsibilities per room/session type
+	- Assign people times and/or have a sign up party
+		- Typically the helpers/room staff will want to attend some sessions, so allowing them to sign up in a round-robin fashion allows staff to attend the sessions they are most interested in. 
+	- Keep several printed copies of the finalized schedule on a clipboard. 
+		- The AV techs often appreciate having a copy of the schedule
+		- People will ask you about when and where things are
+		- A clipboard makes you look official
+- Ensure session timeliness
+- Be visible on-site for anyone with questions (“Where is room X?”, “What time is session Y?”, “Where is the coffee?”, “Have you seen Bob?”, etc)
+- Keep running notes of feedback and how rooms can be run better
+- Keep an eye on the summit slack channels
+- Facilitate the Docs sprint, if one happens
+	- Do not interrupt the quiet room
+	- Make sure they have everything they need, usually with visual cues, like a thumbs up/down
+	- Make sure they know when lunch/coffee breaks are happening
+- Assist in creation of the day-of operations event brief for all staff members
+- Event wrap up: Participate in retro
+
+## Room Duties
+
+This is a (possibly incomplete) list of duties for all volunteers/room monitors:
+- Verify sound, projection, and recording are working appropriately, depending on the rooms’ needs
+	- Fix any problems with AV, facilities, or event staff
+- Make sure rooms have pens/paper/etc, as appropriate
+- Prompt the room to assign a note-taker, as appropriate.  This is particularly important in unconference sessions.
+        - Notes will typically be available in a shared drive through a k8s.dev short link, with access granted to the k-dev mailing list
+- Do not let someone monopolize the conversation.  
+	- This is a judgement call.  If one person is speaking, and everyone is listening, that might be fine, but if multiple hands are raised, make sure everyone who wants to speak gets a chance to do so.
+	- Definitely ask "Has everyone who wants to speak had a chance to do so?"
+- Keep the room schedule moving on time.  
+	- In an unconference or SIG meeting, feel free to interrupt with "Sorry, but I just want to let everyone know we only have 5 minutes left." and/or "Time's up and there's another session in this room."
+	- In a presentation or workshop session, sit in the front and flag the speaker, to let them know when time is getting close.
+- Hallway track: Make time announcements so people know to move to sessions
+- Keep an eye on the summit slack channels
+
+It is recommended to have a total number of onsite room staff (shadows plus 
+volunteers) that is equal to at least the number of active rooms plus one.  Having 
+one or two people as standby/hot spare is ideal for when someone needs a break 
+or is giving a presentation.  The Operations Lead typically wanders the event 
+for the entire day, ensuring there are no problems that need to be dealt with.
+
+[Example Sheet]: https://docs.google.com/spreadsheets/d/19AozvMyS3OcCO9qA7Rq5YAVKnasDgHRIZ_V2rqYHOro/edit?usp=sharing


### PR DESCRIPTION
Add Operations handbook and update base event team page with appropriate links