### PR TITLE
Add cri-dockerd slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -88,6 +88,7 @@ channels:
   - name: craft
   - name: crash-diagnostics
   - name: crd-installation
+  - name: cri-dockerd
   - name: crio
   - name: crossplane
   - name: csi-secrets-store #this channel is for secrets-store-csi-driver which is a subproject of sig-auth


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
This PR adds a channel in slack for the [cri-dockerd](https://github.com/Mirantis/cri-dockerd) project
