### PR TITLE
deprecated comms event role

### DIFF
--- a/communication/contributor-comms/README.md
+++ b/communication/contributor-comms/README.md
@@ -14,14 +14,13 @@ The Contributor Comms subproject uses leadership roles to organize and delegate 
 | Subproject Lead | @kaslin, @chris-short | @AvineshTripathi (shadow) |
 | [Social Media Coordinator](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/Social-Media.md) |@kaslin | Shadow role is available. |
 | [Comms Tech Lead](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/Comms-Tech-Lead.md) | @SD-13 | Shadow role is available. |
-| [Comms Event Lead] | @AvineshTripathi | Shadow role is available. |
 | [Comms Blog Coordinator](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/role-handbooks/blog-coordinator.md) | @fsmunoz |  Shadow role is available. |
 | Emeritus | @parispittman, @mbbroberg |
 
 ## Contact Us!
 
 - Reach out to an individual above via Slack
-  - Ping the whole team: @contributor-comms in #sig-contribex on slack
+  - Ping the whole team: Join our slack #sig-contribex-comms or tag us @contributor-comms in #sig-contribex slack
 - Tag us in an issue in [kubernetes/community] with the label [area/contributor-comms]
   - Set a marketing issue template in [kubernetes/community]
 - Follow us on @K8sContributors on [Twitter] and [Mastodon]
@@ -31,12 +30,12 @@ The Contributor Comms subproject uses leadership roles to organize and delegate 
 We are always open to being a home for contributors to Kubernetes whether you code or not. 
 
 To find out what projects we're currently working on and explore what you could do to contribute:
-* Come to one of our [meetings] (Every Friday at 8am PT). See the [calendar] to add it to your own calendar.
+* Come to one of our [meetings] (Every Friday 8:00 PT, [Convert into your time zone](https://dateful.com/time-zone-converter?t=8:00&tz=PT%20%28Pacific%20Time%29)). See the [calendar] to add it to your own calendar.
 * Reach out to us on the #sig-contribex-comms channel on the Kubernetes slack ([slack.k8s.io](http://slack.k8s.io)).
 * Join our [mailing-list]
 
 [meetings]: /sig-contributor-experience#contributor-comms
-[calendar]: https://calendar.google.com/calendar/u/0/r/customday?eid=NmU5MjFnYWwwMzIwNjVwamFvNmszZHBuYzhfMjAyMDEyMDRUMTYwMDAwWiBjYWxlbmRhckBrdWJlcm5ldGVzLmlv&ctz=America/Los_Angeles&sf=true
+[calendar]: https://www.kubernetes.dev/resources/calendar/
 [mailing-list]: https://groups.google.com/g/kubernetes-sig-contribex
 [charter]: ./CHARTER.md
 [Could be you!]: #could-be-you
@@ -44,7 +43,6 @@ To find out what projects we're currently working on and explore what you could 
 [Internal Communications]: ./role-handbooks/internal-marketing.md
 [Social Media]: ./role-handbooks/social-media.md
 [Comms Tech Lead]: ./role-handbooks/Comms-Tech-Lead.md
-[Comms Event Lead]: ./role-handbooks/Comms-Event-Lead.md
 [Comms Blog Coordinator]: ./role-handbooks/blog-coordinator.md
 [Storytellers]: ./role-handbooks/storytellers.md
 [Designer]: ./role-handbooks/wip-roles.md

--- a/communication/contributor-comms/role-handbooks/[Deprecated]Comms-Events.md
+++ b/communication/contributor-comms/role-handbooks/[Deprecated]Comms-Events.md
@@ -1,5 +1,7 @@
 # Comms Events Lead Role Handbook 
 
+**NOTE**: This role is deprecated as of mid 2023
+
 ## Overview
 
 As Event Co-ordinator Lead, you are responsible for

--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -75,7 +75,7 @@ Contributor Communications focuses on amplifying the success of Kubernetes contr
   - [kubernetes/community/communication/contributor-comms](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/OWNERS)
 - **Meetings:**
   - Contributor Comms - Contributor Comms Team Meeting: [Fridays at 8:00 PT (Pacific Time)](https://zoom.us/j/596959769?pwd=TURBNlZPb3BEWVFmbWlCYXlMVVJiUT09) (weekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=8:00&tz=PT%20%28Pacific%20Time%29).
-    - [Meeting notes and Agenda](https://docs.google.com/document/d/1KDoqbw2A6W7rLSbIRuOlqH8gkoOnp2IHHuV9KyJDD2c/edit).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/1K3vjCZ9C3LwYrOJOhztQtFuDQCe-urv-ewx1bI8IPVQ/edit?usp=sharing).
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr).
 ### contributors-documentation
 writes and maintains documentation around contributing to Kubernetes, including the Contributor's Guide, Developer's Guide, and contributor website.

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1444,7 +1444,7 @@ sigs:
       tz: PT (Pacific Time)
       frequency: weekly
       url: https://zoom.us/j/596959769?pwd=TURBNlZPb3BEWVFmbWlCYXlMVVJiUT09
-      archive_url: https://docs.google.com/document/d/1KDoqbw2A6W7rLSbIRuOlqH8gkoOnp2IHHuV9KyJDD2c/edit
+      archive_url: https://docs.google.com/document/d/1K3vjCZ9C3LwYrOJOhztQtFuDQCe-urv-ewx1bI8IPVQ/edit?usp=sharing
       recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr
   - name: contributors-documentation
     description: writes and maintains documentation around contributing to Kubernetes,


### PR DESCRIPTION
From Comms meet it was decided to settle down the comms event role as of mid 2023.

Also fixed few links that were pointing to our old doc