### PR TITLE
Add Slack channel for kustomize training cohort

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -291,6 +291,7 @@ channels:
   - name: kudo
   - name: kurl
   - name: kustomize
+  - name: kustomize-training-cohort # archive once cohort finishes
   - name: kwok
   - name: kwok-dev
   - name: kyverno


### PR DESCRIPTION
Create Slack channel that will be archived once kustomize maintainer training cohort finishes.

Reference #7401 

/cc @natasha41575 
