### PR TITLE
Add Krkn slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -537,3 +537,4 @@ channels:
   - name: yaml-overlay-tool
   - name: zarf
   - name: zarf-dev
+  - name: krkn


### PR DESCRIPTION
This commit adds a slack channel for Krkn project - https://github.com/redhat-chaos/krkn, a chaos testing tool for Kubernetes focusing on resiliece and performance validation under failure conditions.

This channel will act a discussion place for the Kubernetes community interested in the Krkn tooling and methodology as well Chaos and Performance Engineering.
