### PR TITLE
Contributor Social handbook

### DIFF
--- a/events/events-team/content/social-content.md
+++ b/events/events-team/content/social-content.md
@@ -29,8 +29,30 @@ Other activities:
 
 ## Time Commitment
 
-* 12-25 hours over 3 months before the Contributor Summit
+* 12-40 hours over 3 months before the Contributor Summit
 * 4-5 hours at the Summit
+
+The preparation time depends heavily on the chosen social activities.
+
+## Shadows and Volunteers
+
+### Shadow
+
+The Social reasonably supports one Shadow or the role can be shared between two co-Leads.  There really isn't enough work for more than one Shadow to be useful.  The Shadow will work on the same tasks below, just based on having them individually assigned by the Lead.  
+
+Volunteers are needed for Door Warden (see below) shifts, usually 2-3 of them.
+
+Volunteers can optionally contribute to the following tasks:
+
+* Designing and detailing the Social Activitie(s)
+* Promoting the Social
+* Directing contributors to the Social venue
+* Quiz master if doing a quiz
+* Stage manager if doing Karaoke or similar
+* Other onside social activity support
+* New Contributor Welcome, particularly if doing Bingo
+
+While it's entirely possible for volunteers to work on Social prep while being unable to attend in person, it seems cruel to them.
 
 ## Instructions and Tips for Specific Tasks
 
@@ -38,10 +60,106 @@ The tasks below are in more-or-less the order in which they occur.  However, eve
 
 ### Venue and Menu
 
+Two to three months before the conference, the CNCF staff will start work with you to pick a venue for the social.  They will need to know how many people we're expecting (usually 50-100), and any preferences or ideas we have for a type of place.  They will then locate 2-3 options for a venue, which will present a set of tradeoffs around location, space, and food.  If there are local contributors, ask them for recommendations which the event staff can check out as well.
+
+In general, any venue that's within 1km of the conference is walkable (weather permitting).  Venues that are further away mean arranging some type of transportation.  In some places, public transit will work, but in others the CNCF will need to arrange a bus. Further away venues, all else being equal, mean lower attendance.  Venues also need to be wheelchair-accessible.
+
+You'll also check available menus. We'll need to be able to accommodate popular special diets (vegetarian, vegan, gluten-free), so check and make sure there are options for everyone.  Beer and wine is generally expected, but also check what's available for non-alcoholic drinks, making sure that there's something more interesting than bar soda. All of these checks may involve event staff checking with the venue multiple times, so start well before any deadlines.
+
+Depending on schedule and budget, some Socials will have a full meal available, and some only snacks.  Either way, buffet-style and passed bites both work, but anything involving table service does not.
+
+Venues may also have limits on bringing family members, particularly minors, so verify that information.
+
 ### Registration
+
+Work with the Registration lead to make sure that questions about the Social are included in registration.  At a minimum, these will be:
+
+* Do you plan to attend the contributor social?
+* Do you have a special diet?
+
+In rare cases, if you have information early enough about planned activities, you might include one or more questions about those.  If not, those will happen in a follow-up. Check the registration reports to see what the rolling total for the Social is.
+
+Closer to Kubecon, you will open up requests for contributors to bring a "plus-one" with them.  We've done this just using emails to the summit team, and sometimes we have an online form (using GDocs).  Either works.  Expect to handle around 6-12 plus one requests.  Note that plus-ones are supposed to be for family members traveling with the contributor and maybe mentees.  They are not for contributor co-workers.
+
+Registration for the Social (as well as for plus ones) closes 2-4 days before the Social itself. There's usually a little leeway for late contributors, but it depends a lot on the guarantee with the venue.
 
 ### Promotion
 
+You are responsible for making sure, by working with Comms, contributors know that:
+
+* The Contributor Social is happening
+* Where and when it is
+* It is only for registered KCS attendees
+
+If you have exciting social activities (see below), you'll also want to promote those to build excitement and make sure that folks are ready to join in.  At a minimum, you'll send out announcements at the following times:
+
+1. When the venue is chosen
+2. 1 month before the social
+3. When "plus one" registration opens
+3. 2 days before social registration closes
+4. Day of the social, if transportation is involved
+
+When the venue is selected, you will also want to create a page for the contributor site under the current Summit that covers the details of the event.  You may need to "TBD" some information like transport and social activities and fill them in later.
+
+If you have other news to impart (like about social activities), you'll want make more announcements via contributor social media.
+
+The least fun, but very necessary, message you need to get across is that *people need to be eligible and registered for the KCS to attend the social*.  The Social is not an open conference party, and while we can accommodate a small number of unregistered Kubernetes contributors, having a large number of them will cause problems with the venue and catering.
+
+As you get additional information about the Social, you will update the web page for it several times.
+
 ### Social Activities
 
+Any party that *only* has drinking and talking is a boring party.  It's also fairly exclusive of new contributors, who don't know who to talk to. Therefore a key part of the Social job is developing and executing social activities of some kind.  The ideal social activity, as well as being fun, also relates to Kubernetes in some way, and encourages meeting new people.  Social activities may or may not have prizes.
+
+What follows are a list of social activities from prior Contributor Socials.  You don't necessarily want to repeat these exactly, but they should serve as inspiration for future events.
+
+**Quiz**: a live pub quiz at the Social, with prizes for the winning teams.  The quiz should have 14-20 questions, with a mix of harder technical questions and sillier community questions. Requires mic, speakers, and projection screen at the venue, prizes, as well as reasonable tables for teams to sit at and participate. Remember to print out blank answer sheets before the Social.  Highly dependent on having a really good quizmaster on stage (like Lachie); recruit that person first, before deciding on this activity.  Also, unless you have a separate space for the quiz, it will take over the Social during the hour or so it's running.
+
+**Bingo Card**: Used in the past as an icebreaker for new contributors.  5x5 bingo card with questions for them to ask other contributors. Newbies who bingo get a prize.  Requires bingo cards, pens, 6+ prizes.  
+
+**Venue Games**: Some venues have games built-in that can be added to the contract.  This can include pool, bowling, darts, video games, axe throwing, or whatever else the venue has.  Desirable because it requires no setup on our part, but often expensive.  Expect around 25% of attendees to participate if there's a per-person contract.
+
+**Puzzles**: For Kubecon Amsterdam we ordered custom jigsaw puzzles with various Kubernetes-related graphics on them, including the infamous CNCF Landscape Puzzle.  These were then put on different tables at the venue.  Requires: design and order custom jigsaw puzzles.
+
+**Board Games**: Make board games available on tables at the venue for groups to play.  A few games will be bought by CNCF Events, and attendees are encouraged (with multiple reminders) to bring board games of their own. Encourage each board game group to recruit 1 new contributor to play with them.  Requires: board games, decent-sized tables at the venue, multiple reminders to attendees, not too loud venue, where ideally folks can stay on after the official end of the event.
+
+**Karaoke**: Attendees can sing or lip-sync karaoke on stage at the venue.  The venue would need to be set up for karaoke, or we would need to bring a portable karaoke machine. If there are multiple rooms this can be a side activity, but on a big stage it dominates the Social and would need to be time-limited.  Before committing to this, recruit and verify at least a couple of folks who love karaoke and will put themselves on the schedule.  Requires: karaoke setup at venue.
+
+**Puppies**: In San Diego, Paris arranged for a local dog training center to bring dogs for contributors to pet, as fun and as a stress relief.
+
+Ideas for new activities that we haven't tried could include:
+
+* mini-golf
+* lasertag or similar
+* talent show of some kind
+* participatory art stations (e.g. make your own linoleum print, etc.)
+* cooking contest
+* having the contributor awards at the social
+
+### Walk-Through
+
+Plan to arrive at the Kubecon city at least a day before the Contributor Summit, so that you can do a walk-through of the Social venue.  CNCF staff will arrange this at your request. Use the walk through to figure out:
+
+* Where will each social activity be?
+* Do any of the activities need to be modified because of the space?
+* Do you need to ask for AV/furniture adjustments from the venue?
+* The walk/transit from the CS to the Social
+* How can you exercise door control?
+
+It's a good idea to do one last checkover of the menu with the venue, particularly that items for special diets haven't been removed or modified at the last minute.  You can also talk over other details, such as music volume levels, with the staff.
+
 ### Door Warden
+
+The Contributor Social is open *only* to registered contributors, and their plus-ones if they registered them. This means that someone has to exercise strict door control at the Social, to prevent random walk-ins.  The CNCF staff will occupy the table or check-in stand, but someone from the Summit team needs to be at the door, or immediately available (depending on venue layout), to help the staff with ambiguous situations.  Set up a schedule, with staffing every 1/2 hour for the first 2 hours of the social.
+
+Generally, if an org member contributor who forgot to register shows up, we generally let them in unless the venue is nearing capacity.  This will require you to check the list of org members, so download that in advance (given the vagaries of wifi).  Usually we also allow plus-ones that a registered contributor forgot to ask for, again provided that the venue isn't almost full.  CNCF staff are also allowed in, even if not registered.
+
+Obviously we block random Kubecon attendees who show up; the Contributor Social is not a free party for the conference. Two kinds of people show up who are more difficult, though.  One is maintainers of other CNCF projects, who are not entitled to attend unless they already went through the exception process.  The other are management at major sponsors of the CNCF or Kubecon.  This is where it's important for you, as contributor staff, to be there to back up the CNCF staff for whom saying no to major sponsors is challenging.
+
+## Other Notes and Ideas
+
+* Assume anything you haven't determined about a venue is wrong.
+* Venues often have music much too loud for conversation.  You'll need to overdetermine this, both by requesting softer music before the event, and then probably requesting that they turn the music down several times during the event.
+* Make *really* sure of what a venue will provide for special diets.  While potato chips are vegan, they are not a meal.
+* If you are relying on Venue Games (above), check some of the games when you visit the venue.
+* If a social activity is failing to draw any interest, abandon it.

--- a/events/events-team/content/social-content.md
+++ b/events/events-team/content/social-content.md
@@ -6,14 +6,42 @@ The Social Event Content Lead is responsible for arranging and recruiting activi
 
 ## Skills and Qualifications
 
-TODO  
+* Can attend the Contributor Summit in person
+* Able to keep track of event organization
+* Can come up with ideas for fun activities
+* Knows enough of the Kubernetes community to reach out to people for participation
+* Can collaborate with CNCF staff and other Summit volunteers
 
-## Activities  
+## Activities
 
-WIP
+Many of the activities associated with planning the Social are easily shared among multiple volunteers.  As such, most of the activities below can be shared.
+
+Planning and execution, together with CNCF Staff:
+
+* Planning the Contributor Social, including venue, food, drink, attendee lists, transportation (if necessary), and activities in coordination
+* Recruiting and supervising volunteers to handle screening attendees at the door
+* Developing and executing social activities to take place during the social, including obtaining any prizes or materials required
+
+Other activities:
+
+* Working with Comms to publicize the Social
+* Working with Registration to make sure that registration for the social is clear and intentional
 
 ## Time Commitment
 
-TODO
+* 12-25 hours over 3 months before the Contributor Summit
+* 4-5 hours at the Summit
 
 ## Instructions and Tips for Specific Tasks
+
+The tasks below are in more-or-less the order in which they occur.  However, event planning can be flexible, and several tasks can be taken care of more or less when you have time.
+
+### Venue and Menu
+
+### Registration
+
+### Promotion
+
+### Social Activities
+
+### Door Warden


### PR DESCRIPTION
Complete draft of the Social handbook for the Contributor Summit.

Includes most of the handbook/guidelines.  Does not include a full timeline of Social planning; I'll leave that for someone else to add.

/sig contributor-experience
/area events
/kind docs

attn: @pnbrown @nitishfy @cici37 @salaxander 
