### PR TITLE
Disambiguate timeline for candidate notifications

### DIFF
--- a/elections/steering/2023/README.md
+++ b/elections/steering/2023/README.md
@@ -123,7 +123,7 @@ Examples of contributions that would NOT be considered:
 - Private announcement of results to SC members is at least ~2 days
   before private announcement to all candidates.
 - The interval between private announcement to all candidates and the
-  public announcement is a weekend.
+  public announcement is 24-48 hours, ideally during a weekend.
 -->
 
 | Date                    | Event                                                                 |

--- a/elections/steering/documentation/README.md
+++ b/elections/steering/documentation/README.md
@@ -154,7 +154,7 @@ where things must happen in a specific number of days.
 | 81    | Election Closes             | Automatic          |                                       |
 | 82    | Send Results to SC          | EO Admin           |                                       |
 | 84    | Approve Results             | Steering Committee |                                       |
-| 86    | Inform Candidates           | EO Member          | MUST BE the day before announcement   |
+| 86    | Inform Candidates           | EO Member          | MUST BE 24-48 hours before announcing |
 | 87    | Announce Results            | EO Comms           | on K/dev, etc.                        |
 | 88    | Election Blog Post          | EO Comms           |                                       |
 | 89    | Results in Elekto           | EO Admin           |                                       |

--- a/elections/steering/documentation/template/README.md
+++ b/elections/steering/documentation/template/README.md
@@ -123,7 +123,7 @@ Examples of contributions that would NOT be considered:
 - Private announcement of results to SC members is at least ~2 days
   before private announcement to all candidates.
 - The interval between private announcement to all candidates and the
-  public announcement is a weekend.
+  public announcement is 24-48 hours, ideally during a weekend.
 -->
 
 | Date                    | Event                                                                 |


### PR DESCRIPTION
Originally these two statements made it sound like the period of time needed to be "a entire weekend" and also "a day" (which cannot both be true).

In discussion among the election officers, we think we should give a reasonable amount of notice to all candidates, but we also want to leave room for election tasks to take place one or both weekend days as necessary before the announcement of results.

This PR clears up the ambiguity by changing the two previously-contradictory statements to convey the same thing. I'm changing the documentation and template file, as well as the 2023 README to match this update.