### PR TITLE
Update CAPI v1.6 Release Team usergroup members list

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -246,21 +246,20 @@ usergroups:
     description: Members of the Cluster API Release Team
     members:
       - adilGhaffarDev
-      - aniruddha2000
-      - CecileRobertMichon
+      - cahillsf
       - chiukapoor
-      - chrischdi
       - furkatgofurov7
       - g-gaston
       - hackeramitkumar
-      - joekr
-      - johannesfrey
-      - killianmuldoon
+      - kranurag7
+      - mjlshen
       - nawazkh
+      - nprokopic
       - prajyot-parab
-      - sadysnaat
-      - sbueringer
-      - tobiasgiese
+      - razashahid107
+      - Sunnatillo
+      - vincepri
+      - willie-yao
 
   - name: kcp-devs
     long_name: kcp Development Team

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -29,6 +29,7 @@ users:
   briandealwis: UAZKM38JV
   bubblemelon: U7K9C643G
   byako: U03GZBD4J4C
+  cahillsf: U04TNKBE92R
   calebamiles: U1ZDD4CUR
   camilamacedo86: UJDM393EH
   castrojo: U1W1Q6PRQ
@@ -118,6 +119,7 @@ users:
   kim-tsao: U02U1LDH4T1
   klihub: U9856A799
   klueska: UF3ARH55Y
+  kranurag7: U02MRK4FY8N
   Kunal Kushwaha: UQ14U3NAY
   kylape: UEUST4S22
   LappleApple: U011C07244F
@@ -139,6 +141,7 @@ users:
   microwavables: UAF606ESE
   mik-dass: UCUULSG1W
   mike-hoang: U03PDV4LS1Z
+  mjlshen: UN08SUPPD
   mspreitz: U0E40F05R
   ming-qiu: U02JVSL5550
   mkorbi: UEBLUUA0P
@@ -152,6 +155,7 @@ users:
   neoaggelos: U02GE88D3SQ
   nikhita: U2PQHGMLN
   nkubala: UA90QL2BE
+  nprokopic: UR434B8TS
   nrb: U7S597E00
   nzoueidi: UBU72MWP2
   onlydole: U1DD4AZND
@@ -175,6 +179,7 @@ users:
   r-lawton: U019CNHR2E6
   rajula96reddy: U7K9EK1HC
   rashmigottipati: U013T1DD3PW
+  razashahid107: U05FB1L2YM8
   reylejano: U01GDNJL5MW
   Rin Oliver: USF4LMDCN
   ritazh: U5CMBA9RD
@@ -202,6 +207,7 @@ users:
   sttts: U0A2VFE8J
   Sujay Pillai: UBW3N1VGW
   sumitranr: UCQN13L9H
+  Sunnatillo: U0261DHJ1Q8
   swamymsft: UHU7ZNXH8
   tabbysable: U01742MGBRT
   tallclair: U64VCBURE
@@ -220,6 +226,7 @@ users:
   vincepri: UCD11GCET
   vladimirmukhin: UHVSCSD4G
   vzhukovs: U030TR1FG85
+  willie-yao: U024EME7SQK
   wilsonehusin: U0100068GF2
   wurbanski: URX7CMK97
   Xander: UDHV1RXB2


### PR DESCRIPTION
This PR updates the slack user groups for the new Cluster API release v1.6 team.


