### PR TITLE
Testing whether the voter list must be non-empty

### DIFF
--- a/elections/steering/2023/voters.yaml
+++ b/elections/steering/2023/voters.yaml
@@ -12,4 +12,4 @@
 # Log of changes to the file
 #
 eligible_voters:
--
+- jberkus


### PR DESCRIPTION
When we merged a PR https://github.com/kubernetes/community/pull/7417 with an empty voter list, Elekto errored out. Testing whether the voter list must contain at least one element. /cc @jberkus 