### PR TITLE
Revert "Testing whether the voter list must be non-empty"

### DIFF
--- a/elections/steering/2023/voters.yaml
+++ b/elections/steering/2023/voters.yaml
@@ -12,4 +12,4 @@
 # Log of changes to the file
 #
 eligible_voters:
-- jberkus
+-


### PR DESCRIPTION
Reverts kubernetes/community#7427

This test was when we were troubleshooting the problem that was eventually fixed in https://github.com/kubernetes/k8s.io/pull/5665.