### PR TITLE
date examples for steering election template

### DIFF
--- a/elections/steering/documentation/template/election-template.yaml
+++ b/elections/steering/documentation/template/election-template.yaml
@@ -1,7 +1,9 @@
 ## RENAME THIS FILE TO election.yaml
 name: {{YEAR}} Steering Committee Election
 organization: Kubernetes
+# Start of day in UTC for opening: 2023-08-29 00:00:01
 start_datetime: {{DATETIME VOTING STARTS IN UTC}}
+# End of day Anywhere on Earth for closing. Write 2023-09-26 as: 2023-09-27 11:59:59
 end_datetime: {{DATETIME VOTING ENDS IN UTC}}
 no_winners: {{# BEING ELECTED}}
 allow_no_opinion: True
@@ -15,4 +17,5 @@ election_officers:
   - {{EO 3}}
 eligibility: Kubernetes Org members with {{NUM}} or more contributions in the last year can vote.  See [the election guide](https://github.com/kubernetes/community/tree/master/elections/steering/{{YEAR}})
 exception_description: Not all contributions are measured by DevStats.  If you have contributions that are not so measured, then please request an exception to allow you to vote via the Elekto application.
+# End of day Anywhere on Earth for closing. Write 2023-09-23 as: 2023-09-24 11:59:59
 exception_due: {{DATETIME 3-4 DAYS BEFORE VOTING ENDS}}


### PR DESCRIPTION
The dates need to be listed in UTC for this file, but they should be chosen to allow for Anywhere on Earth times, which are 12 hours behind UTC and thus need to have the visible date listed as "desired date plus one day, set to 11:59am". 

I made the correction for the 2023 Steering election in https://github.com/kubernetes/community/pull/7432/ and in this PR, I am adding comments to make it easier for people to avoid this error in the future and successfully list the date/time correctly for AoE purposes.

Note that I didn't attempt to adjust the opening date to allow for AoE, just the closing dates. Open to feedback as to whether the opening should also be adjusted; I am slightly concerned that may be a miss in terms of "voting is open" promo.