### PR TITLE
remove outdated reference to email ballots

### DIFF
--- a/elections/steering/2023/README.md
+++ b/elections/steering/2023/README.md
@@ -133,7 +133,7 @@ Examples of contributions that would NOT be considered:
 | TBD                     | Steering Committee Q+A for the candidates                             |
 | Saturday, August 26     | Candidate nominations due at the end of the day in AoE time           |
 | Sunday, August 27       | All candidate bios due at the end of the day in AoE time              |
-| Tuesday, August 29      | Election Begins via email ballots                                     |
+| Tuesday, August 29      | Election Begins                                                       |
 | Saturday, September 23  | Deadline to submit voter exception requests                           |
 | Tuesday, September 26   | Election Closes at the end of the day in AoE time                     |
 | Wednesday, September 27 | Private announcement of Results to SC members not up for election     |

--- a/elections/steering/documentation/template/README.md
+++ b/elections/steering/documentation/template/README.md
@@ -140,7 +140,7 @@ Examples of contributions that would NOT be considered:
 | DATE HERE               | Steering Committee Q+A for the candidates                             |
 | DATE HERE               | Candidate nominations due at the end of the day in AoE time           |
 | DATE HERE               | All candidate bios due at the end of the day in AoE time              |
-| DATE HERE               | Election Begins via email ballots                                     |
+| DATE HERE               | Election Begins                                                       |
 | DATE HERE               | Deadline to submit voter exception requests                           |
 | DATE HERE               | Election Closes at the end of the day in AoE time                     |
 | DATE HERE               | Private announcement of Results to SC members not up for election     |


### PR DESCRIPTION
After setting up the election in https://github.com/kubernetes/community/pull/7417 I noticed this line saying "Election Begins via email ballots" and got it confirmed by sig-contribex-elections that this refers to a past process no longer in use. I'm adjusting it in this year's election as well as the template.