### PR TITLE
add claudie to channels.yaml for slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -49,6 +49,7 @@ channels:
   - name: cka-exam-prep
   - name: ckad-exam-prep
   - name: cks-exam-prep
+  - name: claudie
   - name: client-go-docs
     archived: true
   - name: cluster-addons


### PR DESCRIPTION
This PR creates `#claudie` slack channel.

Claudie is a platform for managing multi/hybrid cloud Kubernetes clusters with each nodepool in a different cloud provider or on-prem. By creating this channel we would like to unify the communication of our community in one place.

Some useful resources:

- [Claudie GH repository](https://github.com/berops/claudie)
- [Claudie documentation ](https://docs.claudie.io)
