### PR TITLE
Fix comment syntax in mentoring REAME

### DIFF
--- a/mentoring/README.md
+++ b/mentoring/README.md
@@ -18,7 +18,7 @@ and organization of every kind. For Kubernetes, the larger the project becomes
 
 ## Current mentoring activities:
 
-Please reach out to #sig-contribex on slack or come to a mentoring meeting to get involved in planning //TODO add contribex README when this is updated
+Please reach out to #sig-contribex on slack or come to a mentoring meeting to get involved in planning. <!--TODO: add contribex README when this is updated -->
 
 SIG's office hours / mentoring
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**What's in the PR?**

This PR fixes a typo in the comment syntax in mentoring README

https://github.com/kubernetes/community/blob/7a0e1f6c8276f884bd789a0eba9e3d6935027c04/mentoring/README.md#L21

The supposed to be comment is visible in the docs.

<img width="1016" alt="Screenshot 2023-08-10 at 3 07 56 PM" src="https://github.com/kubernetes/community/assets/19938474/03937336-9e80-490b-af9a-46e545771733">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7452
