### PR TITLE
github-management: add Priyanka as github admin

### DIFF
--- a/github-management/OWNERS
+++ b/github-management/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - nikhita
   - palnabarun
   - MadhavJivrajani
+  - Priyankasaggu11929
 
 labels:
   - sig/contributor-experience

--- a/github-management/README.md
+++ b/github-management/README.md
@@ -29,10 +29,10 @@ various tasks.
 This team (**[@kubernetes/owners](https://github.com/orgs/kubernetes/teams/owners)**) is as follows:
 * Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**, US Eastern)
 * Christoph Blecker (**[@cblecker](https://github.com/cblecker)**, CA Pacific)
+* Madhav Jivrajani (**[@MadhavJivrajani](https://github.com/MadhavJivrajani)**, Indian Standard Time)
 * Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**, Indian Standard Time)
 * Nikhita Raghunath (**[@nikhita](https://github.com/nikhita)**, Indian Standard Time)
-* Ihor Dvoretskyi (**[@idvoretskyi](https://github.com/idvoretskyi)**, UA Eastern European)
-* Madhav Jivrajani (**[@MadhavJivrajani](https://github.com/MadhavJivrajani)**, Indian Standard Time)
+* Priyanka Saggu (**[@Priyankasaggu11929](https://github.com/Priyankasaggu11929)**, Indian Standard Time)
 
 This team is responsible for holding Org Owner privileges over all the active
 Kubernetes orgs, and will take action in accordance with our polices and


### PR DESCRIPTION
Ref: [sig contribex thread](https://groups.google.com/g/kubernetes-sig-contribex/c/36Y3tT06FyQ/m/WYKUHcAaDAAJ) for nomination

Lazy consensus achieved.

/hold

/committee steering
/cc @kubernetes/steering-committee 
need majority of steering committee to lgtm this change

/assign @cblecker @mrbobbytables @palnabarun @MadhavJivrajani 
Can you also +1 here?

/assign @Priyankasaggu11929  
Can you confirm that you are interested in joining the GitHub Admin Team and accept the security embargo policy?