### PR TITLE
Update Kubernetes core contributor slack channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -279,9 +279,12 @@ channels:
   - name: kubernetes-operators
   - name: kubernetes-org-members
   - name: kubernetes-ruby
+    archived: true
   - name: kubernetes-security
   - name: kubernetes-streaming
+    archived: true
   - name: kubernetes-teachers
+    archived: true
   - name: kubernetes-users
   - name: kubeslice
   - name: kubespray

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -272,11 +272,12 @@ channels:
     archived: true
   - name: kubernetes-careers
   - name: kubernetes-client
-  - name: kubernetes-contributors
+  - name: kubernetes-new-contributors
     id: C09R23FHP
   # kubernetes-docs-* channels are defined in sig-docs/
   - name: kubernetes-novice
   - name: kubernetes-operators
+  - name: kubernetes-org-members
   - name: kubernetes-ruby
   - name: kubernetes-security
   - name: kubernetes-streaming


### PR DESCRIPTION
This PR does 3 things:
- Renames kubernetes-contributors to kubernetes-new-contributors
- Creates kubernetes-maintainers
- Archives some unused channels

**Context:**
The kubernetes-contributors channel has become a place where people drop in and ask for support or requests from those completely new to OSS/K8s ignore the provided onboarding resources (join message + links to k8s.dev etc) and spam the channel or dm individuals with requests for direct 1:1 mentorship (sometimes riding the line of escalating to a CoC issue).

The channel has over 12k people in it, but our intended core audience, our k8s org members, have largely left, ignored, or muted the channel defeating its intended purpose.

To prevent this happening again to the new channel, the change will be backed up with a join message added to the kubernetes-maintainer channel stressing its intended purpose and statement of aggressive moderation. 


/hold
for review & any further discussion 

