### PR TITLE
Correct date discrepancies - 2023 CoCC election

### DIFF
--- a/elections/code-of-conduct/2023/election.yaml
+++ b/elections/code-of-conduct/2023/election.yaml
@@ -1,7 +1,7 @@
 name: 2023 Kubernetes Code of Conduct Committee Election
 organization: Kubernetes
 start_datetime: 2023-08-11 00:00:01
-end_datetime: 2023-08-17 11:59:59
+end_datetime: 2023-08-18 11:59:59
 no_winners: 2
 allow_no_opinion: True
 delete_after: True

--- a/elections/code-of-conduct/2023/election_desc.md
+++ b/elections/code-of-conduct/2023/election_desc.md
@@ -1,3 +1,3 @@
 # Vote for the Kubernetes Code of Conduct Committee
 
-Please complete your voting by the end of 2023/08/15.
+Please complete your voting by the end of 2023/08/17.


### PR DESCRIPTION
The end of the 2023 CCoC election ending date was adjusted from August 15 to August 17 in this commit: https://github.com/kubernetes/community/commit/f15901e9b4d16e4686b7cb657006b9a45460613b - but that commit doesn't change the configs correctly (due to non-intuitive datetimes). This PR fixes the error.

While the text states we're using Anywhere on Earth, the end_datetime still listed in https://github.com/kubernetes/community/blob/master/elections/code-of-conduct/2023/election.yaml#L4 does not reflect August 17 "anywhere on earth" (which needs to be listed as August 18 11:59am UTC). This is a common error I address in https://github.com/kubernetes/community/pull/7433. If we don't set the correct date and time for closing, the election will accidentally automatically close a day earlier than expected.

Also, at the time of the date update, we didn't update the text of "Please complete your voting by the end of 2023/08/15." in  https://github.com/kubernetes/community/blame/master/elections/code-of-conduct/2023/election_desc.md#L3 which now needs correction.

