### PR TITLE
Update governance onboarding checklist for COCC to remove Slack Admin section

### DIFF
--- a/committee-code-of-conduct/governance/onboarding-offboarding.md
+++ b/committee-code-of-conduct/governance/onboarding-offboarding.md
@@ -16,12 +16,6 @@ Different actions on this list must be carried out by different members:
 - [ ] `#kubernetes-moderators` and `#slack-reports` private channels on `kubernetes.slack.com` 
 - [ ] Code of conduct sync Slack channel on `cloud-native.slack.com`
 
-### Slack Channel Admin Privileges
-
-**Who executes:** During transition, carryover members initiate promotion/removal by pinging project Slack admins
-
-- [ ] Ping project Slack admins to add/remove Slack admin privileges for incoming/outgoing members in CoCC channel(s)
-
 ### Kubernetes/community permissions and google permissions
 
 **Who executes:** Carryover members should ensure that outgoing members are removed and incoming members are invited.


### PR DESCRIPTION
The current governance onboarding/offboarding checklist contains the statement:

> Ping project Slack admins to add/remove Slack admin privileges for incoming/outgoing members in CoCC channel(s)"

Currently, Slack does not provide granular admin permissions. Per @mrbobbytables we have not been granting Slack admin access to CoCC members. 

This PR removes the section on slack admin. If we'd like to change to grant Slack admin access, perhaps we can document that in additional places and update the sentence for clarity. 

/committee steering
/committee code-of-conduct
/kind docs