### PR TITLE
generator: add generated section in committee README for emeritus members

### DIFF
--- a/committee-code-of-conduct/README.md
+++ b/committee-code-of-conduct/README.md
@@ -20,6 +20,23 @@ The [charter](charter.md) defines the scope and governance of the Code of Conduc
 * Jeremy Rickard (**[@jeremyrickard](https://github.com/jeremyrickard)**), Microsoft
 * Xander Grzywinski (**[@salaxander](https://github.com/salaxander)**), Microsoft
 
+## Emeritus Members
+
+* Aeva Black (**[@AevaOnline](https://github.com/AevaOnline)**)
+* Jennifer Rondeau (**[@Bradamant3](https://github.com/Bradamant3)**)
+* Carolyn Van Slyck (**[@carolynvs](https://github.com/carolynvs)**)
+* Celeste Horgan (**[@celestehorgan](https://github.com/celestehorgan)**)
+* Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**)
+* Jason DeTiberus (**[@detiber](https://github.com/detiber)**)
+* Eric Paris (**[@eparis](https://github.com/eparis)**)
+* Jaice Singer DuMars (**[@jdumars](https://github.com/jdumars)**)
+* Karen Chu (**[@karenhchu](https://github.com/karenhchu)**)
+* Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**)
+* Paris Pittman (**[@parispittman](https://github.com/parispittman)**)
+* Tasha Drew (**[@tashimi](https://github.com/tashimi)**)
+* Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
+* Vallery Lancey (**[@vllry](https://github.com/vllry)**)
+
 ## Contact
 - Slack: [#code-of-conduct](https://kubernetes.slack.com/messages/code-of-conduct)
 - Private Mailing List: conduct@kubernetes.io

--- a/committee-security-response/README.md
+++ b/committee-security-response/README.md
@@ -22,6 +22,12 @@ The Kubernetes Security Response Committee is the body that is responsible for r
 * Rita Zhang (**[@ritazh](https://github.com/ritazh)**), Microsoft
 * Tabitha Sable (**[@tabbysable](https://github.com/tabbysable)**), Datadog
 
+## Emeritus Members
+
+* Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**)
+* Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**)
+* Tim Allclair (**[@tallclair](https://github.com/tallclair)**)
+
 ## Contact
 - Private Mailing List: security@kubernetes.io
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/committee%2Fsecurity-response)

--- a/generator/committee_readme.tmpl
+++ b/generator/committee_readme.tmpl
@@ -32,6 +32,14 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 * {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
 {{- end }}
 {{- end }}
+
+{{- if .Leadership.EmeritusLeads }}
+
+## Emeritus Members
+{{ range .Leadership.EmeritusLeads }}
+* {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**)
+{{- end }}
+{{- end }}
 {{- end }}
 
 ## Contact
@@ -82,7 +90,7 @@ The following [subprojects][subproject-definition] are owned by the {{.Name}} Co
   - [Mailing List]({{.Contact.MailingList}})
 {{- end }}
 {{- if .Contact.GithubTeams }}
-  - GitHub Teams: 
+  - GitHub Teams:
 {{- range .Contact.GithubTeams }}
     - [@kubernetes/{{.Name}}](https://github.com/orgs/kubernetes/teams/{{.Name}}) {{- if .Description }} - {{.Description}}{{- end}}
 {{- end }}


### PR DESCRIPTION
The committee README template doesn't have a list of Emeritus Members to generate, deviating from what we have for SIGs. This PR adds that.

I have noticed a couple of PRs [1][2] in the past updating custom sections. This needs manual intervention and can be avoided if the section is generated like SIG READMEs.

The PR intentionally doesn't add employers for emeritus members going by reasons described in https://github.com/kubernetes/community/pull/4120.
 
### Changes

- (generator): add emeritus members section to committee template
- (committee/code-of-conduct): update generated changes
- (committee/security-response): update generated changes

[1]: https://github.com/kubernetes/community/pull/7486
[2]: https://github.com/kubernetes/community/pull/7047

/priority important-longterm
/kind documentation
/assign @nikhita @cblecker 