### PR TITLE
Correcting GitHub username for election exception

### DIFF
--- a/elections/steering/2023/voters.yaml
+++ b/elections/steering/2023/voters.yaml
@@ -595,7 +595,7 @@ eligible_voters:
 - spencerhance
 - spiffxp
 - spowelljr
-- sraghunathan
+- savitharaghunathan
 - srm09
 - starpit
 - stevehipwell


### PR DESCRIPTION
Voter alerted us that we used their Slack instead of GitHub username - correcting an already-approved exception.