### PR TITLE
slack-config: add Madhav and Priyanka to GH Admin slack usergroup

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -283,12 +283,12 @@ usergroups:
     long_name: Kubernetes GitHub Admins
     description: Administrators of the Kubernetes GitHub organisations
     members:
-      - ameukam
       - cblecker
-      - idvoretskyi
+      - MadhavJivrajani
       - mrbobbytables
       - nikhita
       - palnabarun
+      - Priyankasaggu11929
 
   - name: kubestellar-devs
     long_name: KubeStellar Development Team

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -131,6 +131,7 @@ users:
   liggitt: U0BGPQ6DS
   listx: UFCU8S8P3
   lukehinds: UN2P2M4F4
+  MadhavJivrajani: U01L7R0JGCE
   maelvls: UKYB4CKNJ
   marc-obrien: UL51BRL9Y
   margocrawf: U01FWP2K74J
@@ -177,7 +178,7 @@ users:
   pohly: U91901TMF
   prajyot-parab: U02MVRCN8CX
   prietyc123: U01D4MBLM52
-  psaggu: U012EE74CU8
+  Priyankasaggu11929: U012EE74CU8
   puerco: ULGHLJ7TP
   PurneswarPrasad: U027CFKVAB0
   pweil-: U0AL6882X


### PR DESCRIPTION
This commit adds MadhavJivrajani and Priyankasaggu11929 to the `github-admins` slack usergroup. As a part of this, their slack IDs are also mapped in users.yaml

Further, Arnaud and Ihor are rotated out.

Ref https://github.com/kubernetes/community/pull/7327 https://github.com/kubernetes/community/pull/7464

/assign @Priyankasaggu11929 @palnabarun 
