### PR TITLE
Add dependency update example for cherry-picks

### DIFF
--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -62,6 +62,9 @@ your case by supplementing your PR with e.g.,
 - Key stakeholder SIG reviewers/approvers attesting to their confidence in the
   change being a required backport
 
+To illustrate the point, dependency updates that just aim to silence some scanners
+and do not fix any vulnerable code are NOT eligible for cherry-picks.
+
 If the change is in cloud provider-specific platform code (which is in the
 process of being moved out of core Kubernetes), describe the customer impact,
 how the issue escaped initial testing, remediation taken to prevent similar


### PR DESCRIPTION
We are getting requests for cherry-picking things that actually do not fix anything. So adding that as an example of something that we should NOT allow to be cherry-picked.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
