### PR TITLE
update wg-lts agenda link

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3246,7 +3246,7 @@ workinggroups:
     tz: PT (Pacific Time)
     frequency: biweekly
     url: https://zoom.us/j/92480197536?pwd=dmtSMGJRQmNYYTIyZkFlQ25JRngrdz09
-    archive_url: TBD
+    archive_url: https://docs.google.com/document/d/1RI_EL35MwQxrHqlWvtQNINhOSWergL3hmOSgC5PeZss/edit
     recordings_url: TBD
   contact:
     slack: wg-lts

--- a/wg-lts/README.md
+++ b/wg-lts/README.md
@@ -21,7 +21,7 @@ The working group is organized with the goal of developing a better understandin
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/a/kubernetes.io/g/wg-lts) for the group will typically add invites for the following meetings to your calendar.*
 * Regular WG Meeting: [Tuesdays at 07:00 PT (Pacific Time)](https://zoom.us/j/92480197536?pwd=dmtSMGJRQmNYYTIyZkFlQ25JRngrdz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](TBD).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1RI_EL35MwQxrHqlWvtQNINhOSWergL3hmOSgC5PeZss/edit).
   * [Meeting recordings](TBD).
 
 ## Organizers


### PR DESCRIPTION
Fixes https://github.com/kubernetes/community/issues/7515

@jeremyrickard
@liggitt 

Meeting recordings link is current a playlist that was created by myself. 
- for a general one, it may look like https://bit.ly/k8s-wg-lts-videos by Kubernetes official account.