### PR TITLE
Request new Slack channel for the Open Component Model (OCM)

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -368,6 +368,7 @@ channels:
   - name: okteto
   - name: olm-dev
   - name: open-cluster-mgmt
+  - name: open-component-model
   - name: opencontainers
   - name: openebs
   - name: openebs-dev


### PR DESCRIPTION
Hi, we would like to request the Slack channel ```open-component-model```  for the open source project [Open Component Model](https://github.com/open-component-model). 

OCM concentrates on modeling and deploying cloud-native software on Kubernetes, but can as well be used for any other kind of software, e.g. large legacy products deployed on-prem to VMs. It supports the whole lifecycle of software artifacts along a secure supply chain.

Useful resources can be found at https://ocm.software


