### PR TITLE
Update Social-Media lead handbook

### DIFF
--- a/communication/contributor-comms/role-handbooks/Social-Media.md
+++ b/communication/contributor-comms/role-handbooks/Social-Media.md
@@ -4,18 +4,22 @@
 
 This handbook outlines expectations and responsibilities for Social Media Leads as well as Contributor Comms team members who wish to contribute to social media efforts.
 
-Social Media leads' contributions further the Contributor Comms team's efforts to communicate with contributors on a broad scale through social media.  At the time of writing, the primary social media channel we communicate through is the [@K8sContributors handle on twitter](https://twitter.com/K8sContributors).
+Social Media leads' contributions further the Contributor Comms team's efforts to communicate with contributors on a broad scale through social media.  At the time of writing, the primary social media channels we communicate through are the [@K8sContributors handle on X (twitter)](https://x.com/K8sContributors) and [@K8sContributors@hachyderm.io on Mastodon](https://hachyderm.io/@K8sContributors).
 
-Any Kubernetes contributor can write tweets to be distributed through the twitter handle by utilizing the [kubernetes-sigs/contributor-tweets repo](https://github.com/kubernetes-sigs/contributor-tweets). This repo utilizes the open source [twitter-together](https://github.com/gr2m/twitter-together) project to automate tweeting approved from the @K8sContributor handle. The repo also features automation to convert issues into PRs, to make it easier to create tweets with minimal interaction with Github's PR process.
+The social media lead's role is to coordinate social media work across the Contributor Comms team. This includes maintaining the [Contributor Comms team social media guidelines]
+(https://github.com/kubernetes/community/blob/master/communication/contributor-comms/blogging-resources/social-guidelines.md) as the source of truth for social media process, etiquette, and ethics. As the social media landscape grows and changes, the social media lead should be ready to adapt by leading conversation and exploration around the new platform.
 
-Do note that tweets targeting the greater Kubernetes community should potentially use the @Kubernetesio account. Tweets using this account must be coordinated with the CNCF. Ownership of @Kubernetesio does not reside within the Contributor Comms team. For any tweets to be coordinated with @Kubernetesio, you will need to make contact with CNCF marketing members in charge of the account. Tweets using the @kubernetesio account are often limited in the content and quantity that may be sent.
+Do note that important posts targeting the greater Kubernetes community (including end users) should potentially use the @Kubernetesio account. Posts using this account must be coordinated with the CNCF. Ownership of @Kubernetesio does not reside within the Contributor Comms team. For any posts to be coordinated with @Kubernetesio, you will need to make contact with CNCF marketing team members in charge of the account. Tweets using the @kubernetesio account are often limited in the content and quantity that may be sent.
 
+A shadow for the social media lead role is someone who is expected, and in training, to take over the role.
 
 ## Minimum Skills and Requirements
 
 - Are a member of the Kubernetes GitHub Org
-- Familiar with twitter by either having a personal account or managing another account (brand, oss project, employer, local nonprofit, etc)
-- Available to either attend regular Contributor Comms meetings or collaborate asynchronously via the #sig-contribex-comms channel in the Kubernetes Slack
+- Familiar with the social media platforms the Contributor Comms team is actively using by either having a personal account or managing another account (brand, oss project, employer, local nonprofit, etc) on these platforms
+- Available to attend regular Contributor Comms meetings regularly
+- Able to collaborate asynchronously via the #sig-contribex-comms channel in the Kubernetes Slack
+- Familiar with and able to maintain the [Contributor Comms team social media guidelines](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/blogging-resources/social-guidelines.md)
 
 ### Expected Time Investment
 
@@ -26,21 +30,34 @@ Team members: 1-3 hours per week.
 
 - Rules for social posts and more can be found in [social guidelines](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/blogging-resources/social-guidelines.md)
 - Be welcoming, be yourself
-- Understanding, communicating, and setting/adjusting [social guidelines](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/blogging-resources/social-guidelines.md)
-- Coordinating work to create tweets, ensuring tweet requests are fulfilled
-- Working with other Contributor Comms leads, such as the Event Coordinator Lead, on social media tasks
-- Approving tweet PRs on [kubernetes-sigs/contributor-tweets](https://github.com/kubernetes-sigs/contributor-tweets)
+- Understanding, communicating, and setting/adjusting the [Contributor Comms social guidelines](https://github.com/kubernetes/community/blob/master/communication/contributor-comms/blogging-resources/social-guidelines.md)
+- Coordinating work to create posts, ensuring social media post requests are fulfilled
+- Working with other Contributor Comms leads on social media tasks
+- Managing Buffer, including
+    - communicating funding needs to the subproject lead (who will ensure they get communicated to the CNCF)
+    - managing the team on Buffer, including adding and removing team members
 - Training new leads
+- Maintaining this document
 
-The leader(s) of the social media team will be expected to monitor the @K8sContributors handle. Retweets, replies, and responding to replies appropriately fall under the purview of the social media lead. Time-sensitive tweets should also be handled directly by the team lead. Team leads should coordinate with team members to plan tweets in advance, particularly for large contributor-focused events such as KubeCon or Contributor Summit.
+The leader(s) of the social media team will be expected to monitor the @K8sContributors handle. Reposts, replies, and responding to replies appropriately fall under the purview of the social media lead. Time-sensitive posts should also be handled directly by the social media lead. Social Media leads should coordinate with team members to plan posts in advance, particularly for large contributor-focused events such as KubeCon or Contributor Summit.
 
-Team members will be expected to keep an eye out for news in need of tweeting. Common sources of such announcements are the k-dev mailing list and the #sig-contribex-comms channel on Slack. Team members can submit less time-sensitive tweets to the [kubernetes-sigs/contributor-tweets repo](https://github.com/kubernetes-sigs/contributor-tweets) for review and tweeting.
+Team members will be expected to keep an eye out for news in need of posting. Common sources of such announcements are the k-dev mailing list and the #sig-contribex-comms channel on Slack. The Social Media Lead can add team members to Buffer so they can create posts for approval across social media platforms
 
-## Associates Overview (Shadow)
+## Social Media Shadow Overview
 
-Team members who wish to become social media leads should express this desire to the current lead.
+### Overview and Eligibility
+Anyone that is interested in helping the social media team, and that finds the general expectations and requirements acceptable, can start working in the team and have their contributions to the project recognised. Additionally, some will feel that they want to make a step towards becoming Social Media Leads themselves.
+
+- Becoming a shadow is something that should come as a result of existing involvement in the team, and not as a starting point; to be eligible to shadow for this role you will need to:
+- Be a regular member of the Comms team, by following the activities and the regular meetings.
+Have demonstrated knowledge of the social media processes and guidelines, namely by having been actively involved in the creation of social media posts.
+
+Team members who want to become Social Media Leads _should express their desire to the current lead_; leads should work with shadows to understand their capacity to take on the needs of the lead role and work with the shadow on a plan to take on the necessary responsibility.
+
+### Shadow Responsibilities
+
 Leads should work with shadows to understand their capacity to take on the needs of the lead role and work with the shadow on a plan for them to take on responsibility including:
-* Becoming an owner (approver privileges) on the [kubernetes-sigs/contributor-tweets](https://github.com/kubernetes-sigs/contributor-tweets) repo
-* Watching for new tweet PRs and working with PR creators on scheduling/approving tweets
-* Watching for new tweet requests and ensuring they get assigned to team members or created directly
-* Taking on direct management of a social media account
+- Taking on approver privileges in Buffer
+- Watching for new social media requests and working with requestors on scheduling/approving posts
+- Ensuring new social media requests get completed either by assigned to team members or creating directly
+- Taking on direct management of social media accounts


### PR DESCRIPTION
Worked with @Hii-Arpit to update the social media lead handbook. Significant updates were made across the doc to remove references to the contributor-tweets repo and to "Twitter." We are also adding in new requirements for Buffer management. And we updated the lead and shadow eligibility requirements, adding clarification on the shadow role.