### PR TITLE
Add educates channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -108,6 +108,7 @@ channels:
   - name: draft-users
   - name: druid-operator
   - name: ebpf
+  - name: educates
   - name: eks
   - name: eksctl
   - name: elastickube


### PR DESCRIPTION
This PR creates #educates slack channel.

The Educates project is designed to provide a platform for hosting workshops. It was primarily created to support the work of a team of developer advocates who needed to train users in using Kubernetes and show case developer tools or applications running on Kubernetes.

Although the principal deployment platform for Educates is Kubernetes, and is being used to teach users about Kubernetes, it could also be used to host training for other purposes as well. It may for example be used to help train users in web based applications, use of databases, or programming languages.

By creating this channel we would like to unify the communication of our community in one place.

Some useful resources:

[Educates GH repository](https://github.com/vmware-tanzu-labs/educates-training-platform)
[Educates documentation](https://docs.educates.dev/)
