### PR TITLE
Adding voter exceptions for Steering 2023 election

### DIFF
--- a/elections/steering/2023/voters.yaml
+++ b/elections/steering/2023/voters.yaml
@@ -325,6 +325,7 @@ eligible_voters:
 - kbhawkey
 - kcmartin
 - keithmattix
+- kendallnelson
 - kerthcet
 - kevindelgado
 - kflynn
@@ -598,6 +599,7 @@ eligible_voters:
 - spencerhance
 - spiffxp
 - spowelljr
+- sreeram-venkitesh
 - srm09
 - starpit
 - stevehipwell


### PR DESCRIPTION
Adding approved voter exceptions for Steering 2023 election.

/cc @dims @kaslin 