### PR TITLE
Link to documentation site and clarify PR/CLA order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Welcome to the Kubernetes Community contributing guide. We are excited about the
 
 We have full documentation on how to get started contributing here:
 
-- [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation
-- [Contributor Cheat Sheet](./contributors/guide/contributor-cheatsheet/) - Common resources for existing developers
+- [Kubernetes Contributor Guide](https://www.kubernetes.dev/docs/guide/) - Main contributor documentation
+- [Contributor Cheat Sheet](https://www.kubernetes.dev/docs/contributor-cheatsheet/) - Common resources for existing developers
 
 ## Mentorship
 

--- a/contributors/guide/pull-requests.md
+++ b/contributors/guide/pull-requests.md
@@ -61,9 +61,9 @@ You can run these local verifications before you submit your pull request to pre
 
 Merging a pull request requires the following steps to be completed before the pull request will be merged automatically.
 
-- [Sign the CLA](https://git.k8s.io/community/CLA.md) (prerequisite)
 - [Open a pull request](https://help.github.com/articles/about-pull-requests/)
   - *For kubernetes/kubernetes repository only:* Add [release notes](/contributors/guide/release-notes.md) if needed.
+- Follow the EasyCLA steps to [sign the CLA](https://git.k8s.io/community/CLA.md) (prerequisite)
 - Pass all e2e tests
 - Get all necessary approvals from reviewers and code owners
 


### PR DESCRIPTION
The current documentation suggests that the CLA must be signed before opening a pull request.

https://github.com/kubernetes/community/blob/586e54c54a4225612e8a2e956a0e36509604b548/contributors/guide/pull-requests.md?plain=1#L60-L65

I tried to do this (submit a pull request ahead of opening a pull request) and received a response that a pull request needs to be opened before signing the CLA.  So I thought I would test out the process by opening a pull request that clarifies that opening a pull request should happen before signing the CLA.

I've also updated a couple links to point to the rendered version of the guide on the documentation website (https://www.kubernetes.dev/docs/guide/).  If it is preferable to use the link shortener or to leave the links as they were, I can change that back.