### PR TITLE
Liaison updates following 2023 Steering election

### DIFF
--- a/committee-code-of-conduct/README.md
+++ b/committee-code-of-conduct/README.md
@@ -43,7 +43,7 @@ The [charter](charter.md) defines the scope and governance of the Code of Conduc
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/committee%2Fcode-of-conduct)
 - GitHub Teams:
     - [@kubernetes/code-of-conduct-committee](https://github.com/orgs/kubernetes/teams/code-of-conduct-committee) - General Discussion
-- Steering Committee Liaison: Maciej Szulik (**[@soltysh](https://github.com/soltysh)**)
+- Steering Committee Liaison: Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/committee-code-of-conduct/README.md
+++ b/committee-code-of-conduct/README.md
@@ -43,7 +43,7 @@ The [charter](charter.md) defines the scope and governance of the Code of Conduc
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/committee%2Fcode-of-conduct)
 - GitHub Teams:
     - [@kubernetes/code-of-conduct-committee](https://github.com/orgs/kubernetes/teams/code-of-conduct-committee) - General Discussion
-- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
+- Steering Committee Liaison: Maciej Szulik (**[@soltysh](https://github.com/soltysh)**)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 <!-- BEGIN CUSTOM CONTENT -->

--- a/liaisons.md
+++ b/liaisons.md
@@ -40,7 +40,7 @@ members will assume one of the departing members groups.
 | [SIG Cluster Lifecycle](sig-cluster-lifecycle/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [SIG Contributor Experience](sig-contributor-experience/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Docs](sig-docs/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
-| [SIG etcd](sig-etcd/README.md) | TBD (**[@TBD](https://github.com/TBD)**) |
+| [SIG etcd](sig-etcd/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Instrumentation](sig-instrumentation/README.md) | Patrick Ohly (**[@pohly](https://github.com/pohly)**) |
 | [SIG K8s Infra](sig-k8s-infra/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Multicluster](sig-multicluster/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |

--- a/liaisons.md
+++ b/liaisons.md
@@ -33,35 +33,35 @@ members will assume one of the departing members groups.
 | [SIG API Machinery](sig-api-machinery/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [SIG Apps](sig-apps/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Architecture](sig-architecture/README.md) | Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**) |
-| [SIG Auth](sig-auth/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
-| [SIG Autoscaling](sig-autoscaling/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
+| [SIG Auth](sig-auth/README.md) | Patrick Ohly (**[@pohly](https://github.com/pohly)**) |
+| [SIG Autoscaling](sig-autoscaling/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
 | [SIG CLI](sig-cli/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Cloud Provider](sig-cloud-provider/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Cluster Lifecycle](sig-cluster-lifecycle/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [SIG Contributor Experience](sig-contributor-experience/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
-| [SIG Docs](sig-docs/README.md) | Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**) |
+| [SIG Docs](sig-docs/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
 | [SIG etcd](sig-etcd/README.md) | TBD (**[@TBD](https://github.com/TBD)**) |
-| [SIG Instrumentation](sig-instrumentation/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
+| [SIG Instrumentation](sig-instrumentation/README.md) | Patrick Ohly (**[@pohly](https://github.com/pohly)**) |
 | [SIG K8s Infra](sig-k8s-infra/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Multicluster](sig-multicluster/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
-| [SIG Network](sig-network/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
-| [SIG Node](sig-node/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
+| [SIG Network](sig-network/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
+| [SIG Node](sig-node/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
 | [SIG Release](sig-release/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [SIG Scalability](sig-scalability/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Scheduling](sig-scheduling/README.md) | Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**) |
-| [SIG Security](sig-security/README.md) | Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**) |
-| [SIG Storage](sig-storage/README.md) | Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**) |
-| [SIG Testing](sig-testing/README.md) | Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**) |
+| [SIG Security](sig-security/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
+| [SIG Storage](sig-storage/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
+| [SIG Testing](sig-testing/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
 | [SIG UI](sig-ui/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Windows](sig-windows/README.md) | Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**) |
 | [WG API Expression](wg-api-expression/README.md) | Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**) |
 | [WG Batch](wg-batch/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
-| [WG Data Protection](wg-data-protection/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
-| [WG IoT Edge](wg-iot-edge/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
+| [WG Data Protection](wg-data-protection/README.md) | Patrick Ohly (**[@pohly](https://github.com/pohly)**) |
+| [WG IoT Edge](wg-iot-edge/README.md) | Patrick Ohly (**[@pohly](https://github.com/pohly)**) |
 | [WG LTS](wg-lts/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
-| [WG Policy](wg-policy/README.md) | Christoph Blecker (**[@cblecker](https://github.com/cblecker)**) |
+| [WG Policy](wg-policy/README.md) | Patrick Ohly (**[@pohly](https://github.com/pohly)**) |
 | [WG Structured Logging](wg-structured-logging/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
-| [Committee Code of Conduct](committee-code-of-conduct/README.md) | Tim Pepper (**[@tpepper](https://github.com/tpepper)**) |
+| [Committee Code of Conduct](committee-code-of-conduct/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
 | [Committee Security Response](committee-security-response/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 <!-- BEGIN CUSTOM CONTENT -->
 ## Expectations

--- a/liaisons.md
+++ b/liaisons.md
@@ -39,7 +39,7 @@ members will assume one of the departing members groups.
 | [SIG Cloud Provider](sig-cloud-provider/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Cluster Lifecycle](sig-cluster-lifecycle/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [SIG Contributor Experience](sig-contributor-experience/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
-| [SIG Docs](sig-docs/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
+| [SIG Docs](sig-docs/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG etcd](sig-etcd/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Instrumentation](sig-instrumentation/README.md) | Patrick Ohly (**[@pohly](https://github.com/pohly)**) |
 | [SIG K8s Infra](sig-k8s-infra/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
@@ -49,7 +49,7 @@ members will assume one of the departing members groups.
 | [SIG Release](sig-release/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [SIG Scalability](sig-scalability/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Scheduling](sig-scheduling/README.md) | Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**) |
-| [SIG Security](sig-security/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
+| [SIG Security](sig-security/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Storage](sig-storage/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
 | [SIG Testing](sig-testing/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
 | [SIG UI](sig-ui/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
@@ -61,7 +61,7 @@ members will assume one of the departing members groups.
 | [WG LTS](wg-lts/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [WG Policy](wg-policy/README.md) | Patrick Ohly (**[@pohly](https://github.com/pohly)**) |
 | [WG Structured Logging](wg-structured-logging/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
-| [Committee Code of Conduct](committee-code-of-conduct/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
+| [Committee Code of Conduct](committee-code-of-conduct/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [Committee Security Response](committee-security-response/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 <!-- BEGIN CUSTOM CONTENT -->
 ## Expectations

--- a/liaisons.md
+++ b/liaisons.md
@@ -35,8 +35,8 @@ members will assume one of the departing members groups.
 | [SIG Architecture](sig-architecture/README.md) | Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**) |
 | [SIG Auth](sig-auth/README.md) | Patrick Ohly (**[@pohly](https://github.com/pohly)**) |
 | [SIG Autoscaling](sig-autoscaling/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
-| [SIG CLI](sig-cli/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
-| [SIG Cloud Provider](sig-cloud-provider/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
+| [SIG CLI](sig-cli/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
+| [SIG Cloud Provider](sig-cloud-provider/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
 | [SIG Cluster Lifecycle](sig-cluster-lifecycle/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [SIG Contributor Experience](sig-contributor-experience/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Docs](sig-docs/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
@@ -45,14 +45,14 @@ members will assume one of the departing members groups.
 | [SIG K8s Infra](sig-k8s-infra/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Multicluster](sig-multicluster/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Network](sig-network/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
-| [SIG Node](sig-node/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
+| [SIG Node](sig-node/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
 | [SIG Release](sig-release/README.md) | Nabarun Pal (**[@palnabarun](https://github.com/palnabarun)**) |
 | [SIG Scalability](sig-scalability/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |
 | [SIG Scheduling](sig-scheduling/README.md) | Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**) |
 | [SIG Security](sig-security/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
 | [SIG Storage](sig-storage/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
 | [SIG Testing](sig-testing/README.md) | Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**) |
-| [SIG UI](sig-ui/README.md) | Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**) |
+| [SIG UI](sig-ui/README.md) | Maciej Szulik (**[@soltysh](https://github.com/soltysh)**) |
 | [SIG Windows](sig-windows/README.md) | Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**) |
 | [WG API Expression](wg-api-expression/README.md) | Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**) |
 | [WG Batch](wg-batch/README.md) | Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**) |

--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -59,7 +59,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-auth-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-auth-pr-reviews) - PR Reviews
     - [@kubernetes/sig-auth-proposals](https://github.com/orgs/kubernetes/teams/sig-auth-proposals) - Design Proposals
     - [@kubernetes/sig-auth-test-failures](https://github.com/orgs/kubernetes/teams/sig-auth-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
+- Steering Committee Liaison: Patrick Ohly (**[@pohly](https://github.com/pohly)**)
 
 ## Working Groups
 

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -37,7 +37,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-autoscaling-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-autoscaling-pr-reviews) - PR Reviews
     - [@kubernetes/sig-autoscaling-proposals](https://github.com/orgs/kubernetes/teams/sig-autoscaling-proposals) - Design Proposals
     - [@kubernetes/sig-autoscaling-test-failures](https://github.com/orgs/kubernetes/teams/sig-autoscaling-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
+- Steering Committee Liaison: Maciej Szulik (**[@soltysh](https://github.com/soltysh)**)
 
 ## Working Groups
 

--- a/sig-cli/README.md
+++ b/sig-cli/README.md
@@ -64,7 +64,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-cli-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-cli-pr-reviews) - PR Reviews
     - [@kubernetes/sig-cli-proposals](https://github.com/orgs/kubernetes/teams/sig-cli-proposals) - Design Proposals
     - [@kubernetes/sig-cli-test-failures](https://github.com/orgs/kubernetes/teams/sig-cli-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
+- Steering Committee Liaison: Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**)
 
 ## Subprojects
 

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -52,7 +52,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-cloud-provider-proposals](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-proposals) - Design Proposals
     - [@kubernetes/sig-cloud-provider-test-failures](https://github.com/orgs/kubernetes/teams/sig-cloud-provider-test-failures) - Test Failures and Triage
     - [@kubernetes/sig-cloud-providers-misc](https://github.com/orgs/kubernetes/teams/sig-cloud-providers-misc) - General Discussion
-- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
+- Steering Committee Liaison: Maciej Szulik (**[@soltysh](https://github.com/soltysh)**)
 
 ## Working Groups
 

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -83,7 +83,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-docs-ru-owners](https://github.com/orgs/kubernetes/teams/sig-docs-ru-owners) - Russian language content
     - [@kubernetes/sig-docs-uk-owners](https://github.com/orgs/kubernetes/teams/sig-docs-uk-owners) - Ukrainian language content
     - [@kubernetes/sig-docs-zh-owners](https://github.com/orgs/kubernetes/teams/sig-docs-zh-owners) - Chinese language content
-- Steering Committee Liaison: Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**)
+- Steering Committee Liaison: Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**)
 
 ## Subprojects
 

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -83,7 +83,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-docs-ru-owners](https://github.com/orgs/kubernetes/teams/sig-docs-ru-owners) - Russian language content
     - [@kubernetes/sig-docs-uk-owners](https://github.com/orgs/kubernetes/teams/sig-docs-uk-owners) - Ukrainian language content
     - [@kubernetes/sig-docs-zh-owners](https://github.com/orgs/kubernetes/teams/sig-docs-zh-owners) - Chinese language content
-- Steering Committee Liaison: Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**)
+- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
 
 ## Subprojects
 

--- a/sig-etcd/README.md
+++ b/sig-etcd/README.md
@@ -41,7 +41,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fetcd)
 - GitHub Teams:
     - [@kubernetes/sig-etcd-leads](https://github.com/orgs/kubernetes/teams/sig-etcd-leads) - SIG Chairs and Tech Leads
-- Steering Committee Liaison: TBD (**[@TBD](https://github.com/TBD)**)
+- Steering Committee Liaison: Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**)
 
 ## Subprojects
 

--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -47,7 +47,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-instrumentation-approvers](https://github.com/orgs/kubernetes/teams/sig-instrumentation-approvers) - SIG Top-level Approvers
     - [@kubernetes/sig-instrumentation-leads](https://github.com/orgs/kubernetes/teams/sig-instrumentation-leads) - SIG Chairs and Tech Leads
     - [@kubernetes/sig-instrumentation-members](https://github.com/orgs/kubernetes/teams/sig-instrumentation-members) - SIG Membership Roster
-- Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
+- Steering Committee Liaison: Patrick Ohly (**[@pohly](https://github.com/pohly)**)
 
 ## Working Groups
 

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -61,7 +61,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
     - [@kubernetes/sig-network-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-network-pr-reviews) - PR Reviews
     - [@kubernetes/sig-network-proposals](https://github.com/orgs/kubernetes/teams/sig-network-proposals) - Design Proposals
     - [@kubernetes/sig-network-test-failures](https://github.com/orgs/kubernetes/teams/sig-network-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
+- Steering Committee Liaison: Maciej Szulik (**[@soltysh](https://github.com/soltysh)**)
 
 ## Working Groups
 

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -47,7 +47,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-node-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) - PR Reviews
     - [@kubernetes/sig-node-proposals](https://github.com/orgs/kubernetes/teams/sig-node-proposals) - Design Proposals
     - [@kubernetes/sig-node-test-failures](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Maciej Szulik (**[@soltysh](https://github.com/soltysh)**)
+- Steering Committee Liaison: Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**)
 
 ## Working Groups
 

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -47,7 +47,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-node-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-node-pr-reviews) - PR Reviews
     - [@kubernetes/sig-node-proposals](https://github.com/orgs/kubernetes/teams/sig-node-proposals) - Design Proposals
     - [@kubernetes/sig-node-test-failures](https://github.com/orgs/kubernetes/teams/sig-node-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Tim Pepper (**[@tpepper](https://github.com/tpepper)**)
+- Steering Committee Liaison: Maciej Szulik (**[@soltysh](https://github.com/soltysh)**)
 
 ## Working Groups
 

--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -33,7 +33,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 - GitHub Teams:
     - [@kubernetes/sig-security-leads](https://github.com/orgs/kubernetes/teams/sig-security-leads) - SIG Security Leads
     - [@kubernetes/sig-security-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-security-pr-reviews) - SIG Security PR review notifications
-- Steering Committee Liaison: Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**)
+- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
 
 ## Working Groups
 

--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -33,7 +33,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 - GitHub Teams:
     - [@kubernetes/sig-security-leads](https://github.com/orgs/kubernetes/teams/sig-security-leads) - SIG Security Leads
     - [@kubernetes/sig-security-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-security-pr-reviews) - SIG Security PR review notifications
-- Steering Committee Liaison: Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**)
+- Steering Committee Liaison: Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**)
 
 ## Working Groups
 

--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -51,7 +51,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
     - [@kubernetes/sig-storage-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-storage-pr-reviews) - PR Reviews
     - [@kubernetes/sig-storage-proposals](https://github.com/orgs/kubernetes/teams/sig-storage-proposals) - Design Proposals
     - [@kubernetes/sig-storage-test-failures](https://github.com/orgs/kubernetes/teams/sig-storage-test-failures) - Test Failures and Triage
-- Steering Committee Liaison: Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**)
+- Steering Committee Liaison: Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**)
 
 ## Working Groups
 

--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -51,7 +51,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 - GitHub Teams:
     - [@kubernetes/sig-testing](https://github.com/orgs/kubernetes/teams/sig-testing) - General Discussion
     - [@kubernetes/sig-testing-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-testing-pr-reviews) - PR Reviews
-- Steering Committee Liaison: Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**)
+- Steering Committee Liaison: Paco Xu 徐俊杰 (**[@pacoxu](https://github.com/pacoxu)**)
 
 ## Working Groups
 

--- a/sig-ui/README.md
+++ b/sig-ui/README.md
@@ -36,7 +36,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 - Slack: [#sig-ui](https://kubernetes.slack.com/messages/sig-ui)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-ui)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fui)
-- Steering Committee Liaison: Stephen Augustus (**[@justaugustus](https://github.com/justaugustus)**)
+- Steering Committee Liaison: Maciej Szulik (**[@soltysh](https://github.com/soltysh)**)
 
 ## Subprojects
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1712,8 +1712,8 @@ sigs:
     - name: sig-etcd-leads
       description: SIG Chairs and Tech Leads
     liaison:
-      github: TBD
-      name: TBD
+      github: mrbobbytables
+      name: Bob Killen
   subprojects:
   - name: bbolt
     description: An embedded key/value database for Go.

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1651,8 +1651,8 @@ sigs:
     - name: sig-docs-zh-owners
       description: Chinese language content
     liaison:
-      github: pacoxu
-      name: Paco Xu 徐俊杰
+      github: justaugustus
+      name: Stephen Augustus
   subprojects:
   - name: kubernetes-blog
     owners:
@@ -2739,8 +2739,8 @@ sigs:
     - name: sig-security-pr-reviews
       description: SIG Security PR review notifications
     liaison:
-      github: pacoxu
-      name: Paco Xu 徐俊杰
+      github: justaugustus
+      name: Stephen Augustus
   subprojects:
   - name: security-assessments
     description: Security self assessments for upstream projects
@@ -3511,8 +3511,8 @@ committees:
     - name: code-of-conduct-committee
       description: General Discussion
     liaison:
-      github: soltysh
-      name: Maciej Szulik
+      github: palnabarun
+      name: Nabarun Pal
 - dir: committee-security-response
   name: Security Response
   mission_statement: >

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -737,8 +737,8 @@ sigs:
     - name: sig-cli-test-failures
       description: Test Failures and Triage
     liaison:
-      github: justaugustus
-      name: Stephen Augustus
+      github: pacoxu
+      name: Paco Xu 徐俊杰
   subprojects:
   - name: cli-experimental
     owners:
@@ -848,8 +848,8 @@ sigs:
     - name: sig-cloud-providers-misc
       description: General Discussion
     liaison:
-      github: justaugustus
-      name: Stephen Augustus
+      github: soltysh
+      name: Maciej Szulik
   subprojects:
   - name: cloud-provider-extraction-migration
     owners:
@@ -2317,8 +2317,8 @@ sigs:
     - name: sig-node-test-failures
       description: Test Failures and Triage
     liaison:
-      github: soltysh
-      name: Maciej Szulik
+      github: pacoxu
+      name: Paco Xu 徐俊杰
   subprojects:
   - name: ci-testing
     contact:
@@ -3058,8 +3058,8 @@ sigs:
     slack: sig-ui
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-ui
     liaison:
-      github: justaugustus
-      name: Stephen Augustus
+      github: soltysh
+      name: Maciej Szulik
   subprojects:
   - name: dashboard
     owners:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -468,8 +468,8 @@ sigs:
     - name: sig-auth-test-failures
       description: Test Failures and Triage
     liaison:
-      github: cblecker
-      name: Christoph Blecker
+      github: pohly
+      name: Patrick Ohly
   subprojects:
   - name: audit-logging
     description: |
@@ -624,8 +624,8 @@ sigs:
     - name: sig-autoscaling-test-failures
       description: Test Failures and Triage
     liaison:
-      github: tpepper
-      name: Tim Pepper
+      github: soltysh
+      name: Maciej Szulik
   subprojects:
   - name: addon-resizer
     owners:
@@ -1651,8 +1651,8 @@ sigs:
     - name: sig-docs-zh-owners
       description: Chinese language content
     liaison:
-      github: cpanato
-      name: Carlos Tadeu Panato Jr.
+      github: pacoxu
+      name: Paco Xu 徐俊杰
   subprojects:
   - name: kubernetes-blog
     owners:
@@ -1836,8 +1836,8 @@ sigs:
     - name: sig-instrumentation-members
       description: SIG Membership Roster
     liaison:
-      github: cblecker
-      name: Christoph Blecker
+      github: pohly
+      name: Patrick Ohly
   subprojects:
   - name: custom-metrics-apiserver
     owners:
@@ -2211,8 +2211,8 @@ sigs:
     - name: sig-network-test-failures
       description: Test Failures and Triage
     liaison:
-      github: tpepper
-      name: Tim Pepper
+      github: soltysh
+      name: Maciej Szulik
   subprojects:
   - name: cluster-proportional-autoscaler
     owners:
@@ -2317,8 +2317,8 @@ sigs:
     - name: sig-node-test-failures
       description: Test Failures and Triage
     liaison:
-      github: tpepper
-      name: Tim Pepper
+      github: soltysh
+      name: Maciej Szulik
   subprojects:
   - name: ci-testing
     contact:
@@ -2739,8 +2739,8 @@ sigs:
     - name: sig-security-pr-reviews
       description: SIG Security PR review notifications
     liaison:
-      github: cpanato
-      name: Carlos Tadeu Panato Jr.
+      github: pacoxu
+      name: Paco Xu 徐俊杰
   subprojects:
   - name: security-assessments
     description: Security self assessments for upstream projects
@@ -2836,8 +2836,8 @@ sigs:
     - name: sig-storage-test-failures
       description: Test Failures and Triage
     liaison:
-      github: cpanato
-      name: Carlos Tadeu Panato Jr.
+      github: pacoxu
+      name: Paco Xu 徐俊杰
   subprojects:
   - name: external-storage
     owners:
@@ -2963,8 +2963,8 @@ sigs:
     - name: sig-testing-pr-reviews
       description: PR Reviews
     liaison:
-      github: cpanato
-      name: Carlos Tadeu Panato Jr.
+      github: pacoxu
+      name: Paco Xu 徐俊杰
   subprojects:
   - name: Cloud Provider for KIND
     description: |
@@ -3277,8 +3277,8 @@ workinggroups:
     slack: wg-data-protection
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-data-protection
     liaison:
-      github: cblecker
-      name: Christoph Blecker
+      github: pohly
+      name: Patrick Ohly
 - dir: wg-iot-edge
   name: IoT Edge
   mission_statement: >
@@ -3322,8 +3322,8 @@ workinggroups:
     slack: wg-iot-edge
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge
     liaison:
-      github: cblecker
-      name: Christoph Blecker
+      github: pohly
+      name: Patrick Ohly
 - dir: wg-lts
   name: LTS
   mission_statement: >
@@ -3405,8 +3405,8 @@ workinggroups:
     slack: wg-policy
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-policy
     liaison:
-      github: cblecker
-      name: Christoph Blecker
+      github: pohly
+      name: Patrick Ohly
 - dir: wg-structured-logging
   name: Structured Logging
   mission_statement: >
@@ -3511,8 +3511,8 @@ committees:
     - name: code-of-conduct-committee
       description: General Discussion
     liaison:
-      github: tpepper
-      name: Tim Pepper
+      github: soltysh
+      name: Maciej Szulik
 - dir: committee-security-response
   name: Security Response
   mission_statement: >

--- a/wg-data-protection/README.md
+++ b/wg-data-protection/README.md
@@ -32,7 +32,7 @@ The [charter](charter.md) defines the scope and governance of the Data Protectio
 - Slack: [#wg-data-protection](https://kubernetes.slack.com/messages/wg-data-protection)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-data-protection)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fdata-protection)
-- Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
+- Steering Committee Liaison: Patrick Ohly (**[@pohly](https://github.com/pohly)**)
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->

--- a/wg-iot-edge/README.md
+++ b/wg-iot-edge/README.md
@@ -35,7 +35,7 @@ A Working Group dedicated to discussing, designing and documenting using Kuberne
 - Slack: [#wg-iot-edge](https://kubernetes.slack.com/messages/wg-iot-edge)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fiot-edge)
-- Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
+- Steering Committee Liaison: Patrick Ohly (**[@pohly](https://github.com/pohly)**)
 <!-- BEGIN CUSTOM CONTENT -->
 This working group is a cross-SIG effort currently sponsored by _sig-networking_ and _sig-multicluster_ with
 a focus on improving Kubernetes IoT and Edge deployments. Community members are encouraged to share their ideas in this working group to reach broad consensus across the SIGs. Once consensus is reached, the enhancements

--- a/wg-policy/README.md
+++ b/wg-policy/README.md
@@ -33,7 +33,7 @@ Provide an overall architecture that describes both the current policy related i
 - Slack: [#wg-policy](https://kubernetes.slack.com/messages/wg-policy)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-policy)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/wg%2Fpolicy)
-- Steering Committee Liaison: Christoph Blecker (**[@cblecker](https://github.com/cblecker)**)
+- Steering Committee Liaison: Patrick Ohly (**[@pohly](https://github.com/pohly)**)
 <!-- BEGIN CUSTOM CONTENT -->
 
 <!-- END CUSTOM CONTENT -->


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/273.)

With @pacoxu, @pohly, and @soltysh joining the @kubernetes/steering-committee, we need to reassign governance group liaisons.

I broke this PR into separate commits to show my work; let me talk through it as well...

### Replace Emeritus members

- Swap Christoph for Patrick
- Swap Tim for Maciej
- Swap Carlos for Paco

There was no methodology here, outside of replacing outgoing members.

### Assign a liaison for SIG etcd

Following the creation of SIG etcd in https://github.com/kubernetes/community/pull/7372, they need a liaison.
Given Bob has been championing this effort, [in my head] he is the obvious choice.

### Affinity-based swaps pt. 1

Updated some liaisons based on existing committee affinities:

- Stephen:
  - SIG Security: OpenSSF maintainer/GB member, SRC liaison
  - SIG Docs: SIG Release Chair/Release Team subproject owner
- Nabarun:
  - CoCC: Previous CoCC member

### Rebalance the rest

The sweet spot for groups:liaison is ~4-6/liaison (33 governance groups / 7 Steering members = 4.714).

I've tried to consider a few things here:

- A lighter liaison load for new members
- Minimizing liaison churn
- Steering members should not be liaisons for groups in which they are also leads
- Potential conflicts of interest
- Affinities

Here are some potential conflicts I determined with new members:

- @soltysh: Leads SIG Apps, SIG CLI, WG Batch
- @pohly: Leads SIG Testing, WG Structured Logging
- @pacoxu: SIG Cloud Provider (works at a cloud provider)

And affinities:

- Maciej: UI (Apps + CLI affinity)
- Patrick: Instrumentation (Testing affinity)
- Paco: Node (SIG Node reviewer)

I resurrected an old spreadsheet if Steering folks are interested in seeing how the weights shake out: https://docs.google.com/spreadsheets/d/14jfFbZYZi1QVy_l6RZXD2kIt8aTqa9wxh-br2Od1FpI/edit?usp=sharing

As of writing, the current weights are:

Liaison | Total | Weighed Total
-- | -- | --
Bob Killen | 6 | 5.75
Nabarun Pal | 6 | 5.5
Benjamin Elder | 4 | 3.75
Stephen Augustus | 4 | 4
Maciej Szulik | 4 | 4
Paco Xu | 4 | 4
Patrick Ohly | 5 | 4.25

(SIGs and Committees have a weight of 1; WGs have a weight of 0.75)

/hold for discussion (private or on this PR)