### PR TITLE
Add a note on how to appear in community calendar

### DIFF
--- a/communication/calendar-guidelines.md
+++ b/communication/calendar-guidelines.md
@@ -67,6 +67,7 @@ addition of [gsuite], this practice may change soon.
     will need to be set to "public".
   - In the calendar invite body - include your meeting notes, zoom information,
     and any other pertinent information that you want your group to know.
+  - Invite `calendar@kubernetes.io` so the event will appear in https://www.kubernetes.dev/resources/calendar/
 
 
 ### Testing Permissions


### PR DESCRIPTION
Tested on Sidecar WG meeting from https://calendar.google.com/calendar/embed?src=c68df4a61d14122e8e81eb42309f6cca63eb1b7b443384eebc803e6832dbe0b6%40group.calendar.google.com&ctz=America%2FLos_Angeles

It wasn't in community calendar before the invite and appeared there after