### PR TITLE
Correcting date for 2023 Steering election retro

### DIFF
--- a/elections/steering/2023/README.md
+++ b/elections/steering/2023/README.md
@@ -139,7 +139,7 @@ Examples of contributions that would NOT be considered:
 | Wednesday, September 27 | Private announcement of Results to SC members not up for election     |
 | Sunday, October 1       | Private announcement of Results to all candidates                     |
 | Monday, October 2       | Public announcement of Results at Public Steering Committee Meeting   |
-| Thursday, October 5     | Election Retro                                                        |
+| Tuesday, October 3      | Election Retro                                                        |
 
 Candidate nomination, bio, and election close deadlines will be done using Anywhere on Earth timing, meaning it is still valid to submit new nominations/bios/votes as long as it is still the last day anywhere on the planet (i.e. at the end of that day in UTC-12).
 


### PR DESCRIPTION
I noticed that the previous date for the scheduled retro was still listed in this file. Due to Election Officer availability, we needed to adjust the retro date. The correct date went out to the k-dev email list today.

/cc @dims @kaslin 