### PR TITLE
sig-multicluster: add cluster-inventory-api subproject

### DIFF
--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -57,6 +57,9 @@ The following [subprojects][subproject-definition] are owned by sig-multicluster
 ### about-api
 - **Owners:**
   - [kubernetes-sigs/about-api](https://github.com/kubernetes-sigs/about-api/blob/master/OWNERS)
+### cluster-inventory-api
+- **Owners:**
+  - [kubernetes-sigs/cluster-inventory-api](https://github.com/kubernetes-sigs/cluster-inventory-api/blob/main/OWNERS)
 ### mcs-api
 - **Owners:**
   - [kubernetes-sigs/mcs-api](https://github.com/kubernetes-sigs/mcs-api/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2089,6 +2089,9 @@ sigs:
   - name: about-api
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/about-api/master/OWNERS
+  - name: cluster-inventory-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-inventory-api/main/OWNERS
   - name: mcs-api
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4440

/assign @JeremyOT

cc @qiujian16 @jnpacker @ryanzhang-oss @RainbowMango @dixudx

/hold

for lgtm from sig-multicluster lead and repo creation.