### PR TITLE
chore: add openstack-magnum channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -379,6 +379,7 @@ channels:
   - name: openshift-users
   - name: openstack-helm
   - name: openstack-kolla
+  - name: openstack-magnum
   - name: operator-builder
   - name: operator-framework-community
   - name: operator-sdk-dev


### PR DESCRIPTION
This is a request to add #openstack-magnum channel in the Kubernetes Slack.

Magnum is an OpenStack project which offers APIs and drivers for deploying and managing Kubernetes as first class resources in OpenStack.

We'd like to have space to discuss with Kubernetes Cloud Provider for OpenStack, CAPI, CAPO and other Kubernetes deployment related projects.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
