### PR TITLE
Clarify AKS-related channels on K8s Slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -5,7 +5,7 @@ channels:
   - name: africa-dev
   - name: airflow-operator
   - name: akri
-  - name: aks
+  - name: azure-aks
     id: CU3N85WJK
   - name: aks-engine-dev
     id: CU1CXUHN0

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -5,9 +5,11 @@ channels:
   - name: africa-dev
   - name: airflow-operator
   - name: akri
-  - name: aks-engine-users
+  - name: aks
+    id: CU3N85WJK
   - name: aks-engine-dev
     id: CU1CXUHN0
+    archived: true
   - name: announcements
   - name: antrea
   - name: api-priority-and-fairness


### PR DESCRIPTION
This PR is intended to update the AKS-related Slack channels to more accurately reflect reality and be more consistent with other cloud providers.

Currently, the two AKS-specific channels on Kubernetes Slack are legacy channels intended for discussion of a [now-archived tool for self-managed non-AKS Kubernetes clusters on Azure](https://github.com/Azure/aks-engine): #aks-engine-users, #aks-engine-dev.

This is a source of ongoing confusion. What ends up happening now is that people looking for Azure Kubernetes Service discussion bring their questions to those legacy channels and often don't get the help they're looking for, since the AKS Engine tool in question is EOL.

I am hoping that by renaming #aks-engine-users to ~#aks~ #azure-aks (edit: see note) (and retiring #aks-engine-dev), we will create clarity. Much like #eks and #gke, we will be able to use ~#aks~ #azure-aks to connect community members with one another. And by moving away from association with the legacy AKS Engine tool, we will hopefully reduce confusion.

[Note: while #aks would be the simplest name, there is a user with that name, so we cannot use #aks as a channel name.]
