### PR TITLE
Document latest process(es) for licenses

### DIFF
--- a/github-management/kubernetes-repositories.md
+++ b/github-management/kubernetes-repositories.md
@@ -97,8 +97,10 @@ Corporate CLA](https://github.com/cncf/cla/blob/master/corporate-cla.pdf)
    * If (a) contributor(s) have not signed the CLA and could not be reached, a
      NOTICE file should be added referencing section 7 of the CLA with a list of
 the developers who could not be reached
-   * Licenses of dependencies are acceptable; project owners can ping
-     [@caniszczyk](https://github.com/caniszczyk) for review of third party deps
+   * Licenses of dependencies are acceptable; please review the [allowed-third-party-license-policy.md](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md)
+     and [exceptions](https://github.com/cncf/foundation/tree/main/license-exceptions).
+     If your dependencies are not covered, then please open a `License Exception Request` issue in
+     [cncf/foundation](https://github.com/cncf/foundation/issues) repository.
    * Boilerplate text across all files should attribute copyright as follows:
      `"Copyright <Project Authors>"` if no CLA was in place prior to donation
    * Additions of [the standard Kubernetes header](https://git.k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt)


### PR DESCRIPTION
The information is dated, updating to what we do now. Also taking specific named people out of the loop as we now have a process in place at the foundation level.