### PR TITLE
Fix typo and grammar in StatusTooManyRequests

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -1476,8 +1476,8 @@ due to invalid data provided as part of the request.
 
 
 * `429 StatusTooManyRequests`
-  * Indicates that the either the client rate limit has been exceeded or the
-server has received more requests then it can process.
+  * Indicates that either the client rate limit has been exceeded or the
+server has received more requests than it can process.
   * Suggested client recovery behavior:
     * Read the `Retry-After` HTTP header from the response, and wait at least
 that long before retrying.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue created yet about the problem. The `StatusTooManyRequests` had two spelling mistakes that have been addressed with the current PR.
