### PR TITLE
Update sig-auth TL

### DIFF
--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -38,8 +38,8 @@ The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
 * David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
+* Mo Khan (**[@enj](https://github.com/enj)**), Microsoft
 * Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**), Google
-* Mike Danese (**[@mikedanese](https://github.com/mikedanese)**), Google
 
 ## Emeritus Leads
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -414,11 +414,11 @@ sigs:
     - github: deads2k
       name: David Eads
       company: Red Hat
+    - github: enj
+      name: Mo Khan
+      company: Microsoft
     - github: liggitt
       name: Jordan Liggitt
-      company: Google
-    - github: mikedanese
-      name: Mike Danese
       company: Google
     emeritus_leads:
     - github: ericchiang


### PR DESCRIPTION
Updating sig-auth to rotate @mikedanese out of TL and @enj in.

Many thanks, Mike! Congrats, Mo!

https://groups.google.com/a/kubernetes.io/g/dev/c/YbcO8tEk82U

/hold for acks
/sig auth
/committee steering
/assign @deads2k @ritazh @mikedanese @enj 