### PR TITLE
sig-cluster-lifecycle: move logical-cluster to a subproject repo

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -71,6 +71,7 @@ A project for figuring out the best way to install, manage and deliver cluster a
 A project focused on providing declarative APIs and tooling to simplify provisioning, upgrading, and operating multiple Kubernetes clusters
 - **Owners:**
   - [kubernetes-sigs/cluster-api](https://github.com/kubernetes-sigs/cluster-api/blob/main/OWNERS)
+  - [kubernetes-sigs/logical-cluster](https://github.com/kubernetes-sigs/logical-cluster/blob/main/OWNERS)
 - **Contact:**
   - Slack: [#cluster-api](https://kubernetes.slack.com/messages/cluster-api)
   - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
@@ -264,10 +265,6 @@ A project that uses Ansible / Vagrant for deploying production ready clusters on
 - **Contact:**
   - Slack: [#kubespray](https://kubernetes.slack.com/messages/kubespray)
   - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
-### logical-cluster
-A set of APIs to improve the Kubernetes user experience for cluster administration by offering utilities to interact with fleet of clusters which can be managed by Cluster API, or other entities (like cloud providers).
-- **Owners:**
-  - [kubernetes-sigs/logical-cluster](https://github.com/kubernetes-sigs/logical-cluster/blob/main/OWNERS)
 ### minikube
 Implements a local Kubernetes cluster for application development on macOS, Linux, and Windows
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1068,6 +1068,7 @@ sigs:
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/main/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/logical-cluster/main/OWNERS
     meetings:
     - description: Cluster API office hours
       day: Wednesday
@@ -1329,12 +1330,6 @@ sigs:
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS
-  - name: logical-cluster
-    description: A set of APIs to improve the Kubernetes user experience for cluster
-      administration by offering utilities to interact with fleet of clusters which
-      can be managed by Cluster API, or other entities (like cloud providers).
-    owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/logical-cluster/main/OWNERS
   - name: minikube
     description: Implements a local Kubernetes cluster for application development
       on macOS, Linux, and Windows


### PR DESCRIPTION
As the [logical-cluster repository README](https://github.com/kubernetes-sigs/logical-cluster) indicates, this project was primary created for serving in CAPI usage. Later it can become used by other subprojects like kOps, or cloud providers.

However, having it as a subproject creates extra work for us that is not necessary - e.g. subproject yearly reports. After discussion in the SIG meeting of 31.10.2023, we have agreed to move it from a subproject to a "associated repository" of the CAPI subproject.

A similar case for this can be seen under kubeadm - e.g. see k/system-validators.

**Which issue(s) this PR fixes**:
NONE
