### PR TITLE
release: document kind/deprecation

### DIFF
--- a/contributors/devel/sig-release/release.md
+++ b/contributors/devel/sig-release/release.md
@@ -337,6 +337,7 @@ issue kind labels must be set:
 - `kind/api-change`: Adds, removes, or changes an API
 - `kind/bug`: Fixes a newly discovered bug.
 - `kind/cleanup`: Adding tests, refactoring, fixing old bugs.
+- `kind/deprecation`: Deprecates an API (release notes required).
 - `kind/design`: Related to design
 - `kind/documentation`: Adds documentation
 - `kind/failing-test`: CI test case is failing consistently.


### PR DESCRIPTION
This appears in the PR templates but isn't documented. Since it enforces release notes, it's presumably intended for PRs deprecating APIs rather than for PRs fixing deprecated usage.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
