### PR TITLE
Changing Jay Vays to Amim Knabben as SIG-Windows tech lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -121,8 +121,8 @@ aliases:
   sig-windows-leads:
     - aravindhp
     - claudiubelu
-    - jayunit100
     - jsturtevant
+    - knabben
     - marosset
   wg-api-expression-leads:
     - apelisse

--- a/sig-windows/README.md
+++ b/sig-windows/README.md
@@ -34,8 +34,8 @@ The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
 * Claudiu Belu (**[@claudiubelu](https://github.com/claudiubelu)**), Cloudbase Solutions
-* Jay Vyas (**[@jayunit100](https://github.com/jayunit100)**), VMware
 * James Sturtevant (**[@jsturtevant](https://github.com/jsturtevant)**), Microsoft
+* Amim Knabben (**[@knabben](https://github.com/knabben)**), VMware
 * Mark Rossetti (**[@marosset](https://github.com/marosset)**), Microsoft
 
 ## Emeritus Leads
@@ -43,6 +43,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 * Patrick Lang (**[@PatrickLang](https://github.com/PatrickLang)**)
 * Ben Moss (**[@benmoss](https://github.com/benmoss)**)
 * Deep Debroy (**[@ddebroy](https://github.com/ddebroy)**)
+* Jay Vyas (**[@jayunit100](https://github.com/jayunit100)**)
 * Michael Michael (**[@michmike](https://github.com/michmike)**)
 
 ## Contact

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3086,12 +3086,12 @@ sigs:
     - github: claudiubelu
       name: Claudiu Belu
       company: Cloudbase Solutions
-    - github: jayunit100
-      name: Jay Vyas
-      company: VMware
     - github: jsturtevant
       name: James Sturtevant
       company: Microsoft
+    - github: knabben
+      name: Amim Knabben
+      company: VMware
     - github: marosset
       name: Mark Rossetti
       company: Microsoft
@@ -3102,6 +3102,8 @@ sigs:
       name: Ben Moss
     - github: ddebroy
       name: Deep Debroy
+    - github: jayunit100
+      name: Jay Vyas
     - github: michmike
       name: Michael Michael
   meetings:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
Adding Amim Knabben as SIG-Windows TL and moving Jay Vyas to Emeritus lead 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7614
