### PR TITLE
Update events handbook for MKCC after NA 2023 event

### DIFF
--- a/events/events-team/content/meet-and-greet.md
+++ b/events/events-team/content/meet-and-greet.md
@@ -1,12 +1,12 @@
 # Meet And Greet Coordination
 
-The SIG Meet & Greet (M&G) is an event we hold during Kubecon in order for new contributors to find a SIG in which to start contributing.  SIG contributors occupy tables, and new and casual contributors drop by to chat.  Secondarily, it is a lunchtime event for SIG members to see each other and chat.
+Meet the Kubernetes Contributor Community (formerly SIG Meet & Greet; now abbreviated MKCC) is an event we hold during KubeCon + CloudNativeCon in order for new contributors to find a SIG in which to start contributing. SIG contributors occupy tables, and new and casual contributors drop by to chat. Secondarily, it is a lunchtime event for SIG members to see each other and chat.
 
-While the M&G does not take place during the Contributor Summit, it is considered part of it.
+While MKCC does not take place during the Contributor Summit, it is considered part of Contributor Summit.
 
 ## Roles & Staffing
 
-Aside from the SIG leads, this event is run by a Meet & Greet Coordinator (MGC), a role selected on the event staff for the Contributor Summit.
+Aside from the SIG leads, this event is run by a MKCC Coordinator (MC), a role selected on the event staff for the Contributor Summit.
 
 ### Skills and Qualifications
 
@@ -20,95 +20,104 @@ Aside from the SIG leads, this event is run by a Meet & Greet Coordinator (MGC),
 
 ## Audience
 
-The audience for the M&G consists of three groups:
+The audience for MKCC consists of three groups:
 
-- SIG and WG Leads and Subproject Owners: anyone who considers themselves a "SIG/WG member" can attend and work the tables.  We particularly want SIG leads and/or Subproject owners who can guide contributors in joining their SIG and/or contributing to a project.
-- New & Casual Contributors: the visitors for the M&G will be people who are interested in contributing to Kubernetes, or have contributed lightly but not really participated in a SIG.
-- Regular Contributors: the M&G is also for regular contributors who are trying to reach out to a SIG, usually about a stuck PR, review, or mutual project.
+- *SIG and WG Leads and Subproject Owners and Committee Members*: anyone who considers themselves a "SIG/WG member" can attend and work the tables. We particularly want SIG leads and/or Subproject owners who can guide contributors in joining their SIG and/or contributing to a project. Committee members are also encouraged to be at a table or otherwise identify themselves with pins to make it easier for contributors to stop by for a chat.
+- *New & Casual Contributors*: the visitors for MKCC will be people who are interested in contributing to Kubernetes or who have contributed lightly but not really participated in a SIG.
+- *Regular Contributors*: MKCC is also for regular contributors who are trying to reach out to a SIG, usually about a stuck PR, review, or mutual project.
 
-Some teams that are not SIGs or WGs may also participate, e.g. ClusterAPI or the CoCC.  There is no specific policy on this, deal with it on a case-by-case basis. Generally speaking, we want to say yes to teams that actually plan to show up as a group. In the rest of this document, "SIGs" should be considered to refer to "SIGs, WGs, and Teams".
+Some teams that are not SIGs or WGs may also participate, e.g. ClusterAPI or the CoCC. There is no specific policy on this, deal with it on a case-by-case basis. Generally speaking, we want to say yes to teams that actually plan to show up as a group. In the rest of this document, "SIGs" should be considered to refer to "SIGs, WGs, and Teams".
 
 ## Time and Location
 
-The M&G is generally held during lunch period on one of the main Kubecon days.  CNCF staff decides the exact schedule in order to not conflict with other lunchtime events.
+MKCC is generally held during lunch period on one of the main Kubecon days. CNCF staff decides the exact schedule in order to not conflict with other lunchtime events.
 
 ## Preparation & Timeline
 
 ### 2-3 Months Before: Room request and SIG gear
 
-Request a large room for the M&G from the CNCF Contributor Summit Liaison.  This will be a large room, set with at least 10 round tables.
+Request a large room for MKCC from the CNCF Contributor Summit Liaison. This will be a large room, set with at least 10 round tables.
 
-The gear for the M&G consists of table sign stands for each SIG, a bag of buttons for each SIG, and Kubernetes Contributor badge ribbons for folks who might not have gotten one.  Some of this gets used/goes missing each KubeCon, so ask CNCF staff to check that:
+The gear for MKCC consists of table sign stands for each SIG, a bag of buttons for each SIG, and Kubernetes Contributor badge ribbons for folks who might not have gotten one. Some of this gets used/goes missing each KubeCon. As the MC, you will get access to a spreadsheet to fill out to identify which SIGs are active and how many buttons should be present for each SIG. Use this sheet to ask CNCF staff to check the geat. Ensure, though the sheet, that:
 
 - All currently active SIGs have at least a dozen buttons
 - All currently active SIGs have table signs, and non-broken table stands
 
-The CNCF staff must do this because they have possession of the case of SIG gear.  However, the MGC should help by giving them a shortlist of the SIGs most likely to staff the event, as well as checking with them to remove any obsolete SIGs or WGs.
+The CNCF staff will handle actual inventory because they have possession of the case of SIG gear.  However, the MC should help by giving them a shortlist of the SIGs most likely to staff the event, as well as checking with them to remove any obsolete SIGs or WGs.
 
 If Kubernetes has a new SIG this year, or a team that really wants to recruit, notify the staff as soon as possible so that they can order new gear for that group.
 
-Additional gear that you might want to have at the M&G, depending on circumstances and availability:
+Additional gear that you might want to have at MKCC, depending on circumstances and availability:
 
 * Approver pins
 * Kubernetes contributor patches
+* Stickers
 
 ### 1 Month Before: Recruit SIG staffers
 
-Prepare a sign-up sheet for SIG volunteers, usually a spreadsheet so that folks from SIGs can see who else has signed up for their SIG.  Then work with Contributor Comms in order to message all of the SIG leads.  Notify folks on the following channels:
+Prepare a sign-up sheet for SIG volunteers, usually a GitHub issue or spreadsheet so that folks from SIGs can see who else has signed up for their SIG. GitHub issues seem to work better currently than spreadsheets, and everyone has access and gets notifications of changes.
+
+Then work with the event comms lead to message all of the SIG leads; you may end up doing this yourself, but ensure that you work with the comms lead to avoid overwhelming a channel with a notification. Notify folks of the signup opportunity on the following channels:
 
 - Slack, #chairs-and-techleads
-- Slack, #contributor-summit
-- kubernetes-dev mailing list
-- LWKD
+- leads mailing list
 - Ideally, a message to each of the primary #sig-* channels (this is a good task for a shadow, and should probably be bundled with outer communications)
+    - Generally, wait to see how the first two comms gains traction before reaching out in each sig-* channel. The leads generally respond very quickly to the first two comms, and then you only have a handful of groups to reach out to versus everyone.
 
 This solicitation might be bundled with other contributor-summit messaging that needs to go to all SIG leads, such as a call for booking SIG meeting rooms.
 
-Add a page in the Contributor Summit website for the Meet & Greet.
+Add a page in the Contributor Summit website for MKCC.
 
 # Follow-ups
 
-Check weekly to see who's signed up.  While participation by all SIGs is valuable, the following SIGs are particularly popular with 1st-time contributors, and if nobody signs up you should message them:  SIG-Docs, SIG-Release, SIG-CLI, SIG-Contributor Experience, SIG-K8s-Infra.
+Check weekly to see who's signed up. While participation by all SIGs is valuable, the following SIGs are particularly popular with 1st-time contributors, and if nobody signs up you should message them:
+    - SIG Docs
+    - SIG Release
+    - SIG CLI
+    - SIG Contributor Experience
+    - SIG K8s Infra
 
 ### 1 Week Before: Solicit Attendees and Send Reminders
 
-By this time, CNCF events should have given you a room number and day. Send out a reminder to all of the chairs and techleads as well as anyone who signed up, and give them the updated information including the location and time.  Update the Summit website with the full information.
+By this time, CNCF events should have given you a room number and day. Send out a reminder to all of the chairs and techleads as well as anyone who signed up, and give them the updated information including the location and time. Update the Summit website with the full information.
 
-Working with Comms, advertise the Meet & Greet to Kubecon attendees and community members.  This should include advertising it on community channels, including social media, #contributor-summit, #kubernetes-contributors, and kubernetes-dev ML, and LWKD.  You should also make sure that it gets into at least one of Kubecon's official messages to attendees; ask CNCF about this.
+Working with Comms, advertise MKCC to any and all KubeCon attendees and community members. This should include advertising it on community channels, including social media, #contributor-summit, #kubernetes-contributors, the kubernetes-dev mailing list, and LWKD. You should also make sure that it gets into at least one of KubeCon's official messages to attendees; ask CNCF about this.
 
-Stretch Goal: prepare a post-M&G survey.  We haven't actually done one of these before, so you'll be starting from scratch.  Good questions to ask: how do they feel it went, how many folks from their SIG were there, and how many contributors did they talk to (and maybe a newbie/experienced estimate).  For attendees, it would ask which SIG(s) they were seeking, why, and if they found what they were looking for. Print QR codes for the survey to have on the tables.
+*Stretch Goal: prepare a post-M&G survey.  We haven't actually done one of these before, so you'll be starting from scratch.  Good questions to ask: how do they feel it went, how many folks from their SIG were there, and how many contributors did they talk to (and maybe a newbie/experienced estimate).  For attendees, it would ask which SIG(s) they were seeking, why, and if they found what they were looking for. Print QR codes for the survey to have on the tables.*
 
-Decide whether you'll have a sign-in sheet for attendees.  This is unnecessary if you're doing a survey, but if you're not, you should at least have sign-ins. If so, design & print it out.
+Decide whether you'll have a sign-in sheet for attendees. This is unnecessary if you're doing a survey, but if you're not, you should at least have sign-ins. If so, design & print it out.
 
 ### 1 Day Before
 
-If possible, check out the space assigned to the M&G, just in case there are problems with it.  If there are, raise them with our CNCF event staff.
+If possible, check out the space assigned to MKCC, just in case there are problems with it. If there are, raise them with our CNCF event staff.
 
 Check that all SIGs who intended to attend are accounted for and were able to make it to the event. In the case of anyone with last-minute travel cancellations, identify if someone can cover for them. If a SIG cannot get members out due to travel issues, solicit help to staff their table from related groups or SIG ContribEx.
 
+If possible, put together short directions (plus pictures) to the MKCC room from the main conference area to send to Comms for posting on social media and via email.
+
 ### Day Of
 
-Get to the room 15-30 minutes before SIG volunteers are due to arrive.  Work with CNCF staff to distribute the SIG packs among the tables.  SIGs will have to share tables, so try to combine them in ways that make sense, such as SIG-Testing with SIG-K8s-Infra and SIG-Networking with SIG-Multicluster.  Consult the signup sheet, though, to see who's actually expected to show up.  While signups are not reliable, they will tell you which SIGs are likely to have large contingents so that you don't seat them together.
+Get to the room 15-30 minutes before SIG volunteers are due to arrive. Work with CNCF staff to distribute the SIG packs among the tables. SIGs will have to share tables, so try to combine them in ways that make sense, such as SIG Testing with SIG K8s Infra and SIG Networking with SIG Multicluster. Consult the signup sheet, though, to see who's actually expected to show up. While signups are not reliable, they will tell you which SIGs are likely to have large contingents so that you don't seat them together.
 
-If you don't have shadow(s), then recruit a couple folks from SIG-ContribEx to help with setup.
+If you don't have shadow(s), then recruit a couple folks from SIG ContribEx to help with setup.
 
-Each pack has SIG buttons in it, and a table stand with a sign.  Set up the table stands for the SIGs who RSVPd; leave the others in the bag.
+Each pack has SIG buttons and a table stand with a sign. Set up the table stands for the SIGs who RSVPd; leave the others in the bag.
 
-The SIG-Beard pack is special. Leave it in the box unless someone who knows what to do with it shows up.
+The SIG Beard pack is special. Leave it in the box unless someone who knows what to do with it shows up.
 
 Wear some kind of Kubernetes gear, to help identify you as staff.
 
-If possible, put together short directions (plus pictures) to the M&G room from the main conference area to send to Comms for posting on social media and via email.
+If possible, put together short directions (plus pictures) to the MKCC room from the main conference area to send to Comms for posting on social media and via email.
 
-### During the M&G
+### During MKCC
 
 Hover near the entrance to help attendees find the SIGs they are looking for. Sometimes they won't know, so be ready to chat about their interests with them and direct them appropriately.
 
 Take pictures and forward them to Comms to send out on social media to further promote contributions.
 
-### After the M&G
+### After MKCC
 
-Folks will probably still be chatting when the event ends.  Generally the room is not otherwise in use and you don't need to kick them out.  However, you do need to pack up the SIG packs for the staff; recruit anyone still at the tables to help.  Members of ContribEx will also help with this.
+Folks will probably still be chatting when the event ends. Generally, the room is not otherwise in use, and you don't need to kick them out. However, you do need to pack up the SIG packs for the staff; recruit anyone still at the tables to help. Members of ContribEx will also help with this.
 
 ### Day After
 
@@ -116,20 +125,20 @@ Send out a thank you to the SIG Leads, and a link to the survey, if you're doing
 
 ## Notes and Tasks
 
-Some additional notes based on experience from prior M&G events:
+Some additional notes based on experience from prior MKCC events:
 
 - Create a form to track the details about each SIG / WG representative. See the example from the [2019 San Diego SIG M&G](https://forms.gle/hxx1qz8XtwtXEBMm8) for more details about what information to gather.
-- Contact each SIG / WG and ask them to have 1 or more experienced members complete the form and commit to represent the group at the Meet and Greet.
+- Contact each SIG / WG and ask them to have 1 or more experienced members complete the form and commit to represent the group at MKCC.
 - Expect to spend a fair amount of time following up with SIGs and WGs to get the name of their representatives.
-- Add these representatives to a calendar notice for the SIG Meet and Greet.
-- Work with the registration lead to make sure that representatives are registered for the summit and follow up with any representatives who have not registered.
-- Make sure that we have table stands and buttons for each SIG that are organized and easy to hand out at the beginning of the event. These were done in alphabetized reusable bags for San Diego, which worked really well. 
+- Add these representatives to a calendar notice for MKCC.
+- Ensure the table stands are all useable when you arrive. It's a lot easier to put each bag on tables, then set up the stands. The CNCF events liasion should have some extras in the box. 
 - Create a plan and map for organizing SIGs / WGs at tables to make it easier for attendees to find SIGs. Get the room layout from the venue and pre-assign SIGs / WGs to tables with some thought given to logical groupings with similar topics in close proximity. Make sure that this plan is communicated to volunteers and other organizers and display the room layout / map on the projector to help people find their tables.
 - Recruit a few volunteers to distribute table stands and buttons and to help SIGs / contributors find the right tables. 
-- Make a short announcement at the beginning with an overview of how it works.
 - Walk around the room throughout the event to help lost contributors get matched up with a SIG table.
+- A lot of contributors use this as a lunchtime hangout. Don't forget to get a lunch, yourself!
 
 ### Prior M&Gs
 
+- [MKCC Chicago 2023](https://github.com/kubernetes/community/issues/7541)
 - [SIG Meet and Greet Barcelona 2019](https://github.com/kubernetes/community/issues/3516)
 - [SIG Meet and Greet San Diego 2019](https://github.com/kubernetes/community/issues/3896)

--- a/events/events-team/content/meet-and-greet.md
+++ b/events/events-team/content/meet-and-greet.md
@@ -30,7 +30,7 @@ Some teams that are not SIGs or WGs may also participate, e.g. ClusterAPI or the
 
 ## Time and Location
 
-MKCC is generally held during lunch period on one of the main Kubecon days. CNCF staff decides the exact schedule in order to not conflict with other lunchtime events.
+MKCC is generally held during lunch period on one of the main KubeCon days. CNCF staff decides the exact schedule in order to not conflict with other lunchtime events.
 
 ## Preparation & Timeline
 
@@ -38,7 +38,7 @@ MKCC is generally held during lunch period on one of the main Kubecon days. CNCF
 
 Request a large room for MKCC from the CNCF Contributor Summit Liaison. This will be a large room, set with at least 10 round tables.
 
-The gear for MKCC consists of table sign stands for each SIG, a bag of buttons for each SIG, and Kubernetes Contributor badge ribbons for folks who might not have gotten one. Some of this gets used/goes missing each KubeCon. As the MC, you will get access to a spreadsheet to fill out to identify which SIGs are active and how many buttons should be present for each SIG. Use this sheet to ask CNCF staff to check the geat. Ensure, though the sheet, that:
+The gear for MKCC consists of table sign stands for each SIG, a bag of buttons for each SIG, and Kubernetes Contributor badge ribbons for folks who might not have gotten one. Some of this gets used/goes missing each KubeCon. As the MC, you will get access to a spreadsheet to fill out to identify which SIGs are active and how many buttons should be present for each SIG. Use this sheet to ask CNCF staff to check the gear. Ensure, though the sheet, that:
 
 - All currently active SIGs have at least a dozen buttons
 - All currently active SIGs have table signs, and non-broken table stands

--- a/events/events-team/content/meet-and-greet.md
+++ b/events/events-team/content/meet-and-greet.md
@@ -131,7 +131,7 @@ Some additional notes based on experience from prior MKCC events:
 - Contact each SIG / WG and ask them to have 1 or more experienced members complete the form and commit to represent the group at MKCC.
 - Expect to spend a fair amount of time following up with SIGs and WGs to get the name of their representatives.
 - Add these representatives to a calendar notice for MKCC.
-- Ensure the table stands are all useable when you arrive. It's a lot easier to put each bag on tables, then set up the stands. The CNCF events liasion should have some extras in the box. 
+- Ensure the table stands are all useable when you arrive. It's a lot easier to put each bag on tables, then set up the stands. The CNCF events liaison should have some extras in the box. 
 - Create a plan and map for organizing SIGs / WGs at tables to make it easier for attendees to find SIGs. Get the room layout from the venue and pre-assign SIGs / WGs to tables with some thought given to logical groupings with similar topics in close proximity. Make sure that this plan is communicated to volunteers and other organizers and display the room layout / map on the projector to help people find their tables.
 - Recruit a few volunteers to distribute table stands and buttons and to help SIGs / contributors find the right tables. 
 - Walk around the room throughout the event to help lost contributors get matched up with a SIG table.


### PR DESCRIPTION
Updating the Contributor Summit events handbook with renaming of the SIG Meet & Greet to Meet the Kubernetes Contributor Community (MKCC) and added notes and updates from this past run at KubeCon/CloudNativeCon NA 2023.

/assign @nimbinatus
/sig contributor-experience
/area contributor-summit