### PR TITLE
Add #myks Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -358,6 +358,7 @@ channels:
   - name: monolith
     archived: true
   - name: multi-platform
+  - name: myks
   - name: mysql-operator
   - name: nais
   - name: nauticus


### PR DESCRIPTION
[Myks](https://github.com/mykso/myks) is an automation tool and configuration framework. It helps to manage configuration for many Kubernetes clusters by generating a source of truth from the provided configuration. It heavily relies on some of the Carvel tools (ytt, vendir) and helm, and provides integration with ArgoCD.

At the moment, it is used in production in a couple of companies, but it is still in active development. We have a channel in one of the companies' Slack workspace, but it is not public. We want to work towards onboarding more users and contributors. We think that Kubernetes Slack is the most appropriate place for that.

I am one of the maintainers of the project, and I am happy to answer any questions.
