### PR TITLE
Fix outdated conformance test requirement

### DIFF
--- a/contributors/devel/sig-architecture/conformance-tests.md
+++ b/contributors/devel/sig-architecture/conformance-tests.md
@@ -38,8 +38,9 @@ specifically, a test is eligible for promotion to conformance if:
   use the kubelet API for debugging purposes upon failure
 - it works for all providers (e.g., no `SkipIfProviderIs`/`SkipUnlessProviderIs`
   calls)
-- it is non-privileged (e.g., does not require root on nodes, access to raw
-  network interfaces, or cluster admin permissions)
+- it limits itself to capabilities exposed via APIs (e.g., does not require
+  root on nodes, access to raw network interfaces) and does not require write
+  access to system namespaces (like kube-system)
 - it works without access to the public internet (short of whatever is required
   to pre-pull images for conformance tests)
 - it works without non-standard filesystem permissions granted to pods


### PR DESCRIPTION
It's not true that running conformance test is non-privileged and does not require cluster admin permissions.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/122220
