### PR TITLE
Remove references to Gubernator in Contributors and Comms docs

### DIFF
--- a/communication/best-practices.md
+++ b/communication/best-practices.md
@@ -14,13 +14,8 @@ your email account to attain a good signal-to-noise ratio with regards to the
 mailing list messages and GitHub notifications. All the steps below are for Gmail
 users, however similar filters can be made in other email clients.
 
-**Note:** Alternatively, we highly encourage people to use [Gubernator] to
-view and acknowledge their Pull Request review notifications.
-
 [Special Interest Groups (SIG)]: /sig-list.md#master-sig-list
 [Working Groups (WG)]: /sig-list.md#master-working-group-list
-[Gubernator]: https://gubernator.k8s.io/pr
-
 
 ## Creating filters for Kubernetes Mailing lists
 

--- a/contributors/chairs-and-techleads/process-workflow-guide.md
+++ b/contributors/chairs-and-techleads/process-workflow-guide.md
@@ -79,7 +79,6 @@ Triaging is an effective method for improving responsiveness to contributor requ
 - maintaining company agnosticism. “Devs from other SIGs don’t have to ask for any favors in getting PRs to move forward—it’s just part of the process,” API Machinery Chair Fede Bongiovanni says. “Features don't get biased development.”
 
 You can find [comprehensive triaging guidelines](/contributors/guide/issue-triage.md) here, along with information about triage tools used across the project:
-- **[Gubernator](https://gubernator.k8s.io)**: a personal dashboard that shows you PRs awaiting your review
 - **[Triage Party](https://github.com/google/triage-party)**: a stateless web app to optimize issue and PR triage for large open-source projects using the GitHub API. More details are below. (Cluster Lifecycle, SIG Release) 
 - **[GitHub project boards](https://docs.github.com/en/github/managing-your-work-on-github/managing-project-boards)**: these kanban boards allow you to track GitHub issues and PRs in an automated way. More details are below.
 

--- a/contributors/guide/contributor-cheatsheet/README-de.md
+++ b/contributors/guide/contributor-cheatsheet/README-de.md
@@ -62,7 +62,6 @@ nützlicher Informationen gedacht, um deine Beitragserfahrung auf GitHub besser 
 
 ### Ablauf
 
-- [Gubernator Dashboard] - Eingehende und Ausgehende Pull-Requests, die Aufmerksamkeit erfordern.
 - [Prow] - Kubernetes CI/CD-System.
 - [Tide] - Prow-Plugin das Merges und Tests verwaltet. [Tide Dashboard]
 - [Bot-Befehle] - Befehle zur Interaktion mit Kubernetes-Bots (zum Beispiel: `/cc`, `/lgtm`, und `/retest`)
@@ -345,7 +344,6 @@ anderer Beitragenden zu überlassen, die als Reviewer und Approver für den PR z
 
 [Contributor Guide]: /contributors/guide/README.md
 [Developer Guide]: /contributors/devel/README.md
-[Gubernator Dashboard]: https://gubernator.k8s.io/pr
 [Prow]: https://prow.k8s.io
 [Tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [Tide Dashboard]: https://prow.k8s.io/tide

--- a/contributors/guide/contributor-cheatsheet/README-fr.md
+++ b/contributors/guide/contributor-cheatsheet/README-fr.md
@@ -57,7 +57,6 @@ C'est un "TL;DR" ou une référence rapide d'informations utiles pour améliorer
 
 ### Workflow
 
-- [Gubernator Dashboard] - Voir les Pull Requests entrantes et sortantes qui nécessitent votre attention.
 - [Prow] - Kubernetes CI/CD System.
 - [Tide] - Prow plugin that manages merges and tests. [Tide Dashboard]
 - [Bot commands] - Commands used to interact with Kubernetes Bots (examples:
@@ -285,7 +284,6 @@ Si vous ne savez pas si vous devez faire un squash de vos commits, il est préf�
 
 [guide du contributeur]: /contributors/guide/README.md
 [guide du développeur]: /contributors/devel/README.md
-[gubernator dashboard]: https://gubernator.k8s.io/pr
 [prow]: https://prow.k8s.io
 [tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [tide dashboard]: https://prow.k8s.io/tide

--- a/contributors/guide/contributor-cheatsheet/README-hi.md
+++ b/contributors/guide/contributor-cheatsheet/README-hi.md
@@ -57,7 +57,6 @@
 
 ### वर्कफ़्लो
 
-- [Gubernator डैशबोर्ड] - आने वाले और बाहर जाने वाले pull requests को देखें जिन्हें आवश्यकता है आपके ध्यान की।
 - [Prow] - कुबेरनेट्स CI/CD सिस्टम।
 - [Tide] - मर्ज और परीक्षण का प्रबंधन करने वाले प्लगइन को साबित करें। [टाइड डैशबोर्ड]
 - [बॉट कमांड] - कमांड को कुबेरनेट्स बॉट्स के साथ बातचीत करने के लिए इस्तेमाल किया जाता है (उदाहरण: `/cc`, `/lgtm`, और `/retest`)
@@ -276,7 +275,6 @@ PR संशोधन का चरण। यदि आप अनिश्चि
 
 [योगदानकर्ता गाइड]: /contributors/guide/README.md
 [डेवलपर गाइड]: /contributors/devel/README.md
-[gubernator डैशबोर्ड]: https://gubernator.k8s.io/pr
 [prow]: https://prow.k8s.io//prow.k8s.io-tide
 [tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [tide डैशबोर्ड]: https:

--- a/contributors/guide/contributor-cheatsheet/README-id.md
+++ b/contributors/guide/contributor-cheatsheet/README-id.md
@@ -63,7 +63,6 @@ di GitHub menjadi lebih baik.
 
 ### _Workflow_
 
-- [Dasbor Gubernator] - Melihat Pull Request yang masuk dan keluar yang memerlukan perhatian.
 - [Prow] - Mekanisme CI/CD Kubernetes.
 - [Tide] - _Plugin_ Prow yang melakukan manajemen _merge_ dan _test_. [Dasbor Tide]
 - [Perintah Bot] - Perintah yang dapat kamu gunakan untuk berinteraksi dengan Bot Kubernetes (contoh:
@@ -346,7 +345,6 @@ _squashing_ perlu dilakukan atau tidak.
 
 [Panduan Kontributor]: /contributors/guide/README.md
 [Panduan Pengembang]: /contributors/devel/README.md
-[dasbor gubernator]: https://gubernator.k8s.io/pr
 [prow]: https://prow.k8s.io
 [tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [dasbor tide]: https://prow.k8s.io/tide

--- a/contributors/guide/contributor-cheatsheet/README-it.md
+++ b/contributors/guide/contributor-cheatsheet/README-it.md
@@ -63,7 +63,6 @@ condensato di informazioni utili per rendere migliore la tua esperienza di GitHu
 
 ### Workflow
 
-- [Gubernator Dashboard] - Visualizza le Pull request che richiedono la tua attenzione.
 - [Prow] - Kubernetes CI/CD System.
 - [Tide] - Prow plugin che gestisce il merge delle PR e l'esecuzione dei tests. [Tide Dashboard]
 - [Bot commands] - Guida ai comandi utilizzati per interagire con i bot di Kubernetes (examples:
@@ -353,7 +352,6 @@ git push --force
 
 [contributor guide]: /contributors/guide/README.md
 [developer guide]: /contributors/devel/README.md
-[gubernator dashboard]: https://gubernator.k8s.io/pr
 [prow]: https://prow.k8s.io
 [tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [tide dashboard]: https://prow.k8s.io/tide

--- a/contributors/guide/contributor-cheatsheet/README-ja.md
+++ b/contributors/guide/contributor-cheatsheet/README-ja.md
@@ -57,7 +57,6 @@ Kubernetesにコントリビュートする際のtipsや、Kubernetesプロジ�
 
 ### ワークフロー
 
-- [Gubernatorダッシュボード] - 注意して見ておくべきPull Requests
 - [Prow] - KubernetesのCI/CDシステム
 - [Tide] - mergeやtestを管理するためのProw用プラグイン [Tideダッシュボード]
 - [Botコマンド] - KubernetesのBotとコミュニケーションをとるためのコマンド (例: `/cc`、`/lgtm`や`/retest`)
@@ -302,7 +301,6 @@ git push --force
 
 [コントリビューターガイド]: /contributors/guide/README.md
 [開発者ガイド]: /contributors/devel/README.md
-[gubernatorダッシュボード]: https://gubernator.k8s.io/pr
 [prow]: https://prow.k8s.io
 [tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [tideダッシュボード]: https://prow.k8s.io/tide

--- a/contributors/guide/contributor-cheatsheet/README-ko.md
+++ b/contributors/guide/contributor-cheatsheet/README-ko.md
@@ -63,8 +63,6 @@
 
 ### 작업 흐름
 
-- [Gubernator 대시보드] - 주목이 필요한 수신/발신 풀 리퀘스트
-  확인
 - [Prow] - 쿠버네티스 CI/CD 시스템
 - [Tide] - 머지와 테스트를 관리하는 Prow 플러그인 [Tide 대시보드]
 - [Bot 명령] - 쿠버네티스 Bot과 상호 작용하는데 사용하는 명령 (예시:
@@ -351,7 +349,6 @@ PR을 검토하고 승인하도록 지정된 다른 참여자의 판단에 맡�
 
 [컨트리뷰터 가이드]: /contributors/guide/README.md
 [개발자 가이드]: /contributors/devel/README.md
-[Gubernator 대시보드]: https://gubernator.k8s.io/pr
 [prow]: https://prow.k8s.io
 [tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [tide 대시보드]: https://prow.k8s.io/tide

--- a/contributors/guide/contributor-cheatsheet/README-pt.md
+++ b/contributors/guide/contributor-cheatsheet/README-pt.md
@@ -59,7 +59,6 @@ Melhor.
 
 ### Fluxo de trabalho
 
-- [Gubernator Dashboard] - Ver Pull Requests que exigem sua atenção.
 - [Prow] - Kubernetes CI/CD System.
 - [Tide] - Plugin Prow que gerencia merges e testes. [Tide Dashboard]
 - [Comandos do Bot] - Comandos usados ​​para interagir com o Kubernetes Bots (exemplos:
@@ -332,7 +331,6 @@ fase de uma revisão do PR. Se você não tem certeza se deve efetuar o squashin
 
 [Guia do Contribuidor]: /contributors/guide/README.md
 [Guia do Desenvolvedor]: /contributors/devel/README.md
-[Gubernator dashboard]: https://gubernator.k8s.io/pr
 [prow]: https://prow.k8s.io
 [tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [tide dashboard]: https://prow.k8s.io/tide

--- a/contributors/guide/contributor-cheatsheet/README-uk.md
+++ b/contributors/guide/contributor-cheatsheet/README-uk.md
@@ -57,7 +57,6 @@
 
 ### Робочий процес
 
-- [Gubernator Dashboard] - Перегляд вхідних та вихідних Pull Request, що потребують вашої уваги.
 - [Prow] - Kubernetes CI/CD система.
 - [Tide] - Prow плаґін для управління процесом злиття змін до основної гілки репозиторія (merge) і тестами. [Tide Dashboard]
 - [Команди бота] - Команди для взаємодії з ботами Kubernetes (наприклад:
@@ -278,7 +277,6 @@ git checkout -b myfeature
 
 [Керівництво для контриб'юторів]: /contributors/guide/README.md
 [Керівництво для розробників]: /contributors/devel/README.md
-[gubernator dashboard]: https://gubernator.k8s.io/pr
 [prow]: https://prow.k8s.io
 [tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [tide dashboard]: https://prow.k8s.io/tide

--- a/contributors/guide/contributor-cheatsheet/README-zh.md
+++ b/contributors/guide/contributor-cheatsheet/README-zh.md
@@ -57,7 +57,6 @@
 
 ### 工作流程
 
-- [Gubernator 仪表盘] - 收到和发出的 PR，您需要关注它们
 - [Prow] - Kubernetes CI/CD 系统
 - [Tide] - 管理合并和测试的 Prow 插件 [Tide 仪表盘]
 - [Bot 命令] - 用来和 Kubernetes 机器人互动的命令（例如 `/cc`、`/lgtm` 和 `/retest`）
@@ -283,7 +282,6 @@ git checkout -b myfeature
 
 [贡献者指南]: /contributors/guide/README.md
 [开发者指南]: /contributors/devel/README.md
-[gubernator 仪表盘]: https://gubernator.k8s.io/pr
 [prow]: https://prow.k8s.io
 [tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
 [tide 仪表盘]: https://prow.k8s.io/tide

--- a/contributors/guide/issue-triage.md
+++ b/contributors/guide/issue-triage.md
@@ -14,7 +14,6 @@ description: |
 - [How to Triage: A Step-by-Step Flow](#how-to-triage-a-step-by-step-flow)
    - [Triage-Related Tools](#triage-related-tools)
       - [Permissions and the Bot](#permissions-and-the-bot)
-      - [Gubernator](#gubernator)
       - [Triage Party](#triage-party)
       - [GitHub Project Boards](#github-project-boards)
       - [DevStats](#devstats)
@@ -78,10 +77,6 @@ These are tools that your SIG can use to make the triage process simpler, more e
 ### Permissions and the Bot
 
 Opening new issues and leaving comments on other people's issues are possible for all contributors. However, permission to assign specific labels (such as `triage`), change milestones, or close other contributors issues is only granted to the author of an issue, assignees, and organization members. For this reason, we use a bot to manage labelling and triaging. For a full list of the bot's commands and permissions, see the [Prow command reference page](https://go.k8s.io/bot-commands).
-
-### Gubernator
-
-[Gubernator](https://gubernator.k8s.io/pr) offers a dashboard that tells you which pull requests are waiting for your feedback and which PRs are waiting for the contributor to respond. Please note that Gubernator only shows *pull requests*. You will not see which issues are assigned to you.
 
 ### Triage Party
 


### PR DESCRIPTION
Gubernator is deprecated since June, 2023
Info on the discontinuation:
https://groups.google.com/a/kubernetes.io/g/dev/c/SIpSxGqu_3Q

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7635 
