### PR TITLE
remove todo of adding instructions to flaking test issue template

### DIFF
--- a/contributors/devel/sig-testing/flaky-tests.md
+++ b/contributors/devel/sig-testing/flaky-tests.md
@@ -191,8 +191,6 @@ In addition, be sure to include the following information:
 For a good example of a flaking test issue,
 [check here](https://github.com/kubernetes/kubernetes/issues/93358).
 
-([TODO](https://github.com/kubernetes/kubernetes/issues/95528): Move these instructions to the issue template.)
-
 ## Deflaking unit tests
 
 To get started with deflaking unit tests, you will need to first


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/95528

```
([TODO](https://github.com/kubernetes/kubernetes/issues/95528): Move these instructions to the issue template.)
```

https://github.com/kubernetes/kubernetes/blob/master/.github/ISSUE_TEMPLATE/flaking-test.yaml is updated by https://github.com/kubernetes/kubernetes/pull/104468.

In https://github.com/kubernetes/kubernetes/issues/new?assignees=&labels=kind%2Fflake&projects=&template=flaking-test.yaml, we can see the link of flaking test now.

Or do we need to add more instructions there? All that we may miss is about how to check multi job failure and multi test failure with similar reason, but this is already in the first link.