### PR TITLE
Add gophercloud-maintainers slack user group

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -323,3 +323,13 @@ usergroups:
       - sgtcodfish
       - inteon
 
+  - name: gophercloud-maintainers
+    long_name: Gophercloud Maintainers
+    description: Gophercloud Maintainers group.
+    channels:
+      - gophercloud
+    members:
+      - EmilienM
+      - kayrus
+      - mandre
+      - pierreprinetti

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -64,6 +64,7 @@ users:
   dougm: U8GG20UE9
   elezar: ULV21K3CH
   elsony: UCW8323KL
+  EmilienM: U01BVTA83D4
   enj: U2T4CVDTJ
   erismaster: U0162FJ79LY
   estroz: UKSEANEC9
@@ -126,6 +127,7 @@ users:
   kaslin: U5ENKU0AE
   katcosgrove: U01GDERGEHF
   katharine: UBTBNJ6GL
+  kayrus: U20RS7A72
   kikisdeliveryservice: U9HFFRFT2
   killianmuldoon: UGW727X6Z
   kim-tsao: U02U1LDH4T1
@@ -141,6 +143,7 @@ users:
   lukehinds: UN2P2M4F4
   MadhavJivrajani: U01L7R0JGCE
   maelvls: UKYB4CKNJ
+  mandre: UHG9XEUU8
   mansikulkarni96: U01SEDZGPA5
   marc-obrien: UL51BRL9Y
   margocrawf: U01FWP2K74J
@@ -186,6 +189,7 @@ users:
   pb82: U019M8295AQ
   pensu91: U44FHF81G
   phenixblue: UB4UVLEAK
+  pierreprinetti: ULU8K49S5
   pnbrown: U011JJTQVGF
   pohly: U91901TMF
   prajyot-parab: U02MVRCN8CX


### PR DESCRIPTION
This PR adds a new `gophercloud-maintainers` slack user group, for the maintainers of the Gophercloud project.
