### PR TITLE
update leadership change template to include OWNERS_ALIAS list item f…

### DIFF
--- a/.github/ISSUE_TEMPLATE/leadership-change.yml
+++ b/.github/ISSUE_TEMPLATE/leadership-change.yml
@@ -53,7 +53,7 @@ body:
     - label: Checked for and updated any other potential teams in [kubernetes/org](https://git.k8s.io/org/).
     - label: Updated [OWNERS_ALIASES](https://git.k8s.io/enhancements/OWNERS_ALIASES) in [kubernetes/enhancements](https://github.com/kubernetes/enhancements).
     - label: Updated [OWNERS_ALIASES](https://git.k8s.io/k8s.io/OWNERS_ALIASES) in [kubernetes/k8s.io](https://git.k8s.io/k8s.io/).
-    - label: Updated feature-approvers in [OWNERS_ALIASES](https://git.k8s.io/k8s.io/OWNERS_ALIASES) in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (when applicable)
+    - label: Updated feature-approvers in [OWNERS_ALIASES](https://git.k8s.io/kubernetes/OWNERS_ALIASES) in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (when applicable)
     - label: "Updated [membership](https://git.k8s.io/k8s.io//groups/groups.yaml) of the [leads mailing list](https://groups.google.com/a/kubernetes.io/g/leads)"
     - label: "Updated membership for any other [mailing list / groups](https://git.k8s.io/k8s.io//groups/)."
     - label: "Added to `#chairs-and-techleads` slack channel."

--- a/.github/ISSUE_TEMPLATE/leadership-change.yml
+++ b/.github/ISSUE_TEMPLATE/leadership-change.yml
@@ -53,7 +53,7 @@ body:
     - label: Checked for and updated any other potential teams in [kubernetes/org](https://git.k8s.io/org/).
     - label: Updated [OWNERS_ALIASES](https://git.k8s.io/enhancements/OWNERS_ALIASES) in [kubernetes/enhancements](https://github.com/kubernetes/enhancements).
     - label: Updated [OWNERS_ALIASES](https://git.k8s.io/k8s.io/OWNERS_ALIASES) in [kubernetes/k8s.io](https://git.k8s.io/k8s.io/).
-    - label: Updated feature-approvers in [OWNERS_ALIASES](https://git.k8s.io/k8s.io/OWNERS_ALIASES) in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+    - label: Updated feature-approvers in [OWNERS_ALIASES](https://git.k8s.io/k8s.io/OWNERS_ALIASES) in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (when applicable)
     - label: "Updated [membership](https://git.k8s.io/k8s.io//groups/groups.yaml) of the [leads mailing list](https://groups.google.com/a/kubernetes.io/g/leads)"
     - label: "Updated membership for any other [mailing list / groups](https://git.k8s.io/k8s.io//groups/)."
     - label: "Added to `#chairs-and-techleads` slack channel."

--- a/.github/ISSUE_TEMPLATE/leadership-change.yml
+++ b/.github/ISSUE_TEMPLATE/leadership-change.yml
@@ -53,6 +53,7 @@ body:
     - label: Checked for and updated any other potential teams in [kubernetes/org](https://git.k8s.io/org/).
     - label: Updated [OWNERS_ALIASES](https://git.k8s.io/enhancements/OWNERS_ALIASES) in [kubernetes/enhancements](https://github.com/kubernetes/enhancements).
     - label: Updated [OWNERS_ALIASES](https://git.k8s.io/k8s.io/OWNERS_ALIASES) in [kubernetes/k8s.io](https://git.k8s.io/k8s.io/).
+    - label: Updated feature-approvers in [OWNERS_ALIASES](https://git.k8s.io/k8s.io/OWNERS_ALIASES) in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
     - label: "Updated [membership](https://git.k8s.io/k8s.io//groups/groups.yaml) of the [leads mailing list](https://groups.google.com/a/kubernetes.io/g/leads)"
     - label: "Updated membership for any other [mailing list / groups](https://git.k8s.io/k8s.io//groups/)."
     - label: "Added to `#chairs-and-techleads` slack channel."


### PR DESCRIPTION
@danwinship mentioned this in https://github.com/kubernetes/community/issues/7650#issuecomment-1860419975, and it seems to me that yes, indeed we should have a list item to remind us to update the `OWNERS_ALIAS` in `kubernetes/kubernetes` (as needed).