### PR TITLE
sig-release: add obscli repo under release-engineering subproject

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -72,6 +72,7 @@ The Release Engineering subproject is responsible for the [process/procedures](h
   - [kubernetes-sigs/bom](https://github.com/kubernetes-sigs/bom/blob/main/OWNERS)
   - [kubernetes-sigs/downloadkubernetes](https://github.com/kubernetes-sigs/downloadkubernetes/blob/master/OWNERS)
   - [kubernetes-sigs/mdtoc](https://github.com/kubernetes-sigs/mdtoc/blob/master/OWNERS)
+  - [kubernetes-sigs/obscli](https://github.com/kubernetes-sigs/obscli/blob/master/OWNERS)
   - [kubernetes-sigs/promo-tools](https://github.com/kubernetes-sigs/promo-tools/blob/main/OWNERS)
   - [kubernetes-sigs/release-actions](https://github.com/kubernetes-sigs/release-actions/blob/master/OWNERS)
   - [kubernetes-sigs/release-notes](https://github.com/kubernetes-sigs/release-notes/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2475,6 +2475,7 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/bom/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/downloadkubernetes/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/mdtoc/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/obscli/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/promo-tools/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/release-actions/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/release-notes/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4550

cc: @kubernetes/sig-release-leads 