### PR TITLE
Add Gaurav Padam as editor for blog

### DIFF
--- a/sig-docs/blog-subproject/README.md
+++ b/sig-docs/blog-subproject/README.md
@@ -17,7 +17,7 @@ See [meetings](/kubernetes/community/tree/master/sig-docs#meetings) for SIG Docs
 
 - **Blog shadow approvers:** _no contributors_
 
-- **Blog editors:** _no contributors_
+- **Blog editors:** [Gaurav Padam](https://github.com/Gauravpadam)
 
 - **Blog shadow editors:** _no contributors_
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**: _none_

Per https://github.com/kubernetes/website/pull/44607, add Gaurav Padam to the blog team.