### PR TITLE
Archive past years of SIG-node agenda

### DIFF
--- a/sig-node/archive/README.md
+++ b/sig-node/archive/README.md
@@ -8,6 +8,9 @@ to the [SIG Node README](../README.md) for details.
 
 ## Meeting Archives
 
+* [2023](meeting-notes-2023.md)
+* [2022](meeting-notes-2022.md)
+* [2021](meeting-notes-2021.md)
 * [2020](meeting-notes-2020.md)
 * [2019](meeting-notes-2019.md)
 * [2018](meeting-notes-2018.md)

--- a/sig-node/archive/meeting-notes-2021.md
+++ b/sig-node/archive/meeting-notes-2021.md
@@ -1,0 +1,3443 @@
+# SIG Node Meeting Notes
+
+## December 28, 2021 Cancelled
+
+
+
+* [dawnchen] Cancelled
+
+
+## December 21, 2021 Cancelled
+
+
+
+* [dawnchen] Cancelled
+
+
+## December 14, 2021
+
+Total active pull requests: [207](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+6)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-12-07T17%3A00%3A00%2B0000..2021-12-14T17%3A52%3A13%2B0000">32</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-12-07T17%3A00%3A00%2B0000..2021-12-14T17%3A52%3A13%2B0000">9</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-12-07T17%3A00%3A00%2B0000..2021-12-14T17%3A52%3A13%2B0000+created%3A%3C2021-12-07T17%3A00%3A00%2B0000">82</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-12-07T17%3A00%3A00%2B0000..2021-12-14T17%3A52%3A13%2B0000">20</a>
+   </td>
+  </tr>
+</table>
+
+
+Highlights:
+
+	[https://github.com/kubernetes/kubernetes/pull/97252](https://github.com/kubernetes/kubernetes/pull/97252) Dockershim was removed!
+
+
+
+* [pohly, klueska] [Dynamic resource allocation KEP](https://github.com/kubernetes/enhancements/pull/3064) discussion
+    * Presentation
+    * [dawn] As a reference, the same use case was explored by us 4 years ago, and here is the proposal made by jiayingz@ from Google: [https://docs.google.com/document/d/1qKiIVs9AMh2Ua5thhtvWqOqW0MSle_RV3lfriO1Aj6U/edit#](https://docs.google.com/document/d/1qKiIVs9AMh2Ua5thhtvWqOqW0MSle_RV3lfriO1Aj6U/edit#) 
+    * [Sergey] Latency in scheduling is in the design. Do we want to keep the existing API and fix similar issues as the KEP solving for it, assuming there are workloads which need low latency
+    * [Patrick] this is speculation at this point. We emphasize long running jobs, not short running ones.
+    * [sergey] resourceClaim has the same name as PVC, perhaps there should be explicitly called out differences table that will simplify the review. 
+    * [Patric] big difference - volumes are intentionally non-configurable, resources - customizeable
+    * Quota management was one of the concerns before. Plus scheduling latency
+    * [Patrick] Quota logic will be managed by vendor’s addon
+    * [Patrick] Implementing scheduler by storage vendor is not the ideal solution. Writing addon may be easier and more natural. Especially if you are using two vendors in the same cluster - implementing custom scheduling wouldn’t work
+    * [Dawn] yes, multiple vendors is a problem. Extending scheduler is a problem that needs to be solved.
+    * 1.24 may be too tight for the alpha. 
+* [mrunal] 1.24 planning (ehashman OOO) 
+    *  
+    * Moved to January
+* [vinaykul] In-Place Pod Vertical Scaling - plan for early 1.24 merge 
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+    * Pod resize E2E tests have been “weakened” for alpha.
+        * Resize success verified at cgroup instead of pod status.
+        * All 31 tests are [passing](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/102884/pull-kubernetes-e2e-gce-alpha-features/1468102950369890304/) now.
+    * Alpha-blocker issues: 
+        * Container hash excludes Resources with in-place-resize feature-gate enabled, toggling fg can restart containers.
+            * Please review [this](https://github.com/kubernetes/kubernetes/commit/a745b12136027c136e0d3dcace23db99ccdd0d71) incremental change which addresses it.
+        * Reviewer claims that code in convertToAPIContainerStatus [breaks non-mutating guarantees](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r665550094).
+            * It is unclear what part of the code [updates or mutates](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r738886048) any state. Need a response/clarification.
+        * Multiple reviewers have felt that the [NodeSwap issue](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-964440882) is a blocking issue. But in last week’s meeting we felt this may not be an <span style="text-decoration:underline;">alpha</span> blocker (No CI test failures seen after I weakened resize E2E tests and all tests passed). However, we want to be sure.
+            * Can we identify exact reasons why this would (or would not) be alpha blocker?
+
+
+## December 7, 2021
+
+Total PRs: [201](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-8)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-11-30T17%3A00%3A00%2B0000..2021-12-07T17%3A45%3A16%2B0000">15</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-11-30T17%3A00%3A00%2B0000..2021-12-07T17%3A45%3A16%2B0000">10</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-11-30T17%3A00%3A00%2B0000..2021-12-07T17%3A45%3A16%2B0000+created%3A%3C2021-11-30T17%3A00%3A00%2B0000">65</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-11-30T17%3A00%3A00%2B0000..2021-12-07T17%3A45%3A16%2B0000">14</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] Announcements
+    * Release is today! 1.24 should be opening soon
+    * Contributor Celebration is Dec. 16-18
+        * Registration & info: [https://www.kubernetes.dev/events/kcc2021/](https://www.kubernetes.dev/events/kcc2021/) 
+* [ehashman] Node 1.23 release retro
+    * 1.22 retro link: 
+    * 1.23 Node KEP Planning  
+    * SIG Node 1.23 KEPs  
+        * 8 of 14 implemented
+        * 3 exceptions requested
+        * 3 exceptions granted
+    * _Things that went well_
+        * Really liked we have a list of KEPs in a Google doc that we talk through; it’s good to see them all in one place and see who is working on what; this helped find connections and collaboration (+1)
+        * Soft freeze made the process much better from a contributor experience point of view, communication around it was also great, reviewers were comfortable reviewing the load of PRs
+        * Fixed a lot of CI issues, CI looks much better than previously (+1)
+        * Deprecation of DynamicKubeletConfig went very smoothly, removed from tests
+        * For the last 2-3 releases we’ve been doing a better job enumerating what we get done, it’s providing a good rhythm and focus everyone’s attention (+1)
+        * Appreciate that approvers are able to say “I’m not familiar with this area” and hold off on merging code they’re not confident with
+        * Lots of effort put into the dockershim deprecation survey and ensuring docker wasn’t broken in 1.23, much appreciated
+        * Soft code freeze helped a lot with flakes not all piling up at the very end of the release
+        * Beta KEPs were removed middle of the release so we didn’t scramble to get them merged last minute
+        * We did a good job of coordination with the container runtimes, not just internal to Kubernetes; much work happening in containerd, CRI-O, cadvisor happening that were all well-coordinated (+1 +1 +1)
+        * General sentiment of a really successful release for node
+        * SIG Node is in a much better position than other SIGs, well organized (from an outside contributor)
+    * _Things that could have gone better_
+        * Working on logging and kubelet flags; was hard to find reviewers for PRs, spoke with one approver who wasn’t familiar (+1)
+            * In an ideal situation, someone would know who to pull in for a review, but if we don’t have that person it just gets moved to the back of the queue
+            * It would be nice to indicate who specializes in which areas of code; kubelet code owner structure isn’t as cleanly articulated as could be ideal
+            * This has been a problem every release; we need more approvers and reviewers overall. Unfortunately, takes time to train people and we need more people/volunteers participating
+        * Sometimes hard to find approver bandwidth as well
+        * Last-minute hiccup with dockershim socket for CRI v1
+* [ehashman, mrunal] 1.24 initial KEP planning
+    *   
+    * [dawn] Overstretched by lack of reviewer bandwidth; have a difficult time prioritizing, expertise for each feature is different. We have 20-30 things on our list with no clear priority.
+        * Next pass, let’s sort by priority+confidence level?
+* [swsehgal/@alukiano] PodResource API Watch endpoint support ([KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2043-pod-resource-concrete-assigments) with List and Watch endpoint support was merged in 1.21 but only List endpoint (with cpuid and device topologyinfo) was implemented). Please track the watch endpoint implementation for 1.24.
+        * Issue: [https://github.com/kubernetes/enhancements/issues/2043](https://github.com/kubernetes/enhancements/issues/2043)
+* [pohly, klueska] [Dynamic resource allocation KEP](https://github.com/kubernetes/enhancements/pull/3064) discussion
+* [rata, giuseppe] user namespaces [KEP PR](https://github.com/kubernetes/enhancements/pull/3065)
+    * Would like to agree on high level and get review from who needs to review
+    * We really want to reduce chances as much as possible of a last-minute showstopper
+    * General notes
+        * Derek/Mrunal: phases make sense, want Tim to have a look just in case
+        * Sergey will review to see if we should target 1.24 or 1.25
+    * Action(rata):
+        * Ping Tim Hockin
+        * Add Sergey as reviewers
+* [vinaykul] In-Place Pod Vertical Scaling - planning for early 1.24 merge 
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+    * Alpha-blocker issue by Elana: Container hash excludes Resources with in-place-resize feature-gate enabled, toggling fg can restart containers.
+        * Please review [this](https://github.com/kubernetes/kubernetes/commit/a745b12136027c136e0d3dcace23db99ccdd0d71) incremental change to PR.
+    * Pod resize E2E tests have been “weakened” for alpha.
+        * All 31 tests are [passing](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/102884/pull-kubernetes-e2e-gce-alpha-features/1468102950369890304/) now.
+        * Please review [this incremental change](https://github.com/kubernetes/kubernetes/commit/eb5cc6e38853b75834ddcce65c16311c2efdbc3c) to the original E2E test.
+            * This change skips spec-resources == status.resources verification for alpha but enforces it in beta.
+            * It verifies everything else besides that.
+            * Resize success is verified by looking at container cgroup values and comparing to expected values after resize.
+        * This gives containerd time to add support for new fields in CRI.
+            * Beta blocker - cannot flip switch to beta without containerd support.
+    * Outstanding issues / TODOs to load-share and fix after merge?
+* [zvonkok] Any comments regarding last weeks 
+    * Derek: go ahead and open the issue as a placeholder for the decision to be made
+* [mweston, swsehgal] looking for feedback re cpu use cases and which cases are covered in the kubelet already, but perhaps not documented.  [https://docs.google.com/document/d/1U4jjRR7kw18Rllh-xpAaNTBcPsK5jl48ZAVo7KRqkJk/edit](https://docs.google.com/document/d/1U4jjRR7kw18Rllh-xpAaNTBcPsK5jl48ZAVo7KRqkJk/edit) 
+
+
+## November 30, 2021
+
+Total PRs: [209](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+10 since last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-11-23T17%3A00%3A00%2B0000..2021-11-30T17%3A51%3A28%2B0000">18</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-11-23T17%3A00%3A00%2B0000..2021-11-30T17%3A51%3A28%2B0000">10</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-11-23T17%3A00%3A00%2B0000..2021-11-30T17%3A51%3A28%2B0000+created%3A%3C2021-11-23T17%3A00%3A00%2B0000">62</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-11-23T17%3A00%3A00%2B0000..2021-11-30T17%3A51%3A28%2B0000">4</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* ~~[klueska] Bug fix for new feature added in 1.23 (please add to the v1.23 milestone)~~
+    * [https://github.com/kubernetes/kubernetes/pull/106599](https://github.com/kubernetes/kubernetes/pull/106599)
+        * [ehashman] this missed test freeze, any fixes will need to be prioritized as release blocking, merged and backported; we should wait until master reopens if this isn’t affecting CI signal
+        * We decided to push this out and include it in 1.23.1
+* [SergeyKanzhelev] Dockershim removal end user [survey results](https://groups.google.com/g/kubernetes-sig-node/c/97dx4Xede40): [https://docs.google.com/document/d/1DiwCRJffBjoLuDguW9auMXS2NTmkp3NAS7SGJQBu8JY/edit#heading=h.wzgwyg229djr](https://docs.google.com/document/d/1DiwCRJffBjoLuDguW9auMXS2NTmkp3NAS7SGJQBu8JY/edit#heading=h.wzgwyg229djr) 
+    * Are dev tools updated? local-up-cluster.sh defaults to docker, can use containerd/cri-o with it but it’s not documented
+        * kubeadm also may need some updates
+        * node e2es are difficult to run locally without docker
+        * Contributor documentation needs to be updated prior to removal
+    * 2 questions:
+        * Did we give enough notice for removal?
+            * **Yes** - full year, 1.24 won’t be released until next April
+        * Did we give sufficient viable options in the time between deprecation and removal?
+            * We have 2 runtimes that can be adopted + instructions for migrations
+            * Some people have specific monitoring agents/tools that don’t support other runtimes, they need dependencies to migrate
+            * This may be beyond what SIG Node can answer
+    * [dawn] We already have delayed a year given the request; What would make the people migrate? Possibly the people won’t make changes if we keep delaying because they are not ready
+    * [ehashman] We just need to go and deprecate, otherwise people will not update. We need to ensure that we ourselves are prepared for that, and update everything so that we can work without dockershim, too. [+1’s from Lantao and Mrunal]
+    * [danielle] It will be painful but once it’s done it’s done and we won’t have to work on it again. Mirantis is working on making dockershim work with CRI (out of tree), so they can always use that.
+    * [dawn] fixing OSS scripts and e2e tests with containerd should be the blocker for the dockershim deprecation, so that OSS users should have the out-of-box experience with containerd.
+    * [dawn] containerd is a straightforward migration but we didn’t want to switch over as a default because it wasn’t GA previously
+    * [derek] Did we collect docker versions? Are they getting security updates?
+        * We didn’t have this as a survey question
+    * [derek] Are any conformance features tied to a particular runtime? One feature that doesn’t work with dockershim, e.g. cgroupsv2
+    * Zoom chat dump:
+        * Derek Carr to Everyone (10:15 AM)
+        * for local-up cluster, it should be just setting CONTAINER_RUNTIME and CONTAINER_RUNTIME_ENDPOINT... here is an example for crio.... export CONTAINER_RUNTIME=remote
+        * export CONTAINER_RUNTIME_ENDPOINT='unix:///var/run/crio/crio.sock'
+        * Lantao Liu to Everyone (10:18 AM)
+        * +1
+        * Mrunal Patel to Everyone (10:18 AM)
+        * +1
+        * Mike Brown to Everyone (10:20 AM)
+        * export CONTAINER_RUNTIME=remote
+        * export CONTAINER_RUNTIME_ENDPOINT="unix:///run/containerd/containerd.sock"
+        * sudo -E PATH=$PATH ./hack/local-up-cluster.sh
+        * nod ^ same as crio
+        * Elana Hashman to Everyone (10:20 AM)
+        * PRs welcome, folks :)
+        * zoom chat is not the best patch tracker :D
+        * Mike Brown to Everyone (10:20 AM)
+        * we could change local-up to work like crictl does
+        * Derek Carr to Everyone (10:20 AM)
+        * more just letting us all know that it works today...
+        * +1 mike
+        * Brian Goff to Everyone (10:21 AM)
+        * There is out of tree dockershim anyway.
+        * Mike Brown to Everyone (10:21 AM)
+        * basically crictl uses a config or.. if not configured loops through the default socks for each container runtime
+        * Jack Francis to Everyone (10:21 AM)
+        * +1, much experience with the unfortunate human behavioral reality that we need to give folks a concrete incentive to migrate
+        * Lantao Liu to Everyone (10:21 AM)
+        * > There is out of tree dockershim anyway.
+        * Yeah, there is backup for those users who can't move away immediately
+        * Brian Goff to Everyone (10:24 AM)
+        * Also maybe could extend support on &lt;last version w/ dockershim> rather than pushing removal.
+        * *pushing out removal
+        * The only version getting sec updates is 20.10
+        * Jack Francis to Everyone (10:26 AM)
+        * I think there is no one answer to “which version of docker are folks using”. The answer is probably “every version”.
+        * Danielle Lancashire to Everyone (10:30 AM)
+        * "whatever version the OS happens to package when the image was built" * every production image * every user I assume
+        * Mike Brown to Everyone (10:32 AM)
+        * noting … kubelet node dependencies include some number of system services/utilities (seccomp/apparmor/…) + container runtime (extern/intern in r.current) + runtime engines (runc/crun/kata/…) … It’s not just container runtime.  Also noting you can run multiple containerd instances at the same time, thus version requirement is scoped to version configured for kubelet to use.
+        * Mike Brown to Everyone (10:35 AM)
+        * the version of containerd configured for kubelet to use.. can be shared with the installed version of docker.. _options_
+        * 
+* [wzshiming] Requesting SIG Node reviewer status. due to the time zone, I may not have time to attend the meeting, but I can review PR while everyone is sleeping. :)
+    * [https://github.com/kubernetes/kubernetes/pull/104143](https://github.com/kubernetes/kubernetes/pull/104143)
+    * Dawn has LGTM’d, Derek will take a look
+* [zvonkok] Promote SRO as a kubernetes-sigs project, joining NFD for special resource enablement 
+    * Ask: want to migrate code into kubernetes-sigs under SIG Node
+        * Request form for repo migration: [https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-repo&template=repo-create.yml&title=REQUEST%3A+%3CCreate+or+Migrate%3E+%3Cgithub+repo%3E](https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-repo&template=repo-create.yml&title=REQUEST%3A+%3CCreate+or+Migrate%3E+%3Cgithub+repo%3E) 
+        * Requirements: [https://github.com/kubernetes/community/blob/master/github-management/kubernetes-repositories.md](https://github.com/kubernetes/community/blob/master/github-management/kubernetes-repositories.md) 
+    * [dawn] Only concerned about latency for initialization if there is a hard requirement on operators
+    * [zvonkok] At its core it’s just a helm chart, and you can use just helm
+    * [Derek] Everyone should get a chance to review the slides as a next step, it would be good for people to have a place to collaborate on this
+        * After a period of a week for review, we can open an issue
+        * Proposed maintainers should be listed on the repo request form
+    * [mikebrown] Container orchestrated devices is another CNCF project that could do this, although it’s not currently well-integrated with Kubernetes
+        * [https://github.com/container-orchestrated-devices/container-device-interface](https://github.com/container-orchestrated-devices/container-device-interface)
+    * [dawn] For SIG Node sponsor a project, we need to figure out the scope first, then figure out if there are the maintenaness and feasibility,etc.  We encourage the collaboration to avoid unnecessary duplication, but it’s not like we will only allow one implementation
+    * There is some intersection between the two projects, so we can collaborate as well
+    * [zvonkok] SRO is and was also used to enable “special resources” that are not devices, e.g. software defined storage (lustre, veritas) with out-of-tree drivers, this kinda does not fit completely into container-orchestrated-devices. 
+    * [zvonkok] On slide 10 we can see that “runtime-enablement” is one of the steps in enabling a soft/hardware device this is actually where CDI fits in, it is the low-level part where SRO tries to abstract it as mentioned “do not care about the peculiarities of the platform/runtime etc.” so the CDI effort fits perfectly in the complete picture. 
+    * 
+* [zvonkok] Related to that, I wanted to pick up [https://github.com/kubernetes/enhancements/pull/1949](https://github.com/kubernetes/enhancements/pull/1949)
+    * Feel free!
+* [adrianreber] Forensic Container Checkpointing - looking for early 1.24 approval
+    * KEP [https://github.com/kubernetes/enhancements/pull/1990](https://github.com/kubernetes/enhancements/pull/1990)
+    * Code PR [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+    * KEP and code PR are ready for 1.24 and waiting for approver feedback
+    * We should start work on 1.24 planning in the next week or two
+* [mweston & swsehgal] Discussion re CPU management prioritization (quick discussion to set follow-up meeting to then bring results back to sig-node)
+    * Will be sharing out a document for feedback, send an email to the mailing list requesting feedback
+        * Send out a doodle with the email to make scheduling a smaller group easier
+    * Will bring it to a future SIG node meeting and will open a tracking issue
+    * Trying to determine a roadmap for what is/isn’t supported; get supported behaviours better documented (especially low-hanging fruit), and determine a roadmap for the gaps
+* [vinaykul] In-Place Pod Vertical Scaling - planning for early 1.24 merge 
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+    * Alpha-blocker issue by Elana: Container hash excludes Resources with in-place-resize feature-gate enabled, toggling fg can restart containers.
+        * We should use the current implementation upon GA+1.
+        * Implemented fix [early prototype](https://github.com/huawei-cloudnative/kubernetes/blob/vertical-scaling/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L534). Updated PR by next week.
+    * Is NodeSwap interop issue an alpha-blocker?
+    * Identify any other alpha blockers.
+    * 27 of 31 pod resize e2e tests fail due to missing containerd support for new CRI field (<span style="text-decoration:underline;">all tests pass with dockershim</span>)
+        * Chicken-egg problem.
+        * What’s a good solution (Decision made at last meeting: Nov 16):
+            * <span style="text-decoration:underline;">Action for vinaykul</span>: Ensure KEP requires containerd support for CRI change - Beta blocker.
+            * Adapt tests to work around lack of support for alpha.
+        * &lt;Mike Brown> you could run off master the upcoming release of containerd.. or you could modify the test to support prior releases.. In the field customers may be using older versions of container runtimes, unless the requirement is now to upgrade the container runtime with the kubernetes release?
+* 
+
+
+## November 23, 2021
+
+Cancelled - US Thanksgiving week.
+
+
+## November 16, 2021
+
+Total active pull requests: [199](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-13 from last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-11-09T17%3A00%3A00%2B0000..2021-11-16T17%3A49%3A26%2B0000">38</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-11-09T17%3A00%3A00%2B0000..2021-11-16T17%3A49%3A26%2B0000">13</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-11-09T17%3A00%3A00%2B0000..2021-11-16T17%3A49%3A26%2B0000+created%3A%3C2021-11-09T17%3A00%3A00%2B0000">100</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-11-09T17%3A00%3A00%2B0000..2021-11-16T17%3A49%3A26%2B0000">39</a>
+   </td>
+  </tr>
+</table>
+
+
+Potential fish out from closed:
+
+
+
+* [https://github.com/kubernetes/kubernetes/pull/96364](https://github.com/kubernetes/kubernetes/pull/96364) 
+* [https://github.com/kubernetes/kubernetes/pull/104651](https://github.com/kubernetes/kubernetes/pull/104651) 
+* [klueska] Pending update to KEP-2902 for 1.23
+    * [https://github.com/kubernetes/enhancements/pull/3009](https://github.com/kubernetes/enhancements/pull/3009)
+* [vinaykul] In-Place Pod Vertical Scaling - status update
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+    * Fixed issues identified by Tim (API) and Huang-Wei (Sched)
+    * Fixed race issue by Lantao (re-do KRTM + PLEG calls ContainerStatus CRI)
+    * One alpha-blocker issue as per Elana: Container hash excludes Resources with in-place-resize feature-gate enabled, so toggling this fg can restart container - no solution identified
+    * Is NodeSwap interop issue an alpha-blocker?
+    * E2E pod resize tests fail: chicken-egg problem?
+        * 27 out of 31 E2E resize tests [fail](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/102884/pull-kubernetes-e2e-gce-alpha-features/1460465135016480768/)
+            * Reason: containerd does not (yet) implement CRI extension in this PR to return ContainerResources (mem/cpu limits, cpu req)
+            * Previous code compensated for this but it has race with PLEG
+        * 4 out of 31 resize tests pass only because ResizePolicy == RestartRequired, resizing memory-request only (ContainerStatus CRI support for ContainerResources not a must in these 4 test cases)
+        * Is “watering down” those 27 resize tests that depend on CRI update a reasonable solution for alpha?
+            * We verify that cgroup has been updated and reflects resize, but skip verifying spec.Resources == status.Resources
+* [SergeyKanzhelev] Please promote this ​​[https://kubernetes.io/blog/2021/11/12/are-you-ready-for-dockershim-removal/](https://kubernetes.io/blog/2021/11/12/are-you-ready-for-dockershim-removal/) 
+* [samwalke] [Feature Request: CPU Core Grouping & Assignment (Performance vs Efficiency cores) · Issue #106157 · kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/issues/106157#issuecomment-966239378)
+* 
+
+
+## November 9, 2021
+
+Total active pull requests: [212](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-8 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-11-02T17%3A00%3A00%2B0000..2021-11-09T18%3A05%3A57%2B0000">26</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-11-02T17%3A00%3A00%2B0000..2021-11-09T18%3A05%3A57%2B0000">15</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-11-02T17%3A00%3A00%2B0000..2021-11-09T18%3A05%3A57%2B0000+created%3A%3C2021-11-02T17%3A00%3A00%2B0000">110</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-11-02T17%3A00%3A00%2B0000..2021-11-09T18%3A05%3A57%2B0000">19</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [vinaykul] In-Place Pod Vertical Scaling - status update ([https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)).
+    * Addressed review comments in Kubelet - needs review from Lantao and Elana
+    * Addressed review comments Huang Wei and updated Scheduler code. He will review it this week.
+* [manugupt1] Discuss KEP for node local pod admission handlers. 
+    * Kep Link : [https://github.com/kubernetes/enhancements/pull/2811](https://github.com/kubernetes/enhancements/pull/2811)
+    * Need to answer Derek’s questions on why not daemonsets and other kube constructs.
+    * Talk more about the use-cases. 
+    * There are already plugins inside the worker node but mainly there built into kubelet source code; one of the things that this KEP proposes is a plugin framework; that will help create plugins outside kubelet’s code base.
+* [Sergey/Mrunal] CRI v1: [https://github.com/kubernetes/kubernetes/pull/106006](https://github.com/kubernetes/kubernetes/pull/106006) 
+    * Lets’ understand if containerd timeline lines up
+    * If lines up - PR is OK, otherwise we may need to postpone to 1.24
+* [Sergey] [https://github.com/kubernetes/enhancements/pull/3042](https://github.com/kubernetes/enhancements/pull/3042) Tests labels clean up
+* [Mark Rossetti/Ravi G] [https://testgrid.k8s.io/sig-node-kubelet#node-kubelet-serial](https://testgrid.k8s.io/sig-node-kubelet#node-kubelet-serial) 
+    * Most jobs were timing out the past few days.
+
+
+## November 2, 2021
+
+Total active pull requests: [220](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+4 from the last meeting)
+
+
+
+* Announcements
+    * Code freeze is **Nov. 17** in 2 weeks!
+    * Vote in the steering election if you’re eligible!
+        * [https://elections.k8s.io/](https://elections.k8s.io/) voting ends **Nov 4th**
+* [@rata]: user namespaces KEP
+    * Agree on high level idea
+    * New proposal incorporated feedback from previous discussions
+    * [Slides](https://docs.google.com/presentation/d/1z4oiZ7v4DjWpZQI2kbFbI8Q6botFaA07KJYaKA-vZpg/edit#slide=id.gc6f73a04f_0_0) to explain the plan & phases proposed
+* [vinaykul] In-Place Pod Vertical Scaling
+    * Rebased code and caught up with latest code.
+    * Need code review from Lantao & Elana
+* [adrianreber] Forensic Container Checkpointing (1.24)
+    * [https://github.com/kubernetes/enhancements/pull/1990](https://github.com/kubernetes/enhancements/pull/1990) 
+    * Unfortunately I missed last week
+    * Wanted to answer questions which came up:
+        * Can this be used for things other than forensics like migration?
+            * Yes, of course, we wanted to limit it to a simple single use case. But every option around checkpoint/restore/migration is possible
+        * There are a bunch of outstanding questions about how networking, storage, etc. will it work on restore with multiple containers. Wanted to rein in scope
+            * Basically all external resources to a container (bind mounts, network configuration) need to be available before restore
+    * Related PRs:
+        * [https://github.com/cri-o/cri-o/pull/4199](https://github.com/cri-o/cri-o/pull/4199)
+        * [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+        * [https://github.com/kubernetes-sigs/cri-tools/pull/662](https://github.com/kubernetes-sigs/cri-tools/pull/662)
+
+
+## October 26, 2021
+
+Total active pull requests: [216](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-7 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-10-19T17%3A00%3A00%2B0000..2021-10-26T16%3A43%3A06%2B0000">11</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-10-19T17%3A00%3A00%2B0000..2021-10-26T16%3A43%3A06%2B0000">7</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-10-19T17%3A00%3A00%2B0000..2021-10-26T16%3A43%3A06%2B0000+created%3A%3C2021-10-19T17%3A00%3A00%2B0000">88</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-10-19T17%3A00%3A00%2B0000..2021-10-26T16%3A43%3A06%2B0000">11</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* 1.23 KEPs review (soft deadline is reached)
+
+From [https://docs.google.com/spreadsheets/d/1P1J1QpayRmh2SNjs8T-wBCb6SgEOdWTRQ7MBol7yibk/edit#gid=936265414](https://docs.google.com/spreadsheets/d/1P1J1QpayRmh2SNjs8T-wBCb6SgEOdWTRQ7MBol7yibk/edit#gid=936265414) 
+
+
+<table>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/277">277</a></p>
+
+   </td>
+   <td>Beta
+   </td>
+   <td>Ephemeral Containers
+   </td>
+   <td>PRs merged
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/1287">1287</a></p>
+
+   </td>
+   <td>Alpha
+   </td>
+   <td>In-place Pod update
+   </td>
+   <td>PR is out: <a href="https://github.com/kubernetes/kubernetes/pull/102884">kubernetes/kubernetes#102884</a> 
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/1977">1977</a></p>
+
+   </td>
+   <td>-
+   </td>
+   <td>ContainerNotifier
+   </td>
+   <td>Removed from milestone
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2040">2040</a></p>
+
+   </td>
+   <td>Beta
+   </td>
+   <td>Kubelet CRI Support
+   </td>
+   <td>PR is out <a href="https://github.com/kubernetes/kubernetes/pull/104575">kubernetes/kubernetes#104575</a> 
+   </td>
+  </tr>
+  <tr>
+   <td><a href="https://github.com/kubernetes/enhancements/issues/2133">2133</a>
+   </td>
+   <td>Beta
+   </td>
+   <td>Kubelet credential provider
+   </td>
+   <td>WIP PR is out. Unit tests are failing: <a href="https://github.com/kubernetes/kubernetes/pull/105624">kubernetes/kubernetes#105624</a> . 
+<p>
+Suggest to remove from milestone
+<p>
+How does this impact the timeline for spinning cloud providers out of tree?
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2273">2273</a></p>
+
+   </td>
+   <td>Alpha
+   </td>
+   <td>VPA CRI Changes
+   </td>
+   <td>Rolled into <a href="https://github.com/kubernetes/kubernetes/pull/102884">kubernetes/kubernetes#102884</a> 
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2400">2400</a></p>
+
+   </td>
+   <td>Beta
+   </td>
+   <td>Node system swap support
+   </td>
+   <td>Will spill into 1.24.
+<p>
+Remove from milestone - no support in runtimes, also failing tests
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2403">2403</a></p>
+
+   </td>
+   <td>Beta
+   </td>
+   <td>Extend podresources API to report allocatable resources
+   </td>
+   <td>PR merged
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2535">2535</a></p>
+
+   </td>
+   <td>Alpha
+   </td>
+   <td>Ensure Secret Pulled Images
+   </td>
+   <td>PR is out: <a href="https://github.com/kubernetes/kubernetes/pull/94899">kubernetes/kubernetes#94899</a> 
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2625">2625</a></p>
+
+   </td>
+   <td>Beta
+   </td>
+   <td>Add options to reject non SMT-aligned workload
+   </td>
+   <td>PR is merged
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2712">2712</a></p>
+
+   </td>
+   <td>Alpha
+   </td>
+   <td>PriorityClassValueBasedGracefulShutdown
+   </td>
+   <td>PR is out: <a href="https://github.com/kubernetes/kubernetes/pull/102915">kubernetes/kubernetes#102915</a> 
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2727">2727</a></p>
+
+   </td>
+   <td>Alpha
+   </td>
+   <td>Add gRPC probe to Pod
+   </td>
+   <td>PR is out: <a href="https://github.com/kubernetes/kubernetes/pull/102162">kubernetes/kubernetes#102162</a> 
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2902">2902</a></p>
+
+   </td>
+   <td>Alpha
+   </td>
+   <td>Add CPUManager policy option to distribute CPUs across NUMA nodes instead of packing them
+   </td>
+   <td>PR is merged. Need to make sure to add it to release tracking sheet.
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+<a href="https://github.com/kubernetes/enhancements/issues/2371">2371</a></p>
+
+   </td>
+   <td>Alpha
+   </td>
+   <td>cAdvisor-less, CRI-full Container and Pod Stats
+   </td>
+   <td>PR is out <a href="https://github.com/kubernetes/kubernetes/pull/103095">https://github.com/kubernetes/kubernetes/pull/103095</a> 
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [Marlow Weston] Looking to solve cpu allocation items, where pinning is important, but also some pods may want to have *some* cores pinned and *some others* shared.  Currently semi-abandoned items are here;  ([https://github.com/kubernetes/community/pull/2435](https://github.com/kubernetes/community/pull/2435),[ https://github.com/kubernetes/enhancements/pull/1319](https://github.com/kubernetes/enhancements/pull/1319))  \
+Would like to move forward and put together a team to try again to come up with a cohesive KEP.  Already have use cases from four companies, and there are likely more that wish to be involved.  Would like an initial list of names, in addition to those already there, so we can critically come up with the use cases we expect to cover and start coming up with what the best design is going forward.
+    * Some of these use cases are already supported - are we trying to isolate the management parts of a node or specific pods?
+    * If there is a set of use cases, we might be able to pull a group together
+* [adrianreber] Looking for approver feedback on the "Forensic Container Checkpoint" KEP (1.24) [https://github.com/kubernetes/enhancements/pull/1990](https://github.com/kubernetes/enhancements/pull/1990) to be ready once the 1.24 period starts to avoid missing the deadline as I did for 1.23.
+    * Dawn wants to review but doesn’t have bandwidth at this moment, she will approve
+    * Can this be used for things other than forensics like migration?
+    * There are a bunch of outstanding questions about how networking, storage, etc. will it work on restore with multiple containers. Wanted to rein in scope
+* [vinaykul] In-place Pod Vertical Scaling
+    * Working on addressing remaining review items this week. Apologies for the delay as my new role has not given me a big enough block of “focus time” until last week. I’ll reach out to reviewers over slack once I update the PR.
+    * [kubernetes/kubernetes#102884](https://github.com/kubernetes/kubernetes/pull/102884) 
+    * Should PR be split? 
+        * Perhaps. SIG-scheduling would prefer scheduler changes in a separate PR. Jiaxin Shan from Bytedance is looking into it in parallel.
+        * If we split, both would need to go in quick succession - 2-phase commit
+* [mrunal/mikebrown] CRI PR version support [https://github.com/kubernetes/kubernetes/pull/104575](https://github.com/kubernetes/kubernetes/pull/104575) 
+    * Support both v1 and v1alpha1 or just one version?
+    * Node overhead for the marshalling/unmarshalling needs to be measured to make a decision.
+    * Perf vs. cognitive load is a decision to make on the next meeting
+    * Also added to API reviews agenda:  
+
+
+## October 19, 2021
+
+Total active pull requests: [223](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-6 in two past weeks)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-10-05T17%3A00%3A00%2B0000..2021-10-19T16%3A49%3A17%2B0000">37</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-10-05T17%3A00%3A00%2B0000..2021-10-19T16%3A49%3A17%2B0000">15</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-10-05T17%3A00%3A00%2B0000..2021-10-19T16%3A49%3A17%2B0000+created%3A%3C2021-10-05T17%3A00%3A00%2B0000">121</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-10-05T17%3A00%3A00%2B0000..2021-10-19T16%3A49%3A17%2B0000">29</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [marga] Possible KEP? Exposing OCI hooks up the stack. [Draft here](https://github.com/kinvolk/kubernetes-enhancements/tree/marga-kinvolk/oci-hooks/keps/sig-node/NNNN-expose-oci-hooks#summary). Inspektor Gadget has wanted this for a long time (see “Future” section from 2019), but now there are more users out there that are resorting to workarounds because these are not exposed. I’d like to get this moving as a KEP in y’all agree.(note [NRI](https://github.com/containerd/nri) effort)
+    * [Mike Brown] lots of interest. NRI hooks is one of the models
+    * [Mrunal Patel] Hooks are wired in CRI-O. Example is nvidia hook. Thai is hard to write CDI is an effort to simplify hooks writing. Hooks are hard to write, so CDI is going for a declarative model to make the actual hook much simpler. 
+    * [Alexander Kanevskiy] Prototype that make NRI more flexible and working both for containerd and CRI-O: [https://github.com/containerd/nri/pull/16](https://github.com/containerd/nri/pull/16) Injecting OCI-hooks was one of the TODO items as example of NRI plugin \
+CDI link: [https://github.com/container-orchestrated-devices/container-device-interface](https://github.com/container-orchestrated-devices/container-device-interface)
+    * [Dawn Chen] Lots of use cases are useful, but hooks are very powerful and some hook implementations may harm the host and raise security concerns. In the past we wanted to continue discussing, maybe more declarative way will work best.
+    * [Lantao] Hook can run anything on host - has access to host and container environment. Exposing in k8s API or CRI - it can make the pod non-portable. Ideally we need to avoid the environment-specific dependencies
+    * [Mike Brown] pre-determined dependencies would be one way to go
+    * [Dawn Chen] Are all use cases around tracing and obtaining labels and other runtime information?
+    * [Marga] Main use case is tracing and applying the labels. Want to detect container start as early as possible. Other use cases for security - being able to detect container before it started and decline based on whitelist set of images.
+    * [Elana] Faster detection of containers - PLEG streaming as oppose to a poll loop (Mike: yes CRI event subscriptions for pod/container/image lifecycle)
+    * [Marga] Other scenarios - some information like PID of a container - would like to get, but there is no way (perhaps should be a different KEP).
+    * [Dawn] Container information is a scenario for runtime. 
+    * [Marga] want it in a unified way.
+    * [Mrunal] There are edge cases - VM runtime, CRI-O may not have a process
+    * [Sergey] Maybe expand motivation section to explain specific scenarios
+    * [Dawn] need to discuss use cases individually. Some may be discussed with sig auth due to security concerns. Hooks may be a right technology, but we need to start with the use cases.
+    * [Elana] Very large scope change as it’s written. Need significantly more resources to ensure this lands and maintained. Not a “1-2 PR and then you’re done” sort of change.
+    * [Mike Brown] There’s no common way to configure these hooks based on each container runtime. Kubernetes integration work would be quite complicated, there’s no obvious generic way to do this right now, it’s WIP.
+    * [Danielle] Every time that piece of code is touched, it leads to regressions as we don’t have a good coverage there.
+    * [Brian Goff] Exposing OCI semantics on CRI seems messy.
+
+        As opposed to configuring the runtime to run hooks
+
+
+        Run anything not on the host *with root privileges
+
+
+        My gut says modify (or make it possible to configure) the runtime to do what you need rather than changing the API.
+
+
+        I don’t think a hook could deny based on image.
+
+    * [Eric Ernst] Second the security concern.  Chance to run a binary on the host (or in guest if kata) w/ out any restrictions...
+    * [Mrunal Patel] There are races in resolving a tag at admission vs. runtime pulling it.
+    * [Alexander Kanevskiy] For anyone interested in CDI and NRI, and see if those can solve their usecases, welcome to join meetings of CNCF/TAG-Runtime/COD WG:  [https://github.com/cncf/tag-runtime/blob/master/wg/COD.md](https://github.com/cncf/tag-runtime/blob/master/wg/COD.md) 
+* [marquiz] Class-based resources in CRI KEP (draft) \
+[https://github.com/kubernetes/enhancements/pull/3004](https://github.com/kubernetes/enhancements/pull/3004)
+    * Looking for feedback
+    * Related KubeCon talk: [https://sched.co/m4t2](https://sched.co/m4t2)
+    * TAG-Runtime presentation with examples on how it is used: 
+    * Annotations should generally be avoided for new KEPs as they are very difficult to manage with version skew, use alpha fields instead
+    * Are we doing anything to expose this information to scheduler?
+    * Not at the moment, optimizing everything on the node now.
+    * What’s the difference between blockio and cgroup v2 controls?
+    * RDT is about memory bandwidth, it uses cgroup v2 underneath.
+    * Classes are used to configure specific controls to scenarios like guaranteed burst or levels of IO support.
+    * Need to make sure cgroup v2 support in k8s will work well with this proposal.
+* [Eric Ernst] Request for feedback/review: [https://github.com/kubernetes/kubernetes/pull/104886](https://github.com/kubernetes/kubernetes/pull/104886) 
+* [SergeyKanzhelev] Please distribute this form: [https://forms.gle/svCJmhvTv78jGdSx8](https://forms.gle/svCJmhvTv78jGdSx8)
+* [SergeyKanzhelev] Follow up on this [https://github.com/kubernetes/kubernetes/pull/105215#issuecomment-946916830](https://github.com/kubernetes/kubernetes/pull/105215#issuecomment-946916830)
+
+
+## October 12, 2021
+
+CANCELLED - KUBECON NA
+
+
+## October 5, 2021
+
+LATE START: 30m shifted due to availability (10:30 instead of 10PT)
+
+Total PRs: [229](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-1 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-09-28T17%3A00%3A00%2B0000..2021-10-05T17%3A21%3A41%2B0000">23</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-09-28T17%3A00%3A00%2B0000..2021-10-05T17%3A21%3A41%2B0000">9</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-09-28T17%3A00%3A00%2B0000..2021-10-05T17%3A21%3A41%2B0000+created%3A%3C2021-09-28T17%3A00%3A00%2B0000">85</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-09-28T17%3A00%3A00%2B0000..2021-10-05T17%3A21%3A41%2B0000">15</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] Reminder: soft code freeze ~Oct. 15, KubeCon next week
+    * SIG Node session: [https://sched.co/lV9D](https://sched.co/lV9D) 
+    * Pushing soft code freeze back one week to not conflict with KubeCon (-> Oct. 22)
+* [SergeyKanzhelev] Dockershim deprecation status [https://docs.google.com/document/d/1DiwCRJffBjoLuDguW9auMXS2NTmkp3NAS7SGJQBu8JY/edit#](https://docs.google.com/document/d/1DiwCRJffBjoLuDguW9auMXS2NTmkp3NAS7SGJQBu8JY/edit#) 
+* [pacoxu] [https://github.com/kubernetes/kubernetes/pull/104186](https://github.com/kubernetes/kubernetes/pull/104186) My application to be a sig-node reviewer has not been responded to after weeks. I am not sure what that means. Does it mean no objections or declined? And I wondered how I could make it happen. At least, I want to get some advice on how to be a qualified reviewer.
+    * [lubomir/sig-cluster-lifecycle] +1 for pacoxu, who is an involved contributor in multiple areas of the project.
+    * Working on a doc amongst Node subproject approvers, got caught up in that.
+    * Paco should meet the criteria for reviewer so Derek and Mrunal have +1’d, thank you for your patience!
+    * If we can get an ack, we’ll share the doc soon -- couple open comments remain, regret not having shared earlier.
+* [SergeyKanzhelev] SIG Node test tags cleanup: [https://docs.google.com/document/d/19HqSyrS-4pyubqTvQV0hJKt_97nbCSt_aD0soL-RGGE/edit?hl=en&forcehl=1#](https://docs.google.com/document/d/19HqSyrS-4pyubqTvQV0hJKt_97nbCSt_aD0soL-RGGE/edit?hl=en&forcehl=1#) 
+* [ehashman] Soft code freeze PR review?
+    * Beta
+        * KEP 277:	Ephemeral Containers
+            * 
+        * KEP 2040:	Kubelet CRI Support
+            * 
+        * KEP 2133:	Kubelet credential provider
+            * 
+        * KEP 2400:	Node system swap support
+            * 
+        * KEP 2403:	Extend podresources API to report allocatable resources
+            * [https://github.com/kubernetes/kubernetes/pull/103289](https://github.com/kubernetes/kubernetes/pull/103289)
+            * [https://github.com/kubernetes/kubernetes/pull/97415](https://github.com/kubernetes/kubernetes/pull/97415)
+            * [https://github.com/kubernetes/kubernetes/pull/105003](https://github.com/kubernetes/kubernetes/pull/105003) 
+                * [fromani] depends on the first two PRs
+        * KEP 2625:	Add options to reject non SMT-aligned workload
+            * [https://github.com/kubernetes/kubernetes/pull/105012](https://github.com/kubernetes/kubernetes/pull/105012) 
+                * [fromani] missing features review/approval
+    * Alpha
+        * KEP 1287:	In-place Pod update
+            * [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884) 
+        * KEP 2273:	VPA CRI Changes
+            * 
+        * KEP 2371:	cAdvisor-less, CRI-full Container and Pod stats
+            * [https://github.com/kubernetes/kubernetes/pull/103095](https://github.com/kubernetes/kubernetes/pull/103095) 
+        * KEP 2535:	Ensure Secret Pulled Images
+            * [https://github.com/kubernetes/kubernetes/pull/94899](https://github.com/kubernetes/kubernetes/pull/94899) 
+        * KEP 2712:	PriorityClassValueBasedGracefulShutdown
+            * 
+        * KEP 2727:	Add gRPC probe to Pod
+            * [https://github.com/kubernetes/kubernetes/pull/102162](https://github.com/kubernetes/kubernetes/pull/102162) 
+        * KEP 2902:	CPUManager policy option to distribute CPUs across NUMA nodes
+            * [fromani] I think this work depends on changes part of 2625
+
+
+## September 28, 2021
+
+Total active pull requests: [230](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-8 since last meeting 2 weeks back)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-09-14T17%3A00%3A00%2B0000..2021-09-28T16%3A35%3A07%2B0000">29</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-09-14T17%3A00%3A00%2B0000..2021-09-28T16%3A35%3A07%2B0000">23</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-09-14T17%3A00%3A00%2B0000..2021-09-28T16%3A35%3A07%2B0000+created%3A%3C2021-09-14T17%3A00%3A00%2B0000">146</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-09-14T17%3A00%3A00%2B0000..2021-09-28T16%3A35%3A07%2B0000">18</a>
+   </td>
+  </tr>
+</table>
+
+
+Reminder:  **[soft code freeze date for](https://groups.google.com/g/kubernetes-sig-node/c/LTONXHu9R9w/m/PSybRudTAgAJ?utm_medium=email&utm_source=footer) SIG Node on October 15** - 2 weeks including a week of KubeCon.
+
+
+
+* [wgahnagl] enable ~~static pods ~~pinned images
+    * [https://github.com/kubernetes/kubernetes/pull/103299](https://github.com/kubernetes/kubernetes/pull/103299) 
+    * Do we need to open an enhancement for this?
+* ~~[pacoxu] is there [an alternative proposed](https://github.com/kubernetes/enhancements/issues/281#issuecomment-909152556) for DynamicKubeletConfig? ~~
+    * ~~Can someone add some comments in the [enhancement issue](https://github.com/kubernetes/enhancements/issues/281#)? I go back to the [weekly meeting on April 6th](https://www.youtube.com/watch?v=RlNm61bpdcU&list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG&index=30), and it seems that dims/dawn agree with the decision. In multi-cluster management, it would be an important feature to change kubelet configuration easily from cluster wide.~~
+        * [https://github.com/kubernetes/enhancements/issues/281#issuecomment-929378712](https://github.com/kubernetes/enhancements/issues/281#issuecomment-929378712) 
+    * ~~Do we have a plan to make the `/var/lib/kubelet/config.yaml` supporting reload like ‘coredns reload plugin’? Asked in #slack as I may have no time to attend the meeting.~~
+* [adrianreber] Checkpoint/Restore KEP and PR ready for review/approval
+    * [https://github.com/kubernetes/enhancements/pull/1990](https://github.com/kubernetes/enhancements/pull/1990)
+    * [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+* [liggitt] treatment of "not ready" pods by eviction / PDB
+    * Bug about not being able to evict unhealthy pods: [https://github.com/kubernetes/kubernetes/issues/72320](https://github.com/kubernetes/kubernetes/issues/72320) 
+    * Proposal to always allow evicting "not ready" pods: [https://github.com/kubernetes/kubernetes/pull/105296](https://github.com/kubernetes/kubernetes/pull/105296)
+    * sig-node thread: [https://groups.google.com/g/kubernetes-sig-node/c/IGHDGECSTWw](https://groups.google.com/g/kubernetes-sig-node/c/IGHDGECSTWw)
+    * Chat dump:
+
+        David Eads to Everyone (10:22 AM)
+
+
+        it is impossible to available=true and ready=false
+
+
+        Derek Carr to Everyone (10:25 AM)
+
+
+        available has no meaning on the pod spec, only in workload controller.
+
+
+        David Eads to Everyone (10:29 AM)
+
+
+        to the point of a kubelet readyness being set to false bug, it seems like we should fix both the bugs.
+
+
+        Elana Hashman to Everyone (10:31 AM)
+
+
+        David, I'll jump in on that after this
+
+
+        &lt;link to referenced bug: [https://github.com/kubernetes/kubernetes/issues/100277](https://github.com/kubernetes/kubernetes/issues/100277)>
+
+
+        Derek Carr to Everyone (10:34 AM)
+
+
+        i think the key tension here is that pdb as written is linked to pod ready state, but it sounds like there is a desire to support additional scope of pod starting but not yet terminal state.
+
+
+        David Eads to Everyone (10:37 AM)
+
+
+        a pod that is not ready seems already disrupted to me
+
+
+        Jordan Liggitt to Everyone (10:38 AM)
+
+
+        not ready pods are excluded from service selection, they do not contribute to pdb status.currentHealthy ... for PDB's definition of disruption, they seem disrupted to me as well
+
+
+        Michael Gugino to Everyone (10:39 AM)
+
+
+        not all pods are behind services, like storage pods
+
+
+        Derek Carr to Everyone (10:39 AM)
+
+
+        i am not debating what jordan/david are saying but only asking if it makes sense to offer a knob for the present behavior before tightening the behavior as implemented.
+
+
+        David Eads to Everyone (10:40 AM)
+
+
+        momentum matters.  If it was ready before and the kubelet hasn't checked, updating to ready=false sounds buggy
+
+
+        David Eads to Everyone (10:49 AM)
+
+
+        having eviction and pdb controller agree on how to count available pods is important for visilbity.
+
+    * 
+* [SergeyKanzhelev] Dockershim deprecation status [https://docs.google.com/document/d/1DiwCRJffBjoLuDguW9auMXS2NTmkp3NAS7SGJQBu8JY/edit#](https://docs.google.com/document/d/1DiwCRJffBjoLuDguW9auMXS2NTmkp3NAS7SGJQBu8JY/edit#) 
+* [pohly]
+    * Deprecation of kubelet command line flags in favor of config file - is that still planned?
+    * Is the logging part of the config alpha? Shouldn't that be mentioned in the field comment so that it shows up in generated documentation?
+    * Heads up on incoming changes/PRs:
+        * WIP: [deprecating several klog command line flags](https://github.com/kubernetes/kubernetes/pull/105042)
+        * WIP: [new command line flags and config options for JSON output](https://github.com/kubernetes/kubernetes/pull/104873)
+        * [generic ephemeral volume checks](https://github.com/kubernetes/kubernetes/pull/100482) \
+
+
+
+## September 21, 2021 [Cancelled]
+
+Cancelled due to lack of agenda.
+
+
+## September 14, 2021
+
+Total active pull requests: [238](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-09-07T17%3A00%3A00%2B0000..2021-09-14T16%3A32%3A47%2B0000">32</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-09-07T17%3A00%3A00%2B0000..2021-09-14T16%3A32%3A47%2B0000">11</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-09-07T17%3A00%3A00%2B0000..2021-09-14T16%3A32%3A47%2B0000+created%3A%3C2021-09-07T17%3A00%3A00%2B0000">79</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-09-07T17%3A00%3A00%2B0000..2021-09-14T16%3A32%3A47%2B0000">8</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] critical-urgent 1.22 static pod regression
+    * Issue [https://github.com/kubernetes/kubernetes/issues/104648](https://github.com/kubernetes/kubernetes/issues/104648) 
+    * WIP PR [https://github.com/kubernetes/kubernetes/pull/104847](https://github.com/kubernetes/kubernetes/pull/104847) 
+    * e2e test reproducer [https://github.com/kubernetes/kubernetes/pull/104919](https://github.com/kubernetes/kubernetes/pull/104919) [https://github.com/kubernetes/kubernetes/pull/104924](https://github.com/kubernetes/kubernetes/pull/104924) 
+    * Do we need any additional reviewers?
+    * [https://docs.google.com/document/d/1NJKYNgoXZKGS5la4MvGrB42-DNQSFf4JQkEcZRnrDzA/edit#heading=h.d2hvrqrlw3e6](https://docs.google.com/document/d/1NJKYNgoXZKGS5la4MvGrB42-DNQSFf4JQkEcZRnrDzA/edit#heading=h.d2hvrqrlw3e6) (from  smarterclayton)
+    * Are we allowing static UID for static pods?
+        * Issue at hand - same manifest re-added generates the same UID
+        * But static UID is also the problem
+        * Does anybody has dependency on static UID?
+            * Not clear?
+            * Big risk to break people if we change this behavior.
+    * More reviewers?
+        * Lantao will take a look
+* [manugupt1] Looking for reviewers / approvers for to add to KEP [https://github.com/kubernetes/enhancements/pull/2811](https://github.com/kubernetes/enhancements/pull/2811)
+    * Slides from the last presentation for SIG Node (July 13, 2021): [NodeLocal Pluggable admit handler-v2.pptx](https://github.com/kubernetes/enhancements/files/6850398/NodeLocal.Pluggable.admit.handler-v2.pptx)
+    * [Derek] Let’s review this for 1.24, too late for 1.23.
+    * Should it be implemented as a Daemonset instead of managed plugin?
+        * Manu: we will investigate options. Fargte doesn’t support Daemonset, but it may be a good option.
+* [adrianreber] Checkpoint/Restore KEP
+    * [https://github.com/kubernetes/enhancements/pull/1990](https://github.com/kubernetes/enhancements/pull/1990)
+        * One "Generally LGTM", second review missing
+    * Code changes also ready for review:
+        * [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+    * Mrunal: need some work to clearly separate stages of implementation
+    * Adrian: actual code changes are WIP
+* [Markus / Mrunal] Speeding up pod startup
+    * [https://docs.google.com/presentation/d/1NdUb0A1MyrDNyyEqztmXqOeBlI0U9uZYZd4P3_-p0Fo/edit?usp=sharing](https://docs.google.com/presentation/d/1NdUb0A1MyrDNyyEqztmXqOeBlI0U9uZYZd4P3_-p0Fo/edit?usp=sharing)
+    * Derek: Reach out to sig-storage on volume manager related problems
+
+		Chat:
+
+
+        Mike Brown to Everyone (10:27 AM)
+
+
+        subsecond probe code draft for possible kep [https://github.com/mikebrow/kubernetes/commit/8926bd2c021a63f365d1a89ed465bd2c5abe599b](https://github.com/mikebrow/kubernetes/commit/8926bd2c021a63f365d1a89ed465bd2c5abe599b) 
+
+
+        sjennings to Everyone (10:28 AM)
+
+
+        [https://github.com/kubernetes/kubernetes/pull/66938](https://github.com/kubernetes/kubernetes/pull/66938) 
+
+
+        Mike Brown to Everyone (10:28 AM)
+
+
+        ^ to be merged with existing efforts to refactor probes
+
+
+        Elana Hashman to Everyone (10:31 AM)
+
+
+        interesting API change. seems a little hacky to me to only have one field that's milliseconds, as opposed to optionally allowing someone to change the units for all probe fields
+
+
+        Mike Brown to Everyone (10:33 AM)
+
+
+        yeah all probe fields make sense
+
+
+        let me find the actual kep text
+
+
+        Elana Hashman to Everyone (10:34 AM)
+
+
+        like I'm thinking a string config that defaults to seconds/"" but you can optionally set to milliseconds
+
+
+        Mike Brown to Everyone (10:34 AM)
+
+
+        i like it elana
+
+
+        Elana Hashman to Everyone (10:34 AM)
+
+
+        will require a lot of refactoring of probes
+
+
+        heh
+
+
+        Mike Brown to Everyone (10:35 AM)
+
+
+        subsecond kep text wip.. [https://hackmd.io/TgKlRqwCRLSXQ8btgKt9GA](https://hackmd.io/TgKlRqwCRLSXQ8btgKt9GA) 
+
+
+        agreed Elana
+
+
+        Brian Goff to Everyone (10:35 AM)
+
+
+        Nice! One of those things I disliked about CRI, glad to have an event based API.
+
+
+        Mike Brown to Everyone (10:38 AM)
+
+
+        oh man lantau i’m hearing interest in eventing vs poling state updates :-)
+
+
+        subscription models would be more efficient  for smaller scale applications
+
+
+        Lantao Liu to Everyone (10:41 AM)
+
+
+        Yeah, we wanted to do that in early days [https://github.com/kubernetes/kubernetes/issues/16831](https://github.com/kubernetes/kubernetes/issues/16831). Just not a priority, because relist has brought down the kubelet and container runtime resource usage to the number we targed. :p
+
+
+        Mike Brown to Everyone (10:43 AM)
+
+
+        ^ fair..
+
+
+        Brian Goff to Everyone (10:43 AM)
+
+
+        Yep.
+
+
+        We wound up with an optional event based API in VK. (Mike: thx Brian will be interesting to revisit that in the k/k/pkg/kubelet tree)
+
+
+        Mike Brown to Everyone (10:43 AM)
+
+
+        maybe a workgroup to revisit to help k8s scale for these micro services
+
+
+        Mike Brown to Everyone (10:44 AM)
+
+
+        optional works.. esp. if for a specific node instead of doing both eventing and poling
+
+
+
+* [ehashman] Great work on meeting enhancements deadline for 1.23!
+    * Soft freeze for node will be in Oct, email forthcoming
+
+
+## September 7, 2021
+
+Total active pull requests:: [222](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-08-31T17%3A00%3A00%2B0000..2021-09-07T16%3A50%3A00%2B0000">18</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-08-31T17%3A00%3A00%2B0000..2021-09-07T16%3A50%3A00%2B0000">8</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-08-31T17%3A00%3A00%2B0000..2021-09-07T16%3A50%3A00%2B0000+created%3A%3C2021-08-31T17%3A00%3A00%2B0000">67</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-08-31T17%3A00%3A00%2B0000..2021-09-07T16%3A50%3A00%2B0000">2</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [madhav] Feedback on addition of new PodCondition for pods that have ephemeral containers created.
+    * Issue: [https://github.com/kubernetes/kubernetes/issues/84353](https://github.com/kubernetes/kubernetes/issues/84353)
+    * Relevant area in the KEP: [https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/277-ephemeral-containers#identifying-pods-with-ephemeral-containers](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/277-ephemeral-containers#identifying-pods-with-ephemeral-containers) 
+    * Feedback needed mainly on: should this new PodCondition be added to pods on which `exec` is done and those which have `ContainerNotifier` defined on them?
+* [clayton/ryan] static pod lifecycle, static pod bugs, and static pod uids
+    * [Static pod lifecycle regression](https://docs.google.com/document/d/1NJKYNgoXZKGS5la4MvGrB42-DNQSFf4JQkEcZRnrDzA/edit#) - summary of issues identified
+    * Static pods that change UID or have fixed UID are recreated and deleted on disk are broken
+        * The fixes to pod workers guaranteed that other kubelet loops finish - those loops depend only on UID, so “delete/recreate by same UID” is also broken because the volume manager might be tearing down a static pod with one set of volumes and needs to complete before we let it spin up a new pod (which means we need to decide how to handle that)
+    * Admission around static pods with fixed static pod uids is potentially broken
+    * Working to identify what the right fix is
+        * Suspect it involves limiting what static pod fixed UID can do, as well as supporting the key use case of “only want one instance of a static pod running at the same time”, but will need feedback
+    * Also, we need a KEP (and then docs) for what static pods are actually supposed to be doing and what we support and test those
+        * Ryan / Clayton to pair up on static pods
+        * Clayton to clarify pod safety around pods (which was what triggered the refactor that led to the regression)
+        * Sergey to help with pod admission KEP
+* [aditi] Just a note, Please add [Kubelet credential provider KEP](https://github.com/kubernetes/enhancements/issues/2133) to 1.23 [Tracking sheet](https://docs.google.com/spreadsheets/d/1P1J1QpayRmh2SNjs8T-wBCb6SgEOdWTRQ7MBol7yibk/edit#gid=1954476102).
+* [vinaykul] In-place Pod Vertical Scaling KEP - status update
+    * I just got back from vacation, I won’t be in today’s meeting.
+    * Thanks Elana for getting the two KEPs tracked towards 1.23
+        * Please approve/merge PR updating the milestones for these KEPs
+        * [https://github.com/kubernetes/enhancements/pull/2948](https://github.com/kubernetes/enhancements/pull/2948)
+    * I’m planning to address the outstanding items in the next few weeks.
+
+
+## August 31, 2021
+
+Total active pull requests:: [213](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-08-24T17%3A00%3A00%2B0000..2021-08-31T16%3A39%3A26%2B0000">25</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-08-24T17%3A00%3A00%2B0000..2021-08-31T16%3A39%3A26%2B0000">7</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-08-24T17%3A00%3A00%2B0000..2021-08-31T16%3A39%3A26%2B0000+created%3A%3C2021-08-24T17%3A00%3A00%2B0000">53</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-08-24T17%3A00%3A00%2B0000..2021-08-31T16%3A39%3A26%2B0000">10</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [klueska] Please add this [KEP](https://github.com/kubernetes/enhancements/issues/2902) to [tracking sheet](https://docs.google.com/spreadsheets/d/1P1J1QpayRmh2SNjs8T-wBCb6SgEOdWTRQ7MBol7yibk/edit#gid=1954476102) (only SIG leads can edit the sheet)
+    * As referenced in the [“SIG Node - 1.23 Planning”](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.piluljhxzmsc) document
+* [mrunalp] Limiting number of concurrent image pulls
+    * making it on runtime level is also possible. Maybe easier to do it on kubelet to minimize back and forth on CRI API level
+    * [Lantao] memory-based limit or number limit? 
+        * likely specific for go version and likely based on the number 
+    * [Lantao] another concurrency setting - parallelism on number of layers
+    * [Derek] let’s try serial puller as well to compare.
+* [madhav] Feedback on addition of a new PodCondition on pods that have an EphermeralContainer created
+    * [https://github.com/kubernetes/kubernetes/issues/84353](https://github.com/kubernetes/kubernetes/issues/84353)
+    * [Derek] [https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/277-ephemeral-containers#identifying-pods-with-ephemeral-containers](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/277-ephemeral-containers#identifying-pods-with-ephemeral-containers) 
+* [MikeBrown post meeting] (memory, storage, number of concurrent)/(number of network devices/bandwidth)... possibly need a controller at the scheduler level instead of handling failures at the kubelet to reduce thrashing.
+* [marosset] Failures when starting sandbox container keep Pod in pending state indefinitely - should pod be marked as failed?
+    * [https://github.com/kubernetes/kubernetes/issues/104635](https://github.com/kubernetes/kubernetes/issues/104635) 
+    * [Derek] PodPhases are designed this way and the hope is that sandbox will be created. It is hard to change this behavior/assumption
+    * [Alex] should we have a condition or known errors which will indicate the terminate state?
+    * [Ibrahim] another example - image that doesn’t match the platform will never start
+    * [] CSI failure is another example where kubelet keep retrying even if the failure is terminal
+    * [Derek] maybe look into the timeout when kubelet should stop trying to start the pod and will mark is failed?
+    * There is also a device plugin scenario where pod cannot be scheduled on the node
+    * [Derek] if this were only CRI flows, it would be easier
+    * [rphillips] found a link after the meeting, there is a logic to recreate a sandbox if it failed, perhaps the error is not being reported in the sandbox statuses [[link](https://github.com/rphillips/kubernetes/blob/d1da6d47dd9dc8eeee9b96bffa9523e4c91f32b8/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L482-L516)] \
+	
+
+
+## August 24, 2021
+
+
+
+* [keerthan]  [https://github.com/kubernetes/kubernetes/pull/98934](https://github.com/kubernetes/kubernetes/pull/98934) (needs Clayton presence to discuss)
+    * We are missing a state in the PodSandbox, there is only READY/NOTREADY, but kubelet doesn’t know whether a PodSandbox is broken, or fully cleaned up. Especially for the containerd implementation, once the pause container is stopped (before network teardown), the PodSandbox is considered NOTREADY.
+    * However, even though we get the above issue fixed, there are still various corner cases that the pod in the apiserver may be deleted before kubelet stops the pod locally, e.g. network partition, force deletion. So the CNI needs to tolerate that anyway to clean up properly.
+    * The CNI plugin may need to do some local checkpoint to cleanup properly in that case, e.g. what did checkpoint for dockershim network plugin [https://github.com/kubernetes/kubernetes/commit/51526d310385d6f3791db8bd00ed16abab46658f](https://github.com/kubernetes/kubernetes/commit/51526d310385d6f3791db8bd00ed16abab46658f) 
+    * What information is needed from the pod object? Annotations and labels. In that case, actually CNI plugin may be able to get that information from the container runtime, e.g. containerd.
+* [manugupt1] [https://github.com/kubernetes/kubernetes/issues/81134](https://github.com/kubernetes/kubernetes/issues/81134) (discuss comments)
+* [adisky] Keystone container KEP [https://github.com/kubernetes/enhancements/pull/2869](https://github.com/kubernetes/enhancements/pull/2869)
+    * Looking for reviewers and feedback
+    * Mrunal and Derek will take a look 
+* [fromani] promoting [https://github.com/kubernetes/enhancements/issues/2403](https://github.com/kubernetes/enhancements/issues/2403) to beta
+    * still in time for 1.23? We mostly need to [land](https://github.com/kubernetes/kubernetes/pull/104123) [some](https://github.com/kubernetes/kubernetes/pull/102989) [fixes](https://github.com/kubernetes/kubernetes/pull/103289), then we should be able to move to beta.
+    * fromani to add this item to the sig-node tracking document
+* [dawnchen] Plan to promote [https://features.k8s.io/2892](https://features.k8s.io/2892) for beta in 1.23. 
+
+
+## August 17, 2021
+
+
+<table>
+  <tr>
+   <td>Total active pull requests:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+">207</a>
+   </td>
+   <td>(+5 from the last meeting)
+   </td>
+  </tr>
+</table>
+
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-08-10T17%3A00%3A00%2B0000..2021-08-17T16%3A50%3A52%2B0000">21</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-08-10T17%3A00%3A00%2B0000..2021-08-17T16%3A50%3A52%2B0000">5</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-08-10T17%3A00%3A00%2B0000..2021-08-17T16%3A50%3A52%2B0000+created%3A%3C2021-08-10T17%3A00%3A00%2B0000">73</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-08-10T17%3A00%3A00%2B0000..2021-08-17T16%3A50%3A52%2B0000">13</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Finish with KEPs for 1.23 review: [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#heading=h.vc5zckz3wr33)
+* [kmala]  [https://github.com/kubernetes/kubernetes/pull/98934](https://github.com/kubernetes/kubernetes/pull/98934)
+    * Moved to next week. Need Clayton presence
+* [bobbypage/qiutongs] Complications with cAdvisor/CRI integration (e.g. [file system metrics](https://github.com/google/cadvisor/pull/2872)) and thoughts on moving CRI API out of k/k staging
+    * let’s move CRI to its own repository to avoid circular dependencies
+    * long term want to move metrics to CRI. 
+    * Question: when will this happen and whether moving CRI out of staging is a long term goal anyway?
+    * Derek: trying to think of a mechanics of it. Important to preserve the promise that CRI is versioned with the k8s. if we decouple it from k/k, we need to be careful about it’s versioning. 
+    * David: maybe we can have a process of feature freeze date for CRI and propagate this across multiple repos.
+    * Mike: or have a k8s release branch in the cri repo specifically tied to each k8s release.
+    * Dawn: CSI recently had dependencies and release issues. Maybe they can share some experiences.
+    * Xiangqian, Xing: k/k has dependency on CSI. Every release there is an update in k/k. Sometimes development is on CSI repository. Trying to align these changes and coordinate them with k/k changes. Issues mitigated by the fact that SIg has control over the CSI repo.
+    * Dawn: heard that there are some regrets to have CSI in separate rero. Process overhead is high.
+    * Xing: also working on moving drivers from in-tree. Having them in the repo can cause issues. So pros and cons are in both cases.
+    * Lantao: is it possible to do go module magic? (yes but.. managing n apis via submodule is also problematic)
+    * Dawn: let’s start e-mail thread on this topic.
+* [matthyx/adisky] Draft Proposal for Keystone containers KEP [https://github.com/kubernetes/enhancements/pull/2869](https://github.com/kubernetes/enhancements/pull/2869)
+    * Derek: didn't have time to read through the KEP, questions can be addressed in another meeting later.
+    * Matthias: only need a reviewer and then we do it asynchronously.
+* [sjennings/decarr] Notification API KEP discussion \
+[https://github.com/kubernetes/enhancements/pull/1995](https://github.com/kubernetes/enhancements/pull/1995) 
+
+
+## August 10, 2021
+
+Total active pull requests: [202](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-08-03T17%3A00%3A00%2B0000..2021-08-10T16%3A25%3A31%2B0000">28</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-08-03T17%3A00%3A00%2B0000..2021-08-10T16%3A25%3A31%2B0000">13</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-08-03T17%3A00%3A00%2B0000..2021-08-10T16%3A25%3A31%2B0000+created%3A%3C2021-08-03T17%3A00%3A00%2B0000">88</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-08-03T17%3A00%3A00%2B0000..2021-08-10T16%3A25%3A31%2B0000">29</a>
+   </td>
+  </tr>
+</table>
+
+
+	Rotten: #[98542](https://github.com/kubernetes/kubernetes/pull/98542) #[90727](https://github.com/kubernetes/kubernetes/pull/90727) (related bug may be addressed by other PRs) 
+
+
+
+* 1.23 KEP planning [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#heading=h.vc5zckz3wr33)
+* [ehashman/mrunalp] Suggestion: alpha features/deprecrations deadline for SIG Node of **Oct. 15, 2021** (halfway through code freeze)
+    * Rationale: things keep landing much too late, deprecation broke things right during code freeze in 1.22
+    * [dawn] Easier to set this for beta/GA and deprecations than alpha features, alpha features are off by default so it’s okay to land them later
+    * [sergey] Also, ensure everything has a WIP out by this date.
+    * **Action:** Elana to send an email to SIG Node proposing the soft deadline
+* [dawnchen/derek] Update on SIG Node approver process
+* [manugupt1] [https://github.com/kubernetes/kubernetes/issues/81134#issuecomment-540800845](https://github.com/kubernetes/kubernetes/issues/81134#issuecomment-540800845) 
+    * Discuss comments that I made
+* [kmala]  [https://github.com/kubernetes/kubernetes/pull/98934](https://github.com/kubernetes/kubernetes/pull/98934)
+* ~~[qiutongs] Add new container label in [pkg/kubelet/types/labels.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/types/labels.go) - io.kubernetes.container.restart~~
+    * ~~It will be consumed by cadvisor. `k8s_&lt;container-name>_&lt;pod-name>_&lt;namespace>_&lt;pod-uid>_&lt;restart-count>`~~
+    * ~~Discuss feasibility and the right place to make change. (e.g. [pkg/kubelet/kuberuntime/kuberuntime_container.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_container.go))~~
+
+
+## August 3, 2021
+
+Total active pull requests: [216](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-07-27T17%3A00%3A00%2B0000..2021-08-03T16%3A55%3A15%2B0000">41</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-07-27T17%3A00%3A00%2B0000..2021-08-03T16%3A55%3A15%2B0000">20</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-07-27T17%3A00%3A00%2B0000..2021-08-03T16%3A55%3A15%2B0000+created%3A%3C2021-07-27T17%3A00%3A00%2B0000">54</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-07-27T17%3A00%3A00%2B0000..2021-08-03T16%3A55%3A15%2B0000">10</a>
+   </td>
+  </tr>
+</table>
+
+
+Closed PRs - mostly WIP, test validation PRs. A few Rotten: #[84032](https://github.com/kubernetes/kubernetes/pull/84032) #[99611](https://github.com/kubernetes/kubernetes/pull/99611/). Merged PRs are mostly cherry-picks and test updates since we are in test freeze now.
+
+
+
+* 1.22 release date: tomorrow, Aug. 4
+* [ehashman] 1.22 burndown update
+    * [https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+milestone%3Av1.22+label%3Asig%2Fnode+](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+milestone%3Av1.22+label%3Asig%2Fnode+) 
+* [matthyx] requesting reviewer and later approver role to help sig-node CI subgroup in:
+    * test/e2e/common/OWNERShttps://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+milestone%3Av1.22+label%3Asig%2Fnode+
+    * test/e2e/node/OWNERS
+    * test/e2e_node/OWNERS
+    * [dawn] Possible areas of approver: top-level node, community repo, node tests in k/k, cadvisor (not a Kubernetes project), node problem detector
+    * What about test-infra?
+        * [derek] Should probably be tied with node e2e, would be happy with Elana and Sergey to both apply for node test approver, test-infra
+    * Need to keep balancing new energy with existing contributors
+* [adrianreber] checkpoint/restore KEP reworked and ready for review
+    * [https://github.com/kubernetes/enhancements/pull/1990](https://github.com/kubernetes/enhancements/pull/1990)
+        * Kep #2008
+    * Update KEP to split into stages to mention that 1.23 only includes checkpoint part of it with ability to review the checkpoint later outside of K8s.
+    * Adrian to send e-mail when KEP is updated.
+    * runc already can do checkpoint. This KEP only adding the initiation of the checkpoint. What this KEP adds from the value add?
+        * Derek:
+            * this work adds context to checkpoint around secrets?
+            * Problem with restore: images that the pod was restored with, and prevent these images to be used on later restart is hard.
+        * Adrian:
+            * Container engines cannot handle checkpoint in containers running in shared namespaces. Want to add it to CRI API, container engine will do the implementation. Main value-add is to decide to make it in CRI.
+        * Dawn:
+            * Since it’s only CRI API and not leak out to Pod API, it is fine to implement without the restore for now. 
+
+
+## July 27, 2021
+
+Total active pull requests: [204](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-07-20T17%3A00%3A00%2B0000..2021-07-27T16%3A35%3A21%2B0000">24</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-07-20T17%3A00%3A00%2B0000..2021-07-27T16%3A35%3A21%2B0000">6</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-07-20T17%3A00%3A00%2B0000..2021-07-27T16%3A35%3A21%2B0000+created%3A%3C2021-07-20T17%3A00%3A00%2B0000">53</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-07-20T17%3A00%3A00%2B0000..2021-07-27T16%3A35%3A21%2B0000">8</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Announcement: doc freeze is today!
+* [ehashman] 1.22 burndown
+    * Current release blockers:
+        * [https://github.com/kubernetes/kubernetes/issues/103879](https://github.com/kubernetes/kubernetes/issues/103879)
+        * [https://github.com/kubernetes/kubernetes/issues/103651](https://github.com/kubernetes/kubernetes/issues/103651) 
+* [adrianreber] checkpoint/restore KEP reworked and ready for review
+    * [https://github.com/kubernetes/enhancements/pull/1990](https://github.com/kubernetes/enhancements/pull/1990)
+        * Kep #2008
+    * Will move this to next week - working through comments from Derek/Mrunal
+    * [sergey] Was the discussion from last time for how checkpoint/restore on different nodes will work resolved?
+    * We want to store the checkpoint image in a registry so it can be transferred and avoid local storage between nodes
+    * Lifecycle: can checkpoint a container so long as it doesn’t use external devices (e.g. GPUs, SRIOV) once the init container has finished running
+    * [vinay] Checkpointing the running container’s image?
+    * Including its memory footprint/pages and all, will be available after migration/reboot as it was before
+* [vinaykul] In-place Pod Vertical Scaling KEP for early v1.23 - Status update
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+        * API review approved by Tim Hockin
+        * Current PR squashed and rebased.
+        * Starting work on unresolved issues in kubelet
+            * Outstanding issues tracked [here](https://github.com/kubernetes/enhancements/issues/1287).
+    * Scheduler changes are a bit more involved than I initially thought. They requested a separate PR that follows the above main PR. 
+        * Can we do that? (Two PRs need to go in quick succession.)
+        * No problem with this, but code will be reverted if one PR misses deadline.
+
+
+## July 20, 2021
+
+Total active pull requests: [193](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-1 from last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-07-13T17%3A00%3A00%2B0000..2021-07-20T16%3A47%3A16%2B0000">13</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-07-13T17%3A00%3A00%2B0000..2021-07-20T16%3A47%3A16%2B0000">6</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-07-13T17%3A00%3A00%2B0000..2021-07-20T16%3A47%3A16%2B0000+created%3A%3C2021-07-13T17%3A00%3A00%2B0000">58</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-07-13T17%3A00%3A00%2B0000..2021-07-20T16%3A47%3A16%2B0000">8</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] Reminder: docs reviewable deadline today!
+* [ehashman] 1.22 burndown:
+    * [https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+milestone%3Av1.22+label%3Asig%2Fnode+](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+milestone%3Av1.22+label%3Asig%2Fnode+) 
+* KEPs retrospective for 1.22
+    * SIG Node KEPs planning: [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.7mxl83pa2zof](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.7mxl83pa2zof) 
+    * [sig node 1.22 KEPs retrospective](https://docs.google.com/spreadsheets/d/15XjKZ3ZUp8_VVWigM33VKwCmnjd5pVp28DTslweiH0I/edit#gid=0) 
+        * 13 of 24 implemented
+        * 2 - w/exception
+        * 4 - denied with exception
+    * Kubernetes 1.22 Release Information: [https://www.kubernetes.dev/resources/release/#kubernetes-122](https://www.kubernetes.dev/resources/release/#kubernetes-122)
+    * [Kubernetes 1.22 Enhancements Tracking](https://docs.google.com/spreadsheets/d/1mlui0brYypOAsgS2D13fvcs3At1uMq4i1gWfneq-jxY/edit#gid=936265414)
+    * _Things that could have gone better_
+        * Difficulty with API reviews. Until the last day we didn’t have comments from API reviewers. Some PRs were not marked for API reviews unless the last moment.
+        * **Suggested action:** in future releases, ensure all node KEP PRs are tagged with api-review and have a reviewer assigned as early as possible.
+        * Reviews came in late for a lot of feature PRs, a lot of them were marked WIP until the very last week
+        * **Suggested action:** KEP PRs need to be marked as ready for review well before the final week before code freeze
+        * Some things we asked for exceptions that weren’t quite ready
+        * **Suggested action:** In the future, only ask for exceptions when we’ve engaged with chairs early and the feature is nearly complete
+        * PRR didn’t catch some of the breaking issues with seccomp by default; by enabling it by default, could break some workloads
+    * _Things that went well_
+        * Required e2es to be ready in PRs themselves and that worked really well: gRPC probes were an example and we found quite a few issues by asking for tests
+        * Small KEPs like pod FQDN, Size memory backed volumes merged very early
+    * 
+* [ddebroy] Introduce Draft KEP “Runtime Assisted Mounting”
+    * [https://docs.google.com/document/d/1ieVOqe1-Dc4lTMHTmp-vd0ivG_KZYvU7x30p3AYBndA/](https://docs.google.com/document/d/1ieVOqe1-Dc4lTMHTmp-vd0ivG_KZYvU7x30p3AYBndA/)
+    * Overview [slides](https://docs.google.com/presentation/d/1xvrJMt5zum4wig1h9VHHyKofIQ9PDnJj--OYNkpwchQ/edit?usp=sharing)
+    * Discussed overview with sig-storage
+    * Gather initial thoughts from sig-node
+* Lantao: what exact problems it is solving, it seems like kata already solved this with Raw Block? ([https://github.com/kata-containers/runtime/issues/1354](https://github.com/kata-containers/runtime/issues/1354)) Would be nice to know more about the pros/cons of this approach to understand whether or what we need to change in Kubernetes.
+* Mrunal: does it have some intersection with how Kata wants to know more about other things like Devices information
+* Dawn: want more proposal to outline more details on the problem. Why it couldnt be solved in the current design of CRI?
+* [xyang] Non-graceful node shutdown: [https://github.com/kubernetes/enhancements/pull/1116](https://github.com/kubernetes/enhancements/pull/1116)
+    * In the KEP, we are proposing to add a “quarantine” taint to a node that is being shutdown.  It is to prevent new pods from being scheduled to this node when it comes up before it is cleaned up.
+    * Can we rely on the Node Shutdown Manager to apply this taint?
+* David: it is there already. NodeReady state is already set. Reason of NodeReady condition can be checked.
+* Elana: caution against the taints - they are unreliable. 
+* Xing: we want the status to be changed when Node is coming back up. 
+* Elana: maybe look at the previous status.
+
+
+## July 13, 2021
+
+Total active pull requests: [194](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-23 from last two weeks)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-06-29T17%3A00%3A00%2B0000..2021-07-13T15%3A51%3A59%2B0000">42</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-06-29T17%3A00%3A00%2B0000..2021-07-13T15%3A51%3A59%2B0000">23</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-06-29T17%3A00%3A00%2B0000..2021-07-13T15%3A51%3A59%2B0000+created%3A%3C2021-06-29T17%3A00%3A00%2B0000">127</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-06-29T17%3A00%3A00%2B0000..2021-07-13T15%3A51%3A59%2B0000">43</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [swsehgal] Are the requirements of being reviewer of a well defined subsystem (eg Container Manager) same as [requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#reviewer) of an entire component (like kubelet)
+    * Background/Motivation: Hard to find reviewers in the area of CM/CPU Manager/PodResource API (in general in pkg/kubelet/cm)
+    * [Dawn] approver status today is too coarse grain. We have some subareas (not implicit), but generally known. Like resource management, monitoring, security, storage, etc. In the past we had clear owners for these areas. As time passed some people moved, some changed interests. So discussion now behind the scenes how to make these areas explicit.
+* ~~[fromani] final call for cpumanager policy aliases - [we need a decision](https://kubernetes.slack.com/archives/C0BP8PW9G/p1625061895006400)~~
+    * ~~fromani’s take: i think this is an issue more when the feature reaches beta rather than for alpha stage~~
+    * update: settled in the PR comments
+* [vinaykul] In-place Pod Vertical Scaling KEP - Status update
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+        * API review approved by Tim Hockin
+        * Most items from Lantao’s review addressed and TODOs taken
+            * Outstanding issues also tracked [here](https://github.com/kubernetes/enhancements/issues/1287).
+    * Cut from 1.22, let’s shoot for early 1.23 check-in.
+    * SIG-scheduling review ETA this week.
+    * Identify any missing reviewers and loop them in.
+* [Balaji] KEP Add support for pluggable pod admit handler
+    * PR: [https://github.com/kubernetes/enhancements/pull/2811](https://github.com/kubernetes/enhancements/pull/2811) 
+    * Slides for presentation: [https://github.com/kubernetes/enhancements/pull/2811#issuecomment-875203470](https://github.com/kubernetes/enhancements/pull/2811#issuecomment-875203470) 
+    * Alternative (possible): static webhook: [https://github.com/kubernetes/enhancements/issues/1872](https://github.com/kubernetes/enhancements/issues/1872) 
+    * 
+    *  
+
+
+## July 6, 2021
+
+Cancelled due to US holiday
+
+
+## June 29, 2021
+
+
+
+* PR/Issue update
+* Bugs scrub charts:
+* 
+
+* [ehashman] Swap update
+* [ehashman] Requesting Node approver [https://github.com/kubernetes/kubernetes/pull/103122](https://github.com/kubernetes/kubernetes/pull/103122) 
+    * [https://github.com/kubernetes/community/blob/master/community-membership.md#approver](https://github.com/kubernetes/community/blob/master/community-membership.md#approver)
+    * Need to have more granular approach on how to carve out the path to approver
+* [vinaykul] In-place Pod Vertical Scaling KEP - Updates & PR review request
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+        * API changes - see [commit](https://github.com/kubernetes/kubernetes/pull/102884/commits/e42ff603f553db37a5c22390cf7bc4e11ec2bb52)
+        * CRI changes - see [commit](https://github.com/kubernetes/kubernetes/pull/102884/commits/b1d910ff8afd3c47f63dfc30301cb273bf2747c9)
+        * Core implementation mostly done - see [commit](https://github.com/kubernetes/kubernetes/pull/102884/commits/e659e3423d076f9767b248998cfee4650e24c170)
+            * Scheduler & RQ accounting left to finish
+        * Next major task: E2E tests.
+            * @wangchen615 from IBM is working on this
+        * Lantao to review the PRs
+        * Tim Hockin has it in his backlog
+        * E2E needs to be part of the main PR
+* [danielfoehrkn] Auto system/kube-reserved based on actual resource usage
+    * Issue: [https://github.com/kubernetes/kubernetes/issues/103046](https://github.com/kubernetes/kubernetes/issues/103046)
+    * [Alexander]: The cgroup hierarchy would have to be parsed to evaluate the actual utilization? \
+Expanded question/comment: I like the overall idea about adjusting some of kubelet parameters during the lifecycle of kubelet. However, it might not be a good idea to add complexity into kubelet to be dependent on cgroups implementation (v1 vs v2, linux vs windows, etc). It might be a bit better idea to generalize the way of dynamically updating kubelet configuration and use e.g. external operator(s) that would be evaluating the state of the node (e.g. via some external metrics, like Prometheus) or overall cluster health and make a decision about adjusting reserved portions.
+    * [Derek]: Has there testing been done with Enforced Allocatable feature enabled?
+        * recommended setup explored
+        * needs further investigation
+        * has runtime and kubelet put in separate cgroups?
+    * Has cgroupv2 been explored? 
+        * Cgroupv2 will allow more signal from kernel
+    * [Dawn]: Kernel OOM is best effort at the moment
+    * Kubectl exec should also be taken into consideration
+    * [Eric]: Problems with under-reserved have been highlighted. What about over reservation?
+        * less resources advertised to the scheduler
+    * [Derek]: An interesting area that should be explored/researched further
+* [bart0sh] request for PR review & approval:
+
+    [promote huge page storage medium size to GA](https://github.com/kubernetes/kubernetes/pull/99144)
+
+
+    	PR to add conformance tests? Needs update to the hardware config
+
+
+    	Needs approval
+
+* [vinayakankugoyal] thoughts on [https://github.com/cri-o/cri-o/pull/5043](https://github.com/cri-o/cri-o/pull/5043) and [https://github.com/containerd/containerd/pull/5668](https://github.com/containerd/containerd/pull/5668) could we support ambient capabilities without making a change to k8s API and CRI API? I think we can and so I opened those PRs. I would love to hear the thoughts of the CRI maintainers though!
+* 
+
+PRs status:
+
+Total active pull requests: [217](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-06-22T17%3A00%3A00%2B0000..2021-06-29T17%3A08%3A45%2B0000">36</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-06-22T17%3A00%3A00%2B0000..2021-06-29T17%3A08%3A45%2B0000">10</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-06-22T17%3A00%3A00%2B0000..2021-06-29T17%3A08%3A45%2B0000+created%3A%3C2021-06-22T17%3A00%3A00%2B0000">143</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-06-22T17%3A00%3A00%2B0000..2021-06-29T17%3A08%3A45%2B0000">23</a>
+   </td>
+  </tr>
+</table>
+
+
+Three weeks stats (since last update):
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-06-08T17%3A00%3A00%2B0000..2021-06-29T17%3A10%3A27%2B0000">92</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-06-08T17%3A00%3A00%2B0000..2021-06-29T17%3A10%3A27%2B0000">31</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-06-08T17%3A00%3A00%2B0000..2021-06-29T17%3A10%3A27%2B0000+created%3A%3C2021-06-08T17%3A00%3A00%2B0000">184</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-06-08T17%3A00%3A00%2B0000..2021-06-29T17%3A10%3A27%2B0000">56</a>
+   </td>
+  </tr>
+</table>
+
+
+
+## June 22, 2021
+
+
+
+* [ehashman] Reminder: SIG Node Bug Scrub this week! Drop in and help us scrub bugs! Starts 00:00 UTC on June 24!
+* [dawnchen] Review of PRs up for KEPs [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#) 
+* [vinaykul] In-place Pod Vertical Scaling KEP - Updates & PR review request
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+        * Core API changes - see [commit](https://github.com/kubernetes/kubernetes/pull/102884/commits/20e51697ba19e1730ed21d17aae72e8950ae0192)
+        * CRI changes - see [commit](https://github.com/kubernetes/kubernetes/pull/102884/commits/e9bfbc5c46853d421de1489fb8fa9b34425b47a7)
+        * This is partial implementation, work-in-progress.
+            * Node checkpointing is working
+            * Basic e2e resize cases are working
+            * Working on ‘Resize’ status reporting and scheduler, RQ accounting change. ETA - a couple of days.
+        * Next major task: E2E tests.
+            * @wangchen615 from IBM is working on this
+* [ehashman] How to handle SIG Node issues in k/k marked kind/support
+    * Suggestion: close with a template directing people to official support channels
+    * See also [https://github.com/kubernetes/community/issues/5435](https://github.com/kubernetes/community/issues/5435) 
+    * Can write up a draft for the template: [https://hackmd.io/O_gw_sXGRLC_F0cNr3Ev1Q#Support-Requests](https://hackmd.io/O_gw_sXGRLC_F0cNr3Ev1Q#Support-Requests) 
+* [ehashman] Swap status
+* [vinayakankugoyal] can we add KEP 2763 to the 1.23 planning doc? [https://github.com/kubernetes/enhancements/pull/2757](https://github.com/kubernetes/enhancements/pull/2757) 
+
+
+## June 15, 2021 [Cancelled]
+
+Cancelled as there were no agenda proposed for the meeting.
+
+Important dates:
+
+
+
+* Next SIG Node meeting - review PRs for KEPs 
+* [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#) 
+* June 24th, 25th: bug triage: [https://hackmd.io/O_gw_sXGRLC_F0cNr3Ev1Q](https://hackmd.io/O_gw_sXGRLC_F0cNr3Ev1Q) 
+
+
+## June 8, 2021
+
+Total active pull requests: [204](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+1 since the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-06-01T17%3A00%3A00%2B0000..2021-06-08T16%3A54%3A28%2B0000">29</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-06-01T17%3A00%3A00%2B0000..2021-06-08T16%3A54%3A28%2B0000">7</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-06-01T17%3A00%3A00%2B0000..2021-06-08T16%3A54%3A28%2B0000+created%3A%3C2021-06-01T17%3A00%3A00%2B0000">93</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-06-01T17%3A00%3A00%2B0000..2021-06-08T16%3A54%3A28%2B0000">25</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [SergeyKanzhelev] Currently we have a specific order of container startup. Also second container wouldn’t start before the prestart hook finished for the previous container. This is not a documented scenario, but there are apps taking dependency on this behavior (mostly sidecars). Do we want to promote this behavior to conformance?
+    * Not a conformance
+    * Just have a test - do we have unit tests already?
+    * Changing of this behavior will require a KEP
+    * [ehashman] Conformance tests have a very specific purpose; we should be adding them to reflect universal user expectations, not implementation details. Lots of room to add unit test coverage: kubelet is only at ~56% covered right now
+* [ranchothu] A KEP about taking LLC cache into cpu allocation, for that, in some architectures like AMD rome/milan, more than one LLC exist in an individual socket, original algorithm  may cause performance decrease in this scenario.
+    * KEP: [https://github.com/kubernetes/enhancements/pull/2684](https://github.com/kubernetes/enhancements/pull/2684)
+    * Issue:  [https://github.com/kubernetes/enhancements/issues/2621](https://github.com/kubernetes/enhancements/issues/2621)
+    * PR:  [https://github.com/kubernetes/kubernetes/pull/102307](https://github.com/kubernetes/kubernetes/pull/102307)
+    * [dawn] Is this a new policy or addition to existing policy?
+* Francesco has been in touch with the review author - timing is not good for them. Can we have an APAC-friendly node meeting time?
+* Used to run an APAC time for node for about half a year (11PM PT) but people stopped attending after the first few. Would be open to having another meeting, but people need to attend regularly
+    * [fromani] maybe just reserve the slot (once/twice a month) and have the meeting only if there are agenda items?
+* [ike-ma] test-infra node image 
+    * (Context: [https://github.com/kubernetes/test-infra/pull/22453](https://github.com/kubernetes/test-infra/pull/22453) )
+    * Do we have any policy regarding onboarding new images?
+        * [[PUBLIC][Proposal] Re-catogrize the Node E2E tests](https://docs.google.com/document/d/1BdNVUGtYO6NDx10x_fueRh_DLT-SVdlPC_SsXjYCHOE/edit?usp=sharing)
+        * [dawn] Lantao was the founder for this area. Need an owner for each distro. We used to have policy for this, but not specifically for image lifecycle 
+        * [lantao] Previously the coreos was in presubmit, and blocked PR submission, and was later removed.   
+        * [Mrunal] prefer using existing images, will ask Harshal for more details on how the Fedora CoreOS images are used
+        * [dawn] swap feature itself is less OS-distro dependent, more on kernel module
+    * Do we have any policy/process regarding image update/release pipeline? eg: update kernel version, containerd version etc?
+        * Ubuntu/COS/Fedora/CoreOS - focus on existing image 
+    * Do we have any best practice/recommendation of test coverage for image-oriented features? Two patterns in use right now: focus on feature [hugepage](https://testgrid.k8s.io/sig-node-kubelet#kubelet-serial-gce-e2e-hugepages) ([test coverage](https://github.com/kubernetes/test-infra/blame/master/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml#L337)) vs smoke run [cgroupv2](https://testgrid.k8s.io/sig-node-kubelet#pr-node-kubelet-serial-crio-cgroupv2) ([test coverage](https://github.com/kubernetes/test-infra/blame/master/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml#L413))
+        * Prefer to tag on Feature
+* [ehashman] Pod lifecycle rework 
+    * [https://github.com/kubernetes/kubernetes/pull/102344](https://github.com/kubernetes/kubernetes/pull/102344) 
+    * [https://docs.google.com/document/d/1DvAmqp9CV8i4_zYvNdDWZW-V0FMk1NbZ8BAOvLRD3Ds/edit#](https://docs.google.com/document/d/1DvAmqp9CV8i4_zYvNdDWZW-V0FMk1NbZ8BAOvLRD3Ds/edit#) 
+* [jberkus] URGENT: which runtimes does the [Kubelet Stream regression affect](https://github.com/kubernetes/kubernetes/pull/102489)?  Contributor Comms needs answers so we can notify users.	
+    * Went out in the May patch releases
+* [ehashman] Reminder: June cherry-pick deadline is this Friday (June 11)
+
+
+## June 1, 2021
+
+Total active pull requests: [203](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-05-25T17%3A00%3A00%2B0000..2021-06-01T16%3A59%3A20%2B0000">28</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-05-25T17%3A00%3A00%2B0000..2021-06-01T16%3A59%3A20%2B0000">13</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-05-25T17%3A00%3A00%2B0000..2021-06-01T16%3A59%3A20%2B0000+created%3A%3C2021-05-25T17%3A00%3A00%2B0000">74</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-05-25T17%3A00%3A00%2B0000..2021-06-01T16%3A59%3A20%2B0000">8</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] Reminder: code freeze is July 8 (~5.5 weeks)
+* [Sergey] New APAC time for CI+Triage session
+    * tentatively 03:00 UTC on Thursdays (8pm PT on Wednesdays)
+* [swsehgal] Pod Resource API
+    * Issue: [Inability to account for available CPUs as guaranteed pods can belong to shared pool](https://github.com/kubernetes/kubernetes/issues/102190)
+        * Proposed fixes: [here](https://github.com/kubernetes/kubernetes/pull/97415#issuecomment-847891218) but a more broader set of changes might be needed. Being discussed with Intel
+        * Can this fix be treated as a bug fix or we would have to push these changes to 1.23?
+        * More upcoming features in podresources API: [here](https://docs.google.com/spreadsheets/d/1bG_T1Y4j_fqHiuVrcB2HdSTBFFFYc9dg2Ynpof2BZCY/edit?ts=60ad25d3#gid=103165191) (raw data [here](https://github.com/fromanirh/k8smisc/blob/main/docs/planned%20activity%20in%20the%20podresources%20API%20area%20-%20Sheet1.csv))
+    * [https://github.com/kubernetes/kubernetes/issues/102191](https://github.com/kubernetes/kubernetes/issues/102191)
+        * Website Doc update: [#102191](https://github.com/kubernetes/kubernetes/issues/102191)
+        * KEP update: [kubernetes/enhancements#2761](https://github.com/kubernetes/enhancements/pull/2761)
+* [vinayakankugoyal] [KEP-2763](https://github.com/kubernetes/enhancements/pull/2757) - ambient capabilities support
+    * We are proposing changes to CRI API
+    * Could someone from sig-node volunteer to be point-of-contact and help with review and approval from the sig-node side?
+        * Mike Brown - github.com/mikebrow containerd
+        * Mrunal - CRI-O
+    * Also reach out to someone from the PSP++ effort?
+* [n4j] [Redirect container stdout / stderr to file](https://github.com/kubernetes/kubernetes/issues/94892)
+    * Does this need a KEP since this is a non-trivial change and might require a change in the POD API?
+    * Need consensus on the extensibility of the feature i.e. would we support redirect only to file or it can be to external collectors like fluentd
+    * Is there a way to control (redirect) the output of the process via the CRI?
+        * [mrunal] To an additional file? There are serious performance implications of such a change
+        * [n4j] want to be able to set stdout to one file, stderr to another
+        * [mrunal] think there is a bigger story for the CRI and what solutions make sense
+        * [Dawn] this was discussed from the beginning of the CRI - adding redirects for logs or adding additional file targets. Did not do that for many reasons: using journald or other log mechanisms cover most cases that would enable this already. There’s concerns around complexity and performance, this is why the work hasn’t been done in the past. Needs a full design proposal, starting from a problem statement, as there are already ways to do this. At a high level, there are workarounds, so want to hear about why those aren’t enough.
+        * [Lantao] For a legacy container image, you can mount a logfile from the host. Are there security concerns or other issues?
+        * [ehashman] Summary of problem statement from issue… possibly we just need additional documentation because people don’t know how to do this?
+        * [Lantao] Will follow-up with a workaround on the issue. [https://github.com/kubernetes/kubernetes/issues/94892#issuecomment-852321278](https://github.com/kubernetes/kubernetes/issues/94892#issuecomment-852321278) 
+    * Who would be point-of-contact for design discussion and some early code feedback?
+* [adisky] How to proceed further on flags to [component config migration](https://github.com/kubernetes/kubernetes/issues/86843)
+    * Currently 96 flags have been marked as deprecated in favor of component config without any timeline of removal.
+    * New flags being added to Kubelet that are marked as [deprecated](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/options/options.go#L383) on creation. It looks confusing from the user's perspective and also It will be difficult to track later on which flags need to be removed when.
+    * Should new options be added as config only and flag addition be discouraged? 
+        * [ehashman] Appears to be owned by a defunct WG (Component Standard)
+        * [dims] WG is gone. Need to stop the bleeding - new CLI params should be avoided, added in KubeletConfig instead. Could add unit tests to check for this and prevent this, and then a timeline for removal of deprecated flags.
+        * [aditi] All the kubelet flags are getting added as deprecated.
+        * [dims] Need to update community page and/or add a KEP discussing deprecation.
+        * [ehashman] Suggest we do a KEP, solicit feedback, and announce and remove all the flags in one release rather than removing them piecemeal which is causing issues for downstream consumers.
+        * [dawn] We’re paused because kubelet has been leading but there are other components which aren’t migrating away from flags. We paused for a year and we’re waiting on other components. Many flags are GA so we could safely deprecate, but some need their own deprecation processes (e.g. DynamicKubeletConfig)
+        * [Lubomir] +1
+        * [Fabrizio] Situation across Kubernetes is confusing for users and platform tools. Not just a Kubelet issue, but it’s more pressing here because of the deprecation notices.
+        * [dims] It would be ideal if things were handled via Component Config but it’s not staffed. Kubelet is a bit special because it usually doesn’t run containerized like other components.
+        * [Lubomir] Story for kubelet users need to be consistent because it’s very confusing. Would like to see something from SIG Arch for k8s-wide.
+        * [ehashman] Would suggest that we don’t try to increase scope, because we already have tried that with WG which is now defunct. Let’s keep with Cluster Lifecycle driving and working with Node. Might want to get a proposal from them representing user needs and what we might want to change.
+        * [dawn] Let’s ensure KubeletConfig is working with kubeadm and that we’re not adding new flags. Can’t necessarily just get rid of all the deprecated flags in one go as there is more work that needs to be done.
+        * [dims] Want to publish a schedule because it makes it easier to get new contributors helping out.
+        * Agreed: publishing a schedule, identifying immediate pain points is a reasonable thing to spend time on.
+
+
+## May 25, 2021
+
+
+
+* [ehashman] Fixing termination and status reporting ([doc](https://docs.google.com/document/d/1DvAmqp9CV8i4_zYvNdDWZW-V0FMk1NbZ8BAOvLRD3Ds/edit#))
+    * Context: [https://github.com/kubernetes/kubernetes/pull/102025](https://github.com/kubernetes/kubernetes/pull/102025#issue-645031859) 
+* [yangjunmyfm192085] Exposing container start time in kubelet /metrics/resource endpoint
+    * Context: [https://github.com/kubernetes/kubernetes/issues/101851](https://github.com/kubernetes/kubernetes/issues/101851)
+    * [Derek] What is the node start time? When the node boots? When kubelet first marks itself NodeReady?
+    * [Elana] Static pods could start before NodeReady happens
+    * [Dawn] Static pod usage is discouraged, makes sense to set this to first NodeReady time
+    * [Derek] Proposed start time for containers makes sense
+    * Need to be clear on what the node start time metric is used for and how it’s defined
+    * [Elana] Proposal says node metric is not necessarily required, and was added for symmetry - can we potentially not add it?
+    * [Dawn] We should provide the most generic data as possible, e.g. node has started and is ready to join the cluster
+    * [Lantao] Node boot time could be useful in the CPU context
+    * [Dawn] NPE uses node boot time as well
+    * **Action:** summarize discussion on bug, bring to SIG Instrumentation for confirmation
+* [verb] kubelet metrics for types of containers
+    * Context: [https://pr.k8s.io/99000](https://pr.k8s.io/99000)
+    * running_pod/running_containers: what should we measure and where?
+
+
+## May 18, 2021
+
+Total active pull requests: [202](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+1 from the last meeting).
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-05-11T17%3A00%3A00%2B0000..2021-05-18T16%3A55%3A41%2B0000">24</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-05-11T17%3A00%3A00%2B0000..2021-05-18T16%3A55%3A41%2B0000">17</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-05-11T17%3A00%3A00%2B0000..2021-05-18T16%3A55%3A41%2B0000+created%3A%3C2021-05-11T17%3A00%3A00%2B0000">94</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-05-11T17%3A00%3A00%2B0000..2021-05-18T16%3A55%3A41%2B0000">9</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] Node bug scrub
+    * Proposed date: June 24-25
+* [ehashman] Swap work breakdown
+    * [https://issues.redhat.com/browse/OCPNODE-470?_sscc=t](https://issues.redhat.com/browse/OCPNODE-470?_sscc=t) 
+* [mrunal/harshal] node e2e - runc update broke crio tests: 
+    * Enabling this: [https://prow.k8s.io/?job=*pull-kubernetes-node-crio-e2e*](https://prow.k8s.io/?job=*pull-kubernetes-node-crio-e2e*) as presubmit would have caught it.
+    * [Dawn] need to understand how much combinations of systemd versions we need to test. CoreOS was excluded before from presubmits because it was on latest systemd and was very noisy. The decision was that it wasn’t the SIG Node scope to own this.
+    * [Mrunal] this may not be the same as this version of crio is running on production for many customers. Making this job blocking, runc updates would be easier
+    * [Dawn] is it kubelet or systemd/runc integration issue?
+    * [M] it is kubelet running into “wrong“ codepath.
+    * [Elana] Based on previous meetings - the goal os CI upstream is to support CRI, and testing more than 1 container runtime.
+    * [D] if kubelet supports cgroup driver, likely need to run tests
+    * [Brian Goff] Problem is this was exposed *after* rc94 was released. CI is needed against runc HEAD
+    * [Elana] there were some WIP PRs open with runc HEAD but the lack of the blocking job meant no signal
+    * [Dawn] as long as we support these tests it is fine. When CoreOS was breaking people’s PRs it was a problem
+    * [David] Serial tests may have better signal
+    * [Mrunal] making it a runc issue - hard. They don’t have enough CI and we might need to contribute
+    * [Brian] Periodic job on runc would be better to catch regressions early, before runc releases.
+    * [Dawn] In the past we started this conversation. But didn’t follow up these details completely
+    * [Mrunal] I’m on of runc maintainers and can facilitate the discussion. Every time runc tags something, people asking for more changes. Frequent updates are hard on runc because of a tag requirement from kubernetes.
+    * [Lantao] The model we use for containerd today is that containerd decides what runc version to use, and we test containerd + runc as a whole. Containerd does update runc periodically, and the runc update needs to go through Kubernetes node e2e tests.
+    * [Mike Brown] we run tests against master of containerd. SHould be also possible for runc
+    * [Mrunal] Situation is different as runc is vendored into k8s
+    * [Dawn] should we look into this integration and make sure we test it?
+    * [Lantao] Problem is with runc vendoring
+    * [Mrunal] yes, tags are rare and k/k cannot take non-taged deps
+    * [Mike Brown] are tags only for release?
+    * [Mrunal] Dims and Liggit owns this decision (about tags)
+    * [Mike Brown] maybe run both. 
+    * [David] Question is whether test infra would allow to vendor latest for test
+    * [Dawn] kubelet to runc integration is where the challenge is coming from. Maybe runc can tag daily?
+    * **[Mrunal] let’s have a meeting with runc maintainers to work out the plan**
+    * [Elana] talked with Dims. Opinnion: let’s get more tags. In-between vendoring is hard.
+    * [Brian] lots of diff on runc. It needs to slow down. Daily tagging sounds rough.
+    * [Mike] maybe containerd/cAdvisor can run against master runc continuously
+    * [Dawn] since k8s is major runc user, maybe runc is the ultimately the best place to run these tests.
+    * [Mrunal] about too many diffs and slow down - I wish we slow down, but there are so many at-scale issues being discovered now.
+    * [Brian Goff] hard to test all permutations of runc uses is hard. Maybe have a subset of well-known cases integrated into runc.
+    * [Dawn] let’s not overreact and not slow down everything. Not tax everything because of the need to test this integration
+* [Brian Goff] virtual kubelet: downward API was a copy (don’t want to import k8s.io/k). Can we make downward API parsing moved to someplace else?
+    * [Elana] is there issue tracking this?
+    * [Dawn] file an issue, please, to discuss. One con to share: maintaining release is becoming harder with components moving to vendor. Cost increases as less ownership understanding for the components that were moved out. Identifying owners is hard for components that were moved out (like cAdvisor or NPD). 
+    * Also integration and compatibility issues will arise.
+    * [Brian] can sympathize with it. Will open an issue.
+
+
+## May 11, 2021
+
+Total active pull requests: [201](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+2 from the last meeting).
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-05-04T17%3A00%3A00%2B0000..2021-05-11T16%3A58%3A00%2B0000">26</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-05-04T17%3A00%3A00%2B0000..2021-05-11T16%3A58%3A00%2B0000">9</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-05-04T17%3A00%3A00%2B0000..2021-05-11T16%3A58%3A00%2B0000+created%3A%3C2021-05-04T17%3A00%3A00%2B0000">102</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-05-04T17%3A00%3A00%2B0000..2021-05-11T16%3A58%3A00%2B0000">17</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* KEP freeze is **Thursday, May 13**
+* [vinaykul] In-place Pod Vertical Scaling KEP for 1.22
+    * PRR review [https://github.com/kubernetes/enhancements/pull/2474](https://github.com/kubernetes/enhancements/pull/2474)
+        * [https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources)
+        * [https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2273-kubelet-container-resources-cri-api-changes](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2273-kubelet-container-resources-cri-api-changes)
+    * Identify code reviewer (for core feature code + tests)
+* [jackfrancis] Brief overview of a proposed fix to address node ephemeral storage race during kubelet bootstrap
+    * [https://github.com/kubernetes/kubernetes/pull/101882](https://github.com/kubernetes/kubernetes/pull/101882) 
+
+
+## May 4, 2021
+
+Total active pull requests: [199](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-9 from the last meeting).
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-04-27T17%3A00%3A00%2B0000..2021-05-04T16%3A52%3A57%2B0000">24</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-04-27T17%3A00%3A00%2B0000..2021-05-04T16%3A52%3A57%2B0000">9</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-04-27T17%3A00%3A00%2B0000..2021-05-04T16%3A52%3A57%2B0000+created%3A%3C2021-04-27T17%3A00%3A00%2B0000">98</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-04-27T17%3A00%3A00%2B0000..2021-05-04T16%3A52%3A57%2B0000">24</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] 1.22 KEP review/status check [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#) 
+    * **Enhancements freeze is May 13**
+    * [https://bit.ly/k8s122-enhancements](https://bit.ly/k8s122-enhancements) 
+* [ehashman] Developer Guide Audit request [https://github.com/kubernetes/community/issues/5234](https://github.com/kubernetes/community/issues/5234) 
+* [vinaykul] In-place Pod Vertical Scaling KEP sponsorship for 1.22
+    * KEPs for 1.22:
+        * [https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources)
+        * [https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2273-kubelet-container-resources-cri-api-changes](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2273-kubelet-container-resources-cri-api-changes)
+    * [https://github.com/kubernetes/enhancements/pull/1883](https://github.com/kubernetes/enhancements/pull/1883) merged. Thank you!!
+    * ReviewPR [https://github.com/kubernetes/enhancements/pull/2474](https://github.com/kubernetes/enhancements/pull/2474)
+        * It’s just a housekeeping PR that adds PRR section addition to Kubelet-CRI KEP as per updated template guidelines.
+    * Do we have enough runway / reviewer resources to target In-Place Pod Update (core feature + tests) for 1.22?
+* [jackfrancis] Quick discussion about kubelet pod admission during bootstrapping: static pods can be scheduled before node allocatable storage is detected
+    * [https://github.com/kubernetes/kubernetes/issues/99305](https://github.com/kubernetes/kubernetes/issues/99305)
+* [tallclair] PSP replacement KEP, capabilities requirements
+    * [https://github.com/kubernetes/enhancements/pull/2582](https://github.com/kubernetes/enhancements/pull/2582)
+    * Specifically: [https://github.com/kubernetes/enhancements/pull/2582/commits/bf7213c41a9ee0f518e5ce93f7b8dc7394de9900](https://github.com/kubernetes/enhancements/pull/2582/commits/bf7213c41a9ee0f518e5ce93f7b8dc7394de9900)
+    * Additional context: [https://kubernetes.slack.com/archives/C0BP8PW9G/p1619042209240300](https://kubernetes.slack.com/archives/C0BP8PW9G/p1619042209240300)
+* [fromani][if time allows] new cpumanager policy demo available
+    * if no time I’ll upload a asciinema recording and I’ll link it in this document
+    * we had no time, so [demo material](https://github.com/fromanirh/fromanirh/blob/main/docs/presentations/k8s-cpumanager-smtawareness/demo/README.md) , [asciinema recording](https://asciinema.org/a/412556)
+
+
+## Apr 27, 2021
+
+
+
+* Cancelled, no agenda items
+
+
+## Apr 20, 2021
+
+Total active pull requests: [208](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+9 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-04-13T17%3A00%3A00%2B0000..2021-04-20T16%3A49%3A50%2B0000">27</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-04-13T17%3A00%3A00%2B0000..2021-04-20T16%3A49%3A50%2B0000">10</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-04-13T17%3A00%3A00%2B0000..2021-04-20T16%3A49%3A50%2B0000+created%3A%3C2021-04-13T17%3A00%3A00%2B0000">85</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-04-13T17%3A00%3A00%2B0000..2021-04-20T16%3A49%3A50%2B0000">8</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [fromani] (carry from April 13, we had no time to cover this item) extending cpumanager with new policies - [slides](https://github.com/fromanirh/fromanirh/blob/main/docs/presentations/k8s-cpumanager-smtawareness/smt-sware-cpumanger-sig-node-20210420.pdf) - [enh issue](https://github.com/kubernetes/enhancements/issues/2625) - (WIP) [KEP](https://github.com/kubernetes/enhancements/pull/2626)
+    * Add new policies to enable precise threading allocation
+        * use case
+        * how the policies could look like
+    * Followup as discussion on ML: [https://groups.google.com/g/kubernetes-sig-node/c/FMzdUf9UiP0](https://groups.google.com/g/kubernetes-sig-node/c/FMzdUf9UiP0)
+        * (re)evaluate outsourced policies
+        * cpumanager as device plugin?
+* [alukiano]  (carry from April 13, we had no time to cover this item) Extending pod resource API with the memory manager metrics
+    * The WIP PR, that shows changes to the API - [https://github.com/kubernetes/kubernetes/pull/101030](https://github.com/kubernetes/kubernetes/pull/101030)
+    * Does it require a separate KEP? - no
+    * Does it require a separate feature gate? - no
+* [mrunal] 1.22 KEP prioritization
+
+    [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#)
+
+* [ehashman] Feature gate review? [https://docs.google.com/document/d/1-NNfuFMh246_ujQpYBCldLQ9hmqEbukaa79Xe1WGwdQ/edit#](https://docs.google.com/document/d/1-NNfuFMh246_ujQpYBCldLQ9hmqEbukaa79Xe1WGwdQ/edit#) 
+* [paco] about metrics kubelet_running_pods: [https://github.com/kubernetes/kubernetes/issues/99624#issuecomment-820178670](https://github.com/kubernetes/kubernetes/issues/99624#issuecomment-820178670) which proposal is preferred? (will try to attend the sig meeting)
+* [AkihiroSuda] [rootless](https://rootlesscontaine.rs/) mode [https://github.com/kubernetes/kubernetes/pull/92863](https://github.com/kubernetes/kubernetes/pull/92863) 
+    * Unrelated to [UserNS KEP](https://github.com/kubernetes/enhancements/issues/127), and does not conflict either
+    * [The patch set is very small](https://github.com/kubernetes/kubernetes/pull/92863/files), because almost all stuff is handled by [RootlessKit](https://github.com/rootless-containers/rootlesskit), CRI, and OCI.  Changes on k/k are just for ignoring permission errors during setting `sysctl `and `rlimit `values (for kubelet and kube-proxy).
+    * kind (“main” branch) already supports rootless without patching Kubernetes (by faking `/proc/sys` with bind-mount), but merging the patches is still preferred for better robustness and simplicity [https://kind.sigs.k8s.io/docs/user/rootless/](https://kind.sigs.k8s.io/docs/user/rootless/) 
+    * KEP: [https://github.com/kubernetes/enhancements/pull/1371](https://github.com/kubernetes/enhancements/pull/1371) 
+* [wzshiming] Fixing negative TerminationGracePeriodSeconds [https://github.com/kubernetes/kubernetes/pull/98866](https://github.com/kubernetes/kubernetes/pull/98866) 
+    * How to proceed forward?
+* [mewais] (Continuing from Mar 16th) \
+Add Deallocate and PostStopContainer hooks to the device plugin API.
+    * Possible use cases that need to be informed of device end of use, including FPGAs, drivers, etc.
+    * Background:
+        * [https://github.com/kubernetes/enhancements/pull/1949](https://github.com/kubernetes/enhancements/pull/1949)
+        * [https://github.com/kubernetes/kubernetes/pull/91190](https://github.com/kubernetes/kubernetes/pull/91190)
+        * [https://github.com/mewais/enhancements/tree/master/keps/sig-node/1948-add-deallocate-to-device-plugin-api](https://github.com/mewais/enhancements/tree/master/keps/sig-node/1948-add-deallocate-to-device-plugin-api)
+
+
+## Apr 13, 2021
+
+Total active pull requests:[199](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-2 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-04-06T17%3A00%3A00%2B0000..2021-04-13T16%3A44%3A07%2B0000">29</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-04-06T17%3A00%3A00%2B0000..2021-04-13T16%3A44%3A07%2B0000">11</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-04-06T17%3A00%3A00%2B0000..2021-04-13T16%3A44%3A07%2B0000+created%3A%3C2021-04-06T17%3A00%3A00%2B0000">90</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-04-06T17%3A00%3A00%2B0000..2021-04-13T16%3A44%3A07%2B0000">20</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* feedback requested on sig node annual review
+    * [https://github.com/kubernetes/community/pull/5601](https://github.com/kubernetes/community/pull/5601)
+* [dawnchen/mrunal] 1.22 KEP planning
+
+    [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#)
+
+* [fromani] extending cpumanager with [new policies](https://github.com/fromanirh/fromanirh/blob/main/docs/presentations/k8s-cpumanager-smtawareness/smt-aware-cpumanager-sig-node-20210413.pdf):
+    * Add new policies to enable precise threading allocation
+        * use case
+        * how the policies could look like
+    * Followup as discussion on ML: [https://groups.google.com/g/kubernetes-sig-node/c/FMzdUf9UiP0](https://groups.google.com/g/kubernetes-sig-node/c/FMzdUf9UiP0)
+        * (re)evaluate outsourced policies
+        * cpumanager as device plugin?
+* [alukiano] Extending pod resource API with the memory manager metrics
+    * The WIP PR, that shows changes to the API - [https://github.com/kubernetes/kubernetes/pull/101030](https://github.com/kubernetes/kubernetes/pull/101030)
+    * Does it require a separate KEP?
+    * Does it require a separate feature gate?
+* [ehashman] draft swap KEP is up, PTAL: [https://github.com/kubernetes/enhancements/pull/2602](https://github.com/kubernetes/enhancements/pull/2602) 
+* [SergeyKanzhelev] community repo PRs: [https://github.com/kubernetes/community/pulls?q=is%3Apr+is%3Aopen+label%3Asig%2Fnode](https://github.com/kubernetes/community/pulls?q=is%3Apr+is%3Aopen+label%3Asig%2Fnode) 
+* [Harsh] Can [this project](https://github.com/openebs/node-disk-manager ) be considered under sig-node? 
+* 
+
+
+## Apr 06, 2021
+
+Total active pull requests:[201](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+19 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-03-23T17%3A00%3A00%2B0000..2021-04-06T16%3A54%3A51%2B0000">40</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-03-23T17%3A00%3A00%2B0000..2021-04-06T16%3A54%3A51%2B0000">11</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-03-23T17%3A00%3A00%2B0000..2021-04-06T16%3A54%3A51%2B0000+created%3A%3C2021-03-23T17%3A00%3A00%2B0000">125</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-03-23T17%3A00%3A00%2B0000..2021-04-06T16%3A54%3A51%2B0000">12</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [vinaykul] In-place Pod Vertical Scaling (design update) - follow-up
+    * Review @thockin PR [https://github.com/kubernetes/enhancements/pull/1883](https://github.com/kubernetes/enhancements/pull/1883)
+    * Review/merge PRR section addition to Kubelet-CRI KEP. See[ PR](https://github.com/kubernetes/enhancements/pull/2474)
+    * vinaykul is actually on vacation skiing Mt Baker in a hawaiian shirt, but he put this on agenda to remind Derek to <span style="text-decoration:underline;">please</span> review these PRs :)
+* [Jim/Mrunal] Mount propagation test changes - [https://github.com/kubernetes/kubernetes/pull/100859](https://github.com/kubernetes/kubernetes/pull/100859)
+* [Dims] Tech Debt
+    * [Deprecate and remove DynamicKubeletConfig](https://github.com/kubernetes/kubernetes/issues/100799)
+    * [Dockershim deprecation side-effect : "kubenet" will be gone](https://github.com/kubernetes/kubernetes/issues/100707) 
+
+
+## Mar 30, 2021
+
+
+
+* Meeting canceled (lots of folks are out of office)
+
+
+## Mar 23rd, 2021
+
+
+
+* [SergeyKanzhelev/ehashman] CI/Triage subgroup updates
+    * 1.21 test freeze burndown: [https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+milestone%3Av1.21+label%3Asig%2Fnode](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+milestone%3Av1.21+label%3Asig%2Fnode) 
+
+Total active pull requests: [182](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-8 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-03-16T17%3A00%3A00%2B0000..2021-03-23T16%3A53%3A51%2B0000">26</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-03-16T17%3A00%3A00%2B0000..2021-03-23T16%3A53%3A51%2B0000">6</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-03-16T17%3A00%3A00%2B0000..2021-03-23T16%3A53%3A51%2B0000+created%3A%3C2021-03-16T17%3A00%3A00%2B0000">83</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-03-16T17%3A00%3A00%2B0000..2021-03-23T16%3A53%3A51%2B0000">27</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [BenTheElder] Moving pause out of k/k into a k8s-sigs project?
+    * [https://kubernetes.slack.com/archives/C0BP8PW9G/p1615917566008000](https://kubernetes.slack.com/archives/C0BP8PW9G/p1615917566008000) 
+* [haircommander/bobbypage] [CRI stats KEP](https://github.com/kubernetes/enhancements/pull/2364) update
+* [IkeMa] Last call for alignment on Memory Swap alpha scoping before draft KEP
+    * Community doc: [Swap support in Kubernetes](https://docs.google.com/document/d/1CZtRtC8W8FwW_VWQLKP9DW_2H-hcLBcH9KBbukie67M/edit#heading=h.e5o1ougr1fna)
+    * [[Public] Kubernetes Memory Swap Proof of Concept](https://docs.google.com/document/d/1H-DrJPwXZB10CcITgbIB5-gBCjixFEdZUZ97azRn5I4/edit#heading=h.5kd3drh5wmmq) 
+    * TL;DR for alpha
+
+<table>
+  <tr>
+   <td>
+   </td>
+   <td>
+Before Alpha 
+   </td>
+   <td>After Alpha
+   </td>
+   <td>Comment
+   </td>
+  </tr>
+  <tr>
+   <td>kubelet behavior
+   </td>
+   <td>Fail to start on swap-enabled node by default
+   </td>
+   <td>OK to start on swap-enabled node by default
+   </td>
+   <td rowspan="2" >No visible performance/behavior change from workload point of view
+   </td>
+  </tr>
+  <tr>
+   <td>consuming swap
+   </td>
+   <td>N/A (No workload can consume swap)
+   </td>
+   <td>No workload can consume swap by default
+   </td>
+  </tr>
+  <tr>
+   <td>limiting swap
+   </td>
+   <td>N/A
+   </td>
+   <td>Expose a KubeConfig parameter to set limit for all container through CRI
+   </td>
+   <td>Experimental only
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [adrianreber/mrunal] Update on checkpoint/restore KEP
+    * [http://people.redhat.com/~areber/2021-03-23-sig-node.pdf](http://people.redhat.com/~areber/2021-03-23-sig-node.pdf)
+
+
+## Mar 16th, 2021
+
+
+
+* [SergeyKanzhelev] CI/Triage subgroup updates
+
+Total active pull requests: [190](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-4 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-03-09T17%3A00%3A00%2B0000..2021-03-16T16%3A49%3A52%2B0000">55</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-03-09T17%3A00%3A00%2B0000..2021-03-16T16%3A49%3A52%2B0000">22</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-03-09T17%3A00%3A00%2B0000..2021-03-16T16%3A49%3A52%2B0000+created%3A%3C2021-03-09T17%3A00%3A00%2B0000">137</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-03-09T17%3A00%3A00%2B0000..2021-03-16T16%3A49%3A52%2B0000">42</a>
+   </td>
+  </tr>
+</table>
+
+
+merged: 17 cherry-picks, 9 sig/instrumentation
+
+
+
+* Announcements:
+    * Doc PR deadline is today!
+    * 2021 Contributor Survey, please complete! [https://www.surveymonkey.com/r/k8scommsurvey2021](https://www.surveymonkey.com/r/k8scommsurvey2021) 
+* [jackfrancis] [Container exec livenessProbe timeout update](https://docs.google.com/document/u/0/d/1qZqq7_l9pXyrLiWtM0xgoxXSdYDbB6cUqXESxJ_9oCQ/edit).
+    * Brief update from non-dockershim testing of ExecProbeTimeout=false, and discovery of bug in ExecProbeTimeout=false for dockershim.
+        * [https://github.com/kubernetes/kubernetes/issues/100198](https://github.com/kubernetes/kubernetes/issues/100198)
+        * [https://github.com/kubernetes/kubernetes/pull/100200](https://github.com/kubernetes/kubernetes/pull/100200) 
+    * Background document: [https://docs.google.com/document/d/1qZqq7_l9pXyrLiWtM0xgoxXSdYDbB6cUqXESxJ_9oCQ](https://docs.google.com/document/d/1qZqq7_l9pXyrLiWtM0xgoxXSdYDbB6cUqXESxJ_9oCQ)
+* [mewais] Add Deallocate and PostStopContainer hooks to the device plugin API.
+    * Possible use cases that need to be informed of device end of use, including FPGAs, drivers, etc.
+    * Background:
+        * [https://github.com/kubernetes/enhancements/pull/1949](https://github.com/kubernetes/enhancements/pull/1949)
+        * [https://github.com/kubernetes/kubernetes/pull/91190](https://github.com/kubernetes/kubernetes/pull/91190)
+        * [https://github.com/mewais/enhancements/tree/master/keps/sig-node/1948-add-deallocate-to-device-plugin-api](https://github.com/mewais/enhancements/tree/master/keps/sig-node/1948-add-deallocate-to-device-plugin-api)
+* [ehashman] Need approvers for structured logging: [https://github.com/orgs/kubernetes/projects/53#column-13192240](https://github.com/orgs/kubernetes/projects/53#column-13192240) 
+* [vinaykul] In-place Pod Vertical Scaling (design update) - follow-up
+    * Review @thockin PR [https://github.com/kubernetes/enhancements/pull/1883](https://github.com/kubernetes/enhancements/pull/1883)
+    * Review/merge PRR section addition to Kubelet-CRI KEP. See[ PR](https://github.com/kubernetes/enhancements/pull/2474)
+    * Any questions or concerns with the above PRs?
+* [ehashman] Swap: moving towards alignment on an MVP/alpha. Please take a look at the doc, KEP to follow in the next week or two 
+    * [https://docs.google.com/document/d/1CZtRtC8W8FwW_VWQLKP9DW_2H-hcLBcH9KBbukie67M/edit#heading=h.e5o1ougr1fna](https://docs.google.com/document/d/1CZtRtC8W8FwW_VWQLKP9DW_2H-hcLBcH9KBbukie67M/edit#heading=h.e5o1ougr1fna)
+* [jeremyje] node-problem-detector for Windows is in active development.
+    * Issue: [https://github.com/kubernetes/node-problem-detector/issues/461](https://github.com/kubernetes/node-problem-detector/issues/461)
+    * Design: [https://docs.google.com/document/d/1eiK6KAp_TFR0PgBMu2WCf49fMZcg-HHnBHMc9fALquU/edit](https://docs.google.com/document/d/1eiK6KAp_TFR0PgBMu2WCf49fMZcg-HHnBHMc9fALquU/edit)
+* [Jim Ramsay] Added a github issue for the mount namespace idea (has some more specifics about the systemd issue as well): [https://github.com/kubernetes/kubernetes/issues/100259](https://github.com/kubernetes/kubernetes/issues/100259) 
+
+
+## Mar 9th, 2021
+
+
+
+* [SergeyKanzhelev] CI/Triage subgroup updates
+
+    Total active pull requests: [194](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-13 from the last meeting)
+
+
+<table>
+  <tr>
+   <td>
+<strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-03-02T17%3A00%3A00%2B0000..2021-03-09T17%3A51%3A49%2B0000">69</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-03-02T17%3A00%3A00%2B0000..2021-03-09T17%3A51%3A49%2B0000">20</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-03-02T17%3A00%3A00%2B0000..2021-03-09T17%3A51%3A49%2B0000+created%3A%3C2021-03-02T17%3A00%3A00%2B0000">154</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-03-02T17%3A00%3A00%2B0000..2021-03-09T17%3A51%3A49%2B0000">67</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Announcement: Code Freeze is today!
+* [jackfrancis] [Container exec livenessProbe timeout discussion](https://docs.google.com/document/u/0/d/1qZqq7_l9pXyrLiWtM0xgoxXSdYDbB6cUqXESxJ_9oCQ/edit).
+    * Provide a quick overview for folks who aren’t familiar with the side-effects of finally fixing timeout enforcement for container exec livenessProbes.
+    * Background document: https://docs.google.com/document/d/1qZqq7_l9pXyrLiWtM0xgoxXSdYDbB6cUqXESxJ_9oCQ
+    * Summarize ongoing work:
+        * [https://github.com/kubernetes/kubernetes/pull/99856](https://github.com/kubernetes/kubernetes/pull/99856)
+        * [https://github.com/kubernetes/kubernetes/issues/99854](https://github.com/kubernetes/kubernetes/issues/99854)
+        * [https://twitter.com/ultimateboy/status/1367539874606157826](https://twitter.com/ultimateboy/status/1367539874606157826)
+        * [https://github.com/kubernetes/kubernetes/pull/97057](https://github.com/kubernetes/kubernetes/pull/97057)
+* [fromani] (update/heads up) [podresources API PR](https://github.com/kubernetes/kubernetes/pull/95734) needs approval! (warning: [flakes](https://github.com/kubernetes/kubernetes/issues/99947))
+    * @klueska [LGTM’d!](https://github.com/kubernetes/kubernetes/pull/95734#issuecomment-792768971)
+    * [requires approval because featuregate addition](https://github.com/kubernetes/kubernetes/pull/95734#issuecomment-792769319)
+    * [had to rebase because featuregate conflict](https://github.com/kubernetes/kubernetes/pull/95734#issuecomment-794044700) (LGTM’d [again](https://github.com/kubernetes/kubernetes/pull/95734#issuecomment-794068847))
+    * featuregate where requested during [the prod-readiness review](https://github.com/kubernetes/enhancements/pull/2404)
+* [ehashman] need review/approval before code freeze for probe grace period update [https://github.com/kubernetes/kubernetes/pull/99375](https://github.com/kubernetes/kubernetes/pull/99375) 
+
+     -     [Jim Ramsay/Mrunal] - Run container runtime/kubelet under a different mount namespace follow up \
+[https://groups.google.com/g/kubernetes-sig-node/c/yNjFrBdH18Q](https://groups.google.com/g/kubernetes-sig-node/c/yNjFrBdH18Q)
+
+
+
+* [vinaykul] In-place Pod Vertical Scaling (design update) - follow-up
+    * Review @thockin PR [https://github.com/kubernetes/enhancements/pull/1883](https://github.com/kubernetes/enhancements/pull/1883)
+    * Review/merge PRR section addition to Kubelet-CRI KEP. See[ PR](https://github.com/kubernetes/enhancements/pull/2474)
+    * Any questions or concerns with the above PRs?
+* [alukiano] Race condition between scheduler and kubelet - [https://github.com/kubernetes/kubernetes/issues/99919](https://github.com/kubernetes/kubernetes/issues/99919)
+    * Why do we need the same logic under the scheduler and kubelet that validates available resources under the node. \
+
+
+
+## Mar 2nd, 2021
+
+
+
+* [SergeyKanzhelev] CI/Triage subgroup updates
+
+Total active pull requests: [207](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+7 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-02-23T17%3A00%3A00%2B0000..2021-03-02T17%3A39%3A30%2B0000">44</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-02-23T17%3A00%3A00%2B0000..2021-03-02T17%3A39%3A30%2B0000">15</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-02-23T17%3A00%3A00%2B0000..2021-03-02T17%3A39%3A30%2B0000+created%3A%3C2021-02-23T17%3A00%3A00%2B0000">118</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-02-23T17%3A00%3A00%2B0000..2021-03-02T17%3A39%3A30%2B0000">26</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Announcement: Code Freeze is next Tuesday, Mar. 9
+* [ehashman] KEP status
+    * 12 total for the release: 9 on track, 3 at risk
+        * At risk: [https://github.com/kubernetes/enhancements/issues/2411](https://github.com/kubernetes/enhancements/issues/2411) [https://github.com/kubernetes/enhancements/issues/2133](https://github.com/kubernetes/enhancements/issues/2133) [https://github.com/kubernetes/enhancements/issues/2053](https://github.com/kubernetes/enhancements/issues/2053) 
+    * Please ensure PRs are up, are not Waiting on Author, have reviewers assigned, and any placeholder website PRs are up
+* ~~[derekwaynecarr]~~ [ehashman] SIG Annual Report
+    * [https://docs.google.com/document/d/1975dclTeRq--dFX8aJkVr8Ng40lqvzN1l_G9y4JnyHY/edit?ts=603d23a8](https://docs.google.com/document/d/1975dclTeRq--dFX8aJkVr8Ng40lqvzN1l_G9y4JnyHY/edit?ts=603d23a8) 
+* [Urvashi] CRIContainerLogRotation graduation criteria update
+    * Quick update to the graduation criteria, opened a PR [https://github.com/kubernetes/enhancements/pull/2547](https://github.com/kubernetes/enhancements/pull/2547) 
+    * Feedback on this feature gate on platforms other than OpenShift and GKE
+* [vinaykul] In-place Pod Vertical Scaling (design update) - follow-up
+    * Review @thockin PR [https://github.com/kubernetes/enhancements/pull/1883](https://github.com/kubernetes/enhancements/pull/1883)
+    * Review/merge PRR section addition to Kubelet-CRI KEP. See[ PR](https://github.com/kubernetes/enhancements/pull/2474)
+    * Any questions or concerns with the above PRs?
+* [ehashman] Swap feedback reminder
+    * [https://docs.google.com/document/d/1CZtRtC8W8FwW_VWQLKP9DW_2H-hcLBcH9KBbukie67M/edit#](https://docs.google.com/document/d/1CZtRtC8W8FwW_VWQLKP9DW_2H-hcLBcH9KBbukie67M/edit#) 
+* [Jim Ramsay/Mrunal] Run container runtime/kubelet under a different mount namespace
+
+
+## Feb 23rd, 2021
+
+Total active pull requests: [200](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+6 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-02-16T17%3A00%3A00%2B0000..2021-02-23T17%3A34%3A51%2B0000">35</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-02-16T17%3A00%3A00%2B0000..2021-02-23T17%3A34%3A51%2B0000">13</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-02-16T17%3A00%3A00%2B0000..2021-02-23T17%3A34%3A51%2B0000+created%3A%3C2021-02-16T17%3A00%3A00%2B0000">90</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-02-16T17%3A00%3A00%2B0000..2021-02-23T17%3A34%3A51%2B0000">19</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] triage update/PR burndown
+    * cherry-picks how-to: [https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/cherry-picks.md](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/cherry-picks.md) 
+* [dawnchen] Followup: Derek uploaded all past meetings videos today! Thanks!
+* [vinaykul] In-place Pod Vertical Scaling (design update) - follow-up
+    * Review @thockin PR [https://github.com/kubernetes/enhancements/pull/1883](https://github.com/kubernetes/enhancements/pull/1883)
+    * Review/merge PRR section addition to Kubelet-CRI KEP. See[ PR](https://github.com/kubernetes/enhancements/pull/2474)
+    * Any questions or concerns with the above PRs?
+* [dawnchen] [https://github.com/kubernetes/kubernetes/pull/99319](https://github.com/kubernetes/kubernetes/pull/99319)
+    * node e2e on local storage management
+* [fromani] [https://github.com/kubernetes/kubernetes/pull/95734](https://github.com/kubernetes/kubernetes/pull/95734) - podresources API
+    * KEP approved for 1.21, changes requested during the KEP review implemented - it seems it is not on [https://github.com/orgs/kubernetes/projects/49](https://github.com/orgs/kubernetes/projects/49) but has needs-triage label
+    * Still needs reviews! (and eventually approvals) PTAL
+* [ed] Promote multi sizes huge pages to GA: [https://github.com/kubernetes/kubernetes/pull/99144](https://github.com/kubernetes/kubernetes/pull/99144)
+
+
+## Feb 16th, 2021
+
+
+<table>
+  <tr>
+   <td>Total active pull requests:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+">194</a>
+   </td>
+   <td>(+17 from the last meeting)
+   </td>
+  </tr>
+</table>
+
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-02-09T17%3A00%3A00%2B0000..2021-02-16T18%3A08%3A02%2B0000">42</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-02-09T17%3A00%3A00%2B0000..2021-02-16T18%3A08%3A02%2B0000">6</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-02-09T17%3A00%3A00%2B0000..2021-02-16T18%3A08%3A02%2B0000+created%3A%3C2021-02-09T17%3A00%3A00%2B0000">77</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-02-09T17%3A00%3A00%2B0000..2021-02-16T18%3A08%3A02%2B0000">19</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [vinaykul] In-place Pod Vertical Scaling (design update)
+    * Review @thockin PR [https://github.com/kubernetes/enhancements/pull/1883](https://github.com/kubernetes/enhancements/pull/1883)
+    * Key changes to [my KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources) with [tracking issue](https://github.com/kubernetes/enhancements/issues/1287):
+        * Move ResourcesAllocated from PodSpec to PodStatus
+        * ResourcesAllocated is checkpointed in kubelet
+        * Add new object PodStatus.Resize to signal pod resize status
+        * Proposal to add /resize subresource (details TBD)
+    * Review/merge PRs that update KEPs (add PRR section)
+        * PRR section added to Kubelet-CRI KEP. See[ PR](https://github.com/kubernetes/enhancements/pull/2474)
+        * PRR section for InPlace Pod Update KEP on the way (after we merge above Tim’s PR)
+    * Do we still have enough runway to alpha this feature in v1.21 release? (reviewer resource)
+        * No :(
+* [adrianreber] Checkpoint/Restore discussion
+    * experimental CRI API [https://github.com/kubernetes/kubernetes/pull/97689](https://github.com/kubernetes/kubernetes/pull/97689)
+* [Andrei] Fix the getCgroupSubsystemsV1() which uses only the latest record 
+    * [https://github.com/kubernetes/kubernetes/pull/96594](https://github.com/kubernetes/kubernetes/pull/96594) 
+* [Andrei] video recording of past meetings -- same request [Aditi]
+    * **ACTION**: Derek to upload
+* [bobbypage] Approvers for orphaned pod's dangling volumes PR [https://github.com/kubernetes/kubernetes/pull/95301](https://github.com/kubernetes/kubernetes/pull/95301) needed
+* [haircommander/bobbypage] KEP for cAdvisor-less, CRI-full Container and Pod Stats 
+    * KEP - [https://github.com/kubernetes/enhancements/pull/2364](https://github.com/kubernetes/enhancements/pull/2364)
+* [ehashman] n-2 skew version tests for kubelet? ([slack](https://kubernetes.slack.com/archives/C78F00H99/p1613497306047700))
+* [ehashman] reminder: feedback on swap proposal [https://docs.google.com/document/d/1CZtRtC8W8FwW_VWQLKP9DW_2H-hcLBcH9KBbukie67M/edit#](https://docs.google.com/document/d/1CZtRtC8W8FwW_VWQLKP9DW_2H-hcLBcH9KBbukie67M/edit#) 
+
+
+## Feb 9th, 2021
+
+ Total active pull requests: [178](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-1 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-02-02T17%3A00%3A00%2B0000..2021-02-09T17%3A51%3A14%2B0000">21</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-02-02T17%3A00%3A00%2B0000..2021-02-09T17%3A51%3A14%2B0000">15</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-02-02T17%3A00%3A00%2B0000..2021-02-09T17%3A51%3A14%2B0000+created%3A%3C2021-02-02T17%3A00%3A00%2B0000">90</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-02-02T17%3A00%3A00%2B0000..2021-02-09T17%3A51%3A14%2B0000">8</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] Quick 1.21 KEP update: 10 at risk, 5 confirmed
+    * [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#) 
+* [SergeyKanzhelev] - Dockershim deprecation timeline and updates: [https://docs.google.com/document/d/1OmMe27l5dYR0KtWYrVzSeect6_Mmw5trX8z-Ydc897U/edit?usp=sharing](https://docs.google.com/document/d/1OmMe27l5dYR0KtWYrVzSeect6_Mmw5trX8z-Ydc897U/edit?usp=sharing) 
+* [adrianreber] Checkpoint/Restore discussion
+    * All related PRs and issues updated
+        * [https://github.com/kubernetes/enhancements/pull/1990](https://github.com/kubernetes/enhancements/pull/1990)
+        * [https://github.com/kubernetes/kubernetes/pull/97194](https://github.com/kubernetes/kubernetes/pull/97194) (complete PR)
+        * [https://github.com/cri-o/cri-o/pull/4199](https://github.com/cri-o/cri-o/pull/4199)
+        * [https://github.com/kubernetes/kubernetes/pull/97689](https://github.com/kubernetes/kubernetes/pull/97689) (API changes PR)
+        * [https://github.com/opencontainers/runc/pull/2798](https://github.com/opencontainers/runc/pull/2798)
+    * Demo using these PRs
+        * [https://people.redhat.com/~areber/2021-01-29-kubectl-drain-checkpoint.mp4](https://people.redhat.com/~areber/2021-01-29-kubectl-drain-checkpoint.mp4)
+    * Short live demo if needed
+* [@bobbypage] KEP 2000: Update graceful shutdown KEP for beta in 1.21 [https://github.com/kubernetes/enhancements/pull/2472](https://github.com/kubernetes/enhancements/pull/2472) 
+    * PRR review is complete, need approvals from SIG chairs
+* [harche] Kubelet Node Sizing Provider KEP 
+    * [https://github.com/kubernetes/enhancements/pull/2370](https://github.com/kubernetes/enhancements/pull/2370)
+    * 
+* [Andrei] Fix the getCgroupSubsystemsV1() which uses only the latest record [https://github.com/kubernetes/kubernetes/pull/96594](https://github.com/kubernetes/kubernetes/pull/96594) 
+* [DawnChen/Lee] KEP of changing the securityContext behavior for Ephemeral Container was approved 
+    * [https://github.com/kubernetes/enhancements/pull/1690](https://github.com/kubernetes/enhancements/pull/1690)
+    * [https://github.com/kubernetes/enhancements/pull/2244](https://github.com/kubernetes/enhancements/pull/2244)
+* [ehashman] Triage updates
+    * PR documenting triage process, needs approval: [https://github.com/kubernetes/community/pull/5436](https://github.com/kubernetes/community/pull/5436) 
+    * [SergeyKanzhelev] CI Subgroup + Triage meeting moving to Wednesdays
+
+
+## Feb 2nd, 2021
+
+ Total active pull requests: [179](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+4 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-01-26T17%3A00%3A00%2B0000..2021-02-02T17%3A38%3A22%2B0000">38</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-01-26T17%3A00%3A00%2B0000..2021-02-02T17%3A38%3A22%2B0000">17</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-01-26T17%3A00%3A00%2B0000..2021-02-02T17%3A38%3A22%2B0000+created%3A%3C2021-01-26T17%3A00%3A00%2B0000">97</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-01-26T17%3A00%3A00%2B0000..2021-02-02T17%3A38%3A22%2B0000">17</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] 1.21 KEP finalization - enhancements freeze is Feb. 9
+    * KEPs **must**:
+        * have a tracking issue (in k/enhancements/issues)
+        * have issue in v1.21 milestone
+        * be “implementable” in kep.yaml
+        * target the correct release and stage in kep.yaml
+    * Planning doc (17): [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#) 
+        * TODOs listed for each thing agreed upon here
+    * Outstanding PRs (31): [https://github.com/kubernetes/enhancements/pulls?q=is%3Aopen+is%3Apr+label%3Asig%2Fnode](https://github.com/kubernetes/enhancements/pulls?q=is%3Aopen+is%3Apr+label%3Asig%2Fnode) 
+* [harche] Dynamic node sizing for kubelet
+    * KEP - [https://github.com/kubernetes/enhancements/pull/2370](https://github.com/kubernetes/enhancements/pull/2370)
+* [haircommander/bobbypage] KEP for cAdvisor-less, CRI-full Container and Pod Stats 
+    * KEP - [https://github.com/kubernetes/enhancements/pull/2364](https://github.com/kubernetes/enhancements/pull/2364)
+* [karan] NPD: New metrics added in last release. Deprecating certain labels: [https://github.com/kubernetes/node-problem-detector/pull/522](https://github.com/kubernetes/node-problem-detector/pull/522)
+    * Any users of NPD?
+    * If you haven’t upgraded, please wait until the PR is merged to avoid backwards-incompatibility.
+* [Sascha / Mrunal] - Seccomp by default
+* [SergeyKanzhelev] - Dockershim deprecation timeline and updates: [https://docs.google.com/document/d/1OmMe27l5dYR0KtWYrVzSeect6_Mmw5trX8z-Ydc897U/edit?usp=sharing](https://docs.google.com/document/d/1OmMe27l5dYR0KtWYrVzSeect6_Mmw5trX8z-Ydc897U/edit?usp=sharing) 
+
+
+## Jan 26th, 2021
+
+Total active pull requests: [172](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+7 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-01-19T17%3A00%3A00%2B0000..2021-01-26T17%3A44%3A24%2B0000">33</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-01-19T17%3A00%3A00%2B0000..2021-01-26T17%3A44%3A24%2B0000">11</a>
+   </td>
+  </tr>
+  <tr>
+   <td>fUpdated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-01-19T17%3A00%3A00%2B0000..2021-01-26T17%3A44%3A24%2B0000+created%3A%3C2021-01-19T17%3A00%3A00%2B0000">91</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-01-19T17%3A00%3A00%2B0000..2021-01-26T17%3A44%3A24%2B0000">15</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [kmala] Discuss what needs to be done to get the fix back in. [https://github.com/kubernetes/kubernetes/pull/97980](https://github.com/kubernetes/kubernetes/pull/97980)
+* [xing-yang] What is the recommended way to monitor node components
+    * Volume health KEP: [https://github.com/kubernetes/enhancements/pull/2286](https://github.com/kubernetes/enhancements/pull/2286) 
+    * Volume health monitoring agent deployed as a sidecar with CSI driver on every node; each agent has a pod informer; log event on pod if abnormal volume condition detected
+* [Peter/Robert] Cadvisor / CRI stats performance 
+    * [https://github.com/kubernetes/kubernetes/pull/98435](https://github.com/kubernetes/kubernetes/pull/98435)
+    * CRI stats path duplicates work between CRI implementation and cadvisor
+    * next steps:
+        * investigate performance in containerd
+        * investigate CRI stats implementations without cadvisor stats (are there missing fields?)
+        * investigate taking out the container stats from cadvisor, so we have machine metrics, but no duplicated work
+* [[Paco](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Apacoxu+label%3Asig%2Fnode+is%3Aclosed)/Shiming] volunteers. We have fixed some small bugs recently on sig-node 
+* (wzshiming fix some [small issues in node graceful shutdown](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Awzshiming+label%3Asig%2Fnode+is%3Aclosed+) )and we want to take more responsibility in sig-node. Are there any features or tasks that we can participate in? Or any suggestions? A simple todo list  from recent researches & learning plan
+    * [unsafe sysctl optimizatio](https://github.com/kubernetes/kubernetes/issues/72593#issuecomment-752034446)n(but low priority)
+    * image pull related: [pull image priority](https://github.com/kubernetes/enhancements/pull/2217)(parallel-image-pulls is more preferred)
+    * init-container restarted after docker prune image [#86531](https://github.com/kubernetes/kubernetes/issues/86531)
+    * [sergey recommends:] still many tests are failing or flaking: [https://testgrid.k8s.io/sig-node](https://testgrid.k8s.io/sig-node) Some ToDo items from CI group: [https://github.com/orgs/kubernetes/projects/43#column-9494825](https://github.com/orgs/kubernetes/projects/43#column-9494825) 
+* [saranbalaji90] [https://github.com/kubernetes/kubernetes/issues/84165](https://github.com/kubernetes/kubernetes/issues/84165) should we have separate flags for controlling pprof and flags endpoints.
+
+
+## Jan 19th, 2021
+
+Total active pull requests: [161](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-4 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-01-12T17%3A00%3A00%2B0000..2021-01-19T17%3A48%3A53%2B0000">29</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-01-12T17%3A00%3A00%2B0000..2021-01-19T17%3A48%3A53%2B0000">15</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-01-12T17%3A00%3A00%2B0000..2021-01-19T17%3A48%3A53%2B0000+created%3A%3C2021-01-12T17%3A00%3A00%2B0000">65</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-01-12T17%3A00%3A00%2B0000..2021-01-19T17%3A48%3A53%2B0000">18</a>
+   </td>
+  </tr>
+</table>
+
+
+Only two rotten - one needed a KEP. Another may be interesting to pick up: [https://github.com/kubernetes/kubernetes/pull/81774](https://github.com/kubernetes/kubernetes/pull/81774) if anybody is interested.
+
+Spilled over from last meeting:
+
+
+
+* [SergeyKanzhelev/ehashman] KubeCon EU maintainer track presentation
+* [ehashman] non-CI PR board, bug backlog updates
+    * board: [https://github.com/orgs/kubernetes/projects/49](https://github.com/orgs/kubernetes/projects/49) 
+    * [Dims/Dawn] Bug triage process - we may need another meeting? Or offline process? This meeting needs to be kept on KEPs, Design reviews, and critical bugs. Do we need another generic SIG node meeting?
+    * Dims: triage meeting shouldn’t be that big. Maybe a small audience triage meeting for only interested people.
+    * Dawn: Want a formal process and velocity as goals.
+    * Action: To follow up at next CI meeting, second half
+* [ehashman] SIG Node KEP triage, per last meeting’s action
+    * spreadsheet: [https://docs.google.com/spreadsheets/d/1nN_b8ypVxvxK1fvygBs3jvRoiNj1CZPsE2S-oTcpxEA/edit#gid=593791586](https://docs.google.com/spreadsheets/d/1nN_b8ypVxvxK1fvygBs3jvRoiNj1CZPsE2S-oTcpxEA/edit#gid=593791586) 
+    * down to 46 from 54!
+    * might be missing some from the list of KEPs on hold missing items: [https://github.com/kubernetes/enhancements/pulls?q=is%3Aopen+is%3Apr+label%3Asig%2Fnode+label%3Ado-not-merge%2Fhold](https://github.com/kubernetes/enhancements/pulls?q=is%3Aopen+is%3Apr+label%3Asig%2Fnode+label%3Ado-not-merge%2Fhold) 
+    * please make sure your KEP has a tracking item!
+* [rphillips] TOCTTOU issues in kuberuntime_sandbox [https://github.com/kubernetes/kubernetes/issues/98142](https://github.com/kubernetes/kubernetes/issues/98142) 
+* [???] Issue to discuss - [Allow the configuration of the interval of cr healthcheck](https://github.com/kubernetes/kubernetes/issues/96664)
+    * Needs someone to present
+* [adrianreber] Initial Checkpoint/Restore/Migration discussion
+    * Pod Migration issue: [https://github.com/kubernetes/kubernetes/issues/3949](https://github.com/kubernetes/kubernetes/issues/3949)
+    * Checkpoint/Restore KEP: [https://github.com/kubernetes/enhancements/pull/1990](https://github.com/kubernetes/enhancements/pull/1990)
+    * Implementation of one possible checkpoint/restore use case: \
+kubectl drain --checkpoint \
+[https://github.com/kubernetes/kubernetes/pull/97194](https://github.com/kubernetes/kubernetes/pull/97194)
+    * Proposed CRI API change \
+[https://github.com/kubernet		es/kubernetes/pull/97689](https://github.com/kubernetes/kubernetes/pull/97689)
+    * CRI API changes implemented in CRI-O \
+[https://github.com/cri-o/cri-o/pull/4199](https://github.com/cri-o/cri-o/pull/4199) \
+(and crictl [https://github.com/kubernetes-sigs/cri-tools/pull/662](https://github.com/kubernetes-sigs/cri-tools/pull/662) )
+    * Happy to answer any questions around checkpoint/restore
+* [MaRosset] Windows KEPs / issues
+    * Looking for advice on
+        * [Add Windows container device support to CRI-API #97739](https://github.com/kubernetes/kubernetes/issues/97739)
+            * > @RenaudWasTaken, @kad, Mike Brown, Mrunal
+            * COD WG: [https://docs.google.com/document/d/1gUgAMEThkRt4RJ7pA7ZbPPmIOX2Vb7fwH025MjfcTYU/edit](https://docs.google.com/document/d/1gUgAMEThkRt4RJ7pA7ZbPPmIOX2Vb7fwH025MjfcTYU/edit)
+            * 
+    * Looking for reviewers 
+        * [KEP 1981: Windows privileged container KEP updates for alpha #2288](https://github.com/kubernetes/enhancements/pull/2288)
+        * [KEP 2258: Use kubectl to view system service logs #2271](https://github.com/kubernetes/enhancements/pull/2271)
+            * Implemented in OpenShift, want to upstream changes (impacts linux nodes with journald as well)
+* [@mythi, @kad]: [non-root user containers and devices access](https://docs.google.com/document/d/1SX4o71AIIrJAzbGJEIfhT2NxQpPvLlrHiZj5uUawWxk) - PSA: Update, POC patches available for review ([k/k#92211](https://github.com/kubernetes/kubernetes/issues/92211))
+    * Please review
+
+
+## Jan 12th, 2021
+
+Total active pull requests: [164](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-12 from the last meeting) Way to go!!!
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-01-05T17%3A00%3A00%2B0000..2021-01-12T17%3A06%3A23%2B0000">23</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-01-05T17%3A00%3A00%2B0000..2021-01-12T17%3A06%3A23%2B0000">19</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-01-05T17%3A00%3A00%2B0000..2021-01-12T17%3A06%3A23%2B0000+created%3A%3C2021-01-05T17%3A00%3A00%2B0000">94</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-01-05T17%3A00%3A00%2B0000..2021-01-12T17%3A06%3A23%2B0000">16</a>
+   </td>
+  </tr>
+</table>
+
+
+
+Please approve lgtm’d PRs from SIG Node CI group: [https://github.com/orgs/kubernetes/projects/43#column-9494828](https://github.com/orgs/kubernetes/projects/43#column-9494828) 
+
+
+
+* [derekwaynecarr, ehashman] graceful termination period and liveness probe failures
+    * see: [https://github.com/kubernetes/kubernetes/issues/64715](https://github.com/kubernetes/kubernetes/issues/64715)
+    * provisional KEP for fix: [https://github.com/kubernetes/enhancements/pull/2241](https://github.com/kubernetes/enhancements/pull/2241) 
+* [mrunal] 1.21 planning
+    * [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#)
+* [rphillips, harche] auto system reserved sizing
+    * [https://docs.google.com/document/d/1DOKK5div3MuUV5A8WxZauBA7XCOK8QVDoH6qZGK964k/edit?ts=5ffdc238#heading=h.kg7a8pe4fi0u](https://docs.google.com/document/d/1DOKK5div3MuUV5A8WxZauBA7XCOK8QVDoH6qZGK964k/edit?ts=5ffdc238#heading=h.kg7a8pe4fi0u)
+* [SergeyKanzhelev (if I can attend)] [https://github.com/kubernetes/kubernetes/issues/97288](https://github.com/kubernetes/kubernetes/issues/97288) I suggest to revert the logic in 1.20 - possible fixes might be risky for 1.20. Reverting [https://github.com/kubernetes/kubernetes/pull/92817](https://github.com/kubernetes/kubernetes/pull/92817) will revert [https://github.com/kubernetes/kubernetes/issues/88543](https://github.com/kubernetes/kubernetes/issues/88543).
+    * Revert for now, sync back up next week to investigate a root cause
+
+
+## Jan 5th, 2021
+
+Total active pull requests: [183](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-13 from the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2020-12-08T17%3A00%3A00%2B0000..2021-01-05T17%3A42%3A55%2B0000">66</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2020-12-08T17%3A00%3A00%2B0000..2021-01-05T17%3A42%3A55%2B0000">34</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2020-12-08T17%3A00%3A00%2B0000..2021-01-05T17%3A42%3A55%2B0000+created%3A%3C2020-12-08T17%3A00%3A00%2B0000">128</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2020-12-08T17%3A00%3A00%2B0000..2021-01-05T17%3A42%3A55%2B0000">45</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [SergeyKanzhelev] we are turning things around wrt [open PRs](https://k8s.devstats.cncf.io/d/71/prs-labels-by-sig?orgId=1&var-sig_name=node&var-label_name=All%20labels%20combined&from=1548540596095&to=1611785396095) 🎉:
+
+
+
+
+* [SergeyKanzhelev] From CI group, lgtm’d, needs approval: [https://github.com/orgs/kubernetes/projects/43#column-9494828](https://github.com/orgs/kubernetes/projects/43#column-9494828) 
+* [SergeyKanzhelev] Please review and contribute: migrating from Dockershim documentation: [https://github.com/kubernetes/website/pull/25787](https://github.com/kubernetes/website/pull/25787) 
+* [Karan] [Swap support](https://github.com/kubernetes/kubernetes/issues/53533) in kubelet (need to write a use-cases and scope KEP in the next few weeks)? Volunteers to help spec it?
+    * Some initial thoughts and investigation by me: [doc](https://docs.google.com/document/d/1qFH-RA7GvaEidOnp7Y-QwAZ8g5Zcyk28VkEJFWcEX-U/edit#)
+    * ehashman put together a doc full of use cases (not yet publicly shared)
+    * Timeline: 1.21 for use case and scope and high-level design possibly. 1.22 alpha is a good goal
+    * Doc: [https://docs.google.com/document/d/1CZtRtC8W8FwW_VWQLKP9DW_2H-hcLBcH9KBbukie67M/edit#](https://docs.google.com/document/d/1CZtRtC8W8FwW_VWQLKP9DW_2H-hcLBcH9KBbukie67M/edit#) 
+* [fromani] Would like to move forward the initial [podresources API extension PR](https://github.com/kubernetes/kubernetes/pull/95734) as we have more changes coming to complete the planned extensions. Any more comments for this PR? another round of reviews?
+* [ehashman] SIG Node KEP triage? 54 [currently open](https://github.com/kubernetes/enhancements/issues?q=is%3Aissue+is%3Aopen+label%3Asig%2Fnode), 37 not tracked
+    * from the last release: [https://docs.google.com/document/d/1-NNfuFMh246_ujQpYBCldLQ9hmqEbukaa79Xe1WGwdQ/edit#](https://docs.google.com/document/d/1-NNfuFMh246_ujQpYBCldLQ9hmqEbukaa79Xe1WGwdQ/edit#) 
+    * has been a lot of duplication of effort between SIG Node/enhancements team
+    * haven’t had the bandwidth to close out stale issues because that still involves a lot of effort
+    * ACTION: ehashman to sync with enhancements team, put together a spreadsheet with KEP owners to start working on driving down the KEP backlog
+* [pacoxu] (not join the meeting because of zoom issues, hope to discuss next time)
+    * [1.20 regression: pods failing to terminate #97288](https://github.com/kubernetes/kubernetes/issues/97288)<span style="text-decoration:underline;"> </span>(a regression, currently no one is working on)
+    * [volume stats disabled when negative.(Currently, 0 means default 1m)](https://github.com/kubernetes/kubernetes/pull/96675)<span style="text-decoration:underline;"> </span>@paco a small pr but bug.
+    * [Is there a plan to improve the experience of unsafe sysctl?](https://github.com/kubernetes/kubernetes/issues/72593#issuecomment-752034446) an initial proposal.

--- a/sig-node/archive/meeting-notes-2022.md
+++ b/sig-node/archive/meeting-notes-2022.md
@@ -1,0 +1,2622 @@
+# SIG Node Meeting Notes
+
+## Dec 27th [Canceled for holidays]
+
+
+## Dec 20th [Canceled for holidays] 
+
+Dec 13th, 2022
+
+Recording: [https://www.youtube.com/watch?v=iw_xZZPuXDI](https://www.youtube.com/watch?v=iw_xZZPuXDI) 
+
+Total: [196](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-22, yay!)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-12-06T17%3A00%3A00%2B0000..2022-12-13T17%3A55%3A16%2B0000">32</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-12-06T17%3A00%3A00%2B0000..2022-12-13T17%3A55%3A16%2B0000">37</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-12-06T17%3A00%3A00%2B0000..2022-12-13T17%3A55%3A16%2B0000+created%3A%3C2022-12-06T17%3A00%3A00%2B0000">161</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-12-06T17%3A00%3A00%2B0000..2022-12-13T17%3A55%3A16%2B0000">22</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [mrunal/sergey/ruiwen] 1.26 retro/1.27 planning
+    * [1.26 retro](https://docs.google.com/document/d/11ZVH4OfUUIU73R9suoJ36aoOJJQJi4NJJtmuBkQRmkE/edit), with tracked KEPs and finished KEPs
+    * 1.27 planning with initial KEP candidates: 
+* [everpeace] [KEP-3169: Fine-grained SupplementalGroups control](https://github.com/kubernetes/enhancements/pull/3620)
+    * _NOTE: I’m sorry that I can’t attend to the regular community meeting due to timezone gap (3am in my timezone(Tokyo)). I put this agenda to help 1.27 planning._
+    * This KEP can resolve very unfamiliar behavior of `SupplementalGroups` field described in [k/k#112879](https://github.com/kubernetes/kubernetes/issues/112879), which keeps group membership defined in the container image. I believe many (probably most) cluster admins don’t know the behavior. Moreover, when a cluster uses `hostPath` volumes, the unfamiliar behavior could cause security concerns even when cluster admins enforce some policy engines in the cluster.
+* [swsehgal] Topology Manager GA graduation: happy to volunteer to drive this work in 1.27 (~~if we want to move ahead with it?~~)
+    * Lack of Multi NUMA systems in CI is the key blocker
+        * [fromani] this is also relevant for memory manager
+    * Currently e2e tests that require multi NUMA are [skipped](https://github.com/kubernetes/kubernetes/blob/release-1.26/test/e2e_node/topology_manager_test.go#L957-L959)
+    * [https://github.com/kubernetes/test-infra/issues/28211](https://github.com/kubernetes/test-infra/issues/28211)
+        * Inputs/suggestions on how this can be potentially handled welcome on the issue
+        * Slack discussion with test-infra group: [here](https://kubernetes.slack.com/archives/CCK68P2Q2/p1670521506420629) (potential use of equinix nodes is being discussed here)
+* [SergeyKanzhelev] [https://github.com/kubernetes/kubernetes/pull/114394](https://github.com/kubernetes/kubernetes/pull/114394) CRI API version skew policies. See [slides](https://docs.google.com/presentation/d/1s0RM2zDXKTnTn5Yx0_20V0TPbPJLCQSI/edit) from contributors summit for extra details 
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * vinaykul not joining this meeting (on vacation in India)
+    * Please review and merge [KEP milestone update PR](https://github.com/kubernetes/enhancements/pull/3670)
+    * [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) approved by Derek.
+        * @bobbypage fixed containerd/main E2E pull test job, we now have full E2E coverage
+        * I recommend that we merge API changes [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) at the earliest possible point in 1.27 and watch to see nothing bad happens.
+        * And then merge PR 102884 shortly after (&lt; 1 week) and re-add periodic CI test jobs.
+        * Does the 1st week of Jan 2023 look realistic for the above proposed PRs merge plan, assuming the above plan sounds good? 
+* [SergeyKanzhelev] Reconcile SIG Node teams and OWNERs files: [https://github.com/kubernetes/org/pull/3893](https://github.com/kubernetes/org/pull/3893) 
+* [mweston & atanas] Quick update on issue [https://github.com/kubernetes/enhancements/issues/3675](https://github.com/kubernetes/enhancements/issues/3675) 
+    * recording: [https://www.youtube.com/watch?v=ai_d3qXr8xg](https://www.youtube.com/watch?v=ai_d3qXr8xg) 
+
+
+## Dec 6, 2022
+
+Recording: [https://www.youtube.com/watch?v=t3PcHj62f0c](https://www.youtube.com/watch?v=t3PcHj62f0c) 
+
+Total: [218](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-11-29T17%3A00%3A00%2B0000..2022-12-06T17%3A53%3A41%2B0000">11</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-11-29T17%3A00%3A00%2B0000..2022-12-06T17%3A53%3A41%2B0000">7</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-11-29T17%3A00%3A00%2B0000..2022-12-06T17%3A53%3A41%2B0000+created%3A%3C2022-11-29T17%3A00%3A00%2B0000">63</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-11-29T17%3A00%3A00%2B0000..2022-12-06T17%3A53%3A41%2B0000">2</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [mweston & atanas] Ready Dec 6th:  filed issue on kubelet plugin model here:  [https://github.com/kubernetes/enhancements/issues/3675](https://github.com/kubernetes/enhancements/issues/3675)
+    * starting KEP and looking for interested parties, discussion partially based around dynamic resource allocation and thoughts on how to incorporate it.
+* [pacoxu] small [improvement on memoryThrottlingFactor proposal](https://docs.google.com/document/d/1p9awiXhu5f4mWsOqNpCX1W-bLLlICiABKU55XpeOgoA/edit?usp=sharing)(I listed 3 problems here in the link), but a behavior change. ``memory.high = memory.request + (memory.limit - memory.request) * memoryThrottlingFactor``. Also, defaulting to 0.8 may result to performance issue for pods that may always use 80%+ memory of the limit like Java applications. Probably we need a pod level setting for it like `softrequest`/`throttlingLimit` besides limits and requests.
+    * Collect feedback in the doc and then open a KEP update with alternatives (discussion: [https://youtu.be/t3PcHj62f0c?t=686](https://youtu.be/t3PcHj62f0c?t=686))
+* [msau] (joining at 10:30) Looking for maintainers from multiple sigs to participate in a discussion/roundtable with [Data on Kubernetes](https://dok.community/) (stateful end users). If you’re interested, [add your name to the list](https://docs.google.com/document/d/1hAKi4nwfzok_dKj_hsavbQRYJuLGzBqTbQIM3GdzB8w/edit?resourcekey=0-MlCEZ-y_BA3Ee4K4bI_jxw#). First roundtable is going to be sometime in January.
+* [claudiubelu] Proposed changes to how kubelet detects updates for registered plugins b/c current implementation doesn’t work on Windows due to timestamp granularity issues [https://github.com/kubernetes/kubernetes/pull/114136](https://github.com/kubernetes/kubernetes/pull/114136) 
+    * [https://testgrid.k8s.io/sig-windows-signal#windows-unit-master](https://testgrid.k8s.io/sig-windows-signal#windows-unit-master) test failure caused by timestamp
+* [SergeyKanzhelev] Sidecar WG: we are getting to the conclusion. Will send summary soon. Find information here: [https://docs.google.com/document/d/1E1guvFJ5KBQIGcjCrQqFywU9_cBQHRtHvjuqcVbCXvU/edit#](https://docs.google.com/document/d/1E1guvFJ5KBQIGcjCrQqFywU9_cBQHRtHvjuqcVbCXvU/edit#) 
+* [SergeyKanzhelev] No perma betas:
+    * AppArmor beta since 1.4 (owner: @tallclair)
+        * [https://github.com/kubernetes/enhancements/pull/3298](https://github.com/kubernetes/enhancements/pull/3298) 
+    * QOSReserved alpha since 1.11 (owner: @sjenning)
+        * Mrunal or Ryan will take a look
+    * RotateKubeletServerCertificate beta since 1.12 (owner: @mikedanese)
+        * Sergey to ping Mike
+    * CustomCPUCFSQuotaPeriod alpha since 1.12 (owner: @szuecs)
+        * Mrunal to take a look
+    * KubeletPodResources beta since 1.15 (owner: @dashpole)
+        * [@fromanirh] I volunteer to help graduating this in GA in 1.27 - I'll add this to the 1.27 planning document when we start it
+    * TopologyManager beta since 1.18  (owner: @lmdaly)
+        * Graduate before out of process plugins was the past decision
+        * [Dawn] Let’s put together a one pager explaining the roadmap short and longer term.
+        * [Swati] Device and CPU manager are graduated. Maybe let’s be consistent
+    * DownwardAPIHugePages beta since 1.21 (owner: @derekwaynecarr, )
+    * ProbeTerminationGracePeriod beta since 1.22 (owner: )
+
+
+## Nov 29, 2022
+
+
+
+* [aditi] Expose pod cgroup path: [https://github.com/kubernetes/kubernetes/issues/113342](https://github.com/kubernetes/kubernetes/issues/113342)
+
+    [sig-node] Concerns about exposing cgroup information at pod api status level. There could be races depending on how the path will be used. Better to focus down the issue to the interaction between the runtime and CNI plugin at pod bring up time. Peter(CRI-O), David Porter(bobbypage)/mikebrow(containerd) and Mike Zappa(CNI [@MikeZappa87](https://github.com/MikeZappa87) ) to figure out details of approach across runtimes.
+
+* [everperace] [KEP-3169: Fine-grained SupplementalGroups control](https://github.com/kubernetes/enhancements/pull/3620)
+    * _NOTE: I’m sorry that I can’t attend to the regular community meeting due to timezone gap (3am in my timezone(Tokyo)). I put this agenda to gain more visibility of my KEP in the sig-node community._
+    * This KEP can resolve very unfamiliar behavior of `SupplementalGroups` field described in [k/k#112879](https://github.com/kubernetes/kubernetes/issues/112879). I believe many (probably most) cluster admins don’t know the behavior. Moreover, when a cluster uses `hostPath` volumes, the unfamiliar behavior could cause security concerns even when cluster admins enforce PSPs(or some policy engines) in the cluster. So, I would like to implement the KEP hopefully in v1.27.
+    * _I would very appreciate it if somebody help reviewing my KEP._
+    * This KEP includes modification of CRI. So, we probably need to update CRI implementation first, at least most popular ones(containerd and cri-o are enough??). I’m not familiar how to do this. I recognize we can’t apply feature gate on CRI and its implementations. I also appreciate it if some contributors advise it to me.
+* [klueska] Update to KEP to reflect actual implementation that was merged
+    * Needs approval by Dawn or Derek
+    * [https://github.com/kubernetes/enhancements/pull/3663](https://github.com/kubernetes/enhancements/pull/3663)
+* [swsehgal] [Need](https://github.com/kubernetes/kubernetes/pull/110252#issuecomment-1317422472) Derek’s architecture approval on [https://github.com/kubernetes/kubernetes/pull/110252](https://github.com/kubernetes/kubernetes/pull/110252). API updates are proposed in a separate [PR](https://github.com/kubernetes/kubernetes/pull/96275) (ready for review as well).
+* [bobbypage] Update/thoughts on CRI healthz: [https://github.com/kubernetes/kubernetes/pull/109653](https://github.com/kubernetes/kubernetes/pull/109653) 
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * vinaykul may not join due to conflicting appointment
+    * [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) approved, missed 1.26, targeting for 1.27
+    * Please review and merge [KEP milestone update PR](https://github.com/kubernetes/enhancements/pull/3670)
+    * Please review test-infra inplace resize test pull job [PR](https://github.com/kubernetes/test-infra/pull/28112) 
+
+
+## Nov 22, 2022
+
+No meeting due to the Thanksgiving holiday in USA.
+
+
+## Nov 15, 2022
+
+
+
+* [rata, giuseppe] Userns support
+    * For stateful pods, shall we create a new KEP or change the scope of the existing?
+    * Will join sig-storage to start the conversation with them about stateful pods too
+    * [Derek] - Separate KEP and Feature gate recommended
+    * [Sergey] - Should we GA the existing support? 
+    * [Derek/Mrunal] Yes, we should move it to beta.
+    * [Rodrigo] Concerns around validation if we introduce another Feature Flag.
+    * [Rodrigo] Id mapped mounts could solve issues around right permissions for files such as ssh keys.
+    * [Derek] Can we key off the kernel version to figure out if we have id mapped mounts? Any way to implement a fallback?
+* [klueska] Dynamic Resource Allocation (DRA) update
+    * [Merged](https://github.com/kubernetes/kubernetes/pull/111023) on Friday (after an extension request) as an alpha feature for 1.26
+    * New staging repo created for [k8s.io/dynamic-resource-allocation](https://github.com/kubernetes/test-infra/pull/27980) with helper libraries to build resource drivers against the DRA API
+    * Outstanding [request](https://github.com/kubernetes/org/issues/3837) to create dra-example-driver repo
+    * [Request](https://github.com/kubernetes/org/issues/3821#issuecomment-1315409661) to “associate” DRA with an official [sig-node subproject](https://github.com/kubernetes/community/tree/master/sig-node#subprojects)
+        * Should we reuse an existing subproject or create a new one?
+        * My vote is for a new one (but what to call it?)
+* [Sergey] sidecar WG: [https://docs.google.com/document/d/1E1guvFJ5KBQIGcjCrQqFywU9_cBQHRtHvjuqcVbCXvU/edit#](https://docs.google.com/document/d/1E1guvFJ5KBQIGcjCrQqFywU9_cBQHRtHvjuqcVbCXvU/edit#) 
+
+
+## Nov 8, 2022
+
+Recording: [https://www.youtube.com/watch?v=mnZWYAuOJ90](https://www.youtube.com/watch?v=mnZWYAuOJ90)
+
+
+
+* [bobbypage/eric lin] [https://github.com/kubernetes/kubernetes/pull/109653](https://github.com/kubernetes/kubernetes/pull/109653)
+* [pacoxu] [kubelet: make registry qps/Burst to limit parallerel pulling count #112242](https://github.com/kubernetes/kubernetes/pull/112242#top) 
+    * after rethinking, the current qps/burst of image pull makes no sense to users. And the current PR tries to make it limit the image in pulling process at the same time. The flag and the meaning will not match then. So I suggest to just deprecate and then remove the current registryPullQPS and registryBurst flags. Meanwhile if this is a concern, we should provide a new flag like `parallel-image-pull-limit` as a new feature. (#[112044](https://github.com/kubernetes/kubernetes/issues/112044) the issue) At least we should add more explanation for the flag.(registryPullQPS: ``limit registry pull QPS to this value.`` qps is request per second.)
+    * [ruiwen-zhao] +1 on adding a node-level limit of parallel pulls. I can help with this effort.
+    * [paco] [https://github.com/containerd/containerd/pull/7313](https://github.com/containerd/containerd/pull/7313) I am working on a PullRequest in containerd to add some image pull related metrics. One of them is the processing count of image pulling
+    * [mikebrow] needs more declarative hints in the pod/container spec, and more resource information image manager will not know about other activities… declarative info: qos/cache policy/confidential meta/lazy snapshots vs pull all/does the container runtime optimize for common layers/… as mrunalp says, it’s not just about the image it’s the connection cost/manifests/layers and soon artifacts
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * Fixed [nits and updated code](https://github.com/kubernetes/kubernetes/pull/102884/commits/65b032832358d7a57b276fe58aa4b4f2d9935363) to catch up after rebase.
+    * Updated [E2E test to run full-spectrum](https://github.com/kubernetes/kubernetes/pull/102884/commits/ee3c2d3c95f2f997d5dd55bbeadca9d40ba970af) for containerd>=1.6.9. Tested in a local cluster.
+    * Investigating failures with newly added [cgroupv1](https://testgrid.k8s.io/sig-node-containerd#cos-cgroupv1-inplace-pod-resize-containerd-e2e) , [cgroupv2](https://testgrid.k8s.io/sig-node-containerd#cos-cgroupv2-inplace-pod-resize-containerd-e2e) for in-place resize CI job with containerd-main.
+    * Requested 4 day exception to investigate/fix issues from rebase and CI job failure.
+    * IMHO, it may be safer to merge this early 1.27 rather than late 1.26
+* [iancoolidge] cpuset to kubernetes/utils
+    * [time permitting]
+    * [https://github.com/kubernetes/kubernetes/pull/113744](https://github.com/kubernetes/kubernetes/pull/113744)
+    * minor controversies: NoSort/Sort, Int64 vs int
+    * plan: merge all changes here, then copy into k/utils, then revendor in k/k
+* ~~[klueska] Need approval from sig-node-leads for feature gate addition in following PR~~
+    * ~~[https://github.com/kubernetes/kubernetes/pull/112914](https://github.com/kubernetes/kubernetes/pull/112914)~~
+    * ~~I’ve already LGTM’d and APPROVED the kubelet changes, it just needs the feature gate approval now (@liggitt already confirmed to do the API approval)~~
+    * ~~Assigning ~~~~since he did the KEP approval~~
+* ~~[klueska] Need sig-node-leads approval for creation of dynamic-resource-allocation staging repo~~
+    * ~~[https://github.com/kubernetes/org/issues/3821](https://github.com/kubernetes/org/issues/3821)~~
+    * ~~Assigning ~~
+    * ~~Relevant slack conversation: [https://kubernetes.slack.com/archives/C01672LSZL0/p1667751787905519](https://kubernetes.slack.com/archives/C01672LSZL0/p1667751787905519)~~
+* ~~[MaRosset] - Windows hostnetwork alpha #112961~~
+    * ~~[https://github.com/kubernetes/kubernetes/pull/112961](https://github.com/kubernetes/kubernetes/pull/112961) ~~
+
+
+## Nov 1, 2022
+
+
+
+* ~~[klueska] Need approval for minor update to KEP~~
+    * ~~[KEP-3063: dynamic resource allocation: bump latest-milestone to 1.26](https://github.com/kubernetes/enhancements/pull/3601)~~
+* [dashpole] Kubelet context plumbing
+    * [https://github.com/kubernetes/kubernetes/pull/113408](https://github.com/kubernetes/kubernetes/pull/113408)
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * [Fixed](https://github.com/kubernetes/kubernetes/pull/102884/commits/be27900b11cd59ae73321d10d33bf6521bc185ba) scheduler-focussed E2E test flakiness
+    * Cgroupv2 [support](https://github.com/kubernetes/kubernetes/pull/102884/commits/fe3ff951f98943f18e5518cd867f5519e1ad6d5a) and [tests](https://github.com/kubernetes/kubernetes/pull/102884/commits/7198630fdffc94579de6788b1646d263d9651a3c) in review, issues fixed. Mrunal [PTAL](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r958717825).
+    * Ruiwen and I have PRs for running pod resize E2E tests with containerd-main.
+        * [https://github.com/kubernetes/test-infra/pull/27816](https://github.com/kubernetes/test-infra/pull/27816)
+        * [https://github.com/kubernetes/test-infra/pull/27854](https://github.com/kubernetes/test-infra/pull/27854)
+        * One or both of these should give us E2E coverage
+        * I’m working on updating E2E test to run full-mode if containerd >=1.6.9
+* Alexander shared notes from kubecon contributor summit - 
+
+
+## Oct 25, 2022 [Cancelled for KubeCon]
+
+
+## Oct 18, 2022
+
+Total active pull requests: [213](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+8 from last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-10-11T17%3A00%3A00%2B0000..2022-10-18T16%3A56%3A25%2B0000">24</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-10-11T17%3A00%3A00%2B0000..2022-10-18T16%3A56%3A25%2B0000">7</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-10-11T17%3A00%3A00%2B0000..2022-10-18T16%3A56%3A25%2B0000+created%3A%3C2022-10-11T17%3A00%3A00%2B0000">66</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-10-11T17%3A00%3A00%2B0000..2022-10-18T16%3A56%3A25%2B0000">9</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [SergeyKanzhelev] Canceling next week for KubeCon?
+* [Sergey, Swati] CI group report [https://docs.google.com/document/d/1vfqqFtN4Ke2JtB9O4wjoKvMChW2Ptizmsom1_gRGauU/edit#heading=h.eawmmxfxo8vq](https://docs.google.com/document/d/1vfqqFtN4Ke2JtB9O4wjoKvMChW2Ptizmsom1_gRGauU/edit#heading=h.eawmmxfxo8vq) 
+* [Sergey] Sidecar WG proposed times: [https://doodle.com/meeting/participate/id/bkZyZgJa](https://doodle.com/meeting/participate/id/bkZyZgJa) 
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * Please review [KubeCon slides 11-16](https://static.sched.com/hosted_files/kccncna2022/c0/Resize-with-eBPF.pdf), if possible
+    * Cgroupv2 support [changes](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1221332179) are in review, issues fixed. Mrunal [PTAL](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r958717825).
+    * Awaiting containerd release in order to enable full-E2E tests.
+    * Mothership [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) can merge once we have the 1.6.9 containerd release, the CI picks it up, E2E tests are fully enabled (validates PodStatus for resize), and cgroupv2 review issues have been addressed.
+    * API changes [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) also on hold for containerd.
+
+
+## Oct 11, 2022
+
+Total active pull requests: [205](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-3 from last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-10-04T17%3A00%3A00%2B0000..2022-10-11T16%3A41%3A35%2B0000">17</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-10-04T17%3A00%3A00%2B0000..2022-10-11T16%3A41%3A35%2B0000">11</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-10-04T17%3A00%3A00%2B0000..2022-10-11T16%3A41%3A35%2B0000+created%3A%3C2022-10-04T17%3A00%3A00%2B0000">69</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-10-04T17%3A00%3A00%2B0000..2022-10-11T16%3A41%3A35%2B0000">8</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [matthyx] request a WG creation to work on sidecar containers
+    * A summary from Sergey: 
+    * [Dawn] define exit criteria and a way to report back status to this SIG. Also define the term for WG.
+    * [Sergey] wait for the Doodle to decide scheduling.
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * Please review [KubeCon slides 11-16](https://static.sched.com/hosted_files/kccncna2022/c0/Resize-with-eBPF.pdf), if possible
+    * Cgroupv2 support [changes](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1221332179) are in review, issues fixed. Mrunal [PTAL](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r958717825).
+    * Awaiting containerd release in order to enable full-E2E tests.
+    * Mothership [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) can merge once we have the next containerd release (1.7 per Ruiwen - sorry I accidentally deleted Ruiwen’s comment ​), the CI picks it up, E2E tests are fully enabled (validates PodStatus for resize), and cgroupv2 review issues have been addressed.
+    * API changes [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) also on hold for containerd.
+* [mimowo]: Heads up for "Standardization of the OOM kill communication between container runtime and kubelet" ([https://github.com/kubernetes/kubernetes/issues/112910](https://github.com/kubernetes/kubernetes/issues/112910))
+    * first - standardization of what we have
+    * second - add more information - whether it is because exceeding the limits or memory pressure on the node. This is more involving.
+    * [Dawn] user space oom killer in cgroupv2 will also introduce more standardization in this space
+    * [Dawn] thought it is already aligned, how much has it diverged?
+    * [Sergey] is it required for the KEP?
+        * [Michael] no, but may break in future
+    * [Sergey] How easy to troubleshoot that it was indeed the OOM kill when people start relying on job retries based on OOM kills.
+        * [Michael] Feature: customer can define policies for jobs depending on pod end state. Today pod conditions are used to understand the pod end state. Pod condition will be “resource exhausted”.
+* [Dawn] there will be cases when kubelet just cannot tell that something was oom killed. But it is still good to have everything unified.
+* [David Porter] how practically will it be standardized? It is just a string. Are there any conformance tests or something?
+* [Lantao] logging format is the same way
+* [David] Container running multiple processes when subprocesses were OOM killed, container runtime may not detect this. 
+* [Lantao] cgroupv1 behavior is different, is it? IIRC, when there is a cgroup OOM, a random process in the cgroup will be killed. In that case, OOMKilled is still set, even if pid 1 is running happily. ([David] Let’s confirm)
+* [Dawn] this was one of the first issues that was fixed.
+* [SergeyKanzhelev] containerd 1.6 is going LTS [https://github.com/containerd/containerd/pull/7454](https://github.com/containerd/containerd/pull/7454) 
+    * [Lantao] 1.7 introduces major changes like sandbox API, image pull progress etc.
+        * [ruiwen] List of PRs in containerd 1.7: [https://github.com/containerd/containerd/milestone/42](https://github.com/containerd/containerd/milestone/42) 
+    * [Lantao] 2.0 will remove many deprecated APIs and configs
+        * [https://github.com/kubernetes/kubernetes/issues/110312](https://github.com/kubernetes/kubernetes/issues/110312)  
+        * [https://github.com/containerd/containerd/blob/main/RELEASES.md](https://github.com/containerd/containerd/blob/main/RELEASES.md) 
+    * [Mark] Windows brings many features to 1.7, Will we end up not supporting 1.6 by K8s
+
+
+## Oct 4, 2022
+
+Total active pull requests: [208](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-22 since last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-09-27T17%3A00%3A00%2B0000..2022-10-04T16%3A37%3A24%2B0000">11</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-09-27T17%3A00%3A00%2B0000..2022-10-04T16%3A37%3A24%2B0000">21</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-09-27T17%3A00%3A00%2B0000..2022-10-04T16%3A37%3A24%2B0000+created%3A%3C2022-09-27T17%3A00%3A00%2B0000">89</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-09-27T17%3A00%3A00%2B0000..2022-10-04T16%3A37%3A24%2B0000">12</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ruiwen-zhao] [KEP planning] 1.26 KEPs are tracked in: [https://github.com/orgs/kubernetes/projects/98/views/1?filterQuery=sig%3Asig-node](https://github.com/orgs/kubernetes/projects/98/views/1?filterQuery=sig%3Asig-node) 
+    * If you are planning to work on any KEP in 1.26, please make sure it is tracked on the board above. To be tracked, the KEP needs to be in the v1.26 milestone and have a lead-opted-in label.
+* [SergeyKanzhelev] Sidecar containers: [https://docs.google.com/document/d/10xqIf19HPPUa58GXtKGO7D1LGX3t4wfmqiJUN4PJfSA/edit#heading=h.a3qp744ia2p6](https://docs.google.com/document/d/10xqIf19HPPUa58GXtKGO7D1LGX3t4wfmqiJUN4PJfSA/edit#heading=h.a3qp744ia2p6) 
+* ~~[swsehgal] Device Manager graduation to GA~~
+    * ~~[https://github.com/kubernetes/enhancements/issues/3573](https://github.com/kubernetes/enhancements/issues/3573)~~
+    * ~~Please add `milestone` and `lead-opted-in` labels so it can be tracked for 1.26~~
+    * Update: Labels Added (Thanks Mark)
+* [ddebroy] Q around runtimeClass fields
+    * Is introducing capabilities of a container runtime handler (that Kubelet can use for contexts other than CRI) as fields in RuntimeClass allowed?
+    * Previously discussed in the context of KEP [https://github.com/kubernetes/enhancements/pull/2893](https://github.com/kubernetes/enhancements/pull/2893) and it was recommended that fields from runtimeClass should not be passed to CRI.
+* [Alexey Fomenko] image pull improvements - design may take more time - feedback from Derek. 
+    * [Mrunal] need more details on CRI APIs, etc.
+    * [Dawn] still can do progress on this
+    * [Alexey] wasn’t sure the process - KEP process doc says that the first draft will be merged fast and then iterated on.
+
+
+## Sep 27, 2022
+
+Total active pull requests: [230](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+3 since last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-09-20T17%3A00%3A00%2B0000..2022-09-27T16%3A52%3A21%2B0000">22</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-09-20T17%3A00%3A00%2B0000..2022-09-27T16%3A52%3A21%2B0000">12</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-09-20T17%3A00%3A00%2B0000..2022-09-27T16%3A52%3A21%2B0000+created%3A%3C2022-09-20T17%3A00%3A00%2B0000">76</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-09-20T17%3A00%3A00%2B0000..2022-09-27T16%3A52%3A21%2B0000">9</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ruiwen-zhao] Just a quick reminder on 1.26 planning: Please update the status on [1.26 planning](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=kix.qy9qmwlgcn6h), or add to it if you are planning to work on something not tracked there. **KEP freeze is 18:00 PDT Thursday 6th October 2022**
+* [alexey fomenko]: CRI Image Pulling Progress and Notifications: [https://hackmd.io/nyLLTtAkTgOuYwxmnu0sIQ](https://hackmd.io/nyLLTtAkTgOuYwxmnu0sIQ)
+    * [paco]: recently, I see some image pulling related issues. 1. [image pull time is including waiting time ](https://github.com/kubernetes/kubernetes/pull/111772)due to default serialize image pulling behavior. 2. no image pulling related metrics in kubelet([pr](https://github.com/kubernetes/kubernetes/pull/111391)) or containerd([pr](https://github.com/containerd/containerd/pull/7313)). 3. [kubelet registry qps/burst](https://github.com/kubernetes/kubernetes/issues/112044) is not working as expected. The current registry qps is like start n image pulling in a second. The user want parallerel image pulling number is qps. BTW, [enabling parallerel image pulling](https://github.com/kubernetes/kubernetes/issues/108405) will solve some problems that are caused by image pulling stucking. We may discuss this as a whole.
+    * [lantaol]:
+        * We hit this issue as well with serial image pull. A bad container image can block all other pods from coming up forever.
+        * However, with parallel image pull, there is no good way to control the concurrency. The QPS is not the best way to solve this problem, because each image pull request can take a long time, just controlling the query per second is not sufficient.
+        * This is worse with containerd, which doesn’t have an overall image pull timeout, or a progress based timeout like dockershim.
+    * [Derek] Do we want image pull status on Pod as well?
+        * [Alexey] yes, we want but not looked into details yet
+        * [Derek] qps of progress reports may be a concern for a lot of updates
+        * [Alexey] maybe just key points like 25%, 50%
+        * [Derek] still a lot of information on happy path. Must be careful with it, only needed for debugging
+    * [Derek] is serial pull policy still being used? It only exists for very old runtimes
+        * [lantaol] parallel pull may have qps issues
+        * [Derek] we have up to n images in parallel. Exactly for this reason. There is no reason to not switch to parallel
+    * [Wenjun] many customers wants a image pulling status.
+        * [Derek] maybe metrics instead or something that will help minimize the traffic
+    * [Lantaol] What about image pull timeouts? Overall timeout is impossible to set. So we had pull timeout. Is it exist in Containerd?
+        * [Ruiwen] Containerd pull timeout will be in 1.7: [https://github.com/containerd/containerd/pull/6150](https://github.com/containerd/containerd/pull/6150) 
+        * [Sergey] Do we need it configured from kubelet or runtime?
+    * [Alexey] another option is to issue an ETA as an update instead of the progress.
+    * [Derek] How it will work with “lazy image pulling” like GKE image streaming?
+        * [Mrunal] yes, it likely needs to be accounted for.
+        * [Dawn] should work well with it.
+    * [lantaol] Checked with mrunal offline that, for cri-o the “concurrent pulled image layers” configuration is in cri-o.
+        * Containerd only has `MaxConcurrentDownloads` which limits the concurrent downloads for **each image**.
+        * To do this at the containerd level, we will need the CRI plugin to implement a cap at the daemon level.
+        * Or we can consider implementing this at kubelet level to extend `serial-image-pull` to `max-concurrent-image-pull`.
+    * [mikebrow]nod to lantao’s comments.. we have a need to parallelize pulls, a need to identify resource contention when to many parallel pulls (layers/manifest checks/… soon artifacts), a need to handle slow/no progress due to registry contention/access issues… ** Because there is a large cost to getting the resource contention proximity and responding from the back seat if you will, we will probably be better off passing prioritization information/policies from the kubelet side down to the code (in the container runtimes) that is performing the resolve and pulling of layers..
+    * Summary: let’s proceed with CRI part of it
+* [fangyuchen86]: Kubelet Support Custom Prober Protocol
+
+    
+
+    * [Derek] Where is the probe run?
+    * [fangyuchen86] On the node
+    * [Derek] who is charged with the execution of these probes? They are not running inside the cgroup, who is reserving compute and memory for these probes.
+    * [fangyuchen86] Controller will allocate this - it will be a custom pod in VPC network on the same VPC as a user workload. kubelet cannot access the Pod’s network. It can start it, attach storage, but not the network.
+    * [Dawn] I understand the requirement. But maybe that third party controller can take even more responsibility and actually do the pod management on cluster level. It may be easier. Introducing a custom prober to the node has some security concerns too. 
+    * [Wenjun] What prevents to create a proxy?
+        * [fangyuchen86] security does not allow this
+        * [Derek] this is the most interesting question here. Naively we believe that kubelet is an admin for all workload. And why the networking is taken away from the containers. Maybe we can make a session about these requirements?
+        * [Dawn] In some environments, the workload cannot access the kubelet network. This is where gVisor helps for example.
+        * [Derek] there were nobody before pushing back on probes.
+    * [fangyuchen86] we also have a problem of other protocols that needs to be covered. 
+        * [Derek] this is separate requirement that might be solved differently.
+    * **Summary: Let’s create a doc that explains the requirements and scenarios** 
+* [klueska] Small, self-contained TopologyManager update planned for this release:
+    * [https://github.com/kubernetes/enhancements/issues/3545](https://github.com/kubernetes/enhancements/issues/3545)
+    * Already added to 
+    * Please add the **<code>/label lead-opted-in</code></strong> to the issue so it can be tracked
+    * [Derek] this is done
+* sig-node meeting recordings: uploading recent ones.
+    * [Derek] will do
+    * [Dawn] might help with it
+* [Sergey] per container restartPolicy override: [https://docs.google.com/document/d/1gX_SOZXCNMcIe9d8CkekiT0GU9htH_my8OB7HSm3fM8/edit](https://docs.google.com/document/d/1gX_SOZXCNMcIe9d8CkekiT0GU9htH_my8OB7HSm3fM8/edit) 
+    * [Derek] Alternative is “BindsTo” semantics that can be used for termination of sidecar containers. Maybe kubelet can delegate it to OS as well like systemd.
+    * [Mrunal] BindsTo needs to be experimented. But delegating to OS is also appealing
+    * [MikeB] Question is how much we can delegate.
+
+		<strong>summary: read the doc and compare with BindsTo.</strong>
+
+
+
+* [Sergey] more sidecars: [https://github.com/kubernetes/kubernetes/issues/111356#issuecomment-1249670702](https://github.com/kubernetes/kubernetes/issues/111356#issuecomment-1249670702)
+    * [Dawn] restartPolicy and QoS (including OOM score) were per container initially. But then after debate it was changed per pod and convinced community. There were even conversations of scheduling container into the Pod. This is why sidecar feel so unnatural in k8s. Once opening this can of worm, we are starting to do Pod v2.
+    * [Mrunal] this OOM adj calculation may be challenging.
+    * [Derek] I’d rather move to OOMd than change the present state.
+
+    **summary: likely not (closed the issue).**
+
+* [marquiz] update on [QoS-class resources KEP](https://github.com/kubernetes/enhancements/pull/3004) 
+* [pacoxu] If ResourceQuota for cpu/memory is set, no best effort pod can be created. For other resources like ephemeral-storage, best effort pod can be created.
+    * [https://github.com/kubernetes/kubernetes/issues/112310#issuecomment-1247540260](https://github.com/kubernetes/kubernetes/issues/112310#issuecomment-1247540260)  Should we document it? Or should we fix it as a bug(Currently, only some comments in code)?
+
+
+## Sep 20, 2022
+
+
+
+* [ruiwen/mrunal] [1.26 planning](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=kix.qy9qmwlgcn6h)
+* [marquiz]  [QoS-class resources KEP](https://github.com/kubernetes/enhancements/pull/3004) (renamed)
+    * Status update ([slides](https://docs.google.com/presentation/d/1zBzKfieYw6Kkxq0T_wUsMfodHYNGd7WmijZLIVzcQnQ/edit#slide=id.p1)
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * [Fabian](https://github.com/fabi200123) has a PR adding [Windows support](https://github.com/vinaykul/kubernetes/pull/16/commits/457644a47f99f862b31c9d3c306bbb011e13341b) for in-place resize. Thanks Fabian!
+    * [JaffWan](https://github.com/Jeffwan) fixed my [missing unit tests and typo](https://github.com/vinaykul/kubernetes/pull/17) for cgroupv2 :) Thanks Jaixin!
+    * Jaixin also found the root-cause for [issue 112264](https://github.com/kubernetes/kubernetes/issues/112264) and will work on a fix. This should significantly speed up E2E tests.
+    * I tried out in-place resize with CRI-O (in local cluster) and it works!
+    * Tested resize E2E tests using Ruiwen’s containerd support
+        * It works but PodStatus.Resources update takes ~60s. Issue [112264](https://github.com/kubernetes/kubernetes/issues/112264)
+        * UpdateContainerResources (containerd) applies the resize in  &lt; 50 ms
+    * API changes [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) ready for review & preferably early-merge.
+    * Cgroupv2 support [changes](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1221332179) are in review.
+    * Mothership [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) can merge once we have the next containerd release (1.6.9?), the CI picks it up, E2E tests are fully enabled (validates PodStatus for resize), and cgroupv2 review issues have been addressed.
+* [mimowo] Promote KEP-3329 "Retriable and non-retriable Pod failures for Jobs" for Beta
+* [Sergey] SIG ongoing things update:
+
+Total active pull requests: [227](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+35 since June)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-09-06T17%3A00%3A00%2B0000..2022-09-20T16%3A54%3A08%2B0000">32</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-09-06T17%3A00%3A00%2B0000..2022-09-20T16%3A54%3A08%2B0000">10</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-09-06T17%3A00%3A00%2B0000..2022-09-20T16%3A54%3A08%2B0000+created%3A%3C2022-09-06T17%3A00%3A00%2B0000">87</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-09-06T17%3A00%3A00%2B0000..2022-09-20T16%3A54%3A08%2B0000">15</a>
+   </td>
+  </tr>
+</table>
+
+
+Bugs untriaged: 13 [https://github.com/orgs/kubernetes/projects/59](https://github.com/orgs/kubernetes/projects/59) 
+
+PRs untriaged: 99 [https://github.com/orgs/kubernetes/projects/49](https://github.com/orgs/kubernetes/projects/49) 
+
+CI group meetings are back and we will be triaging issues and getting the tests back on track.
+
+
+## Sep 13, 2022
+
+
+
+* [mweston/atanas] KEP involving Resource Control Plugin
+    * [https://docs.google.com/presentation/d/1uIHF_t97WZzIJgvyD75PYu46PRPi62i2/](https://docs.google.com/presentation/d/1uIHF_t97WZzIJgvyD75PYu46PRPi62i2/)
+* 
+* [jstur/MaRosset] Windows cri pod sandbox fields: [https://github.com/kubernetes/enhancements/pull/3439](https://github.com/kubernetes/enhancements/pull/3439)
+    * Decided to keep them separate.  
+* [MaRosset] - Host/Node network support for Windows Pods \
+[https://github.com/kubernetes/enhancements/pull/3507](https://github.com/kubernetes/enhancements/pull/3507)
+    * +1 from sig-node to proceed 
+* [marquiz]  [QoS-class resources KEP](https://github.com/kubernetes/enhancements/pull/3004) (renamed) update
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * vinaykul not in the SIG-node meeting today due to conflict.
+    * Tested resize E2E tests using Ruiwen’s containerd support
+        * It works but PodStatus.Resources update takes ~60s. Issue [112264](https://github.com/kubernetes/kubernetes/issues/112264)
+        * UpdateContainerResources (containerd) applies the resize in  &lt; 50 ms
+    * API changes [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) ready for review & preferably early-merge.
+    * Cgroupv2 support [changes](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1221332179) are in review.
+    * Mothership [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) can merge once we have the next containerd release (1.6.9?), the CI picks it up, E2E tests are fully enabled (validates PodStatus for resize), and cgroupv2 review issues have been addressed.
+
+
+## Sep 6, 2022
+
+
+
+* [ruiwen] [1.25 retro](https://docs.google.com/document/d/1dLmSOjaeahMdHLQyOpGQgrmJBsBrTpBIKto2bdlEwas/edit)
+* [danielye] [CRI Stats Performance Update ](https://docs.google.com/document/d/11kx0bnsKE1GjhtM7maVmEYO1eGfUDdC9yv0AzrEeIuk/edit?resourcekey=0-mGWn_TXfmPirsIWeN6TqXw#heading=h.5irk4csrpu0y)
+* [qiutongs] Issue awareness: unexpected initial delay of probes
+    * [https://github.com/kubernetes/kubernetes/issues/96614#issuecomment-1236258797](https://github.com/kubernetes/kubernetes/issues/96614#issuecomment-1236258797)
+    * ``initialDelaySeconds` `doesn’t work as the API spec says.
+        * first probe time = container start time + initialDelaySeconds
+        * kubelet restart: wait reasonable amount of time; still respect initialDelaySeconds differences for probes in the same container?
+    * Jitter is needed in the case of kubelet restart. Avoid thundering herd problems.
+        * The jitters given to the probes in the same container are different.
+            * [https://github.com/kubernetes/kubernetes/pull/102064](https://github.com/kubernetes/kubernetes/pull/102064)
+        * Since [1.21](https://github.com/kubernetes/kubernetes/blob/v1.21.0/pkg/kubelet/prober/worker.go#L137-L139), the jitter is only added when kubelet recently started/restarted. 
+            * If the `periodSeconds` are the same for all probes in a container, the probes will be invoked at the same time. ``initialDelaySeconds``makes no difference.
+* [adrianreber] Checkpoint/Restore next steps
+    * main focus how to secure checkpoint
+    * a checkpoint contains all memory pages (maybe secrets, random numbers)
+    * possible suggestions how to secure checkpoint archives
+        * add additional authorization to kubelet API checkpoint endpoint
+        * run kubelet API checkpoint endpoint on another port
+        * encrypt checkpoint archives ([https://github.com/containers/ocicrypt](https://github.com/containers/ocicrypt))
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * Attempted “full scope” E2E tests with Ruiwen’s containerd support
+        * Tested this by switching containerd binaries on GKE worker with those I built from master latest.
+        * All tests pass and verify that Ruiwen’s code works correctly.
+        * The tests took <span style="text-decoration:underline;">considerably</span> longer (869s vs 2988s  to run all 34 E2E tests with GKE 1master-1worker cluster)
+            * The issue is NOT in containerd.
+            * ContainerStatus() CRI called within 50 millisec of UpdateContainerResources() shows updated cgroup values.
+            * The long delay is in updating apiPodStatus. This needs further investigation.
+    * [cgroup v2 support](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1221332179) for in-place resize - review is in progress.
+    * Is there any interest in merging API changes ( [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) ) early?
+        * If yes, please add an ok-to-test label.
+* 
+
+
+## Aug 30, 2022
+
+
+
+* [klueska, pohly] Update on Dynamic Resource Allocation
+    * [KEP](https://github.com/kubernetes/enhancements/pull/3064) accepted for 1.25
+    * Delayed implementation to 1.26  \
+(Mostly functional [Draft PR](https://github.com/kubernetes/kubernetes/pull/111023))
+    * Demo with NVIDIA GPUs
+* [dgl] Status of ProcMountType feature gate
+    * This has been alpha since 1.12, I’m interested in potentially progressing it
+* [pehunt] inheritable capabilities regression follow up
+    * [https://github.com/kubernetes/kubernetes/issues/111196](https://github.com/kubernetes/kubernetes/issues/111196) 
+    * Outcome: each CRI should consider whether the capabilities should be added, and optionally be able to configure them. 
+        * CRI-O follow up https://github.com/cri-o/cri-o/pull/6236
+* [mgroot]
+    * Revisiting allowing node labels to be referenced via the downward API
+        * [https://github.com/kubernetes/kubernetes/issues/40610](https://github.com/kubernetes/kubernetes/issues/40610)
+        * Closed PR: [https://github.com/kubernetes/kubernetes/pull/25957#issuecomment-228041766](https://github.com/kubernetes/kubernetes/pull/25957#issuecomment-228041766)
+        * node name and scheduleability are allowed, prior decision from 2016 could be revisited after 6 years
+* [marquiz]  [QoS-class resources KEP](https://github.com/kubernetes/enhancements/pull/3004) (renamed)
+    * request for comments
+    * also for post in k8s developers’ blog ([PR](https://github.com/kubernetes/contributor-site/pull/332))
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * CRI (containerd) [support](https://github.com/containerd/containerd/pull/6517) has been merged. Thanks Ruiwen!
+        * Next step: containerd release. K8s pickup new containerd version.
+    *  [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946)  (API changes for in-place resize from 102884) needs ok-to-test
+    * [cgroup v2 support](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1221332179) for in-place resize awaiting review.
+    * Marion Lobur from the GKE team (Warsaw) is joining this effort.
+        * His use case can help get significant test coverage in alpha.
+* [qbarrand]
+    * [Code push complete](https://github.com/kubernetes-sigs/kernel-module-management/pull/9) - development ongoing
+    * [KMM admin PR](https://github.com/kubernetes/org/pull/3626) - needs attention from one of the chairs
+    * Sponsorship for an additional KMM contributor to become member of the kubernetes org
+
+
+## Aug 23, 2022
+
+
+
+* [rphillips] Ephemeral Storage by Disk/Mount Point [[Issue#111965](https://github.com/kubernetes/kubernetes/issues/111965)]
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * [KEP PR](https://github.com/kubernetes/enhancements/pull/3464) updating milestone to v1.26-alpha has been merged. Thanks Dawn.
+    * Created [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) - API changes for in-place resize. (already reviewed in [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) and stable for quite a while)
+        * Can we merge 111946 early in 1.26?
+        * The mothership 102884 PR can bring in kubelet & scheduler changes when Ruiwen’s [CRI support code](https://github.com/containerd/containerd/pull/6517) has been merged and picked up.
+    * Mrunal, LiuBo, Can you please review [cgroup v2 support](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1221332179) for in-place resize?
+        * Mike, Peter: Should we eventually delegate this to CRI?
+* [dawnchen] SIG Node CI testgrid
+    * [https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-swap-fedora](https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-swap-fedora) failed all the time. 
+    * [https://docs.google.com/spreadsheets/d/1IwONkeXSc2SG_EQMYGRSkfiSWNk8yWLpVhPm-LOTbGM/edit#gid=1187923038](https://docs.google.com/spreadsheets/d/1IwONkeXSc2SG_EQMYGRSkfiSWNk8yWLpVhPm-LOTbGM/edit#gid=1187923038)
+    * [Brian McQueen (github: xmcqueen)] two linked ticket I am currently driving:  [https://github.com/kubernetes/kubernetes/issues/109295](https://github.com/kubernetes/kubernetes/issues/109295) and related PR[ https://github.com/kubernetes/test-infra/pull/27051](https://us01st-cf.zoom.us/web_client/6orpgrb/html/externalLinkPage.html?ref=https://github.com/kubernetes/test-infra/pull/27051)
+
+
+## Aug 16, 2022
+
+
+
+* [bobbypage/pehunt/Daniel] CRI stats Prometheus endpoint and adding cAdvisor metrics to CRI
+    * KEP as it stands proposes to have CRI impl emit the prometheus metrics. New proposal is to enhance CRI API to have CRI impl give Kubelet the metrics, then have Kubelet emit them.
+        * Same concerns with performance, but possibly it won’t be as bad as we worry about
+    * Plan is to have Daniel/David/Peter setup proof of concept with Kubelet/containerd fork to see if it regresses in performance.
+    * Aim to have a POC for 1.26 KEP time to be able to decide how to go forward in 1.26 cycle.
+* [ndixita] Looking for a reviewer for External Credential Provider GA PR: [https://github.com/kubernetes/kubernetes/pull/111495](https://github.com/kubernetes/kubernetes/pull/111495) 
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * vinaykul not in Node meeting today due to conflict
+    * Please review [KEP PR](https://github.com/kubernetes/enhancements/pull/3464) that updates milestones for this feature
+    * I will spawn a separate PR for API changes later this week.
+* [pehunt] How best to request reviewers to look at a PR not attached to a release cycle
+    * shameless plug for [https://github.com/kubernetes/kubernetes/pull/108855](https://github.com/kubernetes/kubernetes/pull/108855) 
+    * Recommendations:
+        * PRs appear on triage board: [https://github.com/orgs/kubernetes/projects/49](https://github.com/orgs/kubernetes/projects/49) 
+        * Poke reviewers on slack (sig-node, pr-reviews)
+        * Propose review trades
+
+
+## Aug 09, 2022
+
+
+
+* [jing]: [https://github.com/kubernetes/kubernetes/issues/110956#issuecomment-1197710132](https://github.com/kubernetes/kubernetes/issues/110956#issuecomment-1197710132)
+    * any reason  “it was a mistake that user must make an explicit request/limit when ResourceQuota has CPU/Memory setting."?
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * Extracted and merged CRI changes in [PR 111645](https://github.com/kubernetes/kubernetes/pull/111645)
+        * Many thanks to Mrunal, Peter, Mike, Ruiwen & Mark for quick reviews!!
+        * Huge thanks to wangchen615 for pushing hard on the scheduler code!
+        * This now unblocks runtime implementing support for in-place update.
+    * If there are no objections, can I squash all the discrete kubelet commits till now into a single commit (easier to rebase), and then add cgroupv2 support?
+    * Can we target an early 1.26 merge of API code? (saves me rebase headache)
+* [qbarrand] kubernetes-sigs membership for the KMMO contributors [PR](https://github.com/kubernetes-sigs/kernel-module-management/pull/7)
+    * feel free to ping @endocrimes
+* [pehunt] repercussions of dropping inheritable capabilities - https://github.com/moby/moby/issues/43420
+
+
+## Aug 02, 2022
+
+Reminder of the coming code freeze on 08/02.
+
+
+
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * Pod resize E2E test failed after rebase because GKE switched to[ cos-97 last week](https://github.com/kubernetes/kubernetes/commit/ead45ba74de3e70a7f807a3b4dee961763401a76) which defaults to cgroup2
+        * we don’t support it yet (it was planned for beta)
+        * disabling cgroup values check for resize verification unblocks but manual test on pre cos-97 (cgroup1) needed
+    * wangchen615 found that the scheduler takes 5 minutes to reevaluate pending pods after resizing down a bound pod.
+        * Late stage fix in commits <code>[563b254](https://github.com/kubernetes/kubernetes/commit/563b254303cb06c4d66195679a10f6c083c8fc54)</code> and <code>[c6581a8](https://github.com/kubernetes/kubernetes/commit/c6581a82ae3f84e7d4ff455c04757e0f1e75293c)</code>
+        * SIG-scheduling feels it is low risk and has signed off unofficially on slack
+    * thockin [has been LGTM](https://github.com/kubernetes/kubernetes/pull/102884#pullrequestreview-923756943) on API changes.
+    * Open issues [tracked here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status).
+    * My sentiment has changed - I am nervous about late stage changes and missing cgroup2 support when CI is on cgv2
+* [harche] evented PLEG - [https://github.com/kubernetes/kubernetes/pull/111384](https://github.com/kubernetes/kubernetes/pull/111384)
+
+                [   https://github.com/kubernetes/kubernetes/pull/111642](https://github.com/kubernetes/kubernetes/pull/111642)
+
+* [rata]: Asked for exception for [userns PR](https://github.com/kubernetes/kubernetes/pull/111090), as talked with Mrunal on slack
+    * Mrunal mentioned there are some concerns with phase II to discuss
+    * rata to update on PR, KEP and exception:
+        * Capture the discussion, we agreed to reduce the scope to stateless pods.
+        * One one hand, this buys us more time to figure out the details that some reviewers want about persistent volume support. On the other, it is very valuable to have support for stateless pods and it is an end in itself.
+        * This should also eliminate all concerns on how this can graduate to beta and GA.
+        * Should we change the feature gate name?
+* [jing]: [https://github.com/kubernetes/kubernetes/issues/110956#issuecomment-1197710132](https://github.com/kubernetes/kubernetes/issues/110956#issuecomment-1197710132)
+    * any reason  “it was a mistake that user must make an explicit request/limit when ResourceQuota has CPU/Memory setting."?
+* [bobbypage] cgroup v2 GA update
+    * CI has been running cgroupv2 images (COS/Ubuntu) on node e2e and cluster e2e 
+    * cgroupv1 specific tests added
+    * More feedback has been obtained on cgroupv2 from customers 
+        * Tencent has been running on cgroups v2 for a while
+    * Planned doc updates and blog post
+
+
+## July 26, 2022
+
+
+
+* [ruiwen-zhao]: 
+    * Reminder of the coming code freeze on 08/02..
+    * KEP status: 
+* [Xander/Anish]: Discuss [KEP #1003](https://github.com/kubernetes/enhancements/pull/1003)
+    * [https://github.com/intel/platform-aware-scheduling/tree/master/telemetry-aware-scheduling/](https://st1.zoom.us/web_client/5ccnbv4/html/externalLinkPage.html?ref=https://github.com/intel/platform-aware-scheduling/tree/master/telemetry-aware-scheduling/)
+    * Power example scheduling: [ https://github.com/intel/platform-aware-scheduling/tree/master/telemetry-aware-scheduling/docs/power](https://st1.zoom.us/web_client/5ccnbv4/html/externalLinkPage.html?ref=https://github.com/intel/platform-aware-scheduling/tree/master/telemetry-aware-scheduling/docs/power)
+* [Jing] Follow up on local Storage Capacity Isolation Feature 
+    * discussed with Ben [https://github.com/kubernetes/enhancements/issues/361#issuecomment-1194457546](https://github.com/kubernetes/enhancements/issues/361#issuecomment-1194457546)
+    * automatic detect and silence the feature will cause problem when system is switching to rootless in the future
+    * (dawnchen): SIG Node is fine with the proposal. 
+* [rata]: [userns k/k PR](https://github.com/kubernetes/kubernetes/pull/111090) is open for 2 weeks now, need review/approvers
+    * We have a LGTM from Ruiwen (thanks!), but need approvers from [lot of paths](https://github.com/kubernetes/kubernetes/pull/111090#issuecomment-1189537665)
+        * Dawn will ping Jordan (github @liggitt) for approval in several paths. Tim Hockin is out this week
+    * Any help to have the lgtm/approved on time?
+    * Unrelated: Maybe user namespaces is a good topic for a kubernetes blog post?
+        * (danielle): yes!
+        * Danielle is asking how to proceed to go with a blog post for this (thanks!)
+        * (danielle): **update: **added to the sig-release tracking sheet!
+* [ddebroy]: PodHasNetwork pod condition PR needs node reviewer/approver
+    * [https://github.com/kubernetes/kubernetes/pull/111358](https://github.com/kubernetes/kubernetes/pull/111358)
+    * Confirmed that API review is not required for Alpha const definitions.
+    * Mrunal has started on this. Thanks Mrunal!!
+    * Qiutong will also take a look
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * Awaiting Node LGTM
+    * Added [concise guidance](https://github.com/kubernetes/kubernetes/pull/102884/commits/0b04ed5a9305f5856294509281f7db307adcef48) for UpdateContainerResources CRI. mikebrow is LGTM
+    * SIG-Scheduling (huang-wei) [signaled LGTM](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1171515624) for current code.
+        * E2E test and optimization can come in follow-up PRs.
+            * wangchen615 is close to wrapping up tests requested by SIG-scheduling
+    * thockin [has been LGTM](https://github.com/kubernetes/kubernetes/pull/102884#pullrequestreview-923756943) on API changes.
+    * Open issues [tracked here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status).
+* [bobbypage] cgroupv2 GA
+    * New tests added to support cgroupv1
+    * Blocking presubmit updated to latest COS-97 and other tests to Ubuntu 22.04 with cgroup v2 enabled([https://github.com/kubernetes/kubernetes/pull/111412](https://github.com/kubernetes/kubernetes/pull/111412) , [https://github.com/kubernetes/test-infra/pull/26847](https://github.com/kubernetes/test-infra/pull/26847), https://github.com/kubernetes/test-infra/pull/26831
+    * Feedback gathered about some customer usage
+
+
+## July 19, 2022
+
+
+
+* [rata]: Can we have a review for [userns k/k PR](https://github.com/kubernetes/kubernetes/pull/111090)? Code freeze is coming soon :)
+    * Mrunal is reviewing it
+    * Ruiwen would review it for Containerd related changes
+* [jstur]: Windows cri-only posandbox stats: [https://github.com/kubernetes/kubernetes/pull/110754](https://github.com/kubernetes/kubernetes/pull/110754).  Do we keep the structure generic or make it specific for windows?
+    * David Porter is reviewing it.
+    * move design (including [https://github.com/kubernetes/kubernetes/pull/110754#issuecomment-1175552676](https://github.com/kubernetes/kubernetes/pull/110754#issuecomment-1175552676)) to the kep
+* [Brett]: SRO to kmmo repo rename
+    * Brett to open an issue to get the rename going
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * Rebased code to resolve latest conflict
+    * Added [concise guidance](https://github.com/kubernetes/kubernetes/pull/102884/commits/eae2354e407ce2af2213b7e44b8f08ec6da619a6) for UpdateContainerResources CRI
+    * SIG-Scheduling (huang-wei) [signaled LGTM](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1171515624) for current code.
+        * E2E test and optimization can come in follow-up PRs.
+            * wangchen615 is working on addressing Danielle’s feedback & E2E test targeting scheduler changes
+    * thockin [has been LGTM](https://github.com/kubernetes/kubernetes/pull/102884#pullrequestreview-923756943) on API changes.
+    * Open issues [tracked here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status).
+    * What do we need for Node & CRI LGTM for alpha?
+* [Jing] Local Storage Capacity Isolation Feature 
+    * Problem: 
+        * [https://github.com/kubernetes/enhancements/issues/361#issuecomment-1172435157](https://github.com/kubernetes/enhancements/issues/361#issuecomment-1172435157)
+        * It depends on the capability of checking local storage root filesystem usage where kubelet is running. Some special systems (kind rootless) cannot detect root file system disk usage, so disable this feature with feature gate for CI testing
+        * Feature gate will be removed when moving to GA 1.25. If rootfs disk usage is not available by cadvisor, it will block kubelet starting. [https://github.com/kubernetes/kubernetes/blob/5b92e46b2238b4d84358451013e634361084ff7d/pkg/kubelet/kubelet.go#L1385](https://github.com/kubernetes/kubernetes/blob/5b92e46b2238b4d84358451013e634361084ff7d/pkg/kubelet/kubelet.go#L1385) 
+    * Proposal: Add kubelet option enableLocalStorageCapacityIsolation(default=true) into kubelet configuration 
+        * The default value is true. 
+        * For systems that cannot support detecting root disk usage, set enableLocalStorageCapacityIsolation=false in kubelet configuration. In this case, kubelet can continue to start without rootfs disk usage information. So ephemeral storage allocatable is not set either. If pod has ephemeral storage request/limit set in this case, pod will fail to create because allocatable storage is not available.
+        * [feedback] whether we can automatically detect this. avoid complicating kubelet
+    * Feedback from sig-storage: seems fine
+* [Peter] CRI stats check-in
+* [Dawn] FYI: PR for SIG Node Contributor ladder was merged: [https://github.com/kubernetes/community/pull/6725](https://github.com/kubernetes/community/pull/6725) Thanks Derek!
+    * Please send your PR against that ladder if you think you are ready. Thanks!
+
+
+## July 12, 2022
+
+
+
+* [danielfoehrn] KEP proposal: [Dynamic Resource Reservations](https://github.com/danielfoehrKn/enhancements/commit/54cc9a3fa5b32d4dd4cc9f556631bb5ca9d73c8a)
+* 
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * Rebased code to resolve latest conflict
+    * Guidance for runtime is [taking shape](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1171809939) - thanks mrunalp & kolyshkin
+    * SIG-Scheduling (huang-wei) [signaled LGTM](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1171515624) for current code.
+        * E2E test and optimization can come in follow-up PRs.
+            * wangchen615 is working on addressing Danielle’s feedback & E2E test targeting scheduler changes
+    * thockin [has been LGTM](https://github.com/kubernetes/kubernetes/pull/102884#pullrequestreview-923756943) on API changes.
+    * Open issues [tracked here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status).
+    * What do we need for Node & CRI LGTM for alpha?
+* [adrianreber] Forensic Container Checkpointing
+    * code PR [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+    * LGTM by Ryan, Danielle, Mike(per existing kep) and Mrunal
+    * I think only Derek's /approve is now missing
+
+
+## July 5, 2022
+
+
+
+* [decarr] [Feedback](https://github.com/kubernetes/community/pull/6725) for evaluating reviewer/approver requests
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update
+    * vinaykul on vacation for the week but below is latest status:
+    * Guidance for runtime is [taking shape](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1171809939) - thanks mrunalp & kolyshkin
+    * SIG-Scheduling (huang-wei) [signaled LGTM](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1171515624) for current code.
+        * E2E test and optimization can come in follow-up PRs.
+    * thockin [has been LGTM](https://github.com/kubernetes/kubernetes/pull/102884#pullrequestreview-923756943) on API changes.
+    * wangchen615 is working on addressing Danielle’s feedback on E2E test and adding E2E test that targets scheduler. Tracked issue [110490](https://github.com/kubernetes/kubernetes/issues/110490).
+* [adrianreber] Forensic Container Checkpointing
+    * code PR [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+    * LGTM by Ryan, Danielle, Mike(per existing kep) .
+    * Ready to be merged?
+    * Derek expressed possible discussion/evaluation needed for the new exposed checkpoint service, mrunalp requested to look it over in that context.
+        * This was discussed a couple of months ago in the KEP and the consensus was that for Alpha we use it as it is right now. The checkpoint archive can only be accessed by the local root user as designed in the KEP. For Beta we need to think about if we want additional authorization on the Kubelet checkpoint API endpoint.
+* [swsehgal] Follow up on populating [Node Resource Topology-api](https://github.com/kubernetes/noderesourcetopology-api/) repository
+    * Issue: [https://github.com/kubernetes/community/issues/6308](https://github.com/kubernetes/community/issues/6308)
+    * [Response](https://docs.google.com/document/d/16GqCjnEh86w8yADcrUylNoE1y1sqjIMYNC_gdk5WPSQ/edit#) from Kubernetes Release Engineering team to follow the github workflow and solicit reviews.
+    * First PR to review: [https://github.com/kubernetes/kubernetes/pull/110252](https://github.com/kubernetes/kubernetes/pull/110252)
+* [ddebroy] Enhance Pod Initialized condition (for pods without init containers) in a fresh KEP
+    * scoped to pods without init containers
+    * will address the comment from Dawn at [https://github.com/kubernetes/enhancements/pull/3087#discussion_r904153856](https://github.com/kubernetes/enhancements/pull/3087#discussion_r904153856)
+* [natalivlatko] SIG Node reviewers for Docs reviews (see Slack thread: [https://kubernetes.slack.com/archives/C0BP8PW9G/p1656915324289179](https://kubernetes.slack.com/archives/C0BP8PW9G/p1656915324289179)) 
+    * [https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Aopen+sig-node-pr-reviews](https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Aopen+sig-node-pr-reviews)
+
+
+## June 28th, 2022
+
+
+
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status update (vinaykul OOO next week)
+    * KEP template changes merged. KEP is now tracked for 1.25
+    * [Fixed](https://github.com/kubernetes/kubernetes/commit/66f6239802aad21e2fa25cec558fa2a11bc8bc5a) CRI & test issues found by Mike and Derek respectively.
+    * _[derek on 6/14] [Reviewed](https://github.com/kubernetes/kubernetes/pull/102884#pullrequestreview-1006146971) with feedback, need to clarify core behavior expectation_
+        * _Kubelet -> CRI [interaction](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r896965708) pattern for observing state_
+            * _This assumes the runtime reports values as read from host cgroup_
+        * >>> [vinaykul] Please review my [response](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-1159606963) on ResizeStatus generation.
+        * >>> [vinaykul] Please review my [comment](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r908049704) on suggested runtime behavior.
+* [bthurber & mrunal] - special-resource-operator repo rename
+    * Issue: [https://github.com/kubernetes-sigs/special-resource-operator/issues/6](https://github.com/kubernetes-sigs/special-resource-operator/issues/6) 
+    * [Community meeting notes](https://docs.google.com/document/d/1b-wFATh2A0Pm1P3k11lniSeRP4q74rUa1fTvmk_ZdWY/edit?usp=sharing)
+    * Derek - Write up a readme and send it to the mailing list
+* [adrianreber] Forensic Container Checkpointing
+    * code PR [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+    * LGTM by Ryan, Danielle, Mike(per existing kep) .
+    * Ready to be merged? Derek expressed possible discussion/evaluation needed for new exposed checkpoint service, mrunalp requested to look it over in that context.
+* [swsehgal] Populating [Node Resource Topology-api](https://github.com/kubernetes/noderesourcetopology-api/) repository
+    * Issue: [https://github.com/kubernetes/community/issues/6308](https://github.com/kubernetes/community/issues/6308)
+    * PRs:
+        * [https://github.com/kubernetes/kubernetes/pull/110252](https://github.com/kubernetes/kubernetes/pull/110252)
+        * [https://github.com/kubernetes/kubernetes/pull/110629](https://github.com/kubernetes/kubernetes/pull/110629)
+        * [https://github.com/kubernetes/kubernetes/pull/96275](https://github.com/kubernetes/kubernetes/pull/96275)
+    * Action Items
+        * [swsehgal] To identify if we need an enhancement proposal for this work (currently no code is being proposed in core Kubernetes only the API) and get a member of the release team to take a look at the PRs.
+            * [Slack thread](https://kubernetes.slack.com/archives/C2C40FMNF/p1656440458212419) created on #sig-release channel
+        * [Derek/ Sasha] To take a look at the PRs/ repo creation request to see if we want to populate the repo.
+
+
+## June 21st, 2022
+
+
+
+* [klueska] Need final approval from [Derek](mailto:decarr@redhat.com) or [Dawn](mailto:dawnchen@google.com) for following KEP
+    * [CPUManager policy option to align CPUs by Socket instead of NUMA node](https://github.com/kubernetes/enhancements/pull/3334)
+    * I have given my [preliminary /lgtm and /approve](https://github.com/kubernetes/enhancements/pull/3334#issuecomment-1161476253) on it already (with caveats of things we should consider before moving to beta)
+* [mrunal] - KEPs needing approval / review
+    * [https://github.com/kubernetes/enhancements/pull/3404](https://github.com/kubernetes/enhancements/pull/3404)
+    * [https://github.com/kubernetes/enhancements/pull/3410](https://github.com/kubernetes/enhancements/pull/3410)
+    * [https://github.com/kubernetes/enhancements/pull/3087](https://github.com/kubernetes/enhancements/pull/3087)
+    * [https://github.com/kubernetes/enhancements/pull/3419](https://github.com/kubernetes/enhancements/pull/3419)
+    * [https://github.com/kubernetes/enhancements/pull/3064](https://github.com/kubernetes/enhancements/pull/3064)
+    * [https://github.com/kubernetes/enhancements/pull/2697](https://github.com/kubernetes/enhancements/pull/2697)
+* [danielle] Testing/Reliability
+    * General agreement that we have work to do
+        * Defining unreliability:
+            * “Simple”: Violating a published invariant of the kubernetes api
+            * More complicated when adding plugin interfaces to the mix, and “undocumented” things around when state transitions will happen.
+        * A few key areas for improvements:
+            * CRI test interfaces, both testing CRIs themselves, and testing how the Kubelet will respond to CRI failure
+                * Kubelet+CRI failure: [https://github.com/kubernetes/kubernetes/issues/110429](https://github.com/kubernetes/kubernetes/issues/110429)
+                * Need an issue for critest in cri-tools.
+                * contract testing
+            * Use tests to document the invariants that exist, to avoid shipping regressions, and be aware when shipping behavioral change.
+                * We don’t need to find every latent bug, but we should make it harder to ship new ones.
+                * Prioritize testing behavior over timing, and then we can fixing timing later.
+                * [unit tests issue] [https://github.com/kubernetes/kubernetes/issues/109717](https://github.com/kubernetes/kubernetes/issues/109717)
+                * 
+            * Clarifying where we’re lacking features that cause failure: [https://github.com/kubernetes/kubernetes/issues/110428](https://github.com/kubernetes/kubernetes/issues/110428)
+            * As reviewers/approvers we need to ensure that new changes get test coverage.
+* [alculquicondor]  Overview of [https://github.com/kubernetes/enhancements/pull/3374](https://github.com/kubernetes/enhancements/pull/3374)
+    * first round reviewers: Qiutong, David
+* [adrianreber] Forensic Container Checkpointing
+    * code PR [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+    * LGTM by Ryan, Danielle, Mike
+    * Ready to be merged?
+
+
+## June 14th, 2022
+
+Total active pull requests: [192](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-06-07T17%3A00%3A00%2B0000..2022-06-14T16%3A55%3A29%2B0000">17</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-06-07T17%3A00%3A00%2B0000..2022-06-14T16%3A55%3A29%2B0000">6</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-06-07T17%3A00%3A00%2B0000..2022-06-14T16%3A55%3A29%2B0000+created%3A%3C2022-06-07T17%3A00%3A00%2B0000">57</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-06-07T17%3A00%3A00%2B0000..2022-06-14T16%3A55%3A29%2B0000">13</a>
+   </td>
+  </tr>
+</table>
+
+
+Fish out: [https://github.com/kubernetes/kubernetes/pull/104140/](https://github.com/kubernetes/kubernetes/pull/104140/)
+
+
+
+* [dawnchen] [https://bit.ly/k8s125-enhancements](https://bit.ly/k8s125-enhancements) is updated for SIG Node.
+    * Total: 19 enhancements
+* [paco] I worked on this [https://github.com/kubernetes/enhancements/issues/1029](https://github.com/kubernetes/enhancements/issues/1029) for sometime since 1.22 and fixed a bug and tried to add metrics/log for this feature, and the promotion pr was updated [https://github.com/kubernetes/enhancements/pull/2697](https://github.com/kubernetes/enhancements/pull/2697) Can we add this to v1.25 if it met the beta-promotion bar?
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status (vinaykul unavailable next two weeks)
+    * [derek] [Reviewed](https://github.com/kubernetes/kubernetes/pull/102884#pullrequestreview-1006146971) with feedback, need to clarify core behavior expectation
+        * Kubelet -> CRI [interaction](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r896965708) pattern for observing state
+            * This assumes the runtime reports values as read from host cgroup
+    * KEP needs a template catch-up update. Please review [this PR](https://github.com/kubernetes/enhancements/pull/3390).
+        * Partial/placeholder current unit-test cov info added. A more detailed breakdown will have to wait until after the OSS NA conference.
+    * API (Tim Hockin) LGTM. Scheduling (need to add E2E test, then LGTM likely)
+    * Issues to fix are being tracked [here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status). Volunteers welcome :)
+* [adrianreber] Forensic Container Checkpointing (not able to join (again))
+    * code PR [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+        * reviews done by Mrunal and Danielle (thanks)
+        * probably almost finished, waiting for additional reviews/approval
+        * Waiting for feedback from Mike about CRI changes
+            * Initially we targeted checkpoints archive on the local file system
+            * Right now we have successfully implemented checkpoint OCI images (not standardized (yet)) in the local registry in containerd and CRI-O
+            * Storing checkpoints as OCI images was a request during early discussions (1.5 years ago)
+            * At this point we could completely drop checkpoints written to the local file system and only store checkpoint images in the local containerd/CRI-O registry
+            * Please let me know in the PR if it would be preferred to drop the local file system checkpoint archives (I am in favor of it)
+    * Concerning the PR discussion this would mean we need to keep the parameter about the checkpoint destination (something like localhost/checkpoint-image:tag) and not remove the destination parameter as suggested by Mike
+
+		[Derek] fundamental question - PR allows to change CPU and Memory request and limit. But when the change will manifest? How kubelet will know if this errored? Should we read the value back on whether change was applied?
+
+		[MikeB] error code from API call will notify if failed to lower the limit. Swallowed on increase.
+
+		[Mrunal] confirm this^^^. As long as we increment properly should be fine.
+
+		[Derek] Need to make sure kubelet always knows the latest applied values. Also in case of emptyDir &lt;missed this> 
+
+		Also PR makes an assumption on a PLEG event being handled properly.
+
+		[Derek] Need to check the behavior on cgroupv2 as well.
+
+
+
+* [ddebroy] SandboxReady pod condition KEP 
+    * KEP https://github.com/kubernetes/enhancements/pull/3087
+        * Reviewed by Qiutong and Ruiwen
+        * Looking for a review from Derek.
+* [ruiwen-zhao] Adding GA criteria for KEP-2133 kubelet credential provider
+    * https://github.com/kubernetes/enhancements/pull/3379
+    * Reviewed/Approved by SergeyKanzhelev and deads2k
+    * Looking for a review from Derek (or other sig node approvers)
+* [mikebrow] exec with uid/gid (maybe user) option vs current root only.. any interest? original discussion1224— 
+    * discussion centered on use cases, comparing with ephemeral container support, login with ssh plugin extension… 
+    * Sergey had a good idea about a flag for disabling root defaulting
+        * perhaps we could use container default here..?
+* [ed] Dynamic resource allocation KEP: request for review: https://github.com/kubernetes/enhancements/pull/3064
+    * Being reviewed by Tim Hockin
+    * Looking for a 2nd review round from Derek
+* [marquiz]  Class resources KEP, re-triage, reviewers/approver were missing last week
+* [mckdev] Always set alpha.kubernetes.io/provided-node-ip https://github.com/kubernetes/kubernetes/pull/109794
+* 
+            * 
+
+
+## June 7th, 2022
+
+Total active pull requests:[192](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+(for the past two weeks):
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-05-24T17%3A00%3A00%2B0000..2022-06-07T16%3A56%3A58%2B0000">29</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-05-24T17%3A00%3A00%2B0000..2022-06-07T16%3A56%3A58%2B0000">17</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-05-24T17%3A00%3A00%2B0000..2022-06-07T16%3A56%3A58%2B0000+created%3A%3C2022-05-24T17%3A00%3A00%2B0000">94</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-05-24T17%3A00%3A00%2B0000..2022-06-07T16%3A56%3A58%2B0000">17</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [Ruiwen] Fill up [https://bit.ly/k8s125-enhancements](https://bit.ly/k8s125-enhancements) from [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.qovbe39npaih](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.qovbe39npaih) 
+* [SergeyKanzhelev] Proposed soft freeze **July 12th**. Expectations for the soft freeze:
+* Beta graduations and deprecations should be fully merged by this date
+* Alpha features and GA must have PRs open that should be ready to review
+* [marquiz]  [Class resources KEP](https://github.com/kubernetes/enhancements/pull/3004), follow-up on blockio
+* [adrianreber] Forensic Container Checkpointing (cannot make it to today's meeting)
+    * KEP [https://github.com/kubernetes/enhancements/pull/3264](https://github.com/kubernetes/enhancements/pull/3264)
+        * Merged, thanks for the review and approval
+    * code PR [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+        * multiple review rounds (thanks Mrunal!)
+        * probably almost finished, waiting for additional reviews/approval
+        * Added unit test, fixed e2e test as suggested by Danielle (thanks)
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status (vinaykul out today)
+    * Enhancements [PR](https://github.com/kubernetes/enhancements/pull/3292) merged - thanks Dawn!
+    * Derek’s re-review is in progress.
+    * API (Tim Hockin) LGTM. Scheduling (need to add E2E test, then LGTM likely)
+    * Issues to fix are being tracked [here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status). Volunteers welcome :)
+* [ddebroy] SandboxReady pod condition KEP 
+    * KEP [https://github.com/kubernetes/enhancements/pull/3087](https://github.com/kubernetes/enhancements/pull/3087)
+        * Reviewed by Qiutong and Ruiwen
+        * Looking for a review from Derek.
+* [Peter] CRI-O and containerd CVE and long-term fix discussion
+    * There is a cap on memory used that we need to document this limitation to k8s customers.
+    * [mrunal] document it in CRI and document the behavior: we truncate at that point.
+    * [peter] will take an action item to do this documentation.
+    * CRI-O: [https://access.redhat.com/security/cve/cve-2022-1708](https://access.redhat.com/security/cve/cve-2022-1708)
+    * containerd: [https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-31030](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-31030) 
+    * Followed up in [https://github.com/kubernetes/kubernetes/pull/110435](https://github.com/kubernetes/kubernetes/pull/110435) 
+* [Hanamantgoud] Reviving [https://github.com/kubernetes/enhancements/pull/1224](https://st1.zoom.us/web_client/3jktxx3/html/externalLinkPage.html?ref=https://github.com/kubernetes/enhancements/pull/1224)
+* 
+
+
+## May 31, 2022
+
+
+
+* [klueska]: Please add following enhancement to tracking sheet:
+    * New CPU Manager Policy: align-by-socket
+    * [Link to enhancement Issue](https://github.com/kubernetes/enhancements/issues/3327)
+    * [Link to row in KEP - Planning document](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.22jz5yk3qwbl)
+* [matthyx] (cannot be present): Please remove [Keystone containers KEP](https://github.com/kubernetes/enhancements/issues/2872) from tracking:
+    * adisky is on maternity leave
+    * code will likely impact PLEG, will prefer to have more tests added by [sig-node: reliability project](https://docs.google.com/document/u/0/d/1jZARfxuqZ2vjs7c4Q48O5HrQu6zekOfHYl4zAIq8eak/edit) (which I want to participate to) before refactoring
+* [rata]: userns [KEP PR](https://github.com/kubernetes/enhancements/pull/3275) open since early April. Anything missing?
+    * The sig-node freeze is in a few days
+    * AFAIK there is nothing missing. Got LGTM a few hours ago, missing /approve
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) - status update
+    * Merged KEPs 2273 with 1287. Awaiting [review](https://github.com/kubernetes/enhancements/pull/3292).
+    * API (Tim Hockin) LGTM. Scheduling (need to add E2E test, then LGTM likely)
+    * Awaiting Derek review completion**.**
+    * Issues to fix are being tracked [here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status). Volunteers welcome :)
+* [adrianreber] Forensic Container Checkpointing (cannot make it to today's meeting)
+    * KEP [https://github.com/kubernetes/enhancements/pull/3264](https://github.com/kubernetes/enhancements/pull/3264)
+        * Reviewed, now waiting for approval
+        * There is a review comment from my Mike which is not totally clear to me and I am looking for clarification what Mike was exactly asking for
+    * code PR [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+        * multiple review rounds (thanks Mrunal!)
+        * probably almost finished, waiting for additional reviews/approval
+* [bobbypage/ruiwen] issue with terminating pods reporting ready=true 
+    * issue: [https://github.com/kubernetes/kubernetes/issues/108594](https://github.com/kubernetes/kubernetes/issues/108594)
+    * Repro test found: [https://github.com/kubernetes/kubernetes/pull/110257](https://github.com/kubernetes/kubernetes/pull/110257)
+    * PR fix: [https://github.com/kubernetes/kubernetes/pull/110256](https://github.com/kubernetes/kubernetes/pull/110256)
+* [ddebroy] SandboxReady pod condition KEP 
+    * KEP [https://github.com/kubernetes/enhancements/pull/3087](https://github.com/kubernetes/enhancements/pull/3087)
+        * Reviewed by Qiutong and Ruiwen
+        * Looking for a review from Derek.
+
+
+## May 24, 2022
+
+
+
+* [rata]: userns [KEP PR](https://github.com/kubernetes/enhancements/pull/3275) open since early April. Can we have a review?
+    * We want to move to alpha (phase I) in 1.25
+    * PR here: [https://github.com/kubernetes/enhancements/pull/3275](https://github.com/kubernetes/enhancements/pull/3275) 
+    * Mrunal will review it this week. Mike Brown and other folks in Containerd will review the related pieces for Containerd.
+* [bobbypage] Pod Lifecycle Documentation / Guarantees Doc needed
+    * xref: [https://github.com/kubernetes/kubernetes/pull/110115](https://github.com/kubernetes/kubernetes/pull/110115) 
+    * 1.22 vs old diff - [https://github.com/kubernetes/kubernetes/issues/109414#issuecomment-1126203054](https://github.com/kubernetes/kubernetes/issues/109414#issuecomment-1126203054) 
+    * Pod Readiness issue and PR fix [https://github.com/kubernetes/kubernetes/issues/102537](https://github.com/kubernetes/kubernetes/issues/102537)
+        * [https://github.com/kubernetes/kubernetes/pull/110191](https://github.com/kubernetes/kubernetes/pull/110191)
+        * 
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status
+    * Merged KEPs 2273 with 1287. Please [review](https://github.com/kubernetes/enhancements/pull/3292).
+    * API (Tim Hockin) LGTM. Scheduling (need to add E2E test, then LGTM likely)
+    * Awaiting Derek to complete the kubelet review. Can we please prioritize to avoid another release slip? My time is going to be limited as June rolls around - [multiple CPFs accepted](https://ossna2022.sched.com/?searchstring=futurewei) for LF OSS conference, I have additional work of content & demo prep.
+    * Issues to fix are tracked [here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status). Volunteers welcome :)
+* [adrianreber] Forensic Container Checkpointing (cannot make it to today's meeting)
+    * KEP [https://github.com/kubernetes/enhancements/pull/3264](https://github.com/kubernetes/enhancements/pull/3264)
+        * Reviewed, now waiting for approval
+    * code PR [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+        * multiple review rounds (thanks Mrunal!)
+        * probably almost finished, waiting for additional reviews/approval
+* [ddebroy] SandboxReady pod condition KEP 
+    * KEP [https://github.com/kubernetes/enhancements/pull/3087](https://github.com/kubernetes/enhancements/pull/3087)
+        * Reviewed by Qiutong and Ruiwen
+        * Looking for a review from Derek.
+* [jan0ski] Promote AppArmor to GA KEP
+    * KEP [https://github.com/kubernetes/enhancements/pull/3298](https://github.com/kubernetes/enhancements/pull/3298) 
+        * Looking for confirmation from sig-node, sig-architecture, sig-auth for 1.25 target
+        * Help with implementation or review is welcome :)
+    * Reworked from old KEP from Sascha [https://github.com/kubernetes/enhancements/pull/1444](https://github.com/kubernetes/enhancements/pull/1444)
+
+
+## May 17, 2022
+
+
+
+* Canceled due to Kubecon
+
+
+## May 10, 2022
+
+
+
+* [Derek/Dawn] Update on sig-node reliability kickoff last week
+
+                will upload the recording
+
+
+                spent time reaching consensus on what reliability means for node - clarify    kubelet vs. runtime vs. operating system.
+
+
+           Increase test coverage and then next steps.
+
+           Calling on the community to help. 
+
+           matthyx - discuss at kubecon 
+
+     
+
+
+
+* [matthyx] discuss about [Keystone containers KEP](https://github.com/kubernetes/enhancements/issues/2872)
+    * matthyx will update the document and come back in a few weeks to present the milestone and design
+* [knight42] review [KEP: Split stdout and stderr log stream](https://github.com/kubernetes/enhancements/pull/3289)
+*            Mrunal will make a pass
+* [rphillips] Evented PLEG initial work [[doc](https://docs.google.com/document/d/1GfWDoKAYiaXApxayXmPl9bcK5ewyiimFDJ966r28TUE/edit?usp=sharing)] (Points of Contacts: Ryan Phillips, Mrunal Patel, Harshal Patil)
+    *  Derek - Data on perf?. Ryan - We don’t have that yet.
+    * Derek - Clarification that we won’t get rid of the list entirely but be able to make the lists less frequent.
+    * Mike will review 
+* [mikebrow/Paul] KEP: Sub-Second Probes
+    * [hackmd version of the KEP update based on review](https://hackmd.io/nsGZk3bySKOstryPoPCcag#Proposal)s
+        * [ hackmd document around the various options](https://hackmd.io/WvgI0MlgTlKRbD7bcPhZLA?view). 
+    * [PR draft ](https://github.com/kubernetes/kubernetes/pull/107958)
+    * KEP: [Sub-Second Probes](https://github.com/kubernetes/enhancements/pull/3067) ([issue](https://github.com/kubernetes/enhancements/issues/3066)) KEP text will be updated to latest implementation/proposal, would like to have agreement on direction and move discussion to prioritization.
+    * Derek: We should as a community agree on how probes should be measured, charged. Mrunal to present what Red Hat has been working on in this area.
+    * Dawn: We haven’t defined how the pod has additional overhead to run probes or logs, etc. The initial step is sharing the performance benchmark to the community.
+* [marquiz] follow-up discussion on  [Class resources KEP](https://github.com/kubernetes/enhancements/pull/3004).
+    * Action to Markus:
+        * blog post for k8s.io blog, description on what is possible now with runtimes and existing annotations
+        * Come back with demo/description of how Block I/O will be utilized by user
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status
+    * Merged KEPs 2273 with 1287 per last week's discussion. Please [review](https://github.com/kubernetes/enhancements/pull/3292).
+    * API (Tim Hockin) LGTM.
+    * Awaiting Derek to complete the review. Can we please prioritize to avoid another release slip? My time is going to be limited as June rolls around - [multiple CPFs accepted](https://ossna2022.sched.com/?searchstring=futurewei) for LF OSS conference, I have additional work of content & demo prep.
+    * Issues to fix are tracked [here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status). Volunteers welcome :)
+* [mrunal] kubecon next week - do we keep the meeting?
+* Cancelling next week. 
+
+
+## May 3, 2022
+
+
+
+* [mrunalp/ ruiwen] 1.25 planning continue: [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.qovbe39npaih](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.qovbe39npaih) 
+* [Announcement, danielle] testing/reliability project, we'll be meeting at 8AM PST (5PM CEST) on Wednesday (more info: [https://groups.google.com/g/kubernetes-sig-node/c/-Y8TC_l7xp8/m/U9b6icAyAwAJ](https://groups.google.com/g/kubernetes-sig-node/c/-Y8TC_l7xp8/m/U9b6icAyAwAJ))
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status
+    * vinaykul not in today due to conflict.
+    * Merged KEPs 2273 with 1287 per last week's discussion. Please [review](https://github.com/kubernetes/enhancements/pull/3292).
+    * API (Tim Hockin) LGTM.is:open is:issue label:sig/node created:
+    * Awaiting Derek to complete the review.
+    * Issues to fix are tracked [here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status). Volunteers welcome :)
+    * Can we make an early commit for v1.25?
+* 
+
+
+## April 26, 2022
+
+
+
+* 1.24 retro
+    * KEPs tracking: [https://docs.google.com/spreadsheets/d/1T21mUTvPh70NB2eseHjCyD4LgRjyxWI9Bd1SoP8zAwA/edit#gid=0](https://docs.google.com/spreadsheets/d/1T21mUTvPh70NB2eseHjCyD4LgRjyxWI9Bd1SoP8zAwA/edit#gid=0) 
+
+Done (6):
+
+
+<table>
+  <tr>
+   <td><strong>Issue Number</strong>
+   </td>
+   <td><strong>Name</strong>
+   </td>
+   <td><strong>Stage Status</strong>
+   </td>
+   <td><strong>Stage</strong>
+   </td>
+   <td><strong>Assignee</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+281</p>
+
+   </td>
+   <td>DynamicKubeletConfig
+   </td>
+   <td>Removal
+   </td>
+   <td>
+   </td>
+   <td>SergeyKanzhelev
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+688</p>
+
+   </td>
+   <td>PodOverhead
+   </td>
+   <td>Graduating
+   </td>
+   <td>Stable
+   </td>
+   <td>SergeyKanzhelev
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2133</p>
+
+   </td>
+   <td>Kubelet Credential Provider
+   </td>
+   <td>Graduating
+   </td>
+   <td>Beta
+   </td>
+   <td>adisky
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2221</p>
+
+   </td>
+   <td>Dockershim removal
+   </td>
+   <td>Major Change
+   </td>
+   <td>Stable
+   </td>
+   <td>SergeyKanzhelev
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2712</p>
+
+   </td>
+   <td>PriorityClassValueBasedGracefulShutdown
+   </td>
+   <td>Graduating
+   </td>
+   <td>Beta
+   </td>
+   <td>mrunalp
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2727</p>
+
+   </td>
+   <td>gRPC probes
+   </td>
+   <td>Graduating
+   </td>
+   <td>Beta
+   </td>
+   <td>SergeyKanzhelev
+   </td>
+  </tr>
+</table>
+
+
+Removed from Milestone (17):
+
+
+<table>
+  <tr>
+   <td><strong>Issue Number</strong>
+   </td>
+   <td><strong>Name</strong>
+   </td>
+   <td><strong>Stage Status</strong>
+   </td>
+   <td><strong>Stage</strong>
+   </td>
+   <td><strong>Assignee</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+127</p>
+
+   </td>
+   <td>User Namespaces
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Alpha
+   </td>
+   <td>rata
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+1287</p>
+
+   </td>
+   <td>In-place Pod Vertical Scaling
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Alpha
+   </td>
+   <td>vinaykul
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+1972</p>
+
+   </td>
+   <td>ExecProbeTimeout
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Stable
+   </td>
+   <td>jackfrancis
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2008</p>
+
+   </td>
+   <td>Container Checkpointing (CRIU)
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Alpha
+   </td>
+   <td>adrianreber
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2043</p>
+
+   </td>
+   <td>List/watch for concrete resource assignments via PodResource API
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Stable
+   </td>
+   <td>swatisehgal
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2254</p>
+
+   </td>
+   <td>Cgroupsv2
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Stable
+   </td>
+   <td>giuseppe
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2371</p>
+
+   </td>
+   <td>cAdvisor-less, CRI-full stats
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Beta
+   </td>
+   <td>haircommander
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2400</p>
+
+   </td>
+   <td>Swap
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Beta
+   </td>
+   <td>ehashman
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2413</p>
+
+   </td>
+   <td>SeccompByDefault
+   </td>
+   <td>Graduating
+   </td>
+   <td>Beta
+   </td>
+   <td>saschagrunert
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2535</p>
+
+   </td>
+   <td>Ensure Secret Pulled Images
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Alpha
+   </td>
+   <td>mikebrow
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2823</p>
+
+   </td>
+   <td>Node-level pod admission handlers
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Alpha
+   </td>
+   <td>SaranBalaji90
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2837</p>
+
+   </td>
+   <td>Pod level resource limits
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Alpha
+   </td>
+   <td>n4j
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2872</p>
+
+   </td>
+   <td>Keystone Containers
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Alpha
+   </td>
+   <td>adisky
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+2902</p>
+
+   </td>
+   <td>New CPU Manager Policy: distribute-across-numa
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Beta
+   </td>
+   <td>klueska
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+3063</p>
+
+   </td>
+   <td>Dynamic resource allocation
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Alpha
+   </td>
+   <td>pohly
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+3085</p>
+
+   </td>
+   <td>Pod conditions around starting and completion of pod sandbox creation
+   </td>
+   <td>Graduating+
+   </td>
+   <td>Alpha
+   </td>
+   <td>ddebroy
+   </td>
+  </tr>
+  <tr>
+   <td><p style="text-align: right">
+3162</p>
+
+   </td>
+   <td>Add Deallocate and PostStopContainer to device plugin API
+   </td>
+   <td>Graduating
+   </td>
+   <td>Alpha
+   </td>
+   <td>zvonkok
+   </td>
+  </tr>
+</table>
+
+
+
+        1.22 release with 24 KEPs tracked and **13 merged**
+
+
+        1.23 was tracking 14 with **8 merged**
+
+
+        1.24 with 23 tracked and **6 merged**
+
+
+        1.23 release retro summary:
+
+
+        Good:
+
+
+
+* Planning and tracking is useful
+* Soft freeze helps
+* Early merges are great
+
+        Can be better:
+
+* Lack of reviewers and early reviews
+* Lack of approver’s bandwidth
+* _Things that went well_
+
+    Notes:
+
+* Reviewer found missing tests during the review process
+* We are making progress even though things are moving slow sometimes.
+* For in-place pod vertical scaling, containerd side changes are done in parallel and ready to go.
+* Collaboration with the runc community is good. 
+* _Things that didn’t went well_
+
+	Notes:
+
+
+
+* In-place vertical scaling takes long, but we are practicing caution in the review process.
+* Original author moved forward last minute 
+* Keystone Containers design came late 
+* In-place scaling scope increased over the review process
+* unit tests in different location than the code
+* Syncing changes between Kubernetes and container runtime. (One side needs to cut a release first.)
+* (compared to runc) Containerd community could be more proactive when cutting releases
+* _AIs_
+    * Investment on testability and reliability next cycle. Leadership to scope and direct these works needed.
+    * Don’t accept changes without test coverage or those lack testability. Reviewers need to hold the bar.
+    * Build component tests - volunteers needed
+    * Clearer instructions on which folder to add tests, based on the code. Automated tool?
+* [SergeyKanzhelev] KEP 1.24 retro and KEPs 1.25 planning kick-off
+    * [https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.qovbe39npaih](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.qovbe39npaih) 
+* [rata]: userns KEP: [CRI changes PR](https://github.com/kubernetes/enhancements/pull/3275) open for 19 days now
+    * Can we ask for a review, please? :)
+    * Do we need review from Windows/VM runtimes maintainers for Alpha phase or for beta?
+        * Mark R (what is the github handle?) will take a look. But it doesn’t seem like a blocker for alpha
+        * rata: Also, this lives inside the Linux section of the CRI
+    * Can you help us to reach out to the relevant runtime maintainers to also take a look?
+    * Can we aim for alpha in 1.25
+        * It is currently not listed in that section in the doc Sergey shared
+        * rata: Added, thanks!
+* [adrianreber] Forensic Container Checkpointing
+    * KEP update PR created as suggested three weeks ago
+        * [https://github.com/kubernetes/enhancements/pull/3264](https://github.com/kubernetes/enhancements/pull/3264)
+        * Move from 1.24 to 1.25
+        * include CRI API changes in KEP
+    * Corresponding code PR updated
+        * [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+    * Ready for review
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR status
+    * API (Tim Hockin) LGTM. Derek’s review is in progress.
+    * Issues to fix are being tracked [here](https://github.com/vinaykul/kubernetes/wiki/In-Place-Pod-Vertical-Scaling-Issues-and-Status).
+    * Can we make an early commit for v1.25?
+
+
+## April 19, 2022
+
+**Cancelled** - due to availability of leads.
+
+
+## April 12, 2022
+
+Total active pull requests: [172](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+10 from last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-04-05T17%3A00%3A00%2B0000..2022-04-12T17%3A03%3A04%2B0000">16</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-04-05T17%3A00%3A00%2B0000..2022-04-12T17%3A03%3A04%2B0000">5</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-04-05T17%3A00%3A00%2B0000..2022-04-12T17%3A03%3A04%2B0000+created%3A%3C2022-04-05T17%3A00%3A00%2B0000">44</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-04-05T17%3A00%3A00%2B0000..2022-04-12T17%3A03%3A04%2B0000">2</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] Status of [https://github.com/kubernetes/kubernetes/issues/109082](https://github.com/kubernetes/kubernetes/issues/109082) ? (final node bug in the milestone)
+    * Release was scheduled for Apr. 19 but there is no 1.24 release branch yet; it will likely be delayed: [https://github.com/kubernetes/sig-release/discussions/1877](https://github.com/kubernetes/sig-release/discussions/1877) 
+    * Node 1.24 burndown: [https://github.com/pulls?q=org%3Akubernetes+label%3Asig%2Fnode+is%3Aopen+milestone%3Av1.24](https://github.com/pulls?q=org%3Akubernetes+label%3Asig%2Fnode+is%3Aopen+milestone%3Av1.24) 
+    * Release blocker: [https://github.com/kubernetes/kubernetes/issues/108910](https://github.com/kubernetes/kubernetes/issues/108910) (go 1.18 related)
+    * We believe #109082 is a regression and should block the release, Dawn to bump priority.. (Mike Brown: i’m looking again..)
+* [marquiz] Intro and demo of [Class resources KEP](https://github.com/kubernetes/enhancements/pull/3004).
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) status
+    * Derek’s PR review is in progress.
+    * Can we make an early commit for v1.25?
+* [adrianreber] Forensic Container Checkpointing (just FYI)
+    * KEP update PR created as suggested last week 
+        * [https://github.com/kubernetes/enhancements/pull/3264](https://github.com/kubernetes/enhancements/pull/3264)
+        * Move from 1.24 to 1.25
+        * include CRI API changes in KEP
+    * Corresponding code PR updated
+        * [https://github.com/kubernetes/kubernetes/pull/104907](https://github.com/kubernetes/kubernetes/pull/104907)
+    * Ready for review
+* [mweston & Alexander Kanevskiy] reminder to please review: [Kubelet Resource Plugin RFC](https://docs.google.com/document/u/0/d/1O5G4HMhfyC9AdaGai1eV5OJpCugV3vFIW19_FCuMOaY/edit?resourcekey=0-qLkKucnl3Y2wJ_WEfZPRVQ)
+
+
+## April 5, 2022
+
+Total active pull requests: [162](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-17 from two weeks)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-03-22T17%3A00%3A00%2B0000..2022-04-05T17%3A06%3A38%2B0000">55</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-03-22T17%3A00%3A00%2B0000..2022-04-05T17%3A06%3A38%2B0000">15</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-03-22T17%3A00%3A00%2B0000..2022-04-05T17%3A06%3A38%2B0000+created%3A%3C2022-03-22T17%3A00%3A00%2B0000">122</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-03-22T17%3A00%3A00%2B0000..2022-04-05T17%3A06%3A38%2B0000">62</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [ehashman] 1.24 release blockers/regressions
+    * [https://github.com/kubernetes/kubernetes/issues/109082](https://github.com/kubernetes/kubernetes/issues/109082)
+    * [https://github.com/kubernetes/kubernetes/issues/109182](https://github.com/kubernetes/kubernetes/issues/109182) 
+    * [https://github.com/kubernetes/kubernetes/issues/109281](https://github.com/kubernetes/kubernetes/issues/109281) 
+    * We need people assigned/actively working on these
+* [adrianreber] Forensic Container Checkpointing
+* [ & Alexander Kanevskiy] Kubelet Resource Plugin Model
+    * 
+    * Ask: please comment so we can figure out how to proceed
+* [ddebroy] SandboxReady KEP comments [https://github.com/kubernetes/enhancements/pull/3087#issuecomment-1076779138](https://github.com/kubernetes/enhancements/pull/3087#issuecomment-1076779138) 
+
+
+## March 29, 2022
+
+No agenda, canceling to focus on code freeze.
+
+For any urgent items for code freeze, please ping sig-node slack channel.
+
+
+## March 22, 2022
+
+Total active pull requests: [179](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+5 from last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-03-15T17%3A00%3A00%2B0000..2022-03-22T16%3A54%3A37%2B0000">25</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-03-15T17%3A00%3A00%2B0000..2022-03-22T16%3A54%3A37%2B0000">5</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-03-15T17%3A00%3A00%2B0000..2022-03-22T16%3A54%3A37%2B0000+created%3A%3C2022-03-15T17%3A00%3A00%2B0000">81</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-03-15T17%3A00%3A00%2B0000..2022-03-22T16%3A54%3A37%2B0000">15</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [Announcements] Code freeze
+    * Reminder: Mar. 29 - next week!
+* [danielle] annual report blocked on Derek (final lgtm on contributor doc)
+* [ehashman] Review of KEPs targeted for release \
+ \
+The following KEPs are expected to be **fully merged** (Beta/Deprecations):
+* [Done] 281: DynamicKubeletConfig [https://github.com/kubernetes/enhancements/issues/281](https://github.com/kubernetes/enhancements/issues/281)
+* [soft cut] 2133: Kubelet Credential Provider [https://github.com/kubernetes/enhancements/issues/2133](https://github.com/kubernetes/enhancements/issues/2133)<span style="text-decoration:underline;"> </span>
+        * e2e tests required for Beta: [https://github.com/kubernetes/kubernetes/pull/108651](https://github.com/kubernetes/kubernetes/pull/108651/)
+        * Feature gate + API promotion to Beta: [https://github.com/kubernetes/kubernetes/pull/108847](https://github.com/kubernetes/kubernetes/pull/108847) 
+* [Done] 2221: Dockershim removal [https://github.com/kubernetes/enhancements/issues/2221](https://github.com/kubernetes/enhancements/issues/2221)
+* [Cut] 2371: cAdvisor-less, CRI-full stats [https://github.com/kubernetes/enhancements/issues/2371](https://github.com/kubernetes/enhancements/issues/2371)<span style="text-decoration:underline;">	</span>
+        * david to update the KEP to reflect keeping in alpha
+* [Cut] 2400: Swap [https://github.com/kubernetes/enhancements/issues/2400](https://github.com/kubernetes/enhancements/issues/2400)
+* [in-progress] 2712: PriorityClassValueBasedGracefulShutdown [https://github.com/kubernetes/enhancements/issues/2712](https://github.com/kubernetes/enhancements/issues/2712)
+        * <span style="text-decoration:underline;">[mrunal] Awaiting approve for feature</span>
+* [in-progress, let’s keep in release] 2727: gRPC probes [https://github.com/kubernetes/enhancements/issues/2727](https://github.com/kubernetes/enhancements/issues/2727)
+
+    The following KEPs should have WIPs up that are **ready for review** (Alpha/GA):
+
+* [only docs left] 688: PodOverhead [https://github.com/kubernetes/enhancements/issues/688](https://github.com/kubernetes/enhancements/issues/688)
+* [keep] 1287: In-place Pod Vertical Scaling [https://github.com/kubernetes/enhancements/issues/1287](https://github.com/kubernetes/enhancements/issues/1287)
+* [review in progress] 2008: Container Checkpointing (CRIU) [https://github.com/kubernetes/enhancements/issues/2008](https://github.com/kubernetes/enhancements/issues/2008)
+* [Cut] 2535: Ensure Secret Pulled Images [https://github.com/kubernetes/enhancements/issues/2535](https://github.com/kubernetes/enhancements/issues/2535)
+        * [mrunal] Cut from release, pr in progress, design changes may be needed [mikebrow] nod.. extending the KEP to include phase II plans for persistence and other related items. \
+
+* [vinaykul] InPlace Pod Vertical Scaling status
+    * WIP - working on API review issues.
+
+
+## March 15, 2022
+
+Total active pull requests: [174](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+3 from last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-03-08T17%3A00%3A00%2B0000..2022-03-15T16%3A58%3A26%2B0000">18</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-03-08T17%3A00%3A00%2B0000..2022-03-15T16%3A58%3A26%2B0000">5</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-03-08T17%3A00%3A00%2B0000..2022-03-15T16%3A58%3A26%2B0000+created%3A%3C2022-03-08T17%3A00%3A00%2B0000">66</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-03-08T17%3A00%3A00%2B0000..2022-03-15T16%3A58%3A26%2B0000">15</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Reminder: Mar. 29 is code freeze
+* [vinaykul] InPlace Pod Vertical Scaling status
+    * WIP. Responding to Derek’s comments and addressing identified issues
+* [danielle] as part of the sig annual report ([https://docs.google.com/document/d/1JAvi8ptbovvjSqh88378YB9irJUqWcT-PQ5YsYmdD3c/edit#](https://docs.google.com/document/d/1JAvi8ptbovvjSqh88378YB9irJUqWcT-PQ5YsYmdD3c/edit#)) we have various pieces of documentation to update across the sig that need discussion.
+    * We need to document the progression ladder from new contributor -> reviewer -> approver, asking for dawn/derek to finalize the doc they were working on to move into the community repo.
+    * CONTRIBUTING.md updates	
+        * We need to refine our on-ramp for new contributors a little here. What do folks think is important?
+            * Today that page is a pile of links, with some helpful intro to building k8s docs from dims at the bottom
+* [ddebroy] Updates to [https://github.com/kubernetes/enhancements/pull/3087](https://github.com/kubernetes/enhancements/pull/3087)
+    * Addressed comments/concerns from Elana and Derek so far
+    * Single SandboxReady condition
+* [dawnchen] Status update on OutOfCpu issue?
+    * regression since 1.22.
+    * Clayton is working on a fix
+    * It’s close, David is testing it. Should merge soon
+
+
+## March 8, 2022
+
+Total active pull requests: [171](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+11 from last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-03-01T17%3A00%3A00%2B0000..2022-03-08T17%3A54%3A24%2B0000">23</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-03-01T17%3A00%3A00%2B0000..2022-03-08T17%3A54%3A24%2B0000">5</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-03-01T17%3A00%3A00%2B0000..2022-03-08T17%3A54%3A24%2B0000+created%3A%3C2022-03-01T17%3A00%3A00%2B0000">59</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-03-01T17%3A00%3A00%2B0000..2022-03-08T17%3A54%3A24%2B0000">10</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [SergeyKanzhelev] Review KEPs which are in soft freeze
+
+    The following KEPs are expected to be **fully merged** (Beta/Deprecations):
+
+* [Done] 281: DynamicKubeletConfig [https://github.com/kubernetes/enhancements/issues/281](https://github.com/kubernetes/enhancements/issues/281)
+* [soft cut] 2133: Kubelet Credential Provider [https://github.com/kubernetes/enhancements/issues/2133](https://github.com/kubernetes/enhancements/issues/2133)
+* [Done] 2221: Dockershim removal [https://github.com/kubernetes/enhancements/issues/2221](https://github.com/kubernetes/enhancements/issues/2221)
+* [keep in alpha] 2371: cAdvisor-less, CRI-full stats [https://github.com/kubernetes/enhancements/issues/2371](https://github.com/kubernetes/enhancements/issues/2371)<span style="text-decoration:underline;">	</span>
+        * david to update the KEP to reflect keeping in alpha
+* [cut from release] 2400: Swap [https://github.com/kubernetes/enhancements/issues/2400](https://github.com/kubernetes/enhancements/issues/2400)
+* [in-progress] 2712: PriorityClassValueBasedGracefulShutdown [https://github.com/kubernetes/enhancements/issues/2712](https://github.com/kubernetes/enhancements/issues/2712)
+* [in-progress, let’s keep in release] 2727: gRPC probes [https://github.com/kubernetes/enhancements/issues/2727](https://github.com/kubernetes/enhancements/issues/2727)
+
+    The following KEPs should have WIPs up that are **ready for review** (Alpha/GA):
+
+*  [keep it] 688: PodOverhead [https://github.com/kubernetes/enhancements/issues/688](https://github.com/kubernetes/enhancements/issues/688)
+* [keep] 1287: In-place Pod Vertical Scaling [https://github.com/kubernetes/enhancements/issues/1287](https://github.com/kubernetes/enhancements/issues/1287)
+* [review in progress] 2008: Container Checkpointing (CRIU) [https://github.com/kubernetes/enhancements/issues/2008](https://github.com/kubernetes/enhancements/issues/2008)
+* [pr in progress, design changes may be needed] 2535: Ensure Secret Pulled Images [https://github.com/kubernetes/enhancements/issues/2353](https://github.com/kubernetes/enhancements/issues/2353)
+        * qq: is phase 1 valuable by itself?
+        * [Derek] there may not be enough benefits in phase 1 alone. Especially if long term the logic is moving to the runtime, some benefit if users wipe imagefs on reboot of host.
+        * mrunal and mike to decide whether to keep it in milestone by confirming the value pf phase 1.
+
+	**29th March 2022**: Week 12 — [Code Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#code-freeze)
+
+
+
+* [vinaykul] InPlace Pod Vertical Scaling status
+    * My company work has taken priority, but I’ll start addressing Derek’s comments after this coming Friday.
+    * Won’t be in today’s meeting due to conflict.
+* [bobbypage] Update on OutOfCPU issue
+    * Fix is in progress ([https://github.com/kubernetes/kubernetes/pull/108366](https://github.com/kubernetes/kubernetes/pull/108366)), but it is a tricky fix and need to be careful to avoid introducing new regressions
+    * Uncovered another related issue with pod lifecycle refactor relating to eviction / graceful node shutdown [Will create a GH issue to track]
+
+
+## Mar 1, 2022
+
+Total active pull requests: [160](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-02-15T17%3A00%3A00%2B0000..2022-03-01T17%3A41%3A49%2B0000">37</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-02-15T17%3A00%3A00%2B0000..2022-03-01T17%3A41%3A49%2B0000">10</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-02-15T17%3A00%3A00%2B0000..2022-03-01T17%3A41%3A49%2B0000+created%3A%3C2022-02-15T17%3A00%3A00%2B0000">76</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-02-15T17%3A00%3A00%2B0000..2022-03-01T17%3A41%3A49%2B0000">24</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Announcements
+    * **Reminder:** Soft freeze: Mar. 4
+    * Anything that won’t make milestone, feel free to remove it now
+* [derekwaynecarr] sig annual report
+    * Danielle offers to help out
+* [derekwaynecarr] got through most of in-place resizing pr, its big!
+    * [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+    * some updates are requested by vinay when he has time in interim
+    * deferring all things cgroups v2 until this merges, but need to reconcile with memory qos by beta.
+* [marquiz] [Class resources KEP](https://github.com/kubernetes/enhancements/pull/3004)
+    * Has been in hibernation but want to take it out of draft and proceed
+* [wenwu449] [https://github.com/kubernetes/kubernetes/issues/106884](https://github.com/kubernetes/kubernetes/issues/106884)
+    * [https://github.com/kubernetes/kubernetes/pull/108366](https://github.com/kubernetes/kubernetes/pull/108366) also [PR#107845](https://github.com/kubernetes/kubernetes/pull/107845)
+* Were autogenerated live captions helpful? We tried that out today for the first time.
+    * Sentiment in chat is that they were quite helpful, and could be turned off if they were not
+
+
+## February 22, 2022 [cancelled]
+
+[dawnchen] The meeting is cancelled due to no agenda proposed. Thanks!
+
+
+## February 15, 2022
+
+Total active pull requests: [154](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-02-08T17%3A00%3A00%2B0000..2022-02-15T17%3A57%3A59%2B0000">16</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-02-08T17%3A00%3A00%2B0000..2022-02-15T17%3A57%3A59%2B0000">21</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-02-08T17%3A00%3A00%2B0000..2022-02-15T17%3A57%3A59%2B0000+created%3A%3C2022-02-08T17%3A00%3A00%2B0000">101</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-02-08T17%3A00%3A00%2B0000..2022-02-15T17%3A57%3A59%2B0000">17</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [rata] Friendly ping for [userns KEP](https://github.com/kubernetes/enhancements/pull/3065#issuecomment-1015586271)
+    * Mrunal will review by EOW
+* [vinaykul] In-Place Pod Vertical Scaling status
+    * I have a conflict and won't be attending tomorrow’s SIG node meeting - status remains unchanged from last week:
+        * @ruiwen-zhao has already [created a draft PR](https://github.com/kubernetes/kubernetes/issues/107911#issuecomment-1030439043) adding containerd CRI support for this reporting effective cgroup CPU/mem config. Thanks Ruiwen!
+        * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+            * Awaiting Derek’s review.
+* [ddebroy] Pod sandbox conditions KEP next steps
+    * [https://github.com/kubernetes/enhancements/pull/3087](https://github.com/kubernetes/enhancements/pull/3087)
+* [mweston] Request for continued discussion re cpu management here (also friendly):  [https://kubernetes.slack.com/archives/C0BP8PW9G/p1644201307891349](https://kubernetes.slack.com/archives/C0BP8PW9G/p1644201307891349) 
+    * https://docs.google.com/document/d/1U4jjRR7kw18Rllh-xpAaNTBcPsK5jl48ZAVo7KRqkJk/edit
+
+
+## February 8, 2022
+
+Total active pull requests: [175](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+3 from last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-02-01T17%3A00%3A00%2B0000..2022-02-08T17%3A56%3A52%2B0000">21</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-02-01T17%3A00%3A00%2B0000..2022-02-08T17%3A56%3A52%2B0000">9</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-02-01T17%3A00%3A00%2B0000..2022-02-08T17%3A56%3A52%2B0000+created%3A%3C2022-02-01T17%3A00%3A00%2B0000">52</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-02-01T17%3A00%3A00%2B0000..2022-02-08T17%3A56%3A52%2B0000">10</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [vinaykul] In-Place Pod Vertical Scaling 
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+        * Awaiting Derek’s review.  (was out with illness, am better now ;-) will review)
+    * @ruiwen-zhao has already [created a draft PR](https://github.com/kubernetes/kubernetes/issues/107911#issuecomment-1030439043) adding containerd CRI support for this feature. Thanks Ruiwen!
+* [qiutongs] share the findings of a containerd issue - “failed to reserve container name”
+    * Issue [https://github.com/containerd/containerd/issues/4604](https://github.com/containerd/containerd/issues/4604)
+* ~~[ahg-g] [https://github.com/kubernetes/kubernetes/pull/103934](https://github.com/kubernetes/kubernetes/pull/103934) (Derek will review)~~
+* [ahg-g] [https://github.com/kubernetes/kubernetes/issues/106884](https://github.com/kubernetes/kubernetes/issues/106884) 
+* [ddebroy]   [KEP 2857]
+
+
+## February 1, 2022
+
+Total active pull requests: [172](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+6 from last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-01-25T17%3A00%3A00%2B0000..2022-02-01T17%3A52%3A59%2B0000">22</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-01-25T17%3A00%3A00%2B0000..2022-02-01T17%3A52%3A59%2B0000">3</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-01-25T17%3A00%3A00%2B0000..2022-02-01T17%3A52%3A59%2B0000+created%3A%3C2022-01-25T17%3A00%3A00%2B0000">49</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-01-25T17%3A00%3A00%2B0000..2022-02-01T17%3A52%3A59%2B0000">11</a>
+   </td>
+  </tr>
+</table>
+
+
+Announcements:
+
+
+
+* KEP freeze is on Thursday!
+* [vinaykul] In-Place Pod Vertical Scaling 
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884) in
+        * Awaiting Derek’s review.
+* [ddebroy] [Pod sandbox conditions KEP](https://github.com/kubernetes/enhancements/pull/3087)
+    * Initial comments from Elana addressed
+    * Awaiting Derek’s review before 1.24 enhancements freeze
+* [adrianreber] [Forensic Container Checkpointing KEP](https://github.com/kubernetes/enhancements/pull/1990)
+    * PRR approval done (thanks Elana)
+    * Waiting for final approval for 1.24
+* [sergeyKanzhelev] CRI versioning - timeline for v1alpha2 deprecation [https://docs.google.com/document/d/1Q0_p7xsZts6aA9xNLuXy1YLpllzCKB0skJ2HPfKdDMk/edit#heading=h.6wfgjj2um01](https://docs.google.com/document/d/1Q0_p7xsZts6aA9xNLuXy1YLpllzCKB0skJ2HPfKdDMk/edit#heading=h.6wfgjj2um01) Consumers of CRI API: [https://github.com/kubernetes-sigs/cri-tools/issues/883](https://github.com/kubernetes-sigs/cri-tools/issues/883) and [https://github.com/containerd/stargz-snapshotter/pull/323](https://github.com/containerd/stargz-snapshotter/pull/323) 
+
+
+## January 25, 2022
+
+Total active pull requests: [166](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+10 since last week)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-01-18T17%3A00%3A00%2B0000..2022-01-25T17%3A39%3A37%2B0000">21</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-01-18T17%3A00%3A00%2B0000..2022-01-25T17%3A39%3A37%2B0000">3</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-01-18T17%3A00%3A00%2B0000..2022-01-25T17%3A39%3A37%2B0000+created%3A%3C2022-01-18T17%3A00%3A00%2B0000">52</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-01-18T17%3A00%3A00%2B0000..2022-01-25T17%3A39%3A37%2B0000">11</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Announcements
+    * [ehashman] PRR Freeze Jan. 27, please fill out our PRR questionnaire
+    * KEP freeze is Feb. 3, next week!
+* [sallyom] kubelet tracing KEP for review
+    * [https://github.com/kubernetes/enhancements/pull/2832](https://github.com/kubernetes/enhancements/pull/2832)
+    * [https://github.com/kubernetes/kubernetes/pull/105126](https://github.com/kubernetes/kubernetes/pull/105126)
+* [ahg-g] Update on batch WG
+    * [https://github.com/kubernetes/community/pull/6299](https://github.com/kubernetes/community/pull/6299)
+* [vinaykul] In-Place Pod Vertical Scaling 
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+    * Enhancements PR (update target to 1.24) needs to be merged before freeze
+        * See [https://github.com/kubernetes/enhancements/pull/3153](https://github.com/kubernetes/enhancements/pull/3153) 
+    * Implementation PR awaiting Derek’s review.
+* [vaibhav2107] Rotated container log files size not counted towards ephemeral-storage's limit on CRI-O
+    * Issue [https://github.com/kubernetes/kubernetes/issues/107447](https://github.com/kubernetes/kubernetes/issues/107447)
+    * Need input
+    * Peter Hunt/Mrunal will take a look..
+* [SergeyKanzhelev] [https://github.com/kubernetes/kubernetes/issues/107190](https://github.com/kubernetes/kubernetes/issues/107190) (please commnet on the doc [https://docs.google.com/document/d/1Q0_p7xsZts6aA9xNLuXy1YLpllzCKB0skJ2HPfKdDMk/edit#](https://docs.google.com/document/d/1Q0_p7xsZts6aA9xNLuXy1YLpllzCKB0skJ2HPfKdDMk/edit#) or the issue itself)
+* [mweston & swseghal] request to add any last notes to [https://docs.google.com/document/d/1U4jjRR7kw18Rllh-xpAaNTBcPsK5jl48ZAVo7KRqkJk/](https://docs.google.com/document/d/1U4jjRR7kw18Rllh-xpAaNTBcPsK5jl48ZAVo7KRqkJk/) so we can go through and start work on documentation/clear up use cases
+* [Mike Tougeron] kubelet & cAdvisor metrics bug with cgroupv2 ​​[https://kubernetes.slack.com/archives/C20HH14P7/p1642595289013400](https://kubernetes.slack.com/archives/C20HH14P7/p1642595289013400) 
+    * v1.21 may be too early of the version for cgroupv2.
+    * What is the problem and what are the expectations?
+    * [Derek] Perhaps follow up on cgroup v2 KEP.
+    * [Mrunal] Need to write blog post to raise awareness where we are on cgroupv2.
+
+
+## January 18, 2022
+
+Total active pull requests: [156](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-34 since the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-01-11T17%3A00%3A00%2B0000..2022-01-18T18%3A06%3A32%2B0000">14</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-01-11T17%3A00%3A00%2B0000..2022-01-18T18%3A06%3A32%2B0000">35</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-01-11T17%3A00%3A00%2B0000..2022-01-18T18%3A06%3A32%2B0000+created%3A%3C2022-01-11T17%3A00%3A00%2B0000">116</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-01-11T17%3A00%3A00%2B0000..2022-01-18T18%3A06%3A32%2B0000">17</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Announcements
+    * Reminder for upcoming dates:
+        * PRR freeze (Jan. 27) - PRR questionnaire should be complete
+        * KEP freeze (Feb. 3) - KEP should be approved and merged
+    * PRR team is seeking shadows/new members: [https://groups.google.com/a/kubernetes.io/g/dev/c/OjepOATqwD4](https://groups.google.com/a/kubernetes.io/g/dev/c/OjepOATqwD4) 
+* [dawnchen/ahg] batch wg: [https://github.com/kubernetes/community/pull/6299](https://github.com/kubernetes/community/pull/6299)
+    * Some concerns about fragmentation for ownership of certain features [raised on Slack](https://kubernetes.slack.com/archives/CPNFRNLTS/p1641940087009300?thread_ts=1641938530.005600&cid=CPNFRNLTS)
+    * Please add any comments on the PR: [https://github.com/kubernetes/community/pull/6299](https://github.com/kubernetes/community/pull/6299) 
+* [vinaykul] In-Place Pod Vertical Scaling - plan for early 1.24 merge 
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+    * Enhancements PR updating target to 1.24 needs to be merged before freeze
+        * [https://github.com/kubernetes/enhancements/pull/3153](https://github.com/kubernetes/enhancements/pull/3153) 
+    * Alpha-blocker issues:
+        * Review claims code in convertToAPIContainerStatus [breaks non-mutating guarantees](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r665550094). - **My [Nov 10 response](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r746572298) needs Elana’s followup**
+            * It is unclear where [updates or mutates](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r738886048) to any state are happening. Need a response/clarification.
+    *  [NodeSwap issue](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-964440882): Not an alpha blocker (No CI test failures seen). Asked [@ichbinblau](https://github.com/ichbinblau) or [@cathyhongzhang](https://github.com/cathyhongzhang) to file tracking issues.
+    * Other non-alpha-blocker issues:
+        * I plan to file tracking github issues for the remaining (7-10) issues/TODOs and assign them to people that have offered to help. They can be fixed after this PR is merged most likely within the 1.24 timeframe.
+* [rata] Friendly ping for [userns KEP](https://github.com/kubernetes/enhancements/pull/3065#issuecomment-1015586271)?
+    * It seems there is agreement to start moving with phase 1 at least
+    * Didn’t receive any reviews from Derek/Mrunal/Sergey yet
+        * Mrunal: Made a pass at the enhancement
+* [vinayakankugoyal/qiutongs] Ping for CRI changes for ambient capability
+    * PR [https://github.com/kubernetes/kubernetes/pull/104620](https://github.com/kubernetes/kubernetes/pull/104620)
+        * Mrunal: Reviewing..
+    * Approved KEP [https://github.com/kubernetes/enhancements/pull/2757](https://github.com/kubernetes/enhancements/pull/2757)
+
+
+## January 11, 2022
+
+Total active pull requests: [190](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (-21 since the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-01-04T17%3A00%3A00%2B0000..2022-01-11T17%3A49%3A58%2B0000">13</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-01-04T17%3A00%3A00%2B0000..2022-01-11T17%3A49%3A58%2B0000">13</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-01-04T17%3A00%3A00%2B0000..2022-01-11T17%3A49%3A58%2B0000+created%3A%3C2022-01-04T17%3A00%3A00%2B0000">176</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-01-04T17%3A00%3A00%2B0000..2022-01-11T17%3A49%3A58%2B0000">26</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Announcements
+    * 1.24 schedule finalized
+    * [ehashman] Proposed date for soft node freeze: Fri. Mar. 4, 2022
+        * Applies to beta/deprecations
+        * Alpha/GA features must have WIPs up
+        * **Action:** ehashman to send email with announcement
+    * [https://github.com/kubernetes/kubernetes/pull/104143](https://github.com/kubernetes/kubernetes/pull/104143) Welcome wzshiming@ (Shiming Zhang) as SIG Node reviewer!
+* [derek] conclusion on special resource operator proposal
+    * see: [https://github.com/kubernetes/org/issues/3140](https://github.com/kubernetes/org/issues/3140)
+    * Approved
+* [ehashman] 1.24 KEP prioritization  
+    * **Action:** Elana to send email requesting review/feedback and explaining the prioritization goals
+* [swsehgal/fromani][heads up] PodResource API watch support to be postponed to 1.25 release due to capacity constraints. We aim to narrow down the design in the 1.24 timeframe and target the implementation in the 1.25 timeframe.
+* [pacoxu] [Quotas for Ephemeral Storage #1029](https://github.com/kubernetes/enhancements/issues/1029) Fixed a bug and try to adding a metric for this feature. Not sure if it can be promoted beta in 1.24 or 1.25.(I will update the KEP if it most likely will be promoted to beta in 1.24. If not, I may update it for 1.25 or later.)
+    * [Derek] There were some feature gaps that may need to be addressed before moving to beta.
+* [vaibhav2107] Rotated container log files size not counted towards ephemeral-storage’s limit
+
+        ( [https://github.com/kubernetes/kubernetes/issues/107447](https://github.com/kubernetes/kubernetes/issues/107447) )
+
+
+        Discussion on the issue
+
+    * [ehashman] Hasn’t been triaged yet. Will be looked at tomorrow during Node CI/Triage subproject
+* [jackfrancis] What to do with ExecProbeTimeout during 1.24 release cycle?
+
+        ( https://github.com/kubernetes/kubernetes/issues/99854 )
+
+* [vinaykul] In-Place Pod Vertical Scaling - plan for early 1.24 merge 
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+    * Pod resize E2E tests have been “weakened” for alpha - now passing CI
+    * Alpha-blocker issues:
+        * Review claims code in convertToAPIContainerStatus [breaks non-mutating guarantees](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r665550094). - **My [Nov 10 response](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r746572298) needs Elana’s followup**
+            * It is unclear to me what part of the code [updates or mutates](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r738886048) any state. Need a response/clarification.
+        * Container hash excludes Resources with in-place-resize feature-gate enabled, toggling fg can restart containers - **Fixed & Reviewed**
+            * This fix seems acceptable to both Elana & Lantao but Hash annotation naming needs to be more specific. Working on it.
+    *  [NodeSwap issue](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-964440882): Not an alpha blocker (No CI test failures seen). Asked [@ichbinblau](https://github.com/ichbinblau) or [@cathyhongzhang](https://github.com/cathyhongzhang) to file tracking issues.
+    * Other non-alpha-blocker issues:
+        * I’m fixing various issues found in reviews of API, scheduler and kubelet.
+        * I’ll file tracking github issues for the remaining (7-10) issues/TODOs and assign them to people that have offered to help. They can be fixed after this PR is merged most likely within the 1.24 timeframe.
+* [mweston & swsehgal] reminder to review this-continued conversation inline for cpu management cases:  [https://docs.google.com/document/d/1U4jjRR7kw18Rllh-xpAaNTBcPsK5jl48ZAVo7KRqkJk/edit](https://docs.google.com/document/d/1U4jjRR7kw18Rllh-xpAaNTBcPsK5jl48ZAVo7KRqkJk/edit) 
+
+
+## January 4, 2022
+
+Total active pull requests: [211](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) (+4 since the last meeting)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2021-12-14T17%3A00%3A00%2B0000..2022-01-04T17%3A58%3A23%2B0000">33</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2021-12-14T17%3A00%3A00%2B0000..2022-01-04T17%3A58%3A23%2B0000">26</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2021-12-14T17%3A00%3A00%2B0000..2022-01-04T17%3A58%3A23%2B0000+created%3A%3C2021-12-14T17%3A00%3A00%2B0000">108</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2021-12-14T17%3A00%3A00%2B0000..2022-01-04T17%3A58%3A23%2B0000">7</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* Announcements
+    * Release dates for 1.24
+        * Cycle start next week (Jan 10)
+        * Tentative release date (Apr 19)
+    * Saying hi to James Laverack, Release Lead
+    * 
+* [mrunal] 1.24 planning
+    *  
+* [ddebroy] [KEP](https://github.com/kubernetes/enhancements/pull/3087) for pod sandbox creation conditions in pod status [[https://github.com/kubernetes/enhancements/pull/3087](https://github.com/kubernetes/enhancements/pull/3087)]
+* [vinaykul] In-Place Pod Vertical Scaling - plan for early 1.24 merge 
+    * PR [https://github.com/kubernetes/kubernetes/pull/102884](https://github.com/kubernetes/kubernetes/pull/102884)
+    * Pod resize E2E tests have been “weakened” for alpha.
+        * Resize success verified at cgroup instead of pod status.
+        * All 31 tests are [passing](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/102884/pull-kubernetes-e2e-gce-alpha-features/1468102950369890304/) now.
+    * Alpha-blocker issues: 
+        * Container hash excludes Resources with in-place-resize feature-gate enabled, toggling fg can restart containers - **Fixed**
+            * Please review [this](https://github.com/kubernetes/kubernetes/commit/a745b12136027c136e0d3dcace23db99ccdd0d71) incremental change which addresses it.
+            * [Lantao] Some customers may rely on the existing label implementation, even though it wasn’t intended for that use. Want to get feedback on this.
+            * Alternative: use the same, current hash field but use it to store both hashes.
+            * It might be clearer to write down both hashes separately.
+            * [Elana] Some concerns about version skew of labels; if one kubelet is on one version and another is on a different one, they need to know how to use the labels correctly and not accidentally break each other.
+            * [Derek] Will focus in and review. People should not assume guarantees for kubelet labels.
+            * [Dawn] Adding an additional label reduces complexity because we don’t have to worry about internal versioning of the label scheme.
+        * Reviewer claims code in convertToAPIContainerStatus [breaks non-mutating guarantees](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r665550094). - **My [Nov 10 response](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r746572298) needs Elana’s followup**
+            * It is unclear what part of the code [updates or mutates](https://github.com/kubernetes/kubernetes/pull/102884#discussion_r738886048) any state. Need a response/clarification.
+        * Multiple reviewers have felt that the [NodeSwap issue](https://github.com/kubernetes/kubernetes/pull/102884#issuecomment-964440882) is a blocking issue. But in the Dec 07 meeting, we felt this may not be an <span style="text-decoration:underline;">alpha</span> blocker (No CI test failures seen. After I weakened resize E2E tests and all-alpha tests passed). However, we want to be sure. - **Need Elana’s input**.
+            * Can we identify exact reasons why this would (or would not) be alpha blocker?
+    * I plan to create issues to track other non-alpha-blocking review items and assign them to folks to fix after PR is merged. A few people have offered to contribute. With help, we should be able to nail most, if not all, of them in the upcoming release.
+* [mweston & swsehgal] Request for reviewers of CPU doc here: 
+    * [swsehgal] How do we make this more pluggable in the long run? Support more bespoke use cases

--- a/sig-node/archive/meeting-notes-2023.md
+++ b/sig-node/archive/meeting-notes-2023.md
@@ -1,0 +1,1634 @@
+# SIG Node Meeting Notes
+
+## Dec [all dates] - meetings canceled, next meeting Jan 2nd 2024
+
+
+## Dec 5, 2023
+
+Recording: [https://youtu.be/k7kzjKnmwSI](https://youtu.be/k7kzjKnmwSI) 
+
+
+
+* [tzneal] Feedback on OOM cgroup killing change [https://github.com/kubernetes/kubernetes/pull/117793#issuecomment-1837400726](https://github.com/kubernetes/kubernetes/pull/117793#issuecomment-1837400726) 
+    * Let’s have a kubelet option to return the old behavior. New behavior is a default
+    * Need to cherry-pick to 1.27
+* [haircommander] [https://github.com/kubernetes/kubernetes/pull/114847](https://github.com/kubernetes/kubernetes/pull/114847) follow ups 
+    * summary of proposed policy changes.. pull-never policy pods must have the same cred to re-use an image that was pulled with a cred; kubelet needs a switch to disable validation checking of in the cache preloaded images (for disconnected mode at node / kubelet restart), otherwise images pulled with not present are subject to revalidation, and pull never will fail if never authenticated; a pod that successfully pulls an image anonymously from registry A(or default) is to be considered “unique”.. we will not use that anonymous pull as an anonymous success for pods pulling from another registry.. requires alg change in current feature implementation
+    * Derek: let’s consider other patterns for time slicing the auth and pull time slots, policies for specifying when and possibly for what reason we need to auth.. (align better with disconnected needs, not just performance/multi-tenant)
+    * future items: possible integration with registries for discovering (header/artifacts) what the expiration is for an image
+* [SergeyKanzhelev] Planning of 1.30 \
+Eliminating perma betas. List of “old” feature gates:
+    * AppArmor
+        * Mostly need to clean up tests
+        * Sergey to follow up
+    * CustomCPUCFSQuotaPeriod - Peter will take a look
+    * GracefulNodeShutdown
+        * Issues with some controllers - Ryan add a comment on KEP indicating what the issue is.
+    * GracefulNodeShutdownBasedOnPodPriority
+    * LocalStorageCapacityIsolationFSQuotaMonitoring 
+        * Kernel issue. Other bugs reported
+        * [https://github.com/kubernetes/kubernetes/pull/112626](https://github.com/kubernetes/kubernetes/pull/112626) 
+        * Mrunal and Peter  to check on kernel issue
+    * MemoryManager
+        * Got as far as PRR review. Lack of observability is concerning from PRR review - need to work on this.
+        * Fracesco will follow up on this.
+        * **Swati**: many issues opened for MemoryManager before GA
+            * totally true we need to address them - silver lining is this can be done in parallel with observability improvements
+    * MemoryQoS
+        * Cut the feature
+        * Experimentation may go on using NRI: [https://containers.github.io/nri-plugins/stable/docs/memory/memory-qos.html](https://containers.github.io/nri-plugins/stable/docs/memory/memory-qos.html) Antti and Dixita made this to allow further experiments
+        * Ping Dixi to see if she can cut it
+    * PodAndContainerStatsFromCRI
+        * Stalled on CRI implementation of those metrics
+        * Working on it in CRI-O
+        * Need some help from Containerd side
+        * Exit criteria: must test performance that is not regressing
+    * RotateKubeletServerCertificate
+        * No tests and docs
+        * Need volunteer to clean it up
+        * Harche will take a look
+    * SizeMemoryBackedVolumes
+        * Need volunteers
+
+    Deprecations:
+
+    * cgroup v1
+    * Mrunal, Dawn: 
+        * let’s announce **deprecation in 1.30**.
+        * Default to cgroupv2 in tests and have cgroupv1 as an “additional”
+        * [Alexander Kanevsky] Collect list of distress that people uses, their default cgroups, and the EOL of those disttros. e.g. centos 7 or some ubuntu lts.
+* [SergeyKanzhelev] Should we cancel all the rest of the meetings for the month of Dec?
+    * Let;s cancel meeting till the end of the year and meet on Jan 2nd
+* [hakman] node-problem-detector maintainers are needed to keep the project alive. I tried to follow the guidelines to step up as a reviewer and later approver, but it seems there is a lack of approvers. If possible, I would like someone from #sig-node to sponsor me. Thanks in advance! [https://github.com/kubernetes/node-problem-detector/pull/830](https://github.com/kubernetes/node-problem-detector/pull/830)
+    * AI: SergeyKanzhelev to follow up
+
+
+## Nov 28, 2023 [Canceled]
+
+
+
+* Canceled due to lack of agenda.
+* Please bring 1.30 planning topics for the next meeting.
+
+
+## Nov 21, 2023 [Cancelled]
+
+
+
+* Cancelled due to Thanksgiving week in US and leads availability
+
+
+## Nov 14, 2023 [Cancelled]
+
+
+
+* Cancelling due to lack of agenda and no bugs marked for the milestone.
+* Remember to send your docs PR!
+* [vinaykul] Notes from the Kubernetes Contributor Summit session on the proposal to rely on PodStatus as source of truth instead of node-local store: [https://static.sched.com/hosted_files/kcsna2023/a4/KCS-LeanKubelet.pdf](https://static.sched.com/hosted_files/kcsna2023/a4/KCS-LeanKubelet.pdf) 
+
+
+## Nov 7, 2023 [Cancelled]
+
+
+
+* Canceled due to kubecon 
+
+
+## October 31, 2023
+
+Recording: [https://youtu.be/RYBb81l1IGw](https://youtu.be/RYBb81l1IGw)
+
+
+
+* [SergeyKanzhelev] Sidecar KEP change: proposed another feature gate for restarts.
+    * AI: plan sounds good
+* [MaRosset] [KEP 4216: Add changes for alpha version under RuntimeClassInImageCriApi feature gate](https://github.com/kubernetes/kubernetes/pull/121456) has LGTM’s needs approvals
+    * AI: Mrunal and Derek to take another look. No issues were highlighted
+* [haircommander/Peter Hunt] Drop-in Kubelet config complications
+    * [https://github.com/kubernetes/kubernetes/pull/121193/](https://github.com/kubernetes/kubernetes/pull/121193/) 
+* [Mrunal] [https://github.com/kubernetes/kubernetes/pull/120616](https://github.com/kubernetes/kubernetes/pull/120616) 
+* [Jeffwan] in-place vpa changes need review and approval
+    * [https://github.com/kubernetes/kubernetes/pull/112599](https://github.com/kubernetes/kubernetes/pull/112599) windows. done
+    * [https://github.com/kubernetes/kubernetes/pull/120145](https://github.com/kubernetes/kubernetes/pull/120145) approved
+    * [https://github.com/kubernetes/kubernetes/pull/120432](https://github.com/kubernetes/kubernetes/pull/120432)
+* [vinaykul] If any K8s contributors are attending Contributor Summit next week and are interested in a change I’m proposing to Kubelet (to move away from node-local checkpointing for in-place pod resize and use PodStatus instead) please drop by [https://sched.co/1Sp9Z](https://sched.co/1Sp9Z) to discuss this.
+
+
+## October 24, 2023
+
+Canceled due to an empty agenda. Review PRs for freeze next week. 
+
+
+## October 17, 2023
+
+Recording: [https://youtu.be/740kJACH3i8](https://youtu.be/740kJACH3i8)
+
+
+
+* [Kevin Hannon] Split Image API Issue
+    * CRI API uses the ImageFsInfoResponse
+    * Services.go uses a shortcut to get the image_filesystem
+    * Path forward?
+    * CRI API: [https://github.com/kubernetes/kubernetes/pull/120914](https://github.com/kubernetes/kubernetes/pull/120914) 
+    * Outcome: Good path forward.
+    * Questions on guarantee of support for services.go
+* [Jiaxin] In-place vpa related PRs need reviewers
+    * [fix inplace VPA stuck in InProgress when custom resources are specified kubernetes#120145](https://github.com/kubernetes/kubernetes/pull/120145)
+    * [Enhance InPlacePodVerticalScaling performance kubernetes#120432](https://github.com/kubernetes/kubernetes/pull/120432)
+    * [Configure MemoryRequest for InPlace pod resize in cgroupv2 systems #121218](https://github.com/kubernetes/kubernetes/pull/121218)
+    * [Handle the case where container resource and request set to minimum values](https://github.com/kubernetes/kubernetes/pull/120791)
+* [SergeyKanzhelev] [https://github.com/kubernetes/community/issues/7234](https://github.com/kubernetes/community/issues/7234) 
+    * [backup-item]<span style="text-decoration:underline;"> [important-soon & LGTMed PR list](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+is%3Aopen+label%3Asig%2Fnode+label%3Algtm+-label%3Aapproved+-label%3Ado-not-merge%2Fhold+-label%3Aneeds-rebase+-label%3Ado-not-merge%2Fwork-in-progress+label%3Apriority%2Fimportant-soon+)</span> 
+    * Also re-starting the PRs stats tracking:	
+
+<table>
+  <tr>
+   <td>
+Total active pull requests:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+">311</a>
+   </td>
+  </tr>
+</table>
+
+
+(weekly changes)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2023-10-10T17%3A00%3A00%2B0000..2023-10-17T16%3A53%3A09%2B0000">41</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2023-10-10T17%3A00%3A00%2B0000..2023-10-17T16%3A53%3A09%2B0000">10</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2023-10-10T17%3A00%3A00%2B0000..2023-10-17T16%3A53%3A09%2B0000+created%3A%3C2023-10-10T17%3A00%3A00%2B0000">113</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2023-10-10T17%3A00%3A00%2B0000..2023-10-17T16%3A53%3A09%2B0000">38</a>
+   </td>
+  </tr>
+</table>
+
+
+	New stats needed:
+
+
+
+* PRs needed other SIG approvals
+* Waiting for approvers
+* Waiting for reviewers
+* Separate cherry-picks and regressions
+
+
+## October 10, 2023
+
+Recording: [https://www.youtube.com/watch?v=akrWtsCbJZo](https://www.youtube.com/watch?v=akrWtsCbJZo)
+
+
+
+* [Adrian Reber] Graduate KEP 2008 "Forensic Container Checkpointing" from Alpha to Beta: [https://github.com/kubernetes/enhancements/pull/4288](https://github.com/kubernetes/enhancements/pull/4288) (1.30)
+* [mfranzil () ] Addressing CRI-API image sizes & opening up new KEP ([https://github.com/kubernetes/kubernetes/issues/120698](https://github.com/kubernetes/kubernetes/issues/120698) and see Slack discussion)
+    * [https://github.com/kubernetes/enhancements/issues/4191](https://github.com/kubernetes/enhancements/issues/4191) 
+    * Image Disk: [https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4191-split-image-filesystem/README.md](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4191-split-image-filesystem/README.md)
+    * 
+* [Kevin Hannon] Consensus on OOM flaky test issue
+    * [https://github.com/kubernetes/kubernetes/issues/119600](https://github.com/kubernetes/kubernetes/issues/119600)
+    * Skip the test? - [https://github.com/kubernetes/kubernetes/pull/121031](https://github.com/kubernetes/kubernetes/pull/121031)
+    * Skip the check for OOM [Todd Neal] - [https://github.com/kubernetes/kubernetes/pull/120460](https://github.com/kubernetes/kubernetes/pull/120460)
+    * Closing 121031 and will go forward with 120460.
+* [mahamed] NPD test change issues
+    * [https://github.com/kubernetes/kubernetes/pull/121007](https://github.com/kubernetes/kubernetes/pull/121007) 
+* KubeCon SIgNode related talks highlights: [https://docs.google.com/document/d/12kAxL7HWiPIcNqcTIjfr70-aLJyiUeGaNZAiZILfPeM/edit](https://docs.google.com/document/d/12kAxL7HWiPIcNqcTIjfr70-aLJyiUeGaNZAiZILfPeM/edit)  
+
+
+## October 3, 2023
+
+Recording: [https://www.youtube.com/watch?v=HdIURTQSm7Q](https://www.youtube.com/watch?v=HdIURTQSm7Q) 
+
+
+
+* [Weipeng([dastonzerg](https://github.com/dastonzerg)), Ian([iancoolidge](https://github.com/iancoolidge))] (Sry for cutting into the first slot as we only have availabilities at early meeting time) Path forward for “in CPU static policy, non-gu pods shouldn't run on reserved CPUs” [https://github.com/kubernetes/kubernetes/pull/118021](https://github.com/kubernetes/kubernetes/pull/118021) 
+* [mo] thoughts on expanding [Kubelet Credential Providers](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2133-kubelet-credential-providers)
+    * currently it only supports giving the plugin the image as input
+        * we could enhance it and maybe the pod API to support sending bound SA tokens through the CredentialProviderRequest
+        * Will require non-trivial changes to the caching logic used by the kubelet
+    * original issue: [Support an image pull credential flow built on bound service account tokens · Issue #68810](https://github.com/kubernetes/kubernetes/issues/68810)
+    * we deferred this to a later time in the original KEP [https://github.com/kubernetes/enhancements/pull/1406/files#r371886703](https://github.com/kubernetes/enhancements/pull/1406/files#r371886703)
+    * Depends on [https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2535-ensure-secret-pulled-images](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2535-ensure-secret-pulled-images) to make sure disk cache does not skip authz checks
+        * Or we could require image pull to be set to always
+    * Are credential providers configurable in cloud envs?  i.e. can I use a registry from vendor A on a kubelet run by vendor B?
+    * Could we isolate this change to kubelet + credential providers?  i.e. no change to the Kube REST API?
+    * Interested (Mo will ping regarding sig auth discussion and will chat with folks at KubeCon as well):
+        * Mike Brown
+        * Sergey Kanzhelev
+        * Dixita Narang
+        * Ruiwen
+        * Harshal Patil (Harshal Patil (RedHat) on k8s slack) 
+        * Peter Hunt (haircommander)
+* [haircommander] revitalize proc mount KEP
+    * [https://github.com/kubernetes/enhancements/issues/4265](https://github.com/kubernetes/enhancements/issues/4265) 
+* ~~[klueska] Update CDI for device plugins KEP for beta graduation in 1.29~~
+    * ~~Comments addressed, please review again: \
+[https://github.com/kubernetes/enhancements/pull/4238#issuecomment-1739120658](https://github.com/kubernetes/enhancements/pull/4238#issuecomment-1739120658)~~
+
+
+## September 26, 2023
+
+Recording: [https://www.youtube.com/watch?v=yEOUKJCJXa8](https://www.youtube.com/watch?v=yEOUKJCJXa8)
+
+
+
+* [Filip Krepinsky] Declarative Node Maintenance: discuss issues related to node drain and the solutions this KEP proposes
+    * [https://github.com/kubernetes/enhancements/pull/4213](https://github.com/kubernetes/enhancements/pull/4213)
+    * need to explore RBAC options for triggering the node drain (NodeMaintenance object)
+* [Adrian Reber] Created PR to avoid filling up local disk space with too many checkpoint archives.
+    * [https://github.com/kubernetes/kubernetes/pull/115888](https://github.com/kubernetes/kubernetes/pull/115888)
+    * bringing to sig-node for awareness
+    * requested by multiple users
+    * functionality: if more than a certain number of checkpoints are created per container/pod/namespace (default 10), older checkpoint archives are deleted
+* [klueska] Update CDI for device plugins KEP for beta graduation in 1.29
+    * Updated issue: \
+[https://github.com/kubernetes/enhancements/issues/4009](https://github.com/kubernetes/enhancements/issues/4009)
+    * Pull Request with update: \
+[https://github.com/kubernetes/enhancements/pull/4238](https://github.com/kubernetes/enhancements/pull/4238)
+    * Update to planning doc: [SIG Node - KEP Planning](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=kix.4hjk6cdmudfx)
+* [marquiz] introducing [KEP-4112](https://github.com/kubernetes/enhancements/pull/4113) “Pass down resources to CRI”
+    * better visibility pod resources in CRI
+    * two goals
+        * pass down all resources (of all containers) at sandbox creation
+        * pass unmodified resource requests and limits to CRI
+* [Kevin Hannon] PodReadyToStartContainers promotion to beta
+    * [https://github.com/kubernetes/enhancements/pull/4139](https://github.com/kubernetes/enhancements/pull/4139)
+    * Looking for an approver for KEP PR
+    * Implementation: [https://github.com/kubernetes/kubernetes/pull/119659](https://github.com/kubernetes/kubernetes/pull/119659)
+* [Kevin Hannon] Split Image Disk KEP
+    * [https://github.com/kubernetes/enhancements/pull/4198](https://github.com/kubernetes/enhancements/pull/4198)
+    * Any interest in separate image filesystems or deal with existing problems, please ping me or comment on KEP.
+    * We are interested in hearing what we should consider in scope for this
+* [katarzyna, robscott]  Kubelet API to return the local pods. Please review
+    * [https://github.com/kubernetes/enhancements/pull/4184](https://github.com/kubernetes/enhancements/pull/4184)
+
+
+## September 19, 2023
+
+Recording: [https://www.youtube.com/watch?v=ngboQ3GvX5o](https://www.youtube.com/watch?v=ngboQ3GvX5o) 
+
+
+
+* [haircommander] CRI stats metrics gaps
+    * create a configurable kubelet option to tell cadvisor which cgroups to collect from to aid migration from cadvisor to cri stats, then consider declaring metrics as deprecated
+    * 
+* [Sergey Kanzhelev] [https://github.com/kubernetes-sigs/metrics-server/issues/1330](https://github.com/kubernetes-sigs/metrics-server/issues/1330) 
+* [haircommander] kubelet.conf.d configuration view
+    * [https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3983-drop-in-configuration/README.md?plain=1#L83](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3983-drop-in-configuration/README.md?plain=1#L83) 
+    * add a e2e test for beta to double check configz endpoint correctly reflects the drop-ins
+* [vaibhav] Is there any current plan of deprecating the existing garbage collection flags in favor of eviction hard ?
+
+    Ref: [https://github.com/kubernetes/design-proposals-archive/blob/main/node/kubelet-eviction.md#deprecation-of-existing-features](https://github.com/kubernetes/design-proposals-archive/blob/main/node/kubelet-eviction.md#deprecation-of-existing-features)
+
+* [ndixita] 
+* [swsehgal] [https://github.com/kubernetes/kubernetes/issues/116086](https://github.com/kubernetes/kubernetes/issues/116086) 
+    * Exclusive CPU allocation at container scope.
+    * Looking for feedback on a potential solution captured [here](https://github.com/kubernetes/kubernetes/issues/116086#issuecomment-1719469058).
+    * Do we want to pursue this in the 1.29 cycle?
+    * ~~[pacoxu] [116086#](https://github.com/kubernetes/kubernetes/issues/116086#issuecomment-1655184757) still need a direction: ~~
+        * ~~1: add it to sidecar KEP: support core binding for pod with a non-guaranteed sidecar (sidecar will not affect QoS) . I +1 for this now.~~
+        * ~~2: generally, core binding for container level. Not pod QoS level(Or add new policy for container level core binding than current `static`).~~
+* [weipeng] [https://github.com/kubernetes/kubernetes/pull/118021](https://github.com/kubernetes/kubernetes/pull/118021) 
+    * Needs review. Does [https://github.com/kubernetes/kubernetes/pull/118021#issuecomment-1722066630](https://github.com/kubernetes/kubernetes/pull/118021#issuecomment-1722066630) answer the concern [https://github.com/kubernetes/kubernetes/pull/118021#issuecomment-1721342181](https://github.com/kubernetes/kubernetes/pull/118021#issuecomment-1721342181) ?
+
+
+## September 12, 2023
+
+Recording: [https://www.youtube.com/watch?v=hVuZg2mqNsw](https://www.youtube.com/watch?v=hVuZg2mqNsw)
+
+
+
+* KEPs planning ([doc](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit))
+    * [Talor] Volunteering to work on Memory Manager GA graduation in 1.29 cycle ([#1769](https://github.com/kubernetes/enhancements/issues/1769))
+        * [swsehgal] Can help with reviews.
+    * [katarzyna] kubelet API [KEP](https://github.com/kubernetes/enhancements/pull/4184#issuecomment-1713779858) 
+    * [Alexey] [CRI pull image with progress](https://github.com/kubernetes/enhancements/pull/3547) PRR
+    * [Kevin Hannon] [Beta Promotion for PodReadyToStartContainers](https://github.com/kubernetes/enhancements/pull/4139)
+    * [Kevin Hannon] [Splitting Image Filesystem](https://github.com/kubernetes/enhancements/issues/4191)
+        * PR: [https://github.com/kubernetes/enhancements/pull/4198](https://github.com/kubernetes/enhancements/pull/4198)
+    * [ndixita] KEP PR targeting 9/14 for PSI metric support.
+    * [Jiaxin] [KEP-4176: Static Policy to spread hyperthreads across physical CPUs](https://github.com/kubernetes/enhancements/pull/4177)
+* [vaibhav] Is there any current plan of deprecating the existing garbage collection flags in favor of eviction hard ?
+
+    Ref: [https://github.com/kubernetes/design-proposals-archive/blob/main/node/kubelet-eviction.md#deprecation-of-existing-features](https://github.com/kubernetes/design-proposals-archive/blob/main/node/kubelet-eviction.md#deprecation-of-existing-features)
+
+
+
+## September 5th, 2023
+
+Recording: [https://www.youtube.com/watch?v=5iiD9OIeJv8](https://www.youtube.com/watch?v=5iiD9OIeJv8)
+
+
+
+* [pacoxu] Should we support static cpu policy for pod with a non-guaranteed sidecar? Details can be found at [116086#issuecomment-1655184757](https://github.com/kubernetes/kubernetes/issues/116086#issuecomment-1655184757). I have no context about the cpu static policy initial design, it is container level cpu mapping, but depends on a pod level QoS. This is a feature request IMO.
+    * [Swati’s comment ](https://github.com/kubernetes/kubernetes/issues/116086#issuecomment-1706386179)and Francesco’s [comment](https://github.com/kubernetes/kubernetes/issues/116086#issuecomment-1706678147) are most likely the answer.
+    * AI: gather more use cases, generalize to cover most of them.
+* [klueska] Update DRA KEP to be inline with changes made in 1.28 (2 PRs)
+    * I am unfortunately unable to attend today, but please review the following PRs to update the DRA KEP to reflect the latest code changes from 1.28
+    * [https://github.com/kubernetes/enhancements/pull/4063](https://github.com/kubernetes/enhancements/pull/4063)
+    * [https://github.com/kubernetes/enhancements/pull/4164](https://github.com/kubernetes/enhancements/pull/4164)
+* [rphillips] Node Graceful Shutdown Issue
+    * Pod termination is taking too long
+    * E2E tests do not run with graceful shutdowns enabled
+        * CI reboots are problematic
+    * [PR#120273](https://github.com/kubernetes/kubernetes/pull/120273)
+    * [Issue#120271](https://github.com/kubernetes/kubernetes/issues/120271)
+    * [Presentation](https://docs.google.com/presentation/d/1aU9hLgza5EF62NmNemCc8llQP3tb9vqaF9PMjWl0Q3k/edit?usp=sharing)
+    * AI: [rphillips] look into termination with drains, make sure they are similar
+* [katarzyna, robscott] KEP for new Kubelet API for local Pod readiness: [https://github.com/kubernetes/enhancements/pull/4184](https://github.com/kubernetes/enhancements/pull/4184)
+* [jeffwan, LingyanYin] Follow up on [Inplace VPA + core binding](https://docs.google.com/document/d/1V3DLh3pH3CD-xhhJvAnOq_oWgPyjO-vj6wY6qdew9H0/edit#heading=h.ybybfdfputt)
+    * [https://github.com/kubernetes/kubernetes/pull/120145](https://github.com/kubernetes/kubernetes/pull/120145)
+    * [https://github.com/kubernetes/kubernetes/pull/120432](https://github.com/kubernetes/kubernetes/pull/120432)
+    * [https://github.com/kubernetes/enhancements/issues/4176](https://github.com/kubernetes/enhancements/issues/4176)
+
+
+## August 29th, 2023
+
+Recording: [https://www.youtube.com/watch?v=tNangR9QLkg](https://www.youtube.com/watch?v=tNangR9QLkg)
+
+
+
+* [kannon92]: Follow up for PodReadyToStartContainers Beta
+    * KEP PR for beta - [https://github.com/kubernetes/enhancements/pull/4139](https://github.com/kubernetes/enhancements/pull/4139)
+    * k/k PR - [https://github.com/kubernetes/kubernetes/pull/119659](https://github.com/kubernetes/kubernetes/pull/119659)
+* [karthik-k-n]: As discussed earlier, Shall we have separate meeting to discuss on scope for [dynamic node resize](https://docs.google.com/document/d/1KfjPRmCc8Xk0xxa4S8ZRle6VMzc1C6MQg4ivOaoB150/edit)
+* [katarzyna, robscott]  
+* [sunnylovestiramisu] Can I use Node -> NodeStatus -> NodePhase(NodePhase is the recently observed lifecycle phase of the node) as evidence that a node is registrationCompleted? If yes, which phase should I use? If not, can I add another status called NodeRegistered to the NodePhase and update it while we set registrationCompleted? - [context issue](https://github.com/kubernetes/kubernetes/issues/120063).
+* [weipeng] Need attention on PR `Fix: Exclude reserved CPUs from shared pool.` Currently the `pull-kubernetes-node-kubelet-serial-cpu-manager` test lane itself has some issues, how should we proceed? [https://github.com/kubernetes/kubernetes/pull/118021](https://github.com/kubernetes/kubernetes/pull/118021) 
+
+
+## August 22th, 2023
+
+Recording: [https://www.youtube.com/watch?v=Y9btZGnyDK0](https://www.youtube.com/watch?v=Y9btZGnyDK0)
+
+
+
+* [rata]: In 1.28 we added support for stateful pods with user namespaces.
+    * Do we want to blog about it?
+    * [rata]: I’ll create a gdocs and share it here. Once that is finalized, I’ll open a PR to the website.
+    * If we can’t find someone from sig-docs to approve it, Sergey can help.
+* ~~[fromani]notification: approvers PTAL to these backports - all lanes fixed, tests passing, LGTMd [https://github.com/kubernetes/kubernetes/pull/119432](https://github.com/kubernetes/kubernetes/pull/119432) [https://github.com/kubernetes/kubernetes/pull/119706](https://github.com/kubernetes/kubernetes/pull/119706) [https://github.com/kubernetes/kubernetes/pull/119707](https://github.com/kubernetes/kubernetes/pull/119707)~~
+* [haircommander] Image GC WG time decided–can we add to the calendar?
+    * Wednesday 12-12:30 PST (3-3:30 EST)
+* [tzneal] Kubelet detecting a readonly filesystem, what’s the boundary between node-problem-detector responsibilities and kubelet - [https://github.com/kubernetes/kubernetes/pull/115746](https://github.com/kubernetes/kubernetes/pull/115746) 
+
+
+## August 15th, 2023
+
+Recording: [https://www.youtube.com/watch?v=wgF8UDgp1sQ](https://www.youtube.com/watch?v=wgF8UDgp1sQ)
+
+
+
+* [ruiwen] 1.28 KEPs [retro](https://docs.google.com/document/d/1NaT0rY0o1cNdTxIlgZ5m0TqLDI7AfYn3rBAAl4qT1Bw/edit) (at least 30 minutes. We may not have much time for many other topics)
+* [haircommander] Kubelet image GC conversation
+    * [Ruiwen] Pin images
+    * [Derek] i am curious if secret pulled images have any unique gc requirements that have surfaced…
+        * Tie lifecycle of image to lifecycle of pod?
+    * [Sergey] Mirror config into kubelet?
+    * Peter to begin a WG in between now and KEP freeze to come up with next steps before bringing to larger group.
+        * Doodle for meeting time selection: [https://doodle.com/meeting/participate/id/eg2qn5jd](https://doodle.com/meeting/participate/id/eg2qn5jd) 
+* [SergeyKanzhelev] Sidecar WG: join for the next push in 1.29:
+
+
+## August 8th, 2023
+
+Recording: [https://www.youtube.com/watch?v=9BBSMdw8dMA](https://www.youtube.com/watch?v=9BBSMdw8dMA)
+
+
+
+* [jiaxin, zewei, lingyan] continued with the meeting on July 18th, we broke down the problems into 4 of them and the detailed doc is here [https://docs.google.com/document/d/1V3DLh3pH3CD-xhhJvAnOq_oWgPyjO-vj6wY6qdew9H0/edit#heading=h.by fdf putt](https://docs.google.com/document/d/1V3DLh3pH3CD-xhhJvAnOq_oWgPyjO-vj6wY6qdew9H0/edit#heading=h.ybybfdfputt)
+    * [fromani] gonna comment with more details on the doc when comments enabled, the gist is: 1. did you tried also using the [cpumanager policy options](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-options)? full-pcpus-only and distribute-cpus-across-numa may have a positive impact. 2. can the new policy be reimplemented as policy option?
+
+
+## August 1st, 2023
+
+Recording: [https://www.youtube.com/watch?v=V9F8jHgs6R4](https://www.youtube.com/watch?v=V9F8jHgs6R4)
+
+
+
+* [kannon92]Taking over PodReadyToStartContainersCondition ([https://github.com/kubernetes/enhancements/issues/3085](https://github.com/kubernetes/enhancements/issues/3085))
+    * new issue: https://github.com/kubernetes/enhancements/issues/4138
+    * Beta promotion in 1.29
+    * Any items we should have for beta?
+    * PR: [https://github.com/kubernetes/kubernetes/pull/119659](https://github.com/kubernetes/kubernetes/pull/119659)
+    * KEP update: [https://github.com/kubernetes/enhancements/pull/4139](https://github.com/kubernetes/enhancements/pull/4139)
+* [mckdev] leaked kubelet leases
+    * PR: [https://github.com/kubernetes/kubernetes/pull/119661](https://github.com/kubernetes/kubernetes/pull/119661)
+    * Issues:
+        * [https://github.com/kubernetes/kubernetes/issues/109777](https://github.com/kubernetes/kubernetes/issues/109777)
+        * [https://github.com/kubernetes/kubernetes/issues/119660](https://github.com/kubernetes/kubernetes/issues/119660)
+* [skrobul] world-writable terminationMessage files
+    * PR: [https://github.com/kubernetes/kubernetes/pull/108076](https://github.com/kubernetes/kubernetes/pull/108076)
+    * How to progress this PR?
+    * Is the Feature Gate or KEP needed?
+* [haircommander] CRI approvers
+    * [https://github.com/kubernetes/kubernetes/pull/119566](https://github.com/kubernetes/kubernetes/pull/119566) 
+
+    [Sunnatillo] Feedback on PR, kubelet: do not set CPU quota for guaranteed pods
+
+
+		[https://github.com/kubernetes/kubernetes/pull/117030](https://github.com/kubernetes/kubernetes/pull/117030)
+
+		[mrunal] the was the bug related to CFS quota, this PR not using the quota
+
+		[dawn] there may be a problem in kernel
+
+		[dawn] what kernel version is it tested?
+
+            [vaibhav] Approach to resolve eviction manager issue
+
+                            [https://github.com/kubernetes/kubernetes/issues/115201](https://github.com/kubernetes/kubernetes/issues/115201)
+
+		[Dawn] Do you want to start enhancement?
+
+
+    [vaibhav] ok 
+
+
+## July 25th, 2023 [Cancelled due to lack of agenda]
+
+
+## July 18th, 2023
+
+Recording: [https://www.youtube.com/watch?v=0Uqq8jNSSDk](https://www.youtube.com/watch?v=0Uqq8jNSSDk)
+
+
+
+* [ndixita] memory QoS Beta K8s 1.28  might be infeasible [https://docs.google.com/document/d/1mY0MTT34P-Eyv5G1t_Pqs4OWyIH-cg9caRKWmqYlSbI/edit#bookmark=id.qaybju6wvb05](https://docs.google.com/document/d/1mY0MTT34P-Eyv5G1t_Pqs4OWyIH-cg9caRKWmqYlSbI/edit#bookmark=id.qaybju6wvb05)
+    * Requesting kernel experts here for discussion around memory.high memcg controller usage, signals for memory reclaim(pgscan, pgsteal from memory.stat?).
+* [jiaxin] new CPU Manager static policy and in-place VPA improvements (performance, make it work with CPU Manager together), KEP or PR? 
+    * Problem 1: noisy neighbor issue. We want to spread hyper thread across physical cores to get better performance.
+    * Problem 2: In-place VPA currently doesn’t work with CPU Manager
+    * Problem 2: In-place VPA sometimes takes up to a minute to finish scaling etc. **We will finish a doc with the problems and solutions for further discussion**.
+    * [fromani] most likely a KEP<sup>+1</sup>, perhaps share a (preliminary) design doc in the community to outline the proposed scope and changes
+    * [Dawn] Please start with a doc on the issue / problem statement and the suggested solution.
+    * [Alex] Please separate in-place VPA improvements from CPU static policy. 
+
+
+## July 11th, 2023
+
+Recording: [https://www.youtube.com/watch?v=0ggcapGYwtc](https://www.youtube.com/watch?v=0ggcapGYwtc)
+
+
+
+* [alexeldeib] cgroupv2/v1 node memory usage calculation/alignment [https://github.com/kubernetes/kubernetes/issues/118916](https://github.com/kubernetes/kubernetes/issues/118916)
+    * aligned on anon + file (rss + cache)? [https://github.com/opencontainers/runc/pull/3933](https://github.com/opencontainers/runc/pull/3933)
+    * testing/e2e suggestions to ensure similarity of v1/v2?
+    * swap usage may have a similar issue, but will follow up separately.
+* ~~[kklues] KEP Update needs approval~~
+    * ~~[https://github.com/kubernetes/enhancements/pull/3915](https://github.com/kubernetes/enhancements/pull/3915)~~
+    * ~~/cc ~~~~ since she approved the original KEP~~
+* [karthik-k-n] looking forward for review and understand the next way forward for node dynamic cpu and memory resize KEP [https://github.com/kubernetes/enhancements/pull/3955](https://github.com/kubernetes/enhancements/pull/3955)
+* [Arka] Exploring [https://github.com/kubernetes/kubernetes/issues/116662](https://github.com/kubernetes/kubernetes/issues/116662) 
+    * Understanding the issue and starting with KEP
+* [SergeyKanzhelev] Sidecar PR got merged. Watch for problems and let us know.
+    * Uber issue: [https://github.com/kubernetes/kubernetes/issues/115934](https://github.com/kubernetes/kubernetes/issues/115934) 
+* [Marosset] - [https://github.com/kubernetes/kubernetes/pull/116968](https://github.com/kubernetes/kubernetes/pull/116968) (cri-only stats implementation for Windows) needs sig-node reviews
+    * [haircommander] I will review this today
+    * [haircommander] shameless plug: while CRI stats are on the mind: [https://github.com/kubernetes/kubernetes/pull/118838](https://github.com/kubernetes/kubernetes/pull/118838) 
+    * mentioned containerd PR.. [https://github.com/containerd/containerd/pull/8671](https://github.com/containerd/containerd/pull/8671) will merge end of day and mark for cherry picking to 1.7/1.6
+*  [Weipeng] `pull-kubernetes-node-kubelet-serial-cpu-manager` failure in PR [https://github.com/kubernetes/kubernetes/pull/118021#issuecomment-1630728455](https://github.com/kubernetes/kubernetes/pull/118021#issuecomment-1630728455)
+* [pacoxu] [ci-crio-cgroupv1-node-e2e-eviction](https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv1-node-e2e-eviction):[ PR #119097](https://github.com/kubernetes/kubernetes/pull/119097), Issue [#119090](https://github.com/kubernetes/kubernetes/issues/119090) PriorityPidEvictionOrdering should eventually evict all of the correct pods
+    * containerd ci is green(flakes for eviction order that is caused by no process stats available in /stats/summary) and cri-o failed for no PIDPressure Condition happen quickly.
+
+
+## July 4th, 2023 [Canceled due to US holiday]
+
+
+## June 27th, 2023
+
+Recording: [https://www.youtube.com/watch?v=KMD17c5EbFU](https://www.youtube.com/watch?v=KMD17c5EbFU)
+
+
+
+* [Wedson] Discuss setting a default runtime handler for CRI image operations if no runtimeclass is specified. Containerd supports using different snapshotters if pods have the runtime handler annotation specified but this can cause some issues if a pod without an annotation is scheduled after a pod with a runtime handler is specified because kubelet will think the image is already present because it was fetched with a different snapshotter.
+    * [mrunal] This intersects with Ensure image pull secrets. Another intersection with signature verification [https://github.com/kubernetes/kubernetes/pull/118652](https://github.com/kubernetes/kubernetes/pull/118652)
+    * Wedson’s PR: [https://github.com/kubernetes/kubernetes/pull/118907](https://github.com/kubernetes/kubernetes/pull/118907) 
+    * [Sergey] How rm works on containerd - does it remove both or just default?
+    * [Peter] we can’t rely on CRI to do all of the handling because image pull policy isn’t propagated. thus, we do need the annotation approach for now until 1.29 planning when kubelet image gc undergoes redesign
+* [mahamed/upodroid] Overhauling sig-node node e2e tests. I have been working with dims on introducing EC2 node e2e tests and I want to use this opportunity to complete [KEP-2464](https://github.com/kubernetes/enhancements/blob/master/keps/sig-testing/2464-kubetest2-ci-migration/README.md) and adopt kops' prowjob generator to generate jobs at scale as we need to test various permutations of multiple OS, architectures and CRI implementations.
+
+    Implementation: [https://github.com/kubernetes/test-infra/pull/29944](https://github.com/kubernetes/test-infra/pull/29944) 
+
+
+    PTAL at the e2e tests guidance in works: 
+
+* 
+* [fromani][discussion if time allows, otherwise PTAL and comment on github!] handling devices assignment on node reboot and kubelet restart: issue [https://github.com/kubernetes/kubernetes/issues/118559](https://github.com/kubernetes/kubernetes/issues/118559) and its proposed fix [https://github.com/kubernetes/kubernetes/pull/118635](https://github.com/kubernetes/kubernetes/pull/118635)  
+* [haircommander] cgroup driver implementation discussion [https://github.com/kubernetes/kubernetes/pull/118770](https://github.com/kubernetes/kubernetes/pull/118770) 
+
+
+## June 20th, 2023 [Cancelled]
+
+
+
+* 
+
+
+## June 13th, 2023
+
+Recording: [https://www.youtube.com/watch?v=nF_3dnZJVnA](https://www.youtube.com/watch?v=nF_3dnZJVnA)
+
+Enhancements tracking board: [https://github.com/orgs/kubernetes/projects/140/views/1?filterQuery=sig%3A%22sig-node%22&sortedBy%5Bdirection%5D=desc&sortedBy%5BcolumnId%5D=Status](https://github.com/orgs/kubernetes/projects/140/views/1?filterQuery=sig%3A%22sig-node%22&sortedBy%5Bdirection%5D=desc&sortedBy%5BcolumnId%5D=Status)
+
+
+
+* [robscott/kl52752] [New Kubelet API to expose Pod readiness](https://groups.google.com/g/kubernetes-sig-node/c/aewFWsNP4dw)
+    * To come back with a doc on the use cases and address concerns raised 
+* [vinaykul] Merge a couple of house-keeping PRs to update in-place resize KEP
+    * PR [k/e#4078](https://github.com/kubernetes/enhancements/pull/4078) updates current-milestone to v1.28 per [enhancement lead ask](https://github.com/kubernetes/enhancements/issues/1287#issuecomment-1585026101)
+    * PR [k/e#3944](https://github.com/kubernetes/enhancements/pull/3944) updates KEP to reflect the last minute API changes we made in the actual implementation
+* [klueska] [KEP Update: Promote Improved multi-numa alignment in Topology Manager](https://github.com/kubernetes/enhancements/pull/4079)
+    * Changes needed to push this feature to beta
+    * Implementation PR already under review
+    *  as she approved the initial KEP
+* [swsehgal] [REQUEST: Create kubernetes-sigs/noderesourcetopology-api](https://github.com/kubernetes/org/issues/4224)
+    * We had a discussion about this and was approved on 
+
+[May 23rd, 2023](#heading=h.5mc4dwbi1o5j)
+    * Need formal approval from SIG Node Tech Leads on the issue
+* [AkihiroSuda] Wants approvals from prod-readiness-approvers for `KEP-3857: Recursive Read-only (RRO) mounts` [https://github.com/kubernetes/enhancements/pull/3858](https://github.com/kubernetes/enhancements/pull/3858) 
+
+
+## June 6th, 2023
+
+Recording: [https://www.youtube.com/watch?v=rR3zOunp6FE](https://www.youtube.com/watch?v=rR3zOunp6FE)
+
+
+
+* KEPs planning for 1.28:  
+* [SergeyKanzhelev] Shared calendar for the SIG: [https://calendar.google.com/calendar/u/0?cid=YzY4ZGY0YTYxZDE0MTIyZThlODFlYjQyMzA5ZjZjY2E2M2ViMWI3YjQ0MzM4NGVlYmM4MDNlNjgzMmRiZTBiNkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t](https://calendar.google.com/calendar/u/0?cid=YzY4ZGY0YTYxZDE0MTIyZThlODFlYjQyMzA5ZjZjY2E2M2ViMWI3YjQ0MzM4NGVlYmM4MDNlNjgzMmRiZTBiNkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) 
+* [sohankunkerkar/haircommander] sandbox image pinning from CRI
+    * [Sergey] I don't think you need a KEP for this. Looks like a simple codebase cleanup of a dead functionality.
+    * Consensus is that no KEP is needed, as it’s cleaning up dead code from dockershim days.
+* [haircommander/sohankunkerkar] Alternative/additional kubelet image GC schemes
+    * There is interest here upstream for additional kubelet gc schemes
+    * sig node is overloaded for 1.28, circle back in 1.29
+* [SergeyKanzhelev] Highlight from the KEP: [https://github.com/kubernetes/enhancements/pull/3858/files](https://github.com/kubernetes/enhancements/pull/3858/files) proposes to introduce the new pattern for feature detection: “RuntimeHandlerFeatures”.
+* ~~[klueska] [KEP: Add CDI devices to device plugin API](https://github.com/kubernetes/enhancements/pull/4011)~~
+    * ~~Now ready for review~~
+    * ~~please take a look~~
+* [ffromani] question/docs: are the kubelet endpoints (like /pods) meant to be consumable by non-core components like 3rd party/external software? (xref: [https://github.com/kubernetes/kubernetes/issues/112119](https://github.com/kubernetes/kubernetes/issues/112119))
+    * [Dawn] Initially wanted those API as internal-only with no guarantees
+        * there are also security concerns
+    * [Sergey] what guarantees we have for podresources?
+        * [ffromani] need to have more guarantees
+        * Syntax of API is guaranteed, but what happened on kubelet restart is not specifried
+* [pacoxu/dims] [https://github.com/kubernetes/kubernetes/issues/118441](https://github.com/kubernetes/kubernetes/issues/118441) 
+    * [Dawn] Need to create more guidance on how to troubleshoot infra issues
+
+
+## May 30th, 2023
+
+Recording: [https://www.youtube.com/watch?v=H9vnLgvTLvo](https://www.youtube.com/watch?v=H9vnLgvTLvo) 
+
+Agenda
+
+KEPs: [https://github.com/kubernetes/enhancements/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Asig%2Fnode+milestone%3Av1.28](https://github.com/kubernetes/enhancements/issues?page=1&q=is%3Aissue+is%3Aopen+label%3Asig%2Fnode+milestone%3Av1.28) 
+
+
+
+* [harche/mrunalp] Cautiously enabling swap only for Burstable Pods - [https://github.com/kubernetes/enhancements/pull/3957](https://github.com/kubernetes/enhancements/pull/3957) 
+* [marquiz/haircommander]: [KEP 4033](https://github.com/kubernetes/enhancements/issues/4033): discover kubelet cgroup driver from CRI
+    * There are other options that the CRI may want to tell the Kubelet what the state of the world is
+    * focus this KEP on cgroup driver, but have API extendable so those other use cases (runtime class, QOS class, user namespace support) can be easily covered in the future
+    * Separate CRI message from RuntimeStatus so Kubelet can request separately.
+* [mimowo] Changed pod phase when containers exit with 0, related issue: [https://github.com/kubernetes/kubernetes/issues/118310](https://github.com/kubernetes/kubernetes/issues/118310). Summary:
+    * eviction_manager, preemption: 1.26: Failed,          1.27: Succeeded
+    * node shutdown                          1.26: Failed,         1.27: Succeeded
+    * active deadline exceeded          1.26: Failed,         1.27: Failed
+* [astoycos] [bpfd](https://bpfd.dev/) Presentation!
+    * [Slides](https://docs.google.com/presentation/d/1QSSx8zX9I2VZJGDJcOCrU3sFYSji9Hv8F0kDJx-NEfo/edit?usp=sharing)
+    * [SergeyKanzhelev] SiG node may help in terms of attributing events to pods metadata. When kernel events received - would be nice to know what Pod is running the process that sent this event. Please let us know if anything can be improved from SIG Node side to help with this.
+* [byako] KEP-3542 CRI PullImageWithProgress [https://github.com/kubernetes/enhancements/pull/3547/files](https://github.com/kubernetes/enhancements/pull/3547/files)
+* [adilGhaffarDev] What is the status of this fix: [https://github.com/kubernetes/kubernetes/pull/117030](https://github.com/kubernetes/kubernetes/pull/117030) what can we do to escalate it, if possible?
+* [haircommander] [KEP 3983](https://github.com/kubernetes/enhancements/pull/4031): Add support for a drop-in kubelet configuration directory
+    * Mostly a review request
+* [SergeyKanzhelev] [https://github.com/kubernetes/kubernetes/pull/116429](https://github.com/kubernetes/kubernetes/pull/116429) sidecar PR.
+
+
+## May 23rd, 2023
+
+Recording: [https://www.youtube.com/watch?v=shmDtrq55V8](https://www.youtube.com/watch?v=shmDtrq55V8) 
+
+Agenda
+
+
+
+* [intunderflow] Following up from meeting on April 25th talking about lowering frequency of Startup / Readiness probe failure events, my preferred approach after digesting feedback, thoughts from the group about this approach? If happy I can put together a KEP
+    * Always emit an event when the result of a probe changes (between Success and Failure, or Failure and Success)
+    * When a startup probe fails or a readiness probe fails:
+        * We emit the first failure
+        * We then emit a failure every 1 hour if still failing
+            * _Should this event be the same as the first failure, or should it be perhaps something like “Probe still failing since [first failure time]”_
+    * No changes to liveness probes failing for now:
+                * This will still cause mass event emission to hit the rate limit, but I want to tackle this incrementally and follow up on liveness probes
+                * Lots of users watch for liveness probe failed events, so it's something to be particularly careful about in my opinion (people of course watch readiness/startup probes too, but I’d assume not as many / that liveness probes are the most populous probe type)
+    * Thoughts from the group about this approach? If happy I can put together a KEP
+* [intunderflow] [https://github.com/kubernetes/kubernetes/pull/115963](https://github.com/kubernetes/kubernetes/pull/115963) needs approver - I’d like to target this for 1.28 if no objections
+* [ffromani] **REQUEST**: looking for approvers for (all items already part of 1.28 tracking document)
+    * [https://github.com/kubernetes/enhancements/issues/2403](https://github.com/kubernetes/enhancements/issues/2403) (should be trivial)
+    * [https://github.com/kubernetes/enhancements/issues/3545](https://github.com/kubernetes/enhancements/issues/3545) 
+    * Could we please also review/approve [https://github.com/kubernetes/enhancements/pull/3980](https://github.com/kubernetes/enhancements/pull/3980) so we can merge [https://github.com/kubernetes/kubernetes/pull/116525](https://github.com/kubernetes/kubernetes/pull/116525)
+* [swsehgal] Proposing NodeResourceTopology API under kubernetes-sigs: [https://github.com/kubernetes/org/issues/4224](https://github.com/kubernetes/org/issues/4224). Previously the API was proposed under staging but that proposal was [rejected](https://github.com/kubernetes/kubernetes/pull/96275#discussion_r1119165747) during API review.
+    * +1: Alexander +1: Francesco
+* [astoycos] Super Short Introduction of [https://github.com/bpfd-dev/bpfd](https://github.com/bpfd-dev/bpfd) (propose an actual 15-20 minute presentation for next week?) Also reach out in K8s slack [#bpfd](https://kubernetes.slack.com/archives/C04UJBW2553) and [#ebpf](https://kubernetes.slack.com/archives/C0562AYHZB3)
+
+
+## May 16th, 2023
+
+Recording: [https://www.youtube.com/watch?v=gnbV1nrXVZc](https://www.youtube.com/watch?v=gnbV1nrXVZc) 
+
+Agenda:
+
+
+
+* [everpeace] I opened a PR for KEP-3169.
+    * PR: [https://github.com/kubernetes/kubernetes/pull/117842](https://github.com/kubernetes/kubernetes/pull/117842) 
+    * KEP: [KEP-3619: Fine-grained SupplementalGroups control](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3619-supplemental-groups-policy) 
+    * I would like the community to triage this and review it.
+    * I’m very glad if someone would mentor me because it’s first time for me to make PR including API changes.
+    * _NOTE: I’m sorry that I can’t show up to the community meeting due to timezone gap (2am in my timezone(Tokyo🇯🇵🗼)). I put this agenda to gain visibility and to help 1.28 planning._
+* [tzneal] Discuss using the cgroup aware OOM killer [https://github.com/kubernetes/kubernetes/pull/117793](https://github.com/kubernetes/kubernetes/pull/117793) 
+    * KEP needed for the API change?
+    * Potential Options
+        * No config, just a new default
+        * Add API to Container to allow workload specific configuration
+        * Add flag to kubelet
+    * [Dawn] Let’s just change the default
+    * [mrunal] OK with this.
+    * Dawn will comment on the PR.
+* [mimowo]
+    * [https://github.com/kubernetes/kubernetes/pull/117586](https://github.com/kubernetes/kubernetes/pull/117586) needs review and approver
+    * [https://github.com/kubernetes/kubernetes/issues/115688](https://github.com/kubernetes/kubernetes/issues/115688) needs discussion. As suggested by API reviewer ([https://github.com/kubernetes/kubernetes/issues/115688#issuecomment-1506909501](https://github.com/kubernetes/kubernetes/issues/115688#issuecomment-1506909501)) we should only add the condition when the Pod is actually killed. This means that refactoring of the handling of the activeDeadline handler is needed.  \
+Questions:
+* Can this refactoring be led by sig-node?
+* Alternatively, can we go with the simple approach of adding the condition whenever when timeout is exceeded, as suggested in the POC PR: [https://github.com/kubernetes/kubernetes/pull/117973](https://github.com/kubernetes/kubernetes/pull/117973). Then, we could document that the behavior when the timeout is exceeded, but the containers aren’t killed (but terminate on their own) is subject to change. Proposed KEP updated for review: [https://github.com/kubernetes/enhancements/pull/3999](https://github.com/kubernetes/enhancements/pull/3999)
+* [SergeyKanzhelev] Sidecar KEP: [https://github.com/kubernetes/enhancements/pull/3968/files](https://github.com/kubernetes/enhancements/pull/3968/files) and [https://github.com/kubernetes/kubernetes/pull/116429](https://github.com/kubernetes/kubernetes/pull/116429) 
+* [mo] looking for a way to provide dynamic environment variables at runtime without persisting them in the Kube API (because the contents are sensitive)
+    * would like to avoid any approach that uses admission to mutate pods
+    * [Anish Ramasekar to Everyone (10:43 AM)] This is the subproject: [https://github.com/kubernetes-sigs/secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) 
+    * [Sergey] will this help: [https://github.com/kubernetes/enhancements/issues/3721](https://github.com/kubernetes/enhancements/issues/3721)?
+    * Init container can download and then regular container will use those.
+    * [mo] this ^^^ can work. Is this the right way?
+    * [kevin] are you familiar with DRA? CDA is lowest level that makes abstract notion of a device available for a container. CDA can inject environment variables into the container. There may be a “device” that will perform all vault work and then will inject those variables to the container
+    * [mo] what is the security model?
+    * [kevin] this information will end up being statically stored at CDA file host system
+    * [mo] is there way to observer this from kubernetes API?
+    * [kevin] DRA is generalization of persistent volumes API. So it will provide some isolation.
+    * [Sasha] this will not protect from exec into container. As no env variables would do.
+    * [mo] can other containers see it? non-priviledged for example.
+    * [mo] what is the interface for DRA? Can it be Daemonset in runtime?
+    * [kevin] there is a talk about it at KubeCon. It has all the pieces to build this.
+        * [Kevin] Here is my talk on how DRA drivers are structured:
+        * 
+* [klueska] New Feature for 1.28: Add CDI devices to device plugin API
+    * Already added to the [planning doc](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.c8sfex5lq85d)
+    * Simple extension given that CDI devices have now been added to the CRI
+    * does it make sense for you to be the approver?
+    * [https://github.com/kubernetes/enhancements/issues/4009](https://github.com/kubernetes/enhancements/issues/4009)
+
+—- MOVED from 5/2/2023. Move above this line if you plan to show up on the meeting —
+
+
+
+* [kannon92] PRs need approval
+    * [https://github.com/kubernetes/kubernetes/pull/116231](https://github.com/kubernetes/kubernetes/pull/116231) - Cleanup around image parsing, test fixes, and more coverage.  Has LGTM but needs a final approval
+    * [https://github.com/kubernetes/kubernetes/pull/117702](https://github.com/kubernetes/kubernetes/pull/117702) - Rename PodHasNetwork to PodReadyToStartContainersCondition Code PR.  Has LGTM but needs approval
+
+
+## May 9th, 2023
+
+Recording: [https://www.youtube.com/watch?v=18cRhXTf0Cc](https://www.youtube.com/watch?v=18cRhXTf0Cc) 
+
+Total active pull requests: [242](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2023-05-02T17%3A00%3A00%2B0000..2023-05-09T16%3A59%3A06%2B0000">19</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2023-05-02T17%3A00%3A00%2B0000..2023-05-09T16%3A59%3A06%2B0000">9</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2023-05-02T17%3A00%3A00%2B0000..2023-05-09T16%3A59%3A06%2B0000+created%3A%3C2023-05-02T17%3A00%3A00%2B0000">118</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2023-05-02T17%3A00%3A00%2B0000..2023-05-09T16%3A59%3A06%2B0000">17</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [swsehgal] Community discussion on device Manager recovery bugfix backport
+    * [Issue](https://github.com/kubernetes/kubernetes/issues/109595), [Fix](https://github.com/kubernetes/kubernetes/pull/116376)
+    * Device Manager is a GA feature so proposing to backport the fix to [1.25](https://github.com/kubernetes/kubernetes/pull/117738), [1.26](https://github.com/kubernetes/kubernetes/pull/116337) and [1.27](https://github.com/kubernetes/kubernetes/pull/117719)
+* [karthik-k-n] Community thoughts on Dynamic Node resize proposal
+    * [Discussion document](https://docs.google.com/document/d/1KfjPRmCc8Xk0xxa4S8ZRle6VMzc1C6MQg4ivOaoB150/edit#heading=h.xgjl2srtytjt)
+    * [Enhancement](https://github.com/kubernetes/enhancements/issues/3953)
+    * [POC code](https://github.com/kubernetes/kubernetes/pull/115755)
+* [clayton] Discussion of kubelet state improvements for 1.28 - trying to identify which areas to focus on
+    *  - doc crafted at end of 1.27
+    * Right now was planning on working with in-place resource (to reduce complexity encountered during alpha and before beta), and also to help address the kubelet subcomponents using the wrong pod_manager [https://github.com/kubernetes/kubernetes/pull/117371](https://github.com/kubernetes/kubernetes/pull/117371) (ryan reviewing) to unblock harder problems static pods are encountering
+    * Other interest from contributors?
+        * kubelet plugins potentially [https://github.com/kubernetes/enhancements/pull/3853](https://github.com/kubernetes/enhancements/pull/3853) 
+        * sidecar enh: [https://github.com/kubernetes/enhancements/issues/753](https://github.com/kubernetes/enhancements/issues/753) 
+        * Github project tracking ongoing pod lifecycle issues: [https://github.com/orgs/kubernetes/projects/133/](https://github.com/orgs/kubernetes/projects/133/) 
+    * Improvements in testing from KEPs
+* [zmerlynn] Discuss 
+    * Dawn: Maybe first restart free, don’t punish
+    * Clayton: DaemonSet that runs effectively a for loop to anneal policy
+        * There are things we don’t account for, like system resources in a crash looping pod - what does it actually cost to restart a container
+    * Derek (on chat): I wonder if we need a way to measure a qps generally for the behavior that crashloopbackoff is trying to protect
+        * systemd gives StartLimitBurst and then when that is exhausted you go to StartLimitInterval.... feels like we could give a burst
+    * Sergey: Maybe we also need “it’s a bad failure, reschedule me”
+    * David: Is it up to the admin to define this?
+    * Kevin: KEP in question that Sergei mentioned: [https://github.com/kubernetes/enhancements/pull/3816](https://github.com/kubernetes/enhancements/pull/3816)
+    * Clayton: Full backoff doesn’t make sense for static pod anyways
+
+—-- End of the meeting. MOVED TO THE NEXT WEEK —--
+
+
+## May 2nd, 2023
+
+Recording: ​​[https://www.youtube.com/watch?v=whN6nPOp62g](https://www.youtube.com/watch?v=whN6nPOp62g) 
+
+Total active pull requests: [241](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2023-04-25T17%3A00%3A00%2B0000..2023-05-02T17%3A02%3A45%2B0000">27</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2023-04-25T17%3A00%3A00%2B0000..2023-05-02T17%3A02%3A45%2B0000">11</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2023-04-25T17%3A00%3A00%2B0000..2023-05-02T17%3A02%3A45%2B0000+created%3A%3C2023-04-25T17%3A00%3A00%2B0000">88</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2023-04-25T17%3A00%3A00%2B0000..2023-05-02T17%3A02%3A45%2B0000">25</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [SergeyKanzhelev, mrunalp] retro and 1.28 planning
+    * [Ruiwen] 1.27 [retro](https://docs.google.com/document/d/1DxJH1w_lrEOfflR-TED1vjc0ZYIXO0aDb3vJXPMKCdY/edit#)
+    * [mrunal] planning: [SIG Node - 1.28 Planning](https://docs.google.com/document/d/1U10J0WwgWXkdYrqWGGvO8iH2HKeerQAlygnqgDgWv4E/edit#bookmark=id.fp500pn2fk1f) 
+* [Seaiii] [https://github.com/kubernetes/kubernetes/pull/113883](https://github.com/kubernetes/kubernetes/pull/113883) The second time the pod deleted the grace period does not take effect .Please review update PR 
+
+
+## Apr 25th, 2023
+
+Recording: [https://www.youtube.com/watch?v=oQi3gPsODV0](https://www.youtube.com/watch?v=oQi3gPsODV0)
+
+
+
+* [intunderflow] [https://github.com/kubernetes/kubernetes/pull/115963](https://github.com/kubernetes/kubernetes/pull/115963) needs approver
+* [intunderflow] Thoughts on startup probe / readiness probe event emission behavior?
+    * Currently the readiness probes and startup probes emit ContainerUnhealthy events each time they probe the container and it is Unhealthy.
+    * For liveness probes a container going from a healthy state to suddenly unhealthy is important and notable, but for Readiness and Startup probes it's pretty typical for a container to be unhealthy since the point of these probes is to wait until the container is healthy.
+    * Emitting these events eats into the rate limit of 25 events per object sent to the API server.
+    * Readiness probes and Startup probes failing multiple times is pretty typical of their operation, since their point is to gate the container until it succeeds.
+    * It would be nice if Readiness probes and Startup probes didn’t eat events as fast as they did.
+    * My thoughts and opinions:
+        * We could consider changing the startup and readiness probe to only emit when they probe the container and it is healthy (since that leads to a change in state and action being taken)
+        * My PR above (if approved) would still then report if a startup probe or readiness probe fail conclusively against a container
+    * [Action Item] Count incrementation on Events? Why not working for failing probes?
+    * [Ryan] The event recorder has a max retries of 12
+    * [https://github.com/kubernetes/client-go/blob/master/tools/record/event.go#L38](https://github.com/kubernetes/client-go/blob/master/tools/record/event.go#L38)
+    * [Todd] we need events to be re-emitted periodically. Do not discard them universally. Less frequency, but definitely more events we want to know about like flakes of readiness probe.
+    * 
+* [SergeyKanzhelev] Probes functionality cleanup: [https://docs.google.com/document/d/1G5nGH97s3UTANbA5IyQ7nVIHnrLKfgVZssSYnvp_qX4/edit](https://docs.google.com/document/d/1G5nGH97s3UTANbA5IyQ7nVIHnrLKfgVZssSYnvp_qX4/edit)  
+* [haircommander/Peter] Kubelet drop-in config support
+    * After conversation about dropping cli flag support, it was illuminated that our users (downstream in Openshift) rely on this feature. Could be a good time to introduce drop-in file support like in `/etc/kubernetes/kubelet.conf.d`
+    * Peter to make proposal to SIG-Arch to see if other components would like to adopt a similar pattern, as well as open an issue to have an asynchronous conversation.
+* [SergeyKanzhelev] ​​[https://github.com/kubernetes/kubernetes/pull/116429](https://github.com/kubernetes/kubernetes/pull/116429) , uber issue: [https://github.com/kubernetes/kubernetes/issues/115934](https://github.com/kubernetes/kubernetes/issues/115934) 
+
+
+## Apr 18th, 2023
+
+No call (kubecon)
+
+
+## Apr 11th, 2023
+
+Recording: [https://www.youtube.com/watch?v=R9bml9YmP3k](https://www.youtube.com/watch?v=R9bml9YmP3k)
+
+
+
+* [klueska] Need approval on PR to update DRA KEP with changes merged into v1.27
+    * [https://github.com/kubernetes/enhancements/pull/3802](https://github.com/kubernetes/enhancements/pull/3802)
+* [liggitt/derek] proposal to support node/control-plane skew of n-3 ([KEP-3935](https://github.com/kubernetes/enhancements/issues/3935), [draft proposal](https://github.com/kubernetes/enhancements/pull/3936))
+    * What in-progress node feature / cleanup rollouts rely on n-2 skew?
+        * might delay default-on of in-place-resize for one release (~~AI: jordan / vinay sync up~~); notes from jordan/vinay 2023-05-03:
+            * a 1.27+ node with the feature disabled will not modify resources as requested, will mark pods requesting resize as "infeasible"
+            * a pre-1.27 node will not modify resources as requested, with no user feedback
+            * after 1.27 work, we realized that kubelet perpetually reports pod resize as InProgress when running against a containerd that supports UpdateContainerResources CRI API (containerd ~1.4/~1.5 era) but does not support ContainerStatus CRI API (added to CRI API in [k8s 1.25](https://github.com/kubernetes/kubernetes/pull/111645), supported in containerd 1.6.9+), so there's already user feedback improvements to make and possibly delay beta for
+            * _if_ we were ready to promote in-place-resize to beta in 1.29, n-3 skew would mean 1.26 kubelets would not give any user feedback about lack of support for the feature, but would otherwise fail safe
+    * derek:
+        * include alternative considered of supporting in-place minor upgrades, rationale why that approach wasn't chosen
+            * OS upgrades, immutable nodes can't use in-place for minor upgrades
+            * cost of supporting/testing in-place minor upgrades is significantly higher, impacts development of new features and evolution of existing features
+        * make sure it is clear what guidance should be given to people working on new features for what to do for features older kubelets don't support yet
+* [mweston & atanas] Still working on the [https://github.com/obiTrinobihttps://github.com/obiTrinobiIntel/enhancements/tree/atanas/cci-updated/keps/sig-node/3675-resource-plugin-managerIntel/enhancements/tree/atanas/cci-updated/keps/sig-node/3675-resource-plugin-manager](https://github.com/obiTrinobiIntel/enhancements/tree/atanas/cci-updated/keps/sig-node/3675-resource-plugin-manager) KEP.  Need help with scheduling re Dawn or other member in getting feedback.
+* [mrunal] Canceling next week's meeting for kubecon.
+
+
+## Apr 4th, 2023
+
+Recording: [https://www.youtube.com/watch?v=Y_TWnklb0vI](https://www.youtube.com/watch?v=Y_TWnklb0vI)
+
+
+
+* [pacoxu] [undeprecate kubelet --provider-id flag](https://github.com/kubernetes/kubernetes/pull/116530#top): what are your plans around graduating kubelet config file/actually deprecating these flags in the future?
+* 
+* [iancoolidge] Follow-up on issue [https://github.com/kubernetes/kubernetes/issues/115994](https://github.com/kubernetes/kubernetes/issues/115994)
+    * discuss specifying –reserved-cpus and also –exclusive-cpus or something like that (see [https://github.com/kubernetes/kubernetes/issues/115994#issuecomment-1495980750](https://github.com/kubernetes/kubernetes/issues/115994#issuecomment-1495980750))
+        * fromani: adding what seems another cpu pool is something already emerged from different conversations and would probably deserve a separate conversation (e.g. not a simple bugfix)
+    * Please also look at KEP: [https://github.com/obiTrinobiIntel/enhancements/tree/atanas/cci-updated/keps/sig-node/3675-resource-plugin-manager](https://github.com/obiTrinobiIntel/enhancements/tree/atanas/cci-updated/keps/sig-node/3675-resource-plugin-manager) 
+* [rata] Userns KEP 127: add support for stateful pods
+    * We don’t need code changes in the kubelet for this (just change the validation)
+    * Therefore, we want to just change the scope of the KEP to support stateful pods too
+    * We want to deprecate the feature gate “UserNamespacesStatelessPodsSupport” and add “UserNamespacesSupport”
+    * This new feature gate will activate userns for all pods (stateful/stateless)
+    * If this sounds good, we will do a PoC and propose the KEP changes widening the scope and explaining how the stateful case works too.
+        * [mrunal] This may be okay but let’s open a KEP change and get opinions of other reviewers involved.
+        * [mrunal] We need to start thinking about how user namespaces will work with pod security policies.
+        * [rata]: Mrunal and I will join sig-auth to start the PSS conversation
+        * [rata] Maybe they need fields to be GA? But happy to start discussing.
+
+
+## Mar 28st, 2023
+
+Recording: [https://www.youtube.com/watch?v=yb_LtE0hGDc](https://www.youtube.com/watch?v=yb_LtE0hGDc) 
+
+
+
+* [SergeyKanzhelev] Annual Report: [https://github.com/kubernetes/community/pull/7220](https://github.com/kubernetes/community/pull/7220) 
+
+    Let’s edit together: [https://docs.google.com/document/d/17Z3LO3pSdv9R-v9yLIMO5a46nwXRQTsaEDg0iN74rhs/edit?usp=sharing](https://docs.google.com/document/d/17Z3LO3pSdv9R-v9yLIMO5a46nwXRQTsaEDg0iN74rhs/edit?usp=sharing) 
+
+* [jlpedrosa]
+    * memory.oom.group setting to oom the whole cgroup in the container. \
+[slack convo](https://kubernetes.slack.com/archives/C0BP8PW9G/p1679649131585659).
+        * [Mrunal] container level makes sense
+        * [Sergey] for sidecars we will adjust oom score for sidecars so it’s almost the “whole Pod” being killed
+        * [Mrunal] we can start with the issue, may not need a KEP for this
+        * [Todd Neal] I think there is a potential for API surface as the new behavior may not be desired in all cases.  haproxy was the example brought up in Slack where it may handle OOM correctly on a single process.  Most everything else probably doesn't, so you might want a default of turning oom.group on and allowing containers to opt-out.
+
+
+## Mar 21st, 2023
+
+Recording: [https://www.youtube.com/watch?v=IjxUleYcKgk](https://www.youtube.com/watch?v=IjxUleYcKgk) 
+
+
+
+* [iholder101/harche] - Graduating Support for Swap to Beta
+    * [https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md#beta](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md#beta)
+    * PoC for setting swap limit in cgroup v2 -[ https://github.com/kubernetes/kubernetes/pull/116637](https://github.com/kubernetes/kubernetes/pull/116637)
+* [adilGhaffarDev] - kubectl drain improvements
+    * I would like to add some improvements in kubectl drain. Kindly check this issue: [https://github.com/kubernetes/kubernetes/issues/116210](https://github.com/kubernetes/kubernetes/issues/116210) 
+* [mrunal] Cgroups v1 deprecation
+* 
+
+
+## Mar 14th, 2023
+
+Recording: [https://www.youtube.com/watch?v=e0DA7x4zTs0](https://www.youtube.com/watch?v=e0DA7x4zTs0)
+
+Total: [200](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2023-02-28T17%3A00%3A00%2B0000..2023-03-14T16%3A56%3A55%2B0000">86</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2023-02-28T17%3A00%3A00%2B0000..2023-03-14T16%3A56%3A55%2B0000">35</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2023-02-28T17%3A00%3A00%2B0000..2023-03-14T16%3A56%3A55%2B0000+created%3A%3C2023-02-28T17%3A00%3A00%2B0000">203</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2023-02-28T17%3A00%3A00%2B0000..2023-03-14T16%3A56%3A55%2B0000">103</a>
+   </td>
+  </tr>
+</table>
+
+
+Needs approval: label:lgtm -label:approved 41
+
+[https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3Apriority%2Fcritical-urgent++label%3Asig%2Fnode+](https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3Apriority%2Fcritical-urgent++label%3Asig%2Fnode+)
+
+[https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3Apriority%2Fimportant-soon++label%3Asig%2Fnode+](https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3Apriority%2Fimportant-soon++label%3Asig%2Fnode+) 
+
+
+
+* [SergeyKanzhelev] Release blocking: 
+    * [https://github.com/kubernetes/kubernetes/issues/116549](https://github.com/kubernetes/kubernetes/issues/116549) [Fixed]
+    * [https://github.com/kubernetes/kubernetes/issues/116262](https://github.com/kubernetes/kubernetes/issues/116262)
+
+    Standalone kubelet mode is de facto GA feature, even though not well documented. No GA feature should be broken by feature gate enablement.
+
+
+    Options: introduce standalone mode tests like so: 
+
+* [https://github.com/kubernetes/kubernetes/pull/116551](https://github.com/kubernetes/kubernetes/pull/116551)
+* revert changes caused the failure
+* fix changes caused the failure before the release
+
+	InPlace update TODOs:
+
+
+
+* api change
+* panic in standalone mode
+* Try moving forward with the feature.
+* [SergeyKanzhelev] Sidecar KEP. [https://github.com/kubernetes/kubernetes/pull/116429](https://github.com/kubernetes/kubernetes/pull/116429) 
+* [pacoxu]<span style="text-decoration:underline;"> [add net.ipv4.ip_local_reserved_ports to safe sysctls](https://github.com/kubernetes/kubernetes/pull/115374#top)#115374</span>, the sysctl is changed to be namespaced since kernel 3.16, and the PR will add it to safe syctl only if the kernel version is 3.16+.
+    * [https://github.com/kubernetes/system-validators/blob/a0cb0d12f4d8ed79fa4ee4725ae179528dd2d522/validators/kernel_validator.go](https://github.com/kubernetes/system-validators/blob/a0cb0d12f4d8ed79fa4ee4725ae179528dd2d522/validators/kernel_validator.go)
+    * [Paco] I have opened an issue ([https://github.com/kubernetes/kubernetes/issues/116799](https://github.com/kubernetes/kubernetes/issues/116799)) to gather feedback and track whether we should modify the minimum kernel version.
+* ~~[klueska] Need approval for feature gates on this PR:~~
+    * ~~I cannot attend the meeting unfortunately~~
+    * ~~The PR is close, and I am confident we can get all the comments addressed before 5pm, but I need help getting the feature gates approved.~~
+    * ~~[https://github.com/kubernetes/kubernetes/pull/115847](https://github.com/kubernetes/kubernetes/pull/115847)~~
+* [aravindh/sig-windows] Next steps for merging [KEP 2258: add node log query](https://github.com/kubernetes/kubernetes/pull/96120#top)
+    * Discussed previously on 
+
+[Jan 31st, 2023](#heading=h.91rl4flxpf59)
+* [marosset/sig-windows] [https://github.com/kubernetes/kubernetes/pull/116546](https://github.com/kubernetes/kubernetes/pull/116546)
+    * updating perfCounterUpdatePeriod in kubelet to 10 seconds on Windows to address some perf issues when running logs of pods
+
+
+## Mar 7th, 2023
+
+Recording: [https://www.youtube.com/watch?v=KgAR613c1Bs](https://www.youtube.com/watch?v=KgAR613c1Bs) 
+
+Total PRs: [241](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2023-02-28T17%3A00%3A00%2B0000..2023-03-07T17%3A58%3A18%2B0000">35</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2023-02-28T17%3A00%3A00%2B0000..2023-03-07T17%3A58%3A18%2B0000">14</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2023-02-28T17%3A00%3A00%2B0000..2023-03-07T17%3A58%3A18%2B0000+created%3A%3C2023-02-28T17%3A00%3A00%2B0000">136</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2023-02-28T17%3A00%3A00%2B0000..2023-03-07T17%3A58%3A18%2B0000">31</a>
+   </td>
+  </tr>
+</table>
+
+
+
+    [https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3Apriority%2Fimportant-soon+label%3Asig%2Fnode](https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+label%3Apriority%2Fimportant-soon+label%3Asig%2Fnode)
+
+
+
+* [SergeyKanzhelev] 19 enhancements tracked, and at the moment 0 were opted-in for Feature Blogs.
+* [KevinHannon@kannon92] Starting work on [https://github.com/kubernetes/enhancements/pull/3816](https://github.com/kubernetes/enhancements/pull/3816) (Pending Pods stuck due to configuration errors) \
+- Created a POC PR to see about validation of some of these configuration errors \
+- [https://github.com/kubernetes/kubernetes/pull/115736](https://github.com/kubernetes/kubernetes/pull/115736) \
+- Should I consider moving this into a KEP of its own?
+* [Francesco @ffromani] setting rate limits for kubelet endpoints (required for KEP 606 GA). Items emerged during the[ API review](https://github.com/kubernetes/kubernetes/pull/115852#pullrequestreview-1326552711):
+    * kubelet has a lot of endpoints, we are adding rate limiting only for the podresources. [Is this coherent with the overall direction of kubelet serving](https://github.com/kubernetes/kubernetes/pull/115852#discussion_r1126611858)?
+    * [The rate limit is global. Clients can disrupt each other](https://github.com/kubernetes/kubernetes/pull/115852#discussion_r1126605828). Is this acceptable?
+        * vs per-connection rate-limit. But then would we need to limit also the max connections?
+    * [Is the QPS/Burst setting good enough for kubelet](https://github.com/kubernetes/kubernetes/pull/115852#discussion_r1126606012)?
+        * vs priority-and-fairness like API server
+* [SergeyKanzhelev] [https://github.com/kubernetes/kubernetes/pull/116121](https://github.com/kubernetes/kubernetes/pull/116121) any concerns with increasing qps limits? 
+    * This really helps, and the first throttling issue is volume mount timeout errors.
+* [mimowo] Looking for reviewers / approvers for:
+    * Mark Deleted Pending Pods as Failed by Kubelet [https://github.com/kubernetes/kubernetes/pull/115331](https://github.com/kubernetes/kubernetes/pull/115331)
+    * Move Deleted Running pods to terminal phase by Kubelet [https://github.com/kubernetes/kubernetes/pull/116324](https://github.com/kubernetes/kubernetes/pull/116324)
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) - status update
+    * Two bugs identified so far from this PR:
+        * [#116262](https://github.com/kubernetes/kubernetes/issues/116262) panic in standalone kubelet in GKE CI (release blocker)
+            * [Fix](https://github.com/kubernetes/kubernetes/pull/116271) is in review
+        * [#116175](https://github.com/kubernetes/kubernetes/issues/116175) new test failure in CI job
+            * Initial investigation shows in-place resize didn’t regress this job
+* [mahamed/@upodroid & todd/@tzneal] Kubelet/node e2e tests on AWS:
+    * [https://github.com/kubernetes/test-infra/issues/28899](https://github.com/kubernetes/test-infra/issues/28899) Top Level Issue
+    * Todd’s PR to add the runner logic in k/k [https://github.com/kubernetes/kubernetes/pull/116236](https://github.com/kubernetes/kubernetes/pull/116236)
+    * My PR to add vanilla ubuntu2204 public GCE images to tests. [https://github.com/kubernetes/test-infra/pull/28856](https://github.com/kubernetes/test-infra/pull/28856) 
+    * e2e ubuntu tests are passing on EC2 instances: [https://github.com/kubernetes/kubernetes/issues/116114](https://github.com/kubernetes/kubernetes/issues/116114) 
+    * AWS accounts for node e2e tests have been created, I need to configure the prow jobs to run tests on there.
+    * AI for Mahamed to take back to sig-k8s-infra
+        * How can members of sig-node access the AWS accounts and view failing nodes, etc?
+        * Someone from AWS to help with this
+    * [Dawn] @mahamed, here is recent discuss on CI failures on Fedora:[ https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit#bookmark=id.rglbf1gnhrpp](https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit#bookmark=id.rglbf1gnhrpp)
+* [atanas] still working on [https://github.com/kubernetes/enhancements/pull/3853](https://github.com/kubernetes/enhancements/pull/3853) and will have further updates soon.  Next meeting is March 7th, directly after this one, zoom here [https://us02web.zoom.us/j/86511166765](https://us02web.zoom.us/j/86511166765) (need to also update Dawn-schedules don’t work correctly so need 2 meetings, unfortunately)
+    * Attribute-based API update 
+    * Architecture Sync - move towards a single CCI driver implementation which can understand DRA claims 
+    * Demo covering possible DRA claim-based approach combined with CCI , boot strap the system , run std pods, demonstrate driver failure scenario , allocate shared and exclusive resources. 
+* [SergeyKanzhelev] any special protections needed for [https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go) (see [conversation](https://kubernetes.slack.com/archives/CJUQN3E4T/p1677664222256419))?
+* [Philip Laine] Read only CRI API access
+    * [https://github.com/containerd/containerd/issues/8085](https://github.com/containerd/containerd/issues/8085)
+    * [https://github.com/cri-o/cri-o/issues/6667](https://github.com/cri-o/cri-o/issues/6667)
+        * Mike Brown(brownwm/mikebrow): suggest opening a google doc link it here.. invite mrunalp, peter hunt, sasha, samuel, mike brown, others that have an interest in shaping the cri into namespaced(or rbac)/access patterns for some cases like monitoring 
+
+
+## Feb 28st, 2023
+
+Recording: [https://www.youtube.com/watch?v=IHcI6Jwo5PQ](https://www.youtube.com/watch?v=IHcI6Jwo5PQ) 
+
+Total PRs: [248](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2023-02-21T17%3A00%3A00%2B0000..2023-02-28T17%3A59%3A00%2B0000">36</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2023-02-21T17%3A00%3A00%2B0000..2023-02-28T17%3A59%3A00%2B0000">9</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2023-02-21T17%3A00%3A00%2B0000..2023-02-28T17%3A59%3A00%2B0000+created%3A%3C2023-02-21T17%3A00%3A00%2B0000">83</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2023-02-21T17%3A00%3A00%2B0000..2023-02-28T17%3A59%3A00%2B0000">11</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* **[01:00 UTC Wednesday 15th March 2023 / 17:00 PDT Tuesday 14th March 2023](https://everytimezone.com/s/c4971746)**: Week 10 — [Code Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#code-freeze)
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * Merged 🙂
+    * ref WIP PR: [https://github.com/kubernetes/kubernetes/pull/116119](https://github.com/kubernetes/kubernetes/pull/116119)
+* [SergeyKanzhelev] Sidecar: [https://github.com/kubernetes/kubernetes/issues/115934](https://github.com/kubernetes/kubernetes/issues/115934)  
+* [mimowo]
+    * need reviewer/approver for: [https://github.com/kubernetes/kubernetes/pull/116082](https://github.com/kubernetes/kubernetes/pull/116082). Is it an issue upstream in containerd? [mike brown] let’s chat I don’t think this is a problem with containerd.. more an issue of expectation of the start request being serial and responding before the async start kicking off.. iow add a sleep/yield to the test itself before it “ooms” and you will/should get the started response flowing back through kubelet before the oom happens.. Changing to an ack model for the start request before actually starting would be in conflict with the start being able to return certain errors.
+    * Discuss implementation decisions for [https://github.com/kubernetes/kubernetes/pull/115331](https://github.com/kubernetes/kubernetes/pull/115331). Specific questions:
+        * Should we restrict the handling to pods with finalizers (to save QPS)?
+        * When Kubelet restarts there is a short time window that the phase may flip back to Pending, is this something specific to this scenario, or a general behavior / bug in Kubelet?
+        * Should we also make sure that all Running pods with deletionTimestamp end up in terminal phase? This is currently not the case for pods with RestartPolicy=OnFailure or Always.
+    * Followup:
+        * Clayton’s PR that may fix the failure case: [https://github.com/kubernetes/kubernetes/pull/113145](https://github.com/kubernetes/kubernetes/pull/113145)
+        * E2E added to Clayton’s PR would be helpful to see if the issue is fixed or not
+
+
+## Feb 21st, 2023
+
+Recording: [https://www.youtube.com/watch?v=Hod1MGk99lc](https://www.youtube.com/watch?v=Hod1MGk99lc) 
+
+Total PRs: [230](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+) 
+
+From Jan 24th:
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2023-01-24T17%3A00%3A00%2B0000..2023-02-21T17%3A53%3A43%2B0000">129</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2023-01-24T17%3A00%3A00%2B0000..2023-02-21T17%3A53%3A43%2B0000">48</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2023-01-24T17%3A00%3A00%2B0000..2023-02-21T17%3A53%3A43%2B0000+created%3A%3C2023-01-24T17%3A00%3A00%2B0000">177</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2023-01-24T17%3A00%3A00%2B0000..2023-02-21T17%3A53%3A43%2B0000">76</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [lucysweet] [Give an indication in container events for probe failure as to whether the failure was ignored due to FailureThreshold](https://github.com/kubernetes/kubernetes/issues/115823)
+    * [SergeyKanzhelev] replied on the issue
+* [iancoolidge] Clarify –reserved-cpus behavior with static CPU manager, but only a subset of pods are static
+    * [swsehgal] This kubelet flag is to specify explicitly the list of CPUs for kubernetes processes or OS processes. These CPUs are removed from the default pool that CPU Manager in kubelet uses for allocation to pods. 
+    * [dawnchen] You can view –reserved-cpus as the interface for non-pod tasks running on the node including kubelet, container runtime, and kernel threads. It is a complement for the static CPU managers. 
+    * [iancoolidge] consensus from discussion is that no workloads should get scheduled on the –reserved-cpus, this seems to be happening on our test case though.
+        * iancoolidge to create issue on github (thanks all for discussion!)
+        * [https://github.com/kubernetes/kubernetes/issues/115994](https://github.com/kubernetes/kubernetes/issues/115994)
+* [mimowo] Looking for approval from sig-node for [https://github.com/kubernetes/kubernetes/pull/113205](https://github.com/kubernetes/kubernetes/pull/113205). Then, for: [https://github.com/kubernetes/kubernetes/pull/112977](https://github.com/kubernetes/kubernetes/pull/112977).
+    * CRITEST: [https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/cri-validation.md?plain=1](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/cri-validation.md?plain=1) 
+    * [https://github.com/kubernetes-sigs/cri-tools/issues/1102](https://github.com/kubernetes-sigs/cri-tools/issues/1102) 
+* [atanas] still working on [https://github.com/kubernetes/enhancements/pull/3853](https://github.com/kubernetes/enhancements/pull/3853) and will have further updates soon.  Next meeting is March 7th, 6:00am PST zoom here:  [https://us02web.zoom.us/j/82567156922?pwd=Q2xscE0rRjluRTlvdk5FK3hzUFpDQT09](https://us02web.zoom.us/j/82567156922?pwd=Q2xscE0rRjluRTlvdk5FK3hzUFpDQT09)  Plan for next meeting is to include a demo and be ready with more cleanup based on feedback from today.
+
+
+## Feb 14th, 2023
+
+Recording: [https://www.youtube.com/watch?v=NsV9TVcJw54](https://www.youtube.com/watch?v=NsV9TVcJw54) 
+
+
+
+* [SergeyKanzhelev] we are tracking 23 KEPs this release: [https://github.com/orgs/kubernetes/projects/117/views/1?filterQuery=+status%3ATrac[…]ode+&sortedBy%5Bdirection%5D=desc&sortedBy%5BcolumnId%5D=Status](https://github.com/orgs/kubernetes/projects/117/views/1?filterQuery=+status%3ATracked+label%3Asig%2Fnode+&sortedBy%5Bdirection%5D=desc&sortedBy%5BcolumnId%5D=Status)
+* Cut from milestone:
+    * [Kubelet Resource Plugin Manager Refactor · Issue #3675](https://github.com/kubernetes/enhancements/issues/3675)
+    * [Add AppArmor support · Issue #24 · kubernetes/enhancements · GitHub](https://github.com/kubernetes/enhancements/issues/24)
+    * [cAdvisor-less, CRI-full Container and Pod Stats · Issue #2371 · kubernetes/enhancements · GitHub](https://github.com/kubernetes/enhancements/issues/2371)
+    * [Support class-based resources to CRI protocol · Issue #3008](https://github.com/kubernetes/enhancements/issues/3008) 
+* [SergeyKanzhelev] Annual report tasks: [https://github.com/kubernetes/community/blob/master/sig-node/annual-report-2022.md](https://github.com/kubernetes/community/blob/master/sig-node/annual-report-2022.md)  
+* [haircommander] [automatic cgroup driver matching between kubelet and CRI](https://github.com/kubernetes/kubernetes/issues/99808)
+    * [paco]+1 for this. I opened a PR to do it for dockershim [#98357](https://github.com/kubernetes/kubernetes/pull/98357/) before.
+    * consensus is to have the runtime be the source of  truth, and report to the Kubelet what cgroup driver to use with a field in the runtime status call. 
+    * Peter to pursue a KEP for this in 1.28
+    * [kad] while we are on this, we can also eliminate misconfiguration between kubelet and runtimes on reserved/infra cpuset: `--reserved-cpus` for kubelet/--infra-ctr-cpuset in cri-o.
+* [Yuan Chen, Deep Debroy]] Discuss decoupling no-execute-taint-manager from node-lifecycle-controller
+    * Mainly a refactoring change as the two are part of the same controller but have somewhat independent functions.
+    * With [https://github.com/kubernetes/enhancements/blob/74e610bb0f7e40862688e8a434c77bfafc53cb9e/keps/sig-scheduling/20200114-taint-based-evictions.md](https://github.com/kubernetes/enhancements/blob/74e610bb0f7e40862688e8a434c77bfafc53cb9e/keps/sig-scheduling/20200114-taint-based-evictions.md), the ability to disable no-execute-taint-manager is going away.
+    * [paco] [karpenter](https://github.com/aws/karpenter) has a requirement of `[startup taint](https://github.com/kubernetes/kubernetes/issues/115139#issuecomment-1424597021)` which is interesting. I am not sure if this can be a possible user case.
+* [MikeBrown] Just a reminder probe granularity enhancement [https://github.com/kubernetes/enhancements/pull/3067](https://github.com/kubernetes/enhancements/pull/3067) needs review.
+
+
+## Feb 7th, 2023
+
+Recording: [https://www.youtube.com/watch?v=cam97qjy8qE](https://www.youtube.com/watch?v=cam97qjy8qE) 
+
+27 KEPs: [https://github.com/kubernetes/enhancements/issues?q=is%3Aissue+is%3Aopen+label%3Asig%2Fnode+milestone%3Av1.27+label%3Alead-opted-in+](https://github.com/kubernetes/enhancements/issues?q=is%3Aissue+is%3Aopen+label%3Asig%2Fnode+milestone%3Av1.27+label%3Alead-opted-in+) 
+
+
+
+* [rata]: [Userns KEP PR](https://github.com/kubernetes/enhancements/pull/3811) rework with idmap mounts.
+    * I think this should be ready to approve for 1.27. Is anything missing?
+* [klueska] KEP with PodResources extensions for DRA
+    * Looking for final approval by  and / or @mrunal
+    * There’s one small change I’d like to see made, but if we get an /approve with a /hold I can make sure the change gets in before giving a final /lgtm
+    * [https://github.com/kubernetes/enhancements/pull/3738](https://github.com/kubernetes/enhancements/pull/3738)
+* ~~[klueska] Milestone and tracking for updates to DRA enhancement issue~~
+    * ~~Needs **<code>lead-opted-in</code></strong> and <strong><code>milestone 1.27</code></strong> label (staying in alpha)</del>
+    * <del>[https://github.com/kubernetes/enhancements/issues/3063](https://github.com/kubernetes/enhancements/issues/3063)</del>
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * Please review and merge k/enhancements housekeeping [PR #3845](https://github.com/kubernetes/enhancements/pull/3845)
+        * To catch up to the latest KEP template, the PR adds integration test section and responds to node scalability section.
+    * I have rebased and updated [PR #102884](https://github.com/kubernetes/kubernetes/pull/102884) after LGTM by @thockin 
+        * Squashed all API commits into single commit + generated files commit
+        * Separate commit for scheduler changes
+        * I plan to squash various kubelet commits into 2 or 3 commits if that’s ok
+        * @thockin awaits Derek’s re-LGTM/approve before approving the PR.
+        * I plan to create follow-up PRs to address a few outstanding items:
+            * ResizePolicy name restructuring
+            * Use PodStatus.QOSClass instead of GetPodQoS across K8s codebase
+* [Atanas] CCI KEP:
+    * [https://github.com/kubernetes/enhancements/pull/3853](https://github.com/kubernetes/enhancements/pull/3853)
+    * Addressing comments as they come in.
+    * Brief discussion on anything else outstanding.
+    * Reviewers: Swati and Kevin, Approver: Dawn or Derek
+* [qbarrand] [Kernel Module Management](https://github.com/kubernetes-sigs/kernel-module-management)
+    * looking for sponsors to get [mresvanis](https://github.com/mresvanis) into the kubernetes / kubernetes-sigs orgs - [contributions](https://github.com/kubernetes-sigs/kernel-module-management/commits?author=mresvanis)
+    * [PR to update admins and maintainers](https://github.com/kubernetes/org/pull/3791)
+* [mimowo] Ask for final review and approval from sig-node for: [Update for second Beta with GA criteria for "KEP-3329: Retriable and non-retriable Pod failures for Jobs"](https://github.com/kubernetes/enhancements/pull/3757)
+
+
+## Jan 31st, 2023
+
+Recording: [https://youtu.be/96DTU9ncSLA](https://youtu.be/96DTU9ncSLA) 
+
+
+
+* [Aravindh Puthiyaparambil] [KEP 2258: Node service log viewer](https://github.com/kubernetes/enhancements/pull/2271#top)
+    * [KEP 2258: add node log query](https://github.com/kubernetes/kubernetes/pull/96120#top) (implementation
+    * Discuss Jordan’s [comment](https://github.com/kubernetes/kubernetes/pull/96120#pullrequestreview-1262371094)
+    * sig-windows is interested in the feature as it helps debugging Windows nodes. We would like to get the viewpoint of #sig-node whether we should move forward or not based on Jordan’s feedback ie. add the feature disabled by default and a warning when enabling.
+* [mimowo] Heads up and discuss Kubelet changes for [Update for second Beta with GA criteria for "KEP-3329: Retriable and non-retriable Pod failures for Jobs"](https://github.com/kubernetes/enhancements/pull/3757)
+    * [Sergey] good direction, original language was a bit cryptic, need more examples
+        * [mimowo] it is already fixed
+    * [mrunal] related to pod lifecycle - Ryan and David might need to review
+    * [David]+1 yes it is related to pod lifecycle, will review as well
+* [pacoxu] Two bugfix PRs need to be reviewed for `[LocalStorageCapacityIsolationFSQuotaMonitoring](https://github.com/kubernetes/enhancements/issues/1029)` (which is promoted to beta in v1.25.0 and revert to alpha in v1.25.1 and v1.26 for the bug) for the same issue: #[112624](https://github.com/kubernetes/kubernetes/pull/112624) and #[115314](https://github.com/kubernetes/kubernetes/pull/115314). If this PR can be reviewed and merged on time. I prefer to re-promote the feature to beta in v1.27.
+    * [Ryan] It was discussed Jan 17th. Thinking about deprecating it. Are you using it?
+    * [Paco] let’s sync up
+        * 112624 is merging
+        * Paco is going to get an upstream E2E running with the feature gate enabled in test-grid
+* [klueska] Update to the DRA KEP for CRI changes
+    * Ready ready for final approval from 
+    * [https://github.com/kubernetes/enhancements/pull/3731](https://github.com/kubernetes/enhancements/pull/3731)
+* [klueska] Update to the DRA KEP for WatchConfiguration call on kubelet plugin
+    * Reviews welcome
+    * [https://github.com/kubernetes/enhancements/pull/3802](https://github.com/kubernetes/enhancements/pull/3802)
+* [atanas & mweston] Container Compute Interface (was Kubelet Resource Plugin) discussion
+    * Notes from this morning: [https://docs.google.com/document/d/1kRSkOqZnalt09UMm-xXcHPuw3ZEzPrFIuhFf2piwIxI/edit](https://docs.google.com/document/d/1kRSkOqZnalt09UMm-xXcHPuw3ZEzPrFIuhFf2piwIxI/edit)
+    * Will get recording up to Sergey today.
+    * PR up here:  [https://github.com/kubernetes/enhancements/pull/3803](https://github.com/kubernetes/enhancements/pull/3803)
+        * Please add in any comments
+    * Opens: 
+        * Describe Kubelet restart scenario
+        * Sketch and describe beta architecture
+        * Illustrate failure and corner case flows
+* [claudiubelu] Proposed changes to how kubelet detects updates for registered plugins b/c current implementation doesn’t work on Windows due to timestamp granularity issues [https://github.com/kubernetes/kubernetes/pull/114136](https://github.com/kubernetes/kubernetes/pull/114136) 
+    * [https://cs.k8s.io/?q=PluginExistsWithCorrectTimestamp&i=nope&files=&excludeFiles=&repos=](https://cs.k8s.io/?q=PluginExistsWithCorrectTimestamp&i=nope&files=&excludeFiles=&repos=)
+    * [https://testgrid.k8s.io/sig-windows-signal#windows-unit-master](https://testgrid.k8s.io/sig-windows-signal#windows-unit-master) test failure caused by timestamp
+    * this has been proposed and brought up in the past, but no reviews came in.
+    * it is one of the last consistently failing tests in the testgrid above.
+    * [MikeBrown] consider keeping existing public method and add another one, deprecate first one later. nod just to protect custom plugin managers test buckets etc .. deprecate first thx.. see:
+        * [https://cs.k8s.io/?q=PluginExistsWithCorrectTimestamp&i=nope&files=&excludeFiles=&repos=](https://cs.k8s.io/?q&#61;PluginExistsWithCorrectTimestamp&i&#61;nope&files&#61;&excludeFiles&#61;&repos&#61;)
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * Can we please get this KEP [officially tracked](https://github.com/orgs/kubernetes/projects/117/views/1) for 1.27?
+    * thockin prefers that we merge [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) in its entirety as opposed to merging API [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) followed by the rebased implementation PR a week later.
+        * Reason: [potential difficulty in unwinding the API merge](https://github.com/kubernetes/kubernetes/pull/111946#pullrequestreview-1239501555) in the event we find something really bad after merging implementation a week later, when other commits have rebased and merged on top of the API changes.
+        * I have no major concerns with merging everything in one shot.
+            * We can re-add periodic CI jobs afterwards and iterate on fixes, if needed.
+            * We are ~6 weeks away to code-freeze. It is best to merge #102884 in one shot at this point while we still have sufficient buffer to merge this change and fix any issues without risk to the release.
+
+[KEPS REVIEW]: 15 minutes
+
+
+## Jan 24th, 2023
+
+Recording: [https://youtu.be/NQaTeTfI9UY](https://youtu.be/NQaTeTfI9UY) 
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2023-01-17T17%3A00%3A00%2B0000..2023-01-24T17%3A53%3A26%2B0000">29</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2023-01-17T17%3A00%3A00%2B0000..2023-01-24T17%3A53%3A26%2B0000">12</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2023-01-17T17%3A00%3A00%2B0000..2023-01-24T17%3A53%3A26%2B0000+created%3A%3C2023-01-17T17%3A00%3A00%2B0000">90</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2023-01-17T17%3A00%3A00%2B0000..2023-01-24T17%3A53%3A26%2B0000">14</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [SergeyKanzhelev] Sidecar containers KEP: [https://github.com/kubernetes/enhancements/pull/3761](https://github.com/kubernetes/enhancements/pull/3761) 
+
+    [https://docs.google.com/presentation/d/1JOfC4YY6tJC4zf83QobPG9W_jlSw1JUhForMm9JHQVw/edit#slide=id.g1eaa3876499_0_0](https://docs.google.com/presentation/d/1JOfC4YY6tJC4zf83QobPG9W_jlSw1JUhForMm9JHQVw/edit#slide=id.g1eaa3876499_0_0) 
+
+* [bobbypage] Thoughts on formalizing Node Lifecycle - [https://github.com/kubernetes/kubernetes/issues/115139](https://github.com/kubernetes/kubernetes/issues/115139) 
+    * [Dawn] we might had several docs in OSS - maybe Lantao knows
+    * [MikeBrown] would be interested to participate
+    * [Sergey] question on slack recently regarding taint for paused VMs. Also recreating node with the same name is another interesting qq here.
+* [asierHuawei] Thoughts on IMA namespace support for pods
+
+    [https://github.com/kubernetes/enhancements/pull/3703](https://github.com/kubernetes/enhancements/pull/3703)
+
+* [mrunalp] kernel changes are not in yet. Then OCI, than CRI, than k8s. 
+* [Asier] runc had the same feedback
+* [Dawn] feature is interesting, we need it implemented in kernel first
+* [klueska] Update to the DRA KEP for CRI changes
+    * Would appreciate review from @mrunal given his background with CRI
+    * Otherwise ready for final approval
+    * [https://github.com/kubernetes/enhancements/pull/3731](https://github.com/kubernetes/enhancements/pull/3731)
+* [klueska] KEP posted to extend PodResources API with CDI device information
+    * Reviews welcome
+    * [https://github.com/kubernetes/enhancements/pull/3738](https://github.com/kubernetes/enhancements/pull/3738)
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * thockin prefers that we merge [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) in its entirety as opposed to merging API [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) followed by the rebased implementation PR a week later.
+        * Reason: [potential difficulty in unwinding the API merge](https://github.com/kubernetes/kubernetes/pull/111946#pullrequestreview-1239501555) in the event we find something really bad after merging implementation a week later, when other commits have rebased and merged on top of the API changes.
+        * I have no major concerns with merging everything in one shot.
+            * We can re-add periodic CI jobs afterwards and iterate on fixes, if needed.
+* [SergeyKanzhelev] http probes and leaking sockets: <code>[https://github.com/kubernetes/kubernetes/pull/115143](https://github.com/kubernetes/kubernetes/pull/115143)</code>
+    * Context: Sig Network from Jan 19th 2023: [aojea] 10 - 15 mins Presentation - “When sockets refuse to die”
+        * Catchy title from [https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/](https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/)
+        * [https://github.com/kubernetes/kubernetes/pull/115143](https://github.com/kubernetes/kubernetes/pull/115143)
+        * [https://docs.google.com/presentation/d/1UYs1tSFeX7-Jjqhpqacn_nlH88LOLr37VOZBPGwhbCI/edit?usp=sharing](https://docs.google.com/presentation/d/1UYs1tSFeX7-Jjqhpqacn_nlH88LOLr37VOZBPGwhbCI/edit?usp=sharing)
+* [swsehgal] Request for reviews:
+    * Topology Manager GA graduation KEP: [https://github.com/kubernetes/enhancements/pull/3745](https://github.com/kubernetes/enhancements/pull/3745)
+        * Dawn to take a look.
+        * Also, milestone and leads-opt-in label needs to be added to the issue: [https://github.com/kubernetes/enhancements/issues/693](https://github.com/kubernetes/enhancements/issues/693)
+    * Device Manager [Bug](https://github.com/kubernetes/kubernetes/issues/109595): 
+        * PR with fix: [https://github.com/kubernetes/kubernetes/pull/114640](https://github.com/kubernetes/kubernetes/pull/114640)
+        * The above PR depends on sample device plugin changes: [https://github.com/kubernetes/kubernetes/pull/115107](https://github.com/kubernetes/kubernetes/pull/115107) for e2e test implementation. Sample device plugin image would have to be updated(promoted) so it can be consumed for e2e testing.
+* [mweston] Reminder of kubelet resource plugin discussion next Tuesday, 6-7am PST:
+    * [https://us02web.zoom.us/j/82567156922?pwd=Q2xscE0rRjluRTlvdk5FK3hzUFpDQT09](https://us02web.zoom.us/j/82567156922?pwd=Q2xscE0rRjluRTlvdk5FK3hzUFpDQT09)
+
+		Notes from previous meetings: [https://docs.google.com/document/d/1ALxPqeHbEc0QOIzJ3rWWPpwRMRlYDzCv0mu2mR4odR8/edit#](https://docs.google.com/document/d/1ALxPqeHbEc0QOIzJ3rWWPpwRMRlYDzCv0mu2mR4odR8/edit#) 
+
+		
+
+
+
+* [ddebroy] KEP for pod condition to indicate Pod Sandbox creation updated to Beta with new name:
+    * Updated the name of the condition from `PodHasNetwork` to `PodReadyToStartContainers` as discussed with Derek and Tim Hockins to align better with sig network concerns with the original name.
+    * [https://github.com/kubernetes/enhancements/pull/3778](https://github.com/kubernetes/enhancements/pull/3778)
+* [jackfrancis] remove ExecProbeTimeout feature gate
+    * ​​[https://github.com/kubernetes/kubernetes/pull/115227](https://github.com/kubernetes/kubernetes/pull/115227)
+    * We need to clarify criteria for removing this feature gate. Background:
+        * Issue for deciding when to remove feature gate:
+            * [https://github.com/kubernetes/kubernetes/issues/99854](https://github.com/kubernetes/kubernetes/issues/99854)
+        * Probe duration metrics feature landed:
+            * [https://github.com/kubernetes/kubernetes/pull/104484](https://github.com/kubernetes/kubernetes/pull/104484)
+            * Released in v1.25.0
+                * [https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#feature-5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#feature-5)
+        * Lock to true PR (never merged)
+            * [https://github.com/kubernetes/kubernetes/pull/107480](https://github.com/kubernetes/kubernetes/pull/107480)
+        * This feature gate only apples to dockershim, removed in v1.24.0:
+            * [https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#dockershim-removed-from-kubelet](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#dockershim-removed-from-kubelet)
+
+
+## Jan 17th, 2023
+
+Recording: [https://youtu.be/wirWRKSqY10](https://youtu.be/wirWRKSqY10) 
+
+Total PRs: [217](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2023-01-10T17%3A00%3A00%2B0000..2023-01-17T17%3A56%3A21%2B0000">30</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2023-01-10T17%3A00%3A00%2B0000..2023-01-17T17%3A56%3A21%2B0000">16</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2023-01-10T17%3A00%3A00%2B0000..2023-01-17T17%3A56%3A21%2B0000+created%3A%3C2023-01-10T17%3A00%3A00%2B0000">103</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2023-01-10T17%3A00%3A00%2B0000..2023-01-17T17%3A56%3A21%2B0000">16</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [rphillips] ​​[https://github.com/kubernetes/kubernetes/issues/114506](https://github.com/kubernetes/kubernetes/issues/114506) deprecating the feature unless somebody wants to pick it up
+    * [mrunal] let’s summarize the current status and blockers
+        * [Ryan] user can change project id of a directory which becomes a security problem.
+        * [mrunal] can we check with upstream?
+    * [Dawn] this is a kernel feature and we don’t have an efficient way to track disk usage. Since there is no efficient way to do it per cgroup there was an idea to do it per process. Kernel implementation is still not what we want. +1 to mrunal if we can ask linux community
+    * [Ryan] any objections deprecating it?
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * Please review and merge [KEP update PR](https://github.com/kubernetes/enhancements/pull/3670)
+    * thockin prefers that we merge [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) in its entirety as opposed to merging API [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) followed by the rebased implementation PR a week later.
+        * Tim is worried about [potential difficulty in unwinding the API merge](https://github.com/kubernetes/kubernetes/pull/111946#pullrequestreview-1239501555) in the event we find something really bad after merging implementation a week later, when other commits have rebased and merged on top of the API changes.
+        * I have no major concerns with merging the mothership in one shot.
+            * We can re-add periodic CI jobs afterwards and iterate on fixes if there are any issues.
+    * Tim & I discussed a [naming change to ResizePolicy](https://github.com/kubernetes/kubernetes/pull/111946#discussion_r1063862866). I plan to do this as a follow-up PR on the heels of #102884 in order to avoid resetting the reviews.
+* [marquiz] [QoS-class resources KEP](https://github.com/kubernetes/enhancements/pull/3004), proposal updated:
+    * ditched pod annotation based UX -> go straight to K8s API
+    * added support for “class capacity” i.e. possibility limit max number of users of classes
+* [Vinay] [https://groups.google.com/u/3/g/kubernetes-sig-network/c/e0U44XyI3Vw](https://groups.google.com/u/3/g/kubernetes-sig-network/c/e0U44XyI3Vw) CRI and CNI.
+* [SergeyKanzhelev] [https://github.com/kubernetes/kubernetes/pull/114989](https://github.com/kubernetes/kubernetes/pull/114989) 
+* [SergeyKanzhelev] sidecar container WG update: [https://docs.google.com/document/d/1E1guvFJ5KBQIGcjCrQqFywU9_cBQHRtHvjuqcVbCXvU/edit#heading=h.m8xoiv5t6qma](https://docs.google.com/document/d/1E1guvFJ5KBQIGcjCrQqFywU9_cBQHRtHvjuqcVbCXvU/edit#heading=h.m8xoiv5t6qma) 
+* [atanas] Kubelet plugin WG update (next meeting 1/31/2023 [https://us02web.zoom.us/j/82567156922?pwd=Q2xscE0rRjluRTlvdk5FK3hzUFpDQT09](https://us02web.zoom.us/j/82567156922?pwd=Q2xscE0rRjluRTlvdk5FK3hzUFpDQT09) (pw is 77777 if it asks) at 6am PST/8am CST/2pm Ireland)
+
+
+## Jan 10th, 2023
+
+Recording: [https://youtu.be/5V0uRxH4O4k](https://youtu.be/5V0uRxH4O4k) 
+
+
+
+* ~~[pacoxu] KEP-3610: namespace-wide global env injection [#3612](https://github.com/kubernetes/enhancements/pull/3612), not sure if this can be an admission controller.(removed due to [mutating CEL admission should be the final solution.](https://github.com/kubernetes/enhancements/pull/3612#discussion_r1063236570)) ~~
+* [ruiwen/pacoxu] KEP-3673: Kubelet limit of Parallel Image Pulls[ #3713](https://github.com/kubernetes/enhancements/pull/3713)
+    * 
+* [klueska] Update CRI to include CDI devices (needed by DRA before moving to beta)
+    * Do we need a new KEP or can we update the existing DRA KEP with details?
+    * **Mrunal**: We can update the existing KEP with the details of the change.
+    * It should just be a simple addition to: \
+[https://github.com/kubernetes/cri-api/blob/c75ef5b/pkg/apis/runtime/v1/api.proto#L682](https://github.com/kubernetes/cri-api/blob/c75ef5b/pkg/apis/runtime/v1/api.proto#L682)
+* [QuentinN42]  Add FileEnvSource and FileKeySelector to add environment generated on the fly [#114674](https://github.com/kubernetes/kubernetes/issues/114674)
+    * Sourcing from any file from any source may be too big of a scope. Would limiting this to empty dir files be enough?
+    * Security - is there a risk to source some secret as an environment variable that would expose the file that wasn’t available otherwise.
+    * **Action**: Need to move this to kubernetes/enhancements as a KEP and follow the process. => [https://github.com/kubernetes/enhancements/issues/3721](https://github.com/kubernetes/enhancements/issues/3721)
+    * [Mike Brown] fyi.. not sure if this is the right pattern but NRI plugins support modifying environment variables for the containers. might be useful at least for prototyping
+    * [QuentinN42] another question is error conditions depending on the file format
+    * [Alexander Kanevsky] my first impression - the env variables are populated in oci spec before container started. sourcing from some file inside container might be not feasible....
+    * [Mike Brown] right would require a set for any env change happening in prestart (which could be done by setting a runc hook via NRI or hook schema, or just doing the set on the update response) 
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * I won’t be in the Node meeting today due to another 10 am meeting.
+    * Please review and merge [KEP update PR](https://github.com/kubernetes/enhancements/pull/3670)
+        * Updated beta target to v1.29
+        * Added details on handling version skew.
+    * Tim prefers that we merge [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) in its entirety as opposed to merging API [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) followed by the rest of it a week later.
+        * We can re-add periodic CI jobs afterwards and iterate on fixes if there are any issues.
+        * I believe this will require both Derek’s & Tim’s lgtm & approve.
+        * **AI: **Derek to catch up on Tims’ objections: [https://github.com/kubernetes/kubernetes/pull/111946#pullrequestreview-1239501555](https://github.com/kubernetes/kubernetes/pull/111946#pullrequestreview-1239501555)
+* [derek] sig updates
+    * email with proposed changes is coming up later today
+    * [https://groups.google.com/g/kubernetes-sig-node/c/NsoYU1Y2rUs](https://groups.google.com/g/kubernetes-sig-node/c/NsoYU1Y2rUs)
+
+
+## Jan 3rd, 2023
+
+Recording: [https://www.youtube.com/watch?v=AG3U91-5keo](https://www.youtube.com/watch?v=AG3U91-5keo) 
+
+Total active pull requests: [205](https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+is%3Aopen+)
+
+
+<table>
+  <tr>
+   <td><strong>Incoming</strong>
+   </td>
+   <td>
+   </td>
+   <td><strong>Completed</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>Created:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++created%3A2022-12-13T17%3A00%3A00%2B0000..2023-01-03T17%3A56%3A53%2B0000">45</a></strong>
+   </td>
+   <td>Closed:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++is%3Aunmerged+closed%3A2022-12-13T17%3A00%3A00%2B0000..2023-01-03T17%3A56%3A53%2B0000">22</a>
+   </td>
+  </tr>
+  <tr>
+   <td>Updated:
+   </td>
+   <td><strong><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode+updated%3A2022-12-13T17%3A00%3A00%2B0000..2023-01-03T17%3A56%3A53%2B0000+created%3A%3C2022-12-13T17%3A00%3A00%2B0000">144</a></strong>
+   </td>
+   <td>Merged:
+   </td>
+   <td><a href="https://github.com/kubernetes/kubernetes/pulls?q=repo%3Akubernetes%2Fkubernetes+type%3Apr+label%3Asig%2Fnode++merged%3A2022-12-13T17%3A00%3A00%2B0000..2023-01-03T17%3A56%3A53%2B0000">18</a>
+   </td>
+  </tr>
+</table>
+
+
+
+
+* [SergeyKanzhelev] [https://github.com/kubernetes/kubernetes/pull/114394](https://github.com/kubernetes/kubernetes/pull/114394) CRI API version skew policies. See [slides](https://docs.google.com/presentation/d/1s0RM2zDXKTnTn5Yx0_20V0TPbPJLCQSI/edit) from contributors summit for extra details 
+* ~~[SergeyKanzhelev] Reconcile SIG Node teams and OWNERs files: [https://github.com/kubernetes/org/pull/3893](https://github.com/kubernetes/org/pull/3893) ~~
+* [vinaykul] [InPlace Pod Vertical Scaling](https://github.com/kubernetes/kubernetes/pull/102884/) PR - status update
+    * Happy 2023!
+    * Please review and merge [KEP milestone update PR](https://github.com/kubernetes/enhancements/pull/3670)
+    * [PR 102884](https://github.com/kubernetes/kubernetes/pull/102884) approved by Derek.
+        * @bobbypage fixed containerd/main E2E pull test job, we now have full E2E coverage (verifies values from ContainerStatus CRI response)
+            * The test has established a [history of successful runs](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-inplace-pod-resize-containerd-main-v2) for PR 102884 over the course of a few rebases.
+        * My recommendation is we merge API changes [PR 111946](https://github.com/kubernetes/kubernetes/pull/111946) at the earliest possible point in 1.27 and watch it to see nothing bad happens.
+            * Can we do it this week?
+            * Can we atleast merge feature gate definition to clean up test failures in [unrelated PRs](https://github.com/kubernetes/kubernetes/pull/114185)?
+        * And then merge PR 102884 shortly after (PR 111946 merge + 1 week)
+            * We can then re-add periodic CI test jobs.
+* [Seaiii] [https://github.com/kubernetes/kubernetes/pull/113883](https://github.com/kubernetes/kubernetes/pull/113883) The second time the pod is deleted the grace period does not take effect .Please review update PR PR 113883


### PR DESCRIPTION
Archiving meeting agenda for historical availability, and to clean up the agenda doc for performance. I'll delete the old entries from https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit once this merges.

Generated using the [Docs to Markdown extension](https://workspace.google.com/marketplace/app/docs_to_markdown/700168918607)

/assign @SergeyKanzhelev @mrunalp 