### PR TITLE
Add riscv to Slack channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -415,6 +415,7 @@ channels:
   - name: random
     archived: true
   - name: reddit-mods
+  - name: riscv
   - name: rktnetes
   - name: ro-users
   - name: rukpak-dev


### PR DESCRIPTION
For discussions about bringing RISC-V support
to Kubernetes.

No SIG at this point.