### PR TITLE
[1.30] Updates RT Slack groups

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -49,16 +49,21 @@ usergroups:
       - sig-release
     members:
       - cpanato # SIG Release Technical Lead
+      - drewhagen # 1.30 Docs Lead
+      - fsmunoz # 1.30 RT Lead Shadow
+      - gracenng # 1.30 RT EA
       - jeremyrickard # SIG Release Chair
       - justaugustus # SIG Release Chair
-      - mehabhalodiya # 1.29 RT Lead Shadow
-      - mickeyboxell # 1.29 RT Lead Shadow
-      - neoaggelos # 1.29 RT Lead Shadow
-      - Priyankasaggu11929 # 1.29 RT Lead
+      - katcosgrove # 1.30 RT Lead
+      - kcmartin # 1.30 Comms Lead
+      - Mohammad Reza Saleh # 1.30 Enhancements Lead
+      - neoaggelos # 1.30 RT Lead Shadow
+      - pacoxu # 1.30 Release Signal Lead
       - puerco # SIG Release Technical Lead
-      - ramrodo # 1.29 RT Lead Shadow
-      - salaxander # 1.29 Emeritus Adviser
+      - ramrodo # 1.30 RT Lead Shadow
+      - rashan # 1.30 Release Notes Lead
       - saschagrunert # SIG Release Chair
+      - Sanchita Mishra # 1.30 RT Lead Shadow
       - Verolop # SIG Release Technical Lead
 
   # Should match SIG Release Leads at all times:

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -62,6 +62,7 @@ users:
   divya-mohan0209: UV4J7K97Z
   dntosas: UKT4D74F3
   dougm: U8GG20UE9
+  drewhagen: U01NTKZDPLK
   elezar: ULV21K3CH
   elsony: UCW8323KL
   enj: U2T4CVDTJ
@@ -73,6 +74,7 @@ users:
   feiskyer: U0ASA4398
   feloy: UFG7CN85U
   furkatgofurov7: UV31DL3CG
+  fsmunoz: U03DL8UAEMQ
   g-gaston: U01SS3GFELV
   gianarb: U0FSCELCR
   girishramnani: U9M4K75EU
@@ -126,6 +128,7 @@ users:
   kaslin: U5ENKU0AE
   katcosgrove: U01GDERGEHF
   katharine: UBTBNJ6GL
+  kcmartin: U8R3WUGM7
   kikisdeliveryservice: U9HFFRFT2
   killianmuldoon: UGW727X6Z
   kim-tsao: U02U1LDH4T1
@@ -161,6 +164,7 @@ users:
   mjlshen: UN08SUPPD
   mkorbi: UEBLUUA0P
   mohammedzee1000: U3PFFE8CD
+  Mohammad Reza Saleh: U02GM9ZLELB
   MonzElmasry: U018U96HYDQ
   mrbobbytables: U511ZSKHD
   mspreitz: U0E40F05R
@@ -197,6 +201,7 @@ users:
   r-lawton: U019CNHR2E6
   rajula96reddy: U7K9EK1HC
   ramrodo: UU74ZC2RX
+  rashan: U01NTKZDPLK
   rashmigottipati: U013T1DD3PW
   razashahid107: U05FB1L2YM8
   reylejano: U01GDNJL5MW
@@ -210,6 +215,7 @@ users:
   sadysnaat: UNQPKAQHE
   salaxander: UDHV1RXB2
   sammy: U8NJFL023
+  Sanchita Mishra: U04BT49MD5W
   sandipanpanda: U02A47HJ517
   SaranBalaji90: U6PNPSULW
   saschagrunert: U53SUDBD4


### PR DESCRIPTION
Adds the release team to Slack groups for v1.30 cycle.

cc: @kubernetes/sig-release-leads 