### PR TITLE
Added hydrophone slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -168,6 +168,7 @@ channels:
     id: C678BMZ89
   - name: hetzner
   - name: homelab
+  - name: hydrophone
   - name: id-events
   - name: id-users
   - name: il-users


### PR DESCRIPTION
Adding the #hydrophone slack channel for https://github.com/kubernetes-sigs/hydrophone which is part of sig-testing. 
