### PR TITLE
Add Stefan as tech lead for sig-api-machinery

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,6 +3,7 @@ aliases:
     - deads2k
     - fedebongio
     - jpbetz
+    - sttts
   sig-apps-leads:
     - janetkuo
     - kow3ns

--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -35,6 +35,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 
 * David Eads (**[@deads2k](https://github.com/deads2k)**), Red Hat
 * Joe Betz (**[@jpbetz](https://github.com/jpbetz)**), Google
+* Stefan Schimanski (**[@sttts](https://github.com/sttts)**), Upbound
 
 ## Contact
 - Slack: [#sig-api-machinery](https://kubernetes.slack.com/messages/sig-api-machinery)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -24,6 +24,9 @@ sigs:
     - github: jpbetz
       name: Joe Betz
       company: Google
+    - github: sttts
+      name: Stefan Schimanski
+      company: Upbound
   meetings:
   - description: Kubebuilder Meeting
     day: Thursday


### PR DESCRIPTION
Stefan has spent eight years working in kubernetes, the majority of those in the apimachinery area developing key infrastructure like CRDs and the less glamorous code like code generators.  His knowledge of the apiserver internals, type system, schemes, generators, clients, controller libraries, binary helper libraries, and all aspects of the apimachinery stack are very deep.

/assign @jpbetz @fedebongio @sttts 