### PR TITLE
Add some slack channels for SIG Network

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -473,6 +473,7 @@ channels:
   - name: sig-instrumentation
   - name: sig-multicluster
   - name: sig-network
+  - name: sig-network-kni
   - name: sig-network-multi-network
   # sig-node channels are defined in sig-node/
   - name: sig-scalability

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -32,6 +32,7 @@ channels:
   - name: azure-service-operator
   - name: bazel
   - name: bindings-discuss
+  - name: blixt
   - name: bootkube
     archived: true
   - name: bpfman


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

This adds a Slack channel for the contributors of https://github.com/kubernetes-sigs/blixt, and also a channel for the SIG Network KNI KEP which resolves #7703.