### PR TITLE
slack-config: Archive appscode slack channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -266,6 +266,7 @@ channels:
   - name: kubectl-trace
   - name: kubectl-validate
   - name: kubedb
+    archived: true
   - name: kubeinit
   - name: kubekhan
     archived: true
@@ -273,6 +274,7 @@ channels:
   - name: kubemove
   - name: kubeone
   - name: kubepack
+    archived: true
   - name: kubestack
   - name: kubestellar-dev
   - name: kuberhealthy
@@ -403,6 +405,7 @@ channels:
   - name: paralus
   - name: pepr
   - name: pharmer
+    archived: true
   - name: pinniped
   - name: pl-users
   - name: podman-desktop


### PR DESCRIPTION
These slack channels were related to various [AppsCode](https://appscode.com) projects. We stopped using these channels 2-3 years ago and moved over to our own discord channels. Now, we would like to archive them to avoid confusion among the users. Your help in this matter is much appreciated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
