### PR TITLE
slack config: add Cozystack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -90,6 +90,7 @@ channels:
   - name: contour
   - name: contributor-summit
   - name: controller-runtime
+  - name: cozystack
   - name: craft
   - name: crash-diagnostics
   - name: crd-installation


### PR DESCRIPTION
Heya, I'd like to propose creating a Slack channel for [Cozystack](https://github.com/aenix-io/cozystack).

Cozystack is a free PaaS platform offering seamless management of virtual machines, managed Kubernetes, and Database-as-a-Service solutions.

After developing [Kubefarm](https://kubernetes.io/blog/2021/12/22/kubernetes-in-kubernetes-and-pxe-bootable-server-farm/) for some time, we decided to embark on a new project aimed at assisting cloud providers in building cloud infrastructures using pure Kubernetes on bare metal.

We have only recently made our public release a few days ago, but we already see a lot of potential in the community.

Our platform integrates numerous CNCF projects, including Kubernetes, Talos Linux, KubeVirt, Kamaji, FluxCD, Cluster API, Cert-Manager, Piraeus, Kube-OVN, Cilium, MetalLB, among others.

We are keen to collaborate closely with these projects. Therefore, it would be highly beneficial to have a dedicated space for communication with peers in the Kubernetes community.