### PR TITLE
sig-architecture: add apisnoop subproject

### DIFF
--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -65,6 +65,10 @@ The following [working groups][working-group-definition] are sponsored by sig-ar
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-architecture:
+### apisnoop
+Snooping on the Kubernetes OpenAPI communications
+- **Owners:**
+  - [kubernetes-sigs/apisnoop](https://github.com/kubernetes-sigs/apisnoop/blob/main/OWNERS)
 ### architecture-and-api-governance
 [Described below](#architecture-and-api-governance-1)
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -346,6 +346,10 @@ sigs:
       github: BenTheElder
       name: Benjamin Elder
   subprojects:
+  - name: apisnoop
+    description: Snooping on the Kubernetes OpenAPI communications
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/apisnoop/main/OWNERS
   - name: architecture-and-api-governance
     description: '[Described below](#architecture-and-api-governance-1)'
     owners:


### PR DESCRIPTION
Towards https://github.com/kubernetes/org/issues/4705

/assign @kubernetes/sig-architecture-leads 
for LGTM
/hold