### PR TITLE
Fix integration-tests  specific test

### DIFF
--- a/contributors/devel/sig-testing/integration-tests.md
+++ b/contributors/devel/sig-testing/integration-tests.md
@@ -71,7 +71,7 @@ to run a specific integration test case:
 
 ```sh
 # Run integration test TestPodUpdateActiveDeadlineSeconds with the verbose flag set.
-make test-integration WHAT=./test/integration/pods GOFLAGS="-v" KUBE_TEST_ARGS="-run ^TestPodUpdateActiveDeadlineSeconds$"
+make test-integration WHAT=./test/integration/pods GOFLAGS="-v" KUBE_TEST_ARGS="-run ^TestPodUpdateActiveDeadlineSeconds\$\$\$\$"
 ```
 
 If you set `KUBE_TEST_ARGS`, the test case will be run with only the `v1` API


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

If you want to use a dollar sign inside a Makefile you need to escape $ with an extra $, so double it.

Use below command to check, `TestAPIServerMetricsNamespaces` should not run
```
make test-integration WHAT=./test/integration/metrics GOFLAGS="-v" KUBE_TEST_ARGS="-run ^TestAPIServerMetrics$" KUBE_VERBOSE=2

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
