### PR TITLE
Add a new requirement to org membership - updated gitdm!

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -39,6 +39,8 @@ remain active contributors to the community.
 ### Requirements
 
 - Enabled [two-factor authentication] on their GitHub account
+- Updated their GitHub username, company affiliation and email in [CNCF gitdm]. If you are
+  not affiliated with a company please mark yourself as "Independent".
 - Have made **multiple contributions** to the project or community, enough to
   demonstrate an **ongoing and long-term commitment** to the project.
   Contributions may include, but is not limited to:
@@ -250,3 +252,4 @@ before being able to contribute effectively.
 [continuously active]: #inactive-members
 [sig-governance-subproject-lead]: /committee-steering/governance/sig-governance.md#subproject-lead
 [sig-governance-subproject-owner]: /committee-steering/governance/sig-governance.md#subproject-owner
+[CNCF gitdm]: https://github.com/cncf/gitdm

--- a/community-membership.md
+++ b/community-membership.md
@@ -39,8 +39,14 @@ remain active contributors to the community.
 ### Requirements
 
 - Enabled [two-factor authentication] on their GitHub account
-- Updated their GitHub username, company affiliation and email in [CNCF gitdm]. If you are
-  not affiliated with a company please mark yourself as "Independent".
+- Ensure GitHub username, company affiliation and email in [CNCF gitdm] are
+  up to date. If you are not affiliated with a company please mark yourself as
+  "Independent". 
+    - gitdm is primarily used by [devstats] to track contributions from the
+      many companies involved in the ecosystem. Kubernetes also uses it to
+      ensure org membership sponsors are from different member companies.
+- Ensure affiliation is up to date in [openprofile.dev]. 
+  - openprofile.dev will replace gitdm in the future to track affiliation.
 - Have made **multiple contributions** to the project or community, enough to
   demonstrate an **ongoing and long-term commitment** to the project.
   Contributions may include, but is not limited to:

--- a/community-membership.md
+++ b/community-membership.md
@@ -259,3 +259,5 @@ before being able to contribute effectively.
 [sig-governance-subproject-lead]: /committee-steering/governance/sig-governance.md#subproject-lead
 [sig-governance-subproject-owner]: /committee-steering/governance/sig-governance.md#subproject-owner
 [CNCF gitdm]: https://github.com/cncf/gitdm
+[devstats]: https://k8s.devstats.cncf.io/
+[openprofile.dev] https://openprofile.dev/edit/profile


### PR DESCRIPTION
With this:
- we ensure that they show up in devstats
- with at least the affiliation when they apply for org membership (instead of the gitdm tool guessing!)
- with at least one working email id if we ever needed to contact them

Bonus, we don't have to store that info ourselves! We should also prompt folks who have no entry there to add one with a deadline of some sort once now and once before the next pruning?