### PR TITLE
Update with the new SIG Testing - TestGrid subproject.

### DIFF
--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -106,6 +106,11 @@ Home for SIG Testing discussion and documents.
 Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
 - **Owners:**
   - [kubernetes/test-infra](https://github.com/kubernetes/test-infra/blob/master/OWNERS)
+### testgrid
+Welcome to TestGrid, a highly-configurable, interactive dashboard for viewing your test results in a grid!
+This hosts Kubernetes-related projects for TestGrid (currently, the new frontend). See https://github.com/GoogleCloudPlatform/testgrid for the main repository (currently, backend components).
+- **Owners:**
+  - [kubernetes-sigs/testgrid](https://github.com/kubernetes-sigs/testgrid/blob/main/OWNERS)
 ### testing-commons
 **[best-effort]** The testing-commons subproject focuses on matters of code structure, layout, and execution of kubernetes/kubernetes test code. It is currently staffed on a best-effort basis; please bring discussions to the sig-testing slack channel or meeting. For historical context, please see the [former testing-commons meeting agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit) and [archived testing-commons slack channel](https://kubernetes.slack.com/archives/C9NK9KFFW)
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3045,6 +3045,12 @@ sigs:
       Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
     owners:
     - https://raw.githubusercontent.com/kubernetes/test-infra/master/OWNERS
+  - name: testgrid
+    description: |
+      Welcome to TestGrid, a highly-configurable, interactive dashboard for viewing your test results in a grid!
+      This hosts Kubernetes-related projects for TestGrid (currently, the new frontend). See https://github.com/GoogleCloudPlatform/testgrid for the main repository (currently, backend components).
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/testgrid/main/OWNERS
   - name: testing-commons
     description: |
       **[best-effort]** The testing-commons subproject focuses on matters of code structure, layout, and execution of kubernetes/kubernetes test code. It is currently staffed on a best-effort basis; please bring discussions to the sig-testing slack channel or meeting. For historical context, please see the [former testing-commons meeting agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit) and [archived testing-commons slack channel](https://kubernetes.slack.com/archives/C9NK9KFFW)


### PR DESCRIPTION
Ran `make WHAT=sig-testing generate` to update the SIG Testing related docs. Follow-up to https://github.com/kubernetes/org/pull/4786.