### PR TITLE
Create the Brazilian dev channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -37,6 +37,7 @@ channels:
     archived: true
   - name: bpfman
     id: C04UJBW2553
+  - name: br-dev
   - name: brigade
   - name: camptocamp-devops-stack
   - name: canonical-kubernetes


### PR DESCRIPTION
During KCD Brazil / Sao Paulo, we have realized the need to gather more contributors from Brazil together on Kubernetes and subprojects.

While we have a channel for docs-pt contributions, the idea is that as the "in-dev" and "jp-dev" we have a more generic channels where Brazilians can join, understand process contributions, some maintainers to announce need for help or some workshops, etc.


