### PR TITLE
Update community-membership.md s/may/should/

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -41,7 +41,7 @@ remain active contributors to the community.
 - Enabled [two-factor authentication] on their GitHub account
 - Have made **multiple contributions** to the project or community, enough to
   demonstrate an **ongoing and long-term commitment** to the project.
-  Contributions may include, but is not limited to:
+  Contributions should include, but is not limited to:
     - Authoring or reviewing PRs on GitHub, with at least one **merged** PR.
       **NOTE:** The PR(s) must demonstrate an ongoing and active commitment.
       A few examples include:


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/html/rfc2119 , we can replace `may` by `should`  on the new contributors requirements to avoid misenterpretations.  The spirit of the requirements is to get people that contributes to the project across all areas, if only attend meetings is enough, per example, can be easily gamed.

