### PR TITLE
chore: add channel for kubecfg

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -266,6 +266,7 @@ channels:
   - name: kubeapps
   - name: kubebuilder
   - name: kubecon
+  - name: kubecfg
   - name: kubectl-trace
   - name: kubectl-validate
   - name: kubedb


### PR DESCRIPTION
[kubecfg](https://github.com/kubecfg/kubecfg) is a tool for managing Kubernetes resources as code. `kubecfg` allows you to express the patterns across your infrastructure and reuse these powerful "templates" across many services, and then manage those templates as files in version control.

Helps https://github.com/kubecfg/kubecfg/issues/429

---

* chore: add channel for kubecfg (f2c3c727)
      
      https://github.com/kubecfg/kubecfg