### PR TITLE
update DNS programming latency SLI

### DIFF
--- a/sig-scalability/slos/dns_programming_latency.md
+++ b/sig-scalability/slos/dns_programming_latency.md
@@ -15,8 +15,10 @@ from all of them.
 DNS will start resolving service name to its newly started backends.
 - As a user of vanilla Kubernetes, I want some guarantee how quickly in-cluster
 DNS will stop resolving service name to its removed (or unhealthy) backends.
-- As a user of vanilla Kubernetes, I wasn some guarantee how quickly newly
+- As a user of vanilla Kubernetes, I want some guarantee how quickly newly
 create services will be resolvable via in-cluster DNS.
+- As a user of vanilla Kubernetes, I want some guarantee how quickly in-cluster
+DNS will start resolving headless service hostnames to its newly started backends.
 
 ### Other notes
 - We are consciously focusing on in-cluster DNS for the purpose of this SLI,
@@ -36,6 +38,10 @@ The reason for doing it this way is feasibility for efficiently computing that:
     Ready state is reflected, we would have to know when exactly it was reflected
     in 99% of programmers (e.g. iptables). That requires tracking metrics on
     per-change base (which we can't do efficiently).
+
+- The SLI is expected to remain constant independently of the number of records, per
+example, in a headless service with thousands of pods the SLI for the first and the
+last Pod should not exhibit a statistically significant difference.
 
 ### How to measure the SLI.
 There [network programming latency](./network_programming_latency.md) is

--- a/sig-scalability/slos/dns_programming_latency.md
+++ b/sig-scalability/slos/dns_programming_latency.md
@@ -41,7 +41,7 @@ The reason for doing it this way is feasibility for efficiently computing that:
 
 - The SLI for DNS publishing should remain constant independent of the number of records.
 For example, in a headless service with thousands of pods the time between the pod being
-assigned an IP and the time DNS makes that IP availabe in the service's A/AAAA record(s)
+assigned an IP and the time DNS makes that IP available in the service's A/AAAA record(s)
 should be statisitically consistent for the first Pod and the last Pod.
 
 

--- a/sig-scalability/slos/dns_programming_latency.md
+++ b/sig-scalability/slos/dns_programming_latency.md
@@ -39,9 +39,11 @@ The reason for doing it this way is feasibility for efficiently computing that:
     in 99% of programmers (e.g. iptables). That requires tracking metrics on
     per-change base (which we can't do efficiently).
 
-- The SLI is expected to remain constant independently of the number of records, per
-example, in a headless service with thousands of pods the SLI for the first and the
-last Pod should not exhibit a statistically significant difference.
+- The SLI for DNS publishing should remain constant independent of the number of records.
+For example, in a headless service with thousands of pods the time between the pod being
+assigned an IP and the time DNS makes that IP availabe in the service's A/AAAA record(s)
+should be statisitically consistent for the first Pod and the last Pod.
+
 
 ### How to measure the SLI.
 There [network programming latency](./network_programming_latency.md) is


### PR DESCRIPTION
Update the SLI to reflect the DNS latency expectactions for headless services, that have a high impact on on AI/ML workloads that make a have use of headless services  and DNS https://github.com/kubeflow/mpi-operator/issues/611#issuecomment-1875645627

