### PR TITLE
Fix broken OWNER links in sig-etcd README

### DIFF
--- a/sig-etcd/README.md
+++ b/sig-etcd/README.md
@@ -53,7 +53,7 @@ Directly access data objects stored in etcd by kubernetes.
 ### bbolt
 An embedded key/value database for Go.
 - **Owners:**
-  - [etcd-io/bbolt/MAINTAINERS](https://github.com/etcd-io/bbolt/blob/master/MAINTAINERS)
+  - [etcd-io/bbolt](https://github.com/etcd-io/bbolt/blob/main/OWNERS)
 ### cetcd
 Serve Consul with etcd
 - **Owners:**
@@ -65,15 +65,15 @@ Distributed database benchmark tester
 ### discovery.etcd.io
 Kubernetes manifests powering discovery.etcd.io
 - **Owners:**
-  - [etcd-io/discovery.etcd.io/MAINTAINERS](https://github.com/etcd-io/discovery.etcd.io/blob/master/MAINTAINERS)
+  - [etcd-io/discovery.etcd.io](https://github.com/etcd-io/discovery.etcd.io/blob/master/OWNERS)
 ### discoveryserver
 Public etcd Discovery Service
 - **Owners:**
-  - [etcd-io/discoveryserver/MAINTAINERS](https://github.com/etcd-io/discoveryserver/blob/master/MAINTAINERS)
+  - [etcd-io/discoveryserver](https://github.com/etcd-io/discoveryserver/blob/master/OWNERS)
 ### etcd
 Distributed reliable key-value store for the most critical data of a distributed system
 - **Owners:**
-  - [etcd-io/etcd/MAINTAINERS](https://github.com/etcd-io/etcd/blob/master/MAINTAINERS)
+  - [etcd-io/etcd](https://github.com/etcd-io/etcd/blob/main/OWNERS)
 ### etcd-play
 etcd playground
 - **Owners:**
@@ -85,15 +85,15 @@ etcd playground
 ### gofail
 failpoints for go
 - **Owners:**
-  - [etcd-io/gofail/MAINTAINERS](https://github.com/etcd-io/gofail/blob/master/MAINTAINERS)
+  - [etcd-io/gofail](https://github.com/etcd-io/gofail/blob/master/OWNERS)
 ### govanityurls
 Use a custom domain in your Go import path
 - **Owners:**
-  - [etcd-io/govanityurls/MAINTAINERS](https://github.com/etcd-io/govanityurls/blob/master/MAINTAINERS)
+  - [etcd-io/govanityurls](https://github.com/etcd-io/govanityurls/blob/master/OWNERS)
 ### jetcd
 etcd java client
 - **Owners:**
-  - [etcd-io/jetcd/MAINTAINERS](https://github.com/etcd-io/jetcd/blob/master/MAINTAINERS)
+  - [etcd-io/jetcd](https://github.com/etcd-io/jetcd/blob/main/OWNERS)
 ### maintainers
 issue tracking for project wide non-code concerns
 - **Owners:**
@@ -101,15 +101,15 @@ issue tracking for project wide non-code concerns
 ### protodoc
 protodoc generates Protocol Buffer documentation.
 - **Owners:**
-  - [etcd-io/protodoc/MAINTAINERS](https://github.com/etcd-io/protodoc/blob/master/MAINTAINERS)
+  - [etcd-io/protodoc](https://github.com/etcd-io/protodoc/blob/master/OWNERS)
 ### raft
 Raft library for maintaining a replicated state machine
 - **Owners:**
-  - [etcd-io/raft/MAINTAINERS](https://github.com/etcd-io/raft/blob/master/MAINTAINERS)
+  - [etcd-io/raft](https://github.com/etcd-io/raft/blob/main/OWNERS)
 ### website
 etcd-io
 - **Owners:**
-  - [etcd-io/website/MAINTAINERS](https://github.com/etcd-io/website/blob/master/MAINTAINERS)
+  - [etcd-io/website](https://github.com/etcd-io/website/blob/main/OWNERS)
 ### zetcd
 Serve the Apache Zookeeper API but back it with an etcd cluster
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1729,7 +1729,7 @@ sigs:
   - name: bbolt
     description: An embedded key/value database for Go.
     owners:
-    - https://raw.githubusercontent.com/etcd-io/bbolt/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/bbolt/main/OWNERS
   - name: cetcd
     description: Serve Consul with etcd
     owners:
@@ -1741,16 +1741,16 @@ sigs:
   - name: discovery.etcd.io
     description: Kubernetes manifests powering discovery.etcd.io
     owners:
-    - https://raw.githubusercontent.com/etcd-io/discovery.etcd.io/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/discovery.etcd.io/master/OWNERS
   - name: discoveryserver
     description: Public etcd Discovery Service
     owners:
-    - https://raw.githubusercontent.com/etcd-io/discoveryserver/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/discoveryserver/master/OWNERS
   - name: etcd
     description: Distributed reliable key-value store for the most critical data of
       a distributed system
     owners:
-    - https://raw.githubusercontent.com/etcd-io/etcd/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/etcd/main/OWNERS
   - name: etcd-play
     description: etcd playground
     owners:
@@ -1762,15 +1762,15 @@ sigs:
   - name: gofail
     description: failpoints for go
     owners:
-    - https://raw.githubusercontent.com/etcd-io/gofail/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/gofail/master/OWNERS
   - name: govanityurls
     description: Use a custom domain in your Go import path
     owners:
-    - https://raw.githubusercontent.com/etcd-io/govanityurls/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/govanityurls/master/OWNERS
   - name: jetcd
     description: etcd java client
     owners:
-    - https://raw.githubusercontent.com/etcd-io/jetcd/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/jetcd/main/OWNERS
   - name: maintainers
     description: issue tracking for project wide non-code concerns
     owners:
@@ -1778,15 +1778,15 @@ sigs:
   - name: protodoc
     description: protodoc generates Protocol Buffer documentation.
     owners:
-    - https://raw.githubusercontent.com/etcd-io/protodoc/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/protodoc/master/OWNERS
   - name: raft
     description: Raft library for maintaining a replicated state machine
     owners:
-    - https://raw.githubusercontent.com/etcd-io/raft/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/raft/main/OWNERS
   - name: website
     description: etcd-io
     owners:
-    - https://raw.githubusercontent.com/etcd-io/website/master/MAINTAINERS
+    - https://raw.githubusercontent.com/etcd-io/website/main/OWNERS
   - name: zetcd
     description: Serve the Apache Zookeeper API but back it with an etcd cluster
     owners:


### PR DESCRIPTION
Fixed active projects' OWNER link only, mainly by changing file name from MAINTAINERS to OWNERS and updating branch name from master to main

Notice that for a repo that doesn't have a MAINTAINER or OWNER file, the link is left as-is, the `dbtester` repo.

References:
- https://github.com/etcd-io/bbolt/pull/578

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->


