### PR TITLE
Add terraform-kops slack channel.

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -510,6 +510,7 @@ channels:
   - name: tanzu-community-edition
     archived: true
   - name: tanzu-streaming-runtimes
+  - name: terraform-kops
   - name: terraform-providers
   - name: terranetes
   - name: test-failures


### PR DESCRIPTION
This PR adds the `terraform-kops` slack channel.
It will be a place for maintainers of the [github.com/terraform-kops/terraform-provider-kops](https://github.com/terraform-kops/terraform-provider-kops) project to discuss the project, which is related to Kubernetes sub-project [github.com/kubernetes/kops](https://github.com/kubernetes/kops)

cc @eddycharly