### PR TITLE
sig-network: add kube-network-policies under network-policy subproject

### DIFF
--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -120,6 +120,7 @@ The following [subprojects][subproject-definition] are owned by sig-network:
   - [kubernetes/dns](https://github.com/kubernetes/dns/blob/master/OWNERS)
 ### network-policy
 - **Owners:**
+  - [kubernetes-sigs/kube-network-policies](https://github.com/kubernetes-sigs/kube-network-policies/blob/master/OWNERS)
   - [kubernetes-sigs/network-policy-api](https://github.com/kubernetes-sigs/network-policy-api/blob/master/OWNERS)
   - [kubernetes/api/networking](https://github.com/kubernetes/api/blob/master/networking/OWNERS)
 - **Contact:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2272,6 +2272,7 @@ sigs:
     contact:
       slack: sig-network-policy-api
     owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kube-network-policies/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
   - name: node-ipam-controller


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4856

/assign @kubernetes/sig-network-leads

cc: @kubernetes/owners 