### PR TITLE
sig-release: Add inaugural subproject leads

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -68,6 +68,8 @@ The following [working groups][working-group-definition] are sponsored by sig-re
 The following [subprojects][subproject-definition] are owned by sig-release:
 ### Release Engineering
 The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
+- **Leads:**
+  - Marko Mudrinić (**[@xmudrii](https://github.com/xmudrii)**), Kubermatic
 - **Owners:**
   - [kubernetes-sigs/bom](https://github.com/kubernetes-sigs/bom/blob/main/OWNERS)
   - [kubernetes-sigs/downloadkubernetes](https://github.com/kubernetes-sigs/downloadkubernetes/blob/master/OWNERS)
@@ -103,6 +105,9 @@ The Release Engineering subproject is responsible for the [process/procedures](h
     - [@kubernetes/repo-infra-maintainers](https://github.com/orgs/kubernetes/teams/repo-infra-maintainers)
 ### Release Team
 The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
+- **Leads:**
+  - Grace Nguyen (**[@gracenng](https://github.com/gracenng)**)
+  - Kat Cosgrove (**[@katcosgrove](https://github.com/katcosgrove)**), Dell
 - **Owners:**
   - [kubernetes-sigs/release-team-shadow-stats](https://github.com/kubernetes-sigs/release-team-shadow-stats/blob/main/OWNERS)
   - [kubernetes/sig-release/release-team](https://github.com/kubernetes/sig-release/blob/master/release-team/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2513,6 +2513,10 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS
     - https://raw.githubusercontent.com/kubernetes/website/main/content/en/releases/OWNERS
     - https://raw.githubusercontent.com/kubernetes/website/main/data/releases/OWNERS
+    leads:
+    - github: xmudrii
+      name: Marko Mudrinić
+      company: Kubermatic
   - name: Release Team
     description: |
       The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
@@ -2532,6 +2536,12 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/release-team-shadow-stats/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
+    leads:
+    - github: gracenng
+      name: Grace Nguyen
+    - github: katcosgrove
+      name: Kat Cosgrove
+      company: Dell
   - name: SIG Release Process Documentation
     description: |
       Documents and processes related to SIG Release


### PR DESCRIPTION
Release Team:
- Grace Nguyen
- Kat Cosgrove

Release Engineering:
- Marko Mudrinić

Thanks for your continued dedication to SIG Release, @gracenng @katcosgrove @xmudrii!

/assign @jeremyrickard @saschagrunert 
cc: @kubernetes/sig-release-leads
/hold