### PR TITLE
sig-storage: add external-snapshot-metadata as new sub-project

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -64,6 +64,9 @@ The following [working groups][working-group-definition] are sponsored by sig-st
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-storage:
+### external-snapshot-metadata
+- **Owners:**
+  - [kubernetes-csi/external-snapshot-metadata](https://github.com/kubernetes-csi/external-snapshot-metadata/blob/main/OWNERS)
 ### external-storage
 - **Owners:**
   - [kubernetes-sigs/sig-storage-lib-external-provisioner](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2875,6 +2875,9 @@ sigs:
       github: pacoxu
       name: Paco Xu 徐俊杰
   subprojects:
+  - name: external-snapshot-metadata
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/main/OWNERS
   - name: external-storage
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-lib-external-provisioner/master/OWNERS


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4874

/assign @kubernetes/sig-storage-leads

cc: @kubernetes/owners