### PR TITLE
Kueue: Add Aldo and Yuki to leads roles

### DIFF
--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -85,6 +85,9 @@ The following [subprojects][subproject-definition] are owned by sig-scheduling:
 - **Owners:**
   - [kubernetes-sigs/kube-scheduler-wasm-extension](https://github.com/kubernetes-sigs/kube-scheduler-wasm-extension/blob/main/OWNERS)
 ### kueue
+- **Leads:**
+  - Aldo Culquicondor (**[@alculquicondor](https://github.com/alculquicondor)**), Google
+  - Yuki Iwai (**[@tenzen-y](https://github.com/tenzen-y)**), CyberAgent, Inc.
 - **Owners:**
   - [kubernetes-sigs/kueue](https://github.com/kubernetes-sigs/kueue/blob/main/OWNERS)
 ### kwok

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2735,6 +2735,13 @@ sigs:
   - name: kueue
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kueue/main/OWNERS
+    leads:
+    - github: alculquicondor
+      name: Aldo Culquicondor
+      company: Google
+    - github: tenzen-y
+      name: Yuki Iwai
+      company: CyberAgent, Inc.
   - name: kwok
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/kwok/main/OWNERS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Based on discussions with @alculquicondor, this PR adds @alculquicondor and @tenzen-y to Kueue leads.

