### PR TITLE
sig-testing: remove outdated links to prow OWNERS

### DIFF
--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -96,7 +96,6 @@ It is the next significant iteration of kubetest. We will be deprecating kubetes
 Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
 - **Owners:**
   - [kubernetes-sigs/prow](https://github.com/kubernetes-sigs/prow/blob/main/OWNERS)
-  - [kubernetes/test-infra/prow](https://github.com/kubernetes/test-infra/blob/master/prow/OWNERS)
 - **Contact:**
   - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
 ### sig-testing

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3049,7 +3049,6 @@ sigs:
       slack: prow
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/prow/main/OWNERS
-    - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
   - name: sig-testing
     description: |
       Home for SIG Testing discussion and documents.


### PR DESCRIPTION
prow has been migrated out of the test-infra repository and this file
has been deleted
