### PR TITLE
Fix broken links in sig-scalability README

### DIFF
--- a/sig-scalability/README.md
+++ b/sig-scalability/README.md
@@ -41,13 +41,9 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scale)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscalability)
 - GitHub Teams:
-    - [@kubernetes/sig-scalability-api-reviews](https://github.com/orgs/kubernetes/teams/sig-scalability-api-reviews) - API Changes and Reviews
-    - [@kubernetes/sig-scalability-bugs](https://github.com/orgs/kubernetes/teams/sig-scalability-bugs) - Bug Triage and Troubleshooting
-    - [@kubernetes/sig-scalability-feature-requests](https://github.com/orgs/kubernetes/teams/sig-scalability-feature-requests) - Feature Requests
-    - [@kubernetes/sig-scalability-misc](https://github.com/orgs/kubernetes/teams/sig-scalability-misc) - General Discussion
+    - [@kubernetes/sig-scalability](https://github.com/orgs/kubernetes/teams/sig-scalability) - General Discussion
+    - [@kubernetes/sig-scalability-leads](https://github.com/orgs/kubernetes/teams/sig-scalability-leads) - Leads
     - [@kubernetes/sig-scalability-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-scalability-pr-reviews) - PR Reviews
-    - [@kubernetes/sig-scalability-proprosals](https://github.com/orgs/kubernetes/teams/sig-scalability-proprosals) - Design Proposals
-    - [@kubernetes/sig-scalability-test-failures](https://github.com/orgs/kubernetes/teams/sig-scalability-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Bob Killen (**[@mrbobbytables](https://github.com/mrbobbytables)**)
 
 ## Subprojects

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2594,20 +2594,12 @@ sigs:
     slack: sig-scalability
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-scale
     teams:
-    - name: sig-scalability-api-reviews
-      description: API Changes and Reviews
-    - name: sig-scalability-bugs
-      description: Bug Triage and Troubleshooting
-    - name: sig-scalability-feature-requests
-      description: Feature Requests
-    - name: sig-scalability-misc
+    - name: sig-scalability
       description: General Discussion
+    - name: sig-scalability-leads
+      description: Leads
     - name: sig-scalability-pr-reviews
       description: PR Reviews
-    - name: sig-scalability-proprosals
-      description: Design Proposals
-    - name: sig-scalability-test-failures
-      description: Test Failures and Triage
     liaison:
       github: mrbobbytables
       name: Bob Killen


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
This PR fixes the broken links to `GitHub-Teams` in the `sig-scalability` README file:
1. Remove non-existing links
2. Add two new links

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/community/issues/7869
