### PR TITLE
Update comms handbook for contributor summit

### DIFF
--- a/events/events-team/marketing/README.md
+++ b/events/events-team/marketing/README.md
@@ -1,6 +1,6 @@
-# Marketing Lead Handbook
+# Communications Lead Handbook
 
-This document defines marketing planning and activities needed to run a
+This document defines communications and marketing activities needed to run a
 Contributor Summit.
 
 - [Overview](#overview)
@@ -11,78 +11,110 @@ Contributor Summit.
 
 ## Overview
 
-As Marketing Lead, you are responsible for the overall marketing communications
-timeline. The role also includes ensuring all non-technical content (web, mail,
+As Communications Lead, you are responsible for the overall marketing communications 
+before, during, and after the event. The role also includes ensuring all non-technical content (web, mail,
 physical prints) is correct and informative, and supporting the other roles
 (registration, content) as needed.
 
 Time Commitment:
 - 1-3 hours a week from 0-1.5 months in
-- 2-5 hours a week from 1.5 months-to event
+- 3-5 hours a week from 1.5 months-to event
 
 ## Skills and Qualifications
 
 - Good grasp on general marketing activities surrounding events  
 - Understanding of common forms of marketing communications
 - Event planning experience
+- If working on the website, you'll need HTML/CSS/JavaScript experience
+- A healthy emoji vocabulary!
 
 ## Responsibilities
 
-- Create a communication schedule - what, when, how, who  
-- Manage online presence - website, social media strategy  
-- Potentially recruit a social media coordinator role  
-- Provide updates on social media, mailing lists, and Slack throughout pre-,
-  during-, and post-event
-- Assist with GitHub event repo adds and edits
-- Work with Event Lead on a recap blog
-- Determine signage needs and copy, coordinate with CNCF on explicit needs  
-- Create/update deck templates for curated talks and/or other purposes
+- Create a communication schedule regarding the event - what, when, how, who
+  - This includes email, Slack, and social media (via the Buffer platform with Contributor Comms)
+  - You'll source the informaton needed from your fellow leads, and can refer to prior art (linked below) for templates
+- Manage online presence of the website, alongside the social media strategy
+- Recruit a website lead to handle all updates to the website
+  - Consider ensuring website reviewers/approvers are on the team to merge upstream changes
+- Provide updates on social media, mailing lists, and Slack before, during, and after the event
+  - After-event communications will include a post-event survey, created by SIG ContribEx leads
+- Work alongside the CNCF Events Team to coordinate communications efforts
+- Assist with deck content for curated talks and/or other purposes
 
 ### Communication Channels and Property Access
 
 Communications to the Kubernetes Contributor Community should be sent from
 official Kubernetes accounts to ensure they reach the community. Mass messages
-from personal accounts can easily wind up being marked as spam.
+from personal accounts can easily wind up being marked as spam. However, in the event 
+that you lead Communications and _aren't_ a member of the [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md), 
+personal email accounts can be used. Please check with the current Event Lead and 
+Emeritus Leads on the best course of action.
 
 **Email**
 
-Mail should be sent from the contributors@kubernetes.io account. For access, work
-with the event lead who will coordinate with [SIG Contributor Experience leads] 
-to grant temporary access to the account for the duration of the event.
+Unless you have access to official Kubernetes accounts, please use your own email account 
+to send all email communications. All emails should include summit-team@kubernetes.io in CC each time. 
+The Event Lead will add all team leads to this distribution list. 
+Outbound communications should always target the main distrubution list, dev@kubernetes.io, as well 
+as the co-chairs and tech leads distribution list, leads@kubernetes.io, when necessary.
 
-**Twitter**
+While it is appreciated that you triage incoming mail for summit-team@kubernetes.io to 
+varying team leads, you are not responsible for answering all incoming messages. The entire 
+summit planning team should triage and handle their ownership areas when it comes to email communications, 
+respectively.
 
-Tweets can be sent from two accounts: [@K8sContributors] and [@Kubernetesio].
+**Website**
 
-Tweets targeting the greater Kubernetes community should use the [@Kubernetesio]
-account. Tweets using this account must be coordinated with the [CNCF]. Work
-with the CNCF events rep to schedule the tweets or put you in contact with
-the CNCF marketing members in charge of the account. Tweets using this account
-are often limited in the content and quantity that may be sent.
+The [Contributor Site](https://www.kubernetes.dev/) should be the source of truth for all Contributor Summit information. 
+As timing, location, registration, and schedule information is confirmed for the event, the website should be populated 
+as soon as possible. The [`OWNERS`](https://github.com/kubernetes/contributor-site/blob/master/OWNERS) file defines 
+who can approve upstream changes.
 
-Tweets targeting the current contributor base should use the [@K8sContributors]
-account. There are no restrictions with this account for the amount or kind of
-messages that may be sent. This account may be used for announcements,
-live-tweeting, pictures and more. Reach out to the Kubernetes [Contributor Comms] to schedule or use this account.
+All communications via email and social media should link out to the Contributor Site whenever possible. The 
+["Events"](https://www.kubernetes.dev/events/) top-level page is where all Contributor Summit information is 
+organized, by calendar year. 
 
+**Slack**
 
-## Shadow to the Marketing Lead Role
+Slack messaging should be implemented so that all corners of our community are communicated with. Let your emoji power shine! 
+The following channels will be important for all major announcements, plus most reminders:
+- **#contributor-summit**
+- **#kubernetes-org-members**
+- **#chairs-and-techleads**
 
-This role can include one or more shadows. The Marketing Lead can delegate/assign
-tasks to the shadows. The expectation from a shadow is to lead one of the
-events-team roles in an upcoming summit. The shadows to the Marketing Lead are
-responsible for handling all Marketing lead related activities in the absence of
-the Lead.
+Please contact the [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md) for access to the Announcement 
+bot in the Kubernetes Slack, which will be useful for broadcasts. The **#contributor-summit** channel should be used for all day-of 
+event communications by you and other summit sub-teams. Contributors and attendees will also ask questions here: this channel should 
+be monitored up until the day of the summit (the Day-of Ops Team will work with you on communications and monitoring on the 
+day of the event).
 
+**X and Mastodon**
+
+Tweets can be sent from two accounts: [@K8sContributors](https://twitter.com/K8sContributors) and [@Kubernetesio](https://twitter.com/kubernetesio). 
+Mastodon uses [@K8sContributors](https://hachyderm.io/@K8sContributors) on the hachyderm.io instance. 
+Messaging is coordinated via Buffer, which is owned by the [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md). 
+Please work with the Contributor Comms team for access.
+
+Announcements, live-tweeting, and pictures are all suitable updates for sharing on social media. 
+Most emails sent should have this information mirrored on social media, with links out to the 
+website for further information.
+
+## Shadow to the Communications Lead Role
+
+This role should include one or more shadows. The Communications Lead should delegate/assign
+tasks to the shadows, including the drafting of emails and Slack/social media posts. 
+The expectation from a shadow is to lead one of the summit planning team roles in an upcoming summit. 
+The shadows to the Communications Lead are responsible for handling all Communications Lead-related 
+activities in the absence of the Lead.
 
 ## Documentation
 
-[Email comms used for Contributor Summit Barcelona, 2019]
-
-
-[Email comms used for Contributor Summit Barcelona, 2019]: /events/2019/05-contributor-summit/communications.md
-[SIG Contributor Experience leads]: /sig-contributor-experience/README.md#leadership
-[@K8sContributors]: https://twitter.com/K8sContributors
-[@Kubernetesio]: https://twitter.com/kubernetesio
-[CNCF]: https://www.cncf.io/
-[SIG-ContribEx Contributor Comms team]: /communication/contributor-comms/README.md
+- [Email comms used for Contributor Summit EU in Paris, 2024](https://drive.google.com/drive/folders/1m2sRXVp_S37V46jPk9SS3pznFZKq41uI?usp=drive_link) (Requires access – please ask Contributor Comms)
+- [Email comms used for Contributor Summit EU in Barcelona, 2019](/events/2019/05-contributor-summit/communications.md)
+- [Contributor Site](https://www.kubernetes.dev/)
+- [SIG Contributor Experience leads](/sig-contributor-experience/README.md#leadership)
+- [@K8sContributors on X](https://twitter.com/K8sContributors)
+- [@Kubernetesio on X](https://twitter.com/kubernetesio)
+- [@K8sContributors on Mastodon](https://hachyderm.io/@K8sContributors)
+- [CNCF](https://www.cncf.io/)
+- [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md)

--- a/events/events-team/marketing/README.md
+++ b/events/events-team/marketing/README.md
@@ -11,7 +11,7 @@ Contributor Summit.
 
 ## Overview
 
-As Communications Lead, you are responsible for the overall marketing communications 
+As Communications Lead, you are responsible for the overall marketing communications
 before, during, and after the event. The role also includes ensuring all non-technical content (web, mail,
 physical prints) is correct and informative, and supporting the other roles
 (registration, content) as needed.
@@ -22,7 +22,7 @@ Time Commitment:
 
 ## Skills and Qualifications
 
-- Good grasp on general marketing activities surrounding events  
+- Good grasp on general marketing activities surrounding events
 - Understanding of common forms of marketing communications
 - Event planning experience
 - If working on the website, you'll need HTML/CSS/JavaScript experience
@@ -45,66 +45,66 @@ Time Commitment:
 
 Communications to the Kubernetes Contributor Community should be sent from
 official Kubernetes accounts to ensure they reach the community. Mass messages
-from personal accounts can easily wind up being marked as spam. However, in the event 
-that you lead Communications and _aren't_ a member of the [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md), 
-personal email accounts can be used. Please check with the current Event Lead and 
+from personal accounts can easily wind up being marked as spam. However, in the event
+that you lead Communications and _aren't_ a member of the [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md),
+personal email accounts can be used. Please check with the current Event Lead and
 Emeritus Leads on the best course of action.
 
 **Email**
 
-Unless you have access to official Kubernetes accounts, please use your own email account 
-to send all email communications. All emails should include summit-team@kubernetes.io in CC each time. 
-The Event Lead will add all team leads to this distribution list. 
-Outbound communications should always target the main distrubution list, dev@kubernetes.io, as well 
+Unless you have access to official Kubernetes accounts, please use your own email account
+to send all email communications. All emails should include summit-team@kubernetes.io in CC each time.
+The Event Lead will add all team leads to this distribution list.
+Outbound communications should always target the main distribution list, dev@kubernetes.io, as well
 as the co-chairs and tech leads distribution list, leads@kubernetes.io, when necessary.
 
-While it is appreciated that you triage incoming mail for summit-team@kubernetes.io to 
-varying team leads, you are not responsible for answering all incoming messages. The entire 
-summit planning team should triage and handle their ownership areas when it comes to email communications, 
+While it is appreciated that you triage incoming mail for summit-team@kubernetes.io to
+varying team leads, you are not responsible for answering all incoming messages. The entire
+summit planning team should triage and handle their ownership areas when it comes to email communications,
 respectively.
 
 **Website**
 
-The [Contributor Site](https://www.kubernetes.dev/) should be the source of truth for all Contributor Summit information. 
-As timing, location, registration, and schedule information is confirmed for the event, the website should be populated 
-as soon as possible. The [`OWNERS`](https://github.com/kubernetes/contributor-site/blob/master/OWNERS) file defines 
+The [Contributor Site](https://www.kubernetes.dev/) should be the source of truth for all Contributor Summit information.
+As timing, location, registration, and schedule information is confirmed for the event, the website should be populated
+as soon as possible. The [`OWNERS`](https://github.com/kubernetes/contributor-site/blob/master/OWNERS) file defines
 who can approve upstream changes.
 
-All communications via email and social media should link out to the Contributor Site whenever possible. The 
-["Events"](https://www.kubernetes.dev/events/) top-level page is where all Contributor Summit information is 
+All communications via email and social media should link out to the Contributor Site whenever possible. The
+["Events"](https://www.kubernetes.dev/events/) top-level page is where all Contributor Summit information is
 organized, by calendar year. 
 
 **Slack**
 
-Slack messaging should be implemented so that all corners of our community are communicated with. Let your emoji power shine! 
+Slack messaging should be implemented so that all corners of our community are communicated with. Let your emoji power shine!
 The following channels will be important for all major announcements, plus most reminders:
 - **#contributor-summit**
 - **#kubernetes-org-members**
 - **#chairs-and-techleads**
 
-Please contact the [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md) for access to the Announcement 
-bot in the Kubernetes Slack, which will be useful for broadcasts. The **#contributor-summit** channel should be used for all day-of 
-event communications by you and other summit sub-teams. Contributors and attendees will also ask questions here: this channel should 
-be monitored up until the day of the summit (the Day-of Ops Team will work with you on communications and monitoring on the 
+Please contact the [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md) for access to the Announcement
+bot in the Kubernetes Slack, which will be useful for broadcasts. The **#contributor-summit** channel should be used for all day-of
+event communications by you and other summit sub-teams. Contributors and attendees will also ask questions here: this channel should
+be monitored up until the day of the summit (the Day-of Ops Team will work with you on communications and monitoring on the
 day of the event).
 
 **X and Mastodon**
 
-Tweets can be sent from two accounts: [@K8sContributors](https://twitter.com/K8sContributors) and [@Kubernetesio](https://twitter.com/kubernetesio). 
-Mastodon uses [@K8sContributors](https://hachyderm.io/@K8sContributors) on the hachyderm.io instance. 
-Messaging is coordinated via Buffer, which is owned by the [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md). 
+Tweets can be sent from two accounts: [@K8sContributors](https://twitter.com/K8sContributors) and [@Kubernetesio](https://twitter.com/kubernetesio).
+Mastodon uses [@K8sContributors](https://hachyderm.io/@K8sContributors) on the hachyderm.io instance.
+Messaging is coordinated via Buffer, which is owned by the [SIG ContribEx Contributor Comms team](/communication/contributor-comms/README.md).
 Please work with the Contributor Comms team for access.
 
-Announcements, live-tweeting, and pictures are all suitable updates for sharing on social media. 
-Most emails sent should have this information mirrored on social media, with links out to the 
+Announcements, live-tweeting, and pictures are all suitable updates for sharing on social media.
+Most emails sent should have this information mirrored on social media, with links out to the
 website for further information.
 
 ## Shadow to the Communications Lead Role
 
 This role should include one or more shadows. The Communications Lead should delegate/assign
-tasks to the shadows, including the drafting of emails and Slack/social media posts. 
-The expectation from a shadow is to lead one of the summit planning team roles in an upcoming summit. 
-The shadows to the Communications Lead are responsible for handling all Communications Lead-related 
+tasks to the shadows, including the drafting of emails and Slack/social media posts.
+The expectation from a shadow is to lead one of the summit planning team roles in an upcoming summit.
+The shadows to the Communications Lead are responsible for handling all Communications Lead-related
 activities in the absence of the Lead.
 
 ## Documentation


### PR DESCRIPTION
This PR updates the Communications Team handbook:

- Add the renamed role name to avoid confusion for future leads/shadows
- Adds explanatory sections for the website, Slack
- Updates social media names and links (with the main k8s X account currently transitioning to ContribEx)
- Adds link to prior GDrive for comms templates