### PR TITLE
Add ThatsMrTalbot to the cert-manager-maintainers group on Slack

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -318,6 +318,7 @@ usergroups:
       - irbekrm
       - sgtcodfish
       - inteon
+      - ThatsMrTalbot
 
   - name: gophercloud-maintainers
     long_name: Gophercloud Maintainers

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -256,6 +256,7 @@ users:
   tallclair: U64VCBURE
   TaoBeier: UCLDV6MN1
   tejal29: UACD7R316
+  ThatsMrTalbot: U7QBP08LR
   theishshah: U01891A4TRS
   thejoycekung: U01AY4VHX25
   thepetk: U04NW4PPY8N


### PR DESCRIPTION
I created the group `@cert-manager-maintainers` a while back in #7368. Today, @ThatsMrTalbot was added as a maintainer after a vote (https://github.com/cert-manager/community/pull/23) and I'd like to add Adam to the Slack handle `@cert-manager-maintainers`.