### PR TITLE
Add contribex-comms blog shadow guide

### DIFF
--- a/communication/contributor-comms/blogging-resources/blogging-shadow-guide.md
+++ b/communication/contributor-comms/blogging-resources/blogging-shadow-guide.md
@@ -1,0 +1,94 @@
+# Contributor Comms Blogging: Shadow Guide
+
+Contribex Comms has leads for different areas, specifically for
+blogging where there's a Blogging Lead that takes additional
+responsibility for making sure that the blogging process not only
+works as expected, but is constantly being improved to better serve the
+goals in the [SIG charter](./CHARTER.md).
+
+Roles in SIG Contribex Comms are part of a journey where each
+individual learns and teaches, improves on what exists and eventually
+moves forward to other challenges; for this to work, it's fundamental
+to develop leadership skills in the community, and one way of doing it is
+through a shadow program.
+
+This document briefly describes the shadowing program, including the
+tasks that are expected from shadows. It is hoped that this extra
+level of detail helps shadows in their path towards additional
+responsibilities in the team.
+
+
+## Shadow Program Goals
+
+It's important to highlight that anyone is welcome to contribute with
+ideas and write articles _without being a shadow_, and the shadowing
+program is not meant to change that, but to enable it by guaranteeing
+that there's the availability to assist contributors that want to
+participate; writing and publishing articles requires a mix of
+technical and non-technical knowledge that shouldn't be an obstacle
+for participation. The Blogging Lead helps with that, and the
+shadowing program is meant to:
+
+* Open up additional venues for participation for those in the community.
+* Provide a more structured way for anyone interested in the blogging
+  side of things to learn by doing.
+* Maintain a pipeline of potential Blogging Leads.
+
+## Shadowing candidates
+
+Anyone is welcome to display their interest in becoming a shadow for
+the blogging team. For practical purposes, the team is limited to 4
+shadows to allow an adequate exposure to the tasks in a reasonable
+period of time.
+
+Anyone interested in being a shadow should indicate that desire to the
+Blogging Lead, who will help in making sure that the candidate is
+aware of the expected commitment. The main requirement for shadowing
+is a willingness to participate actively and consistently.
+
+While not requirements, the following are things that will be a part
+of the work expected from shadows, so any existing mastery of them is
+certainly a plus:
+
+* Knowledge of git and GitHub (issues, PRs, reviews, merges, etc)
+* Knowledge of the existing blogging standards, including the ones
+  external to SIG Contribex Comms (like the [SIG Docs standards](https://kubernetes.io/docs/contribute/style/style-guide/))
+* Participation in the weekly SIG Contribex Comms meetings
+
+In terms of time requirements, this is a very flexible programme since
+writing articles is something that can be done asynchronously. The
+following provides a minimal guideline:
+
+* 1h for weekly participation in the SIG Contribex Comms meeting
+* 2h per week for working on the interviews and articles (reviewing,
+  writing, etc).
+
+
+## Shadowing Program
+
+The first stage is mostly about helping and getting to know the
+process, and it includes:
+
+* Assist in reviewing an article: the shadow will review an article
+  and provide suggestions to improve it.
+* Assist in writing an interview: the shadow will suggest questions
+  and improvements to an existing interview script.
+* Assist in a GitHub PR review: the shadow will partipate in a GitHub
+  discussion during the publishing process.
+* Help contributors: the shadow will reply to contributors in the team
+  Slack channel, steering them in the right direction.
+* Propose a new topic: the shadow will identify new interesting
+  articles and add them to the project board.
+
+The following stage includes tasks that require more direct
+involvement:
+
+* Write an interview script.
+* Open an Issue and a PR to publish the completed article.
+* Carry an article from inception to publication, updating the project
+  board and providing updates in the Slack channel throughout the
+  article lifecycle.
+* Provide feedback during weekly meetings.
+
+This is not an exhaustive list, but it serves as an indicator of what
+a shadow will be exposed to, and what will they be expected to do.


### PR DESCRIPTION
Initial version of the Contribex Comms blogging shadowing guide.

Fixes #7875 
