### PR TITLE
add new tech leads to readme, fix sarah's name

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -46,20 +46,22 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Tim Bannister (**[@sftim](https://github.com/sftim)**), The Scale Factory
+* Kat Cosgrove ((**[@katcosgrove](https://github.com/katcosgrove)**), Dell Technologies
 * Qiming Teng (**[@tengqm](https://github.com/tengqm)**), Sangfor Technologies
+* Xander Grzywinski (**[@salaxander](https://github.com/salaxander)**), Defense Unicorns
 
 ## Emeritus Leads
 
-* Jennifer Rondeau (**[@Bradamant3](https://github.com/Bradamant3)**)
 * Andrew Chen (**[@chenopis](https://github.com/chenopis)**)
 * Irvi Aini (**[@irvifa](https://github.com/irvifa)**)
 * Jared Bhatti (**[@jaredbhatti](https://github.com/jaredbhatti)**)
+* Jennifer Rondeau (**[@Bradamant3](https://github.com/Bradamant3)**)
 * Jim Angel (**[@jimangel](https://github.com/jimangel)**)
 * Kaitlyn Barnard (**[@kbarnard10](https://github.com/kbarnard10)**)
 * Karen Bradshaw (**[@kbhawkey](https://github.com/kbhawkey)**)
 * Taylor Dolezal (**[@onlydole](https://github.com/onlydole)**)
-* Zach Corleissen (**[@zacharysarah](https://github.com/zacharysarah)**)
+* Tim Bannister (**[@sftim](https://github.com/sftim)**)
+* Sarah Corleissen (**[@zacharysarah](https://github.com/zacharysarah)**)
 
 ## Contact
 - Slack: [#sig-docs](https://kubernetes.slack.com/messages/sig-docs)


### PR DESCRIPTION
This PR updates our README to reflect the addition of our new Tech Leads, Kat Cosgrove and Xander Grzywinski. It also moves Tim Bannister to Emeritus, while we also update Sarah's name (it was incorrect previously).

/cc @divya-mohan0209 @reylejano 
/sig docs