### PR TITLE
docs: remove outdated warning

### DIFF
--- a/contributors/guide/owners.md
+++ b/contributors/guide/owners.md
@@ -92,9 +92,6 @@ filters:
 
 Instead, set a `.*` key inside `filters` (as shown in the previous example).
 
-**WARNING**: The `approve` plugin [does not currently respect `filters`][test-infra-7690].
-Until that is fixed, `filters` should only be used for the `labels` key (as shown in the above example).
-
 
 #### Emeritus
 

--- a/contributors/guide/owners.md
+++ b/contributors/guide/owners.md
@@ -92,7 +92,6 @@ filters:
 
 Instead, set a `.*` key inside `filters` (as shown in the previous example).
 
-
 #### Emeritus
 
 It is inevitable, but there are times when someone may shift focuses, change jobs or step away from


### PR DESCRIPTION
Warning message about filters on OWNERS files not working for the approve plugin links to <https://github.com/kubernetes/test-infra/issues/7690>, which appears to be resolved.
