### PR TITLE
SIG Cloud Provider update

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,11 +27,9 @@ aliases:
     - mpuckett159
     - soltysh
   sig-cloud-provider-leads:
-    - andrewsykim
     - bridgetkromhout
     - cheftako
     - elmiko
-    - nckturner
   sig-cluster-lifecycle-leads:
     - fabriziopandini
     - justinsb

--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -30,14 +30,15 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Andrew Sy Kim (**[@andrewsykim](https://github.com/andrewsykim)**), Google
 * Walter Fender (**[@cheftako](https://github.com/cheftako)**), Google
-* Nick Turner (**[@nckturner](https://github.com/nckturner)**), Amazon
+* Michael McCune (**[@elmiko](https://github.com/elmiko)**), Red Hat
 
 ## Emeritus Leads
 
+* Andrew Sy Kim (**[@andrewsykim](https://github.com/andrewsykim)**)
 * Chris Hoge (**[@hogepodge](https://github.com/hogepodge)**)
 * Jago Macleod (**[@jagosan](https://github.com/jagosan)**)
+* Nick Turner (**[@nckturner](https://github.com/nckturner)**)
 
 ## Contact
 - Slack: [#sig-cloud-provider](https://kubernetes.slack.com/messages/sig-cloud-provider)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -823,20 +823,21 @@ sigs:
       name: Michael McCune
       company: Red Hat
     tech_leads:
-    - github: andrewsykim
-      name: Andrew Sy Kim
-      company: Google
     - github: cheftako
       name: Walter Fender
       company: Google
-    - github: nckturner
-      name: Nick Turner
-      company: Amazon
+    - github: elmiko
+      name: Michael McCune
+      company: Red Hat
     emeritus_leads:
+    - github: andrewsykim
+      name: Andrew Sy Kim
     - github: hogepodge
       name: Chris Hoge
     - github: jagosan
       name: Jago Macleod
+    - github: nckturner
+      name: Nick Turner
   meetings:
   - description: Regular SIG Meeting
     day: Wednesday


### PR DESCRIPTION
Updating sigs.yaml and associated generated files for https://github.com/kubernetes/community/issues/7865.

/sig cloud-provider
