### PR TITLE
Fix mysterious local etcd path documentation

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -345,9 +345,12 @@ To test Kubernetes, you will need to install a recent version of [etcd](https://
 This script will instruct you to make a change to your `PATH`. To make
 this permanent, add this to your `.bashrc` or login script:
 
+
 ```sh
-export PATH="$GOPATH/src/k8s.io/kubernetes/third_party/etcd:${PATH}"
+export PATH="$KUBE_ROOT/third_party/etcd:${PATH}"
 ```
+
+Here, KUBE_ROOT is your Kubernetes source root directory
 
 ##### BASH version requirement
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

at contributors/devel/development.md,
in section regarding local etcd installatioin using hack/install-etcd.sh,

```sh
export PATH="$GOPATH/src/k8s.io/kubernetes/third_party/etcd:${PATH}"
```
above line exists.

The problem is that the local etcd installation path is actually 

```sh
export PATH="$KUBE_ROOT/third_party/etcd:${PATH}"
```
So I modified that part and added explanation

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
