### PR TITLE
owners.md: cleanup outdated links / stale gubernator reference

### DIFF
--- a/contributors/guide/owners.md
+++ b/contributors/guide/owners.md
@@ -328,7 +328,6 @@ Good examples of OWNERS usage:
 - OWNERS files that are regularly updated (at least once per release)
 
 [go-regex]: https://golang.org/pkg/regexp/#pkg-overview
-[test-infra-7690]: https://github.com/kubernetes/test-infra/issues/7690
 [approver-role]: https://git.k8s.io/community/community-membership.md#approver
 [reviewer-role]: https://git.k8s.io/community/community-membership.md#reviewer
 [community membership doc]: https://git.k8s.io/community/community-membership.md

--- a/contributors/guide/owners.md
+++ b/contributors/guide/owners.md
@@ -231,8 +231,6 @@ is the state of today.
     PR is being ignored
   - Many **reviewers** and **approvers** are so overloaded by GitHub notifications that @mention'ing
     is unlikely to get a quick response
-  - If an **author** `/assign`'s a PR, **reviewers** and **approvers** will be made aware of it on
-    their [PR dashboard](https://gubernator.k8s.io/pr)
   - An **author** can work around this by manually reading the relevant OWNERS files,
     `/unassign`'ing unresponsive individuals, and `/assign`'ing others
   - This is a sign that our OWNERS files are stale; pruning the **reviewers** and **approvers** lists


### PR DESCRIPTION
~~Should avoid to the next maintainer looking at OWNERS files docs to needlessy avoid `filters` for use with `approvers`~~

- gubernator reference cleanup
- followup to 0fc7f1615b8799e6b25d15b26b8dfb15f8430e35 : clean up leftover links.

/sig contribex
