### PR TITLE
contributors: Add SIG ContribEx as owners

### DIFF
--- a/contributors/OWNERS
+++ b/contributors/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-contributor-experience-leads
+approvers:
+  - sig-contributor-experience-leads
+labels:
+  - sig/contributor-experience


### PR DESCRIPTION
@kubernetes/sig-contributor-experience-leads — I've noticed a few PRs e.g., https://github.com/kubernetes/community/pull/7691, https://github.com/kubernetes/community/pull/7923 that are flagging @kubernetes/steering-committee members for review, when we likely don't need to be in the path.

Raising this PR draw attention to the approval gap.
Let me know if you want me to extend it to other directories or if you're happy to carry any updates as follow-ups.