### PR TITLE
docs: use "https" instead of "http"

### DIFF
--- a/communication/meeting-notes-archive/201902-201911_Community_Meeting_Notes.md
+++ b/communication/meeting-notes-archive/201902-201911_Community_Meeting_Notes.md
@@ -1668,7 +1668,7 @@ Twitter | [Sep 19th](https://twitter.com/stephenaugustus/status/1174797710043430
 
     *   Announcements
     *   WG LTS Survey ending on April 26th.
-        *   This survey was created by the[ LTS Working Group](http://git.k8s.io/community/wg-lts) of the Kubernetes project. The purpose of this survey is to understand the challenges faced by various types of stakeholders with respect to the current release cadence of Kubernetes project. The survey questions are classified based on the stakeholder category.
+        *   This survey was created by the[ LTS Working Group](https://git.k8s.io/community/wg-lts) of the Kubernetes project. The purpose of this survey is to understand the challenges faced by various types of stakeholders with respect to the current release cadence of Kubernetes project. The survey questions are classified based on the stakeholder category.
         *   [https://www.surveymonkey.com/r/kubernetes-support-survey-2019](https://www.surveymonkey.com/r/kubernetes-support-survey-2019)
     *   We now have a `#pr-reviews` slack channel as a last resort if your PR is stuck. We would love to have folks who can triage/review as well to join the channel to 	help wither fellow contributors. The idea is to help get someone get a PR “ready” and get the right SIGs/Reviewers/Approvers involved.
     *   **👏 **Shoutouts this week (Check in #shoutouts on slack) **👏**

--- a/communication/meeting-notes-archive/201911-202010_Community_Meeting_Notes.md
+++ b/communication/meeting-notes-archive/201911-202010_Community_Meeting_Notes.md
@@ -961,7 +961,7 @@ I want to call out [@karenb](https://kubernetes.slack.com/team/UCLQ9GKSP) dealin
                 *   People start to depend on non-ga beta things
                 *   Timebox amount of time a feature is allowed to stay in beta.
             *   [Plan to set up CI to ensure conformance coverage](https://github.com/kubernetes/enhancements/pull/1306)
-            *   [Plan to eliminate dependencies on non-GA features in conformance](http://git.k8s.io/enhancements/keps/sig-architecture/20191023-conformance-without-beta.md)
+            *   [Plan to eliminate dependencies on non-GA features in conformance](https://git.k8s.io/enhancements/keps/sig-architecture/20191023-conformance-without-beta.md)
         *   Started a “KEP reading group”
             *   Team collectively reads KEPs and discusses them in meetings
         *   Code organization

--- a/communication/meeting-notes-archive/201911-202010_Community_Meeting_Notes.md
+++ b/communication/meeting-notes-archive/201911-202010_Community_Meeting_Notes.md
@@ -961,7 +961,7 @@ I want to call out [@karenb](https://kubernetes.slack.com/team/UCLQ9GKSP) dealin
                 *   People start to depend on non-ga beta things
                 *   Timebox amount of time a feature is allowed to stay in beta.
             *   [Plan to set up CI to ensure conformance coverage](https://github.com/kubernetes/enhancements/pull/1306)
-            *   [Plan to eliminate dependencies on non-GA features in conformance](https://git.k8s.io/enhancements/keps/sig-architecture/20191023-conformance-without-beta.md)
+            *   [Plan to eliminate dependencies on non-GA features in conformance](https://git.k8s.io/enhancements/keps/sig-architecture/1333-conformance-without-beta/README.md)
         *   Started a “KEP reading group”
             *   Team collectively reads KEPs and discusses them in meetings
         *   Code organization

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -323,7 +323,7 @@ below message and pin it.
 
 ```
 This channel abides to the Kubernetes Code of Conduct -
-http://git.k8s.io/community/code-of-conduct.md
+https://git.k8s.io/community/code-of-conduct.md
 Contact conduct@kubernetes.io or an admin in the #slack-admins channel if there
 is a problem.
 ```
@@ -393,7 +393,7 @@ Report any actions taken to the other slack admins, and if needed the
 [Slack Archive Download]: https://drive.google.com/drive/folders/1Xnkwsxis3tu0pT7rwp-crRq4IciZ5b1o?usp=sharing
 [cocc]: /committee-code-of-conduct/README.md
 [CNCF Slack]: https://slack.cncf.io/
-[Tempelis]: http://sigs.k8s.io/slack-infra/tempelis
+[Tempelis]: https://sigs.k8s.io/slack-infra/tempelis
 [slack-config]: ./slack-config/
 [Channel Documentation]: ./slack-config/README.md
 [sig-list]: https://www.kubernetes.dev/community/community-groups

--- a/contributors/chairs-and-techleads/technical-lead.md
+++ b/contributors/chairs-and-techleads/technical-lead.md
@@ -15,7 +15,7 @@ role.
 
 The Technical Lead role in Kubernetes is an optional role that each SIG can
 choose to implement as part of its [governance
-model](http://git.k8s.io/community/committee-steering/governance/sig-governance.md#roles).
+model](https://git.k8s.io/community/committee-steering/governance/sig-governance.md#roles).
 This means SIGs can decide on their own if they want to add Technical Leads to
 their charter or not. Depending on the overall size of the SIG, around two to
 three people can be chosen by the SIG Chairs to support the technical aspects of

--- a/contributors/devel/sig-architecture/staging.md
+++ b/contributors/devel/sig-architecture/staging.md
@@ -28,4 +28,4 @@ If further repos under staging are needed, adding them to the bot is easy.
 Contact one of the [owners of the bot](https://git.k8s.io/publishing-bot/OWNERS).
 
 Currently, the bot is hosted on a
-[public CNCF cluster](https://git.k8s.io/publishing-bot/k8s-publishing-bot.md).
+[public CNCF cluster](https://github.com/kubernetes/publishing-bot/blob/master/production.md).

--- a/contributors/devel/sig-architecture/staging.md
+++ b/contributors/devel/sig-architecture/staging.md
@@ -28,4 +28,4 @@ If further repos under staging are needed, adding them to the bot is easy.
 Contact one of the [owners of the bot](https://git.k8s.io/publishing-bot/OWNERS).
 
 Currently, the bot is hosted on a
-[public CNCF cluster](http://git.k8s.io/publishing-bot/k8s-publishing-bot.md).
+[public CNCF cluster](https://git.k8s.io/publishing-bot/k8s-publishing-bot.md).

--- a/contributors/devel/sig-release/cherry-picks.md
+++ b/contributors/devel/sig-release/cherry-picks.md
@@ -15,7 +15,7 @@ branches.
 
 ## Prerequisites
 
-- [Contributor License Agreement](http://git.k8s.io/community/CLA.md) is
+- [Contributor License Agreement](https://git.k8s.io/community/CLA.md) is
   considered implicit for all code within cherry pick pull requests,
   **unless there is a large conflict**.
 - A pull request merged against the `master` branch.

--- a/contributors/guide/first-contribution.md
+++ b/contributors/guide/first-contribution.md
@@ -147,7 +147,7 @@ while opening an issue. Check the [issue triage guide] for more information.
 [sig-contributor-experience]: /sig-contributor-experience/README.md
 [weekly meetings]: https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/edit
 [container networking interface]: https://github.com/containernetworking/cni
-[network SIG]: http://git.k8s.io/community/sig-network
+[network SIG]: https://git.k8s.io/community/sig-network
 [ask in Slack]: http://slack.k8s.io/
 [issue triage guide]: ./issue-triage.md
 [kubernetes/website]: https://github.com/kubernetes/website/issues

--- a/elections/steering/2020/bobkillen.md
+++ b/elections/steering/2020/bobkillen.md
@@ -25,7 +25,7 @@ process and more. A few notable items:
 - [Routinely pruned and update OWNERS files](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)
 - [Defined policy around inactive members](https://groups.google.com/d/msg/kubernetes-dev/AvCa-sGx9Jw/zByeyP9LAgAJ)
 - [Helped run several of our Contributor Summits](https://github.com/kubernetes/community/tree/master/events) (in the before times 😭)
-- Trusted member of the [GitHub Admin Team](http://git.k8s.io/community/github-management#github-administration-team) and a representative to GitHub for the project
+- Trusted member of the [GitHub Admin Team](https://git.k8s.io/community/github-management#github-administration-team) and a representative to GitHub for the project
 - [Moderator of all the things](https://git.k8s.io/community/communication/moderators.md)
 - Driven further automation and improvements in the KEP process.
 - Surface our docs and resources in a more accessible fashion aka contributor site \o/ - [https://k8s.dev](https://k8s.dev)

--- a/elections/steering/2022/candidate-mrbobbytables.md
+++ b/elections/steering/2022/candidate-mrbobbytables.md
@@ -52,7 +52,7 @@ My efforts both for Kubernetes and the broader community were recognized in
 [Defined policy around inactive members]: https://groups.google.com/d/msg/kubernetes-dev/AvCa-sGx9Jw/zByeyP9LAgAJ
 [improved triage automation & workflow]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-contributor-experience/1553-issue-triage
 [Contributor Summits]:  https://www.kubernetes.dev/events/
-[GitHub Admin Team]: http://git.k8s.io/community/github-management#github-administration-team
+[GitHub Admin Team]: https://git.k8s.io/community/github-management#github-administration-team
 [Moderator of all our communications platforms]: https://git.k8s.io/community/communication/moderators.md
 [Keynote talk]: https://youtu.be/aVZWOMGE5q8
 [SIG ContribEx lead shadow program]: https://docs.google.com/document/d/1CBz8qV_mD6rbDmTsMuosTOQGRXGhN3d8UrcULUI6Vkw/edit#bookmark=id.6p8mxrh41rzf

--- a/events/events-team/registration/README.md
+++ b/events/events-team/registration/README.md
@@ -69,7 +69,7 @@ All attendees should be asked the following:
 | Please specify dietary needs (if any)                          | Dropdown  | No      | Options: `none`, `Gluten Free`, `Vegetarian`, `Vegan`, `Halal`,`Other`                                                 |
 | Do you have a disability that we should be mindful of as we try to accommodate everyone for this event?  | Dropdown  | No      | Options: `Yes`, `No`    |
 | What email did you use to register for KubeCon + CloudNative Con <NA/Europe> <year>? **KubeCon + CloudNative Con <NA/Europe> registration is required to attend Kubernetes Contributor Summit <region> <year>**                             | Free Text | Yes      |                                                                                                                |   
-| Are you a member of one of the [Kubernetes GitHub Orgs](http://git.k8s.io/community/github-management#actively-used-github-organizations)  | Dropdown | Options: `Yes`, `No` [Pop up if no is selected] Attending the Kubernetes Contributor Summit in-person is limited to Kubernetes Org Members and Sponsored Attendees. If you have questions, please email summit-team@kubernetes.io.  Yes      |                                                                                                                |    
+| Are you a member of one of the [Kubernetes GitHub Orgs](https://git.k8s.io/community/github-management#actively-used-github-organizations)  | Dropdown | Options: `Yes`, `No` [Pop up if no is selected] Attending the Kubernetes Contributor Summit in-person is limited to Kubernetes Org Members and Sponsored Attendees. If you have questions, please email summit-team@kubernetes.io.  Yes      |                                                                                                                |    
 | What SIGs or WGs are you most active in? Only list the top three. *This will help us plan content and activities.*                 | Dropdown  | Yes      | Options: <list all SIGs and WGs>                                             |
 | What sessions are you most looking forward to? *This will help us plan content and activities.*                 | Dropdown  | No       | Options: `Unconference`, `Prepared Presentations`, `Steering AMA`, `SIG Discussions/Working Sessions`, `Impromptu Discussions`, `Social/Mingling`                                                |
 | What other session(s) would you like to see at the summit? What else would make this event valuable to you? *We've changed content based on contributor feedback to this question in the past.*                          | Free Text | Yes      |                                                                                                                |
@@ -303,7 +303,7 @@ the morning of the Kubernetes Contributor Summit to assist with questions.
 [linux foundation]:https://www.linuxfoundation.org/
 [devstats]: https://k8s.devstats.cncf.io/d/13/developer-activity-counts-by-repository-group?orgId=1
 [sig-list]: /sig-list.yaml
-[voters]: http://git.k8s.io/steering/elections.md#eligibility-for-voting
+[voters]: https://git.k8s.io/steering/elections.md#eligibility-for-voting
 [kubernetes org members]: https://git.k8s.io/org
 [owners files]: https://cs.k8s.io/?q=&i=fosho&files=OWNERS&repos=
 [slack]: http://slack.k8s.io

--- a/sig-auth/CONTRIBUTING.md
+++ b/sig-auth/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome to contributing to SIG Auth.
 
 If you haven't seen them already, the Kubernetes project has:
 
-- A [Contributor Guide](http://git.k8s.io/community/contributors/guide) - some
+- A [Contributor Guide](https://git.k8s.io/community/contributors/guide) - some
   [kubernetes/kubernetes]-specific content, but lots of info for the
   entire project
 - A [Contributor Cheat

--- a/sig-cli/CONTRIBUTING.md
+++ b/sig-cli/CONTRIBUTING.md
@@ -5,7 +5,7 @@ about the prospect of you joining our [community][community page]!
 
 ## Before You Begin
 
-We strongly recommend you to understand the main [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) and adhere to the contribution rules (specially signing the CLA).
+We strongly recommend you to understand the main [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) and adhere to the contribution rules (specially signing the CLA).
 
 You can also check the [Contributor Cheat Sheet](/contributors/guide/contributor-cheatsheet/), with common resources for existing developers.
 

--- a/sig-cloud-provider/CONTRIBUTING.md
+++ b/sig-cloud-provider/CONTRIBUTING.md
@@ -6,7 +6,7 @@ about the prospect of you joining our community!
 ## Before You Begin
 
 We strongly recommend you to understand the main [Kubernetes Contributor
-Guide](http://git.k8s.io/community/contributors/guide) and adhere to the
+Guide](https://git.k8s.io/community/contributors/guide) and adhere to the
 contribution rules (specially signing the CLA).
 
 You can also check the [Contributor Cheat

--- a/sig-cluster-lifecycle/CONTRIBUTING.md
+++ b/sig-cluster-lifecycle/CONTRIBUTING.md
@@ -6,7 +6,7 @@ about the prospect of you joining our [community](https://git.k8s.io/community/s
 ## Before You Begin
 
 We strongly recommend you to understand the main
-[Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide)
+[Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide)
 and adhere to the contribution rules (specially signing the CLA).
 
 You can also check the [Contributor Cheat Sheet](/contributors/guide/contributor-cheatsheet/),
@@ -28,10 +28,10 @@ Video resources:
 
 ## Get in touch with the SIG
 
-Find the SIG contact details in its [community page](http://git.k8s.io/community/sig-cluster-lifecycle/README.md#contact):
+Find the SIG contact details in its [community page](https://git.k8s.io/community/sig-cluster-lifecycle/README.md#contact):
 - Join the SIG [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
 - Join the SIG [slack channel](https://kubernetes.slack.com/messages/sig-cluster-lifecycle)
-- Join the periodic SIG [video call](http://git.k8s.io/community/sig-cluster-lifecycle/README.md#meetings)
+- Join the periodic SIG [video call](https://git.k8s.io/community/sig-cluster-lifecycle/README.md#meetings)
 
 Using the SIG mailing list or video call is preferred for wider discussion topics that affect
 multiple subprojects. The main SIG slack channel should only be used for SIG level updates

--- a/sig-multicluster/annual-report-2020.md
+++ b/sig-multicluster/annual-report-2020.md
@@ -50,7 +50,7 @@ How are you doing with operational tasks in sig-governance.md?
 
 ## Current initiatives and project health
 * What are initiatives that should be highlighted, lauded, shout out, that your group is proud of? Currently underway? What are some of the longer tail projects that your group is working on?
-  * [Kubefed](http://sigs.k8s.io/kubefed) - long running subproject with active contribution. The big initiative for 2020 was to [kick off support for pull-based reconciliation](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/keps/20200619-kubefed-pull-reconciliation.md).
+  * [Kubefed](https://sigs.k8s.io/kubefed) - long running subproject with active contribution. The big initiative for 2020 was to [kick off support for pull-based reconciliation](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/keps/20200619-kubefed-pull-reconciliation.md).
   * [Work API](https://docs.google.com/document/d/1cWcdB40pGg3KS1eSyb9Q6SIRvWVI8dEjFp9RI0Gk0vg) - [sigs.k8s.io/work-api](https://sigs.k8s.io/work-api)
   * MCS API [KEP-1645](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api) - [sigs.k8s.io/mcs-api](https://sigs.k8s.io/mcs-api)
   * Cluster ID [KEP-2149](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/2149-clusterid)

--- a/sig-release/meeting-notes-archive/2019.md
+++ b/sig-release/meeting-notes-archive/2019.md
@@ -1777,7 +1777,7 @@ Proposed v1.10.13 release [@liggitt]
         * Have OWNERS of this subproject distinct from “release-team” subproject, eg: start with Branch Managers + PRMT (Patch Release Mgmt Team)
         * Process and procedures around release tooling and artifacts
         * Overlaps with #k8s-infra-team and #sig-testing perhaps, and especially #sig-cluster-lifecycle
-        * The members of this subproject would be OWNERS of[ http://git.k8s.io/release](http://git.k8s.io/release)  repo
+        * The members of this subproject would be OWNERS of[ https://git.k8s.io/release](https://git.k8s.io/release)  repo
     * Others:
         * PST (Product Security Team)? Who really owns this? Their docs live in k/sig-release, but they are a bit of an outlier on where they fit in the governance model.  Not our SIG Release issue to resolve right now, versus steering committee.  TBD...table for now.
         * Security? There is wg-security-audit, distinct from incident response (Product Security Team). But there’s artifact signing, release thread model, provenance, etc.  Could fall under PST, or under release engineering subproject.  TBD..table for now.

--- a/sig-scalability/CONTRIBUTING.md
+++ b/sig-scalability/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We are thrilled to have you here.
 
 ## Before you begin
 
-Before you begin, please check out [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) and [Contributor Cheat Sheet](https://github.com/kubernetes/community/blob/master/contributors/guide/contributor-cheatsheet)
+Before you begin, please check out [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) and [Contributor Cheat Sheet](https://github.com/kubernetes/community/blob/master/contributors/guide/contributor-cheatsheet)
 
 ## What SIG Scalability works on
 

--- a/sig-ui/CONTRIBUTING.md
+++ b/sig-ui/CONTRIBUTING.md
@@ -15,7 +15,7 @@ All the contributions are done via GitHub.
 More documentation on contributing can be found here:
 
 - [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
-- [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](https://git.k8s.io/community/contributors/guide#contributing)
+- [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](https://git.k8s.io/community/contributors/guide#contributing)
 - [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet/README.md) - Common resources for existing developers
 
 ### Create a patch


### PR DESCRIPTION
This PR is a follow-up to #7884

## Change List

- Changed the links to 
    - "sigs.k8s.io" to use `https://sigs.k8s.io/...` instead of `http://sigs.k8s.io/...`
    - "git.k8s.io" to use `https://git.k8s.io/...` instead of `http://git.k8s.io/...`


ref. https://github.com/kubernetes/community/pull/7884#discussion_r1631501117

> all `sigs.k8s.io` links should be using `https://sigs.k8s.io/...` (`https://` instead of `http://`)

