### PR TITLE
docs: fix 404 errors in Contributor Cheatsheet

### DIFF
--- a/contributors/guide/contributor-cheatsheet/README-de.md
+++ b/contributors/guide/contributor-cheatsheet/README-de.md
@@ -345,7 +345,7 @@ anderer Beitragenden zu überlassen, die als Reviewer und Approver für den PR z
 [Contributor Guide]: /contributors/guide/README.md
 [Developer Guide]: /contributors/devel/README.md
 [Prow]: https://prow.k8s.io
-[Tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[Tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [Tide Dashboard]: https://prow.k8s.io/tide
 [Bot-Befehle]: https://go.k8s.io/bot-commands
 [GitHub Labels]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-es.md
+++ b/contributors/guide/contributor-cheatsheet/README-es.md
@@ -367,7 +367,7 @@ git push --force
 [Guía del Desarrollador]: /contributors/devel/README.md
 [Panel de gubernator]: https://gubernator.k8s.io/pr
 [Prow]: https://prow.k8s.io
-[Tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[Tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [Panel de Tide]: https://prow.k8s.io/tide
 [Comandos de Bots]: https://go.k8s.io/bot-commands
 [GitHub Labels]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-fr.md
+++ b/contributors/guide/contributor-cheatsheet/README-fr.md
@@ -285,7 +285,7 @@ Si vous ne savez pas si vous devez faire un squash de vos commits, il est préf�
 [guide du contributeur]: /contributors/guide/README.md
 [guide du développeur]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [tide dashboard]: https://prow.k8s.io/tide
 [bot commands]: https://go.k8s.io/bot-commands
 [gitHub labels]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-hi.md
+++ b/contributors/guide/contributor-cheatsheet/README-hi.md
@@ -276,7 +276,7 @@ PR संशोधन का चरण। यदि आप अनिश्चि
 [योगदानकर्ता गाइड]: /contributors/guide/README.md
 [डेवलपर गाइड]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io//prow.k8s.io-tide
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [tide डैशबोर्ड]: https:
 [बॉट कमांड]: https://go.k8s.io/bot-commands
 [Github लेबल]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-id.md
+++ b/contributors/guide/contributor-cheatsheet/README-id.md
@@ -346,7 +346,7 @@ _squashing_ perlu dilakukan atau tidak.
 [Panduan Kontributor]: /contributors/guide/README.md
 [Panduan Pengembang]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [dasbor tide]: https://prow.k8s.io/tide
 [perintah bot]: https://go.k8s.io/bot-commands
 [Label GitHub]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-it.md
+++ b/contributors/guide/contributor-cheatsheet/README-it.md
@@ -353,7 +353,7 @@ git push --force
 [contributor guide]: /contributors/guide/README.md
 [developer guide]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [tide dashboard]: https://prow.k8s.io/tide
 [bot commands]: https://go.k8s.io/bot-commands
 [gitHub labels]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-ja.md
+++ b/contributors/guide/contributor-cheatsheet/README-ja.md
@@ -302,7 +302,7 @@ git push --force
 [コントリビューターガイド]: /contributors/guide/README.md
 [開発者ガイド]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [tideダッシュボード]: https://prow.k8s.io/tide
 [botコマンド]: https://go.k8s.io/bot-commands
 [GitHubラベル]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-ko.md
+++ b/contributors/guide/contributor-cheatsheet/README-ko.md
@@ -350,7 +350,7 @@ PR을 검토하고 승인하도록 지정된 다른 참여자의 판단에 맡�
 [컨트리뷰터 가이드]: /contributors/guide/README.md
 [개발자 가이드]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [tide 대시보드]: https://prow.k8s.io/tide
 [bot 명령]: https://go.k8s.io/bot-commands
 [gitHub 레이블]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-pt.md
+++ b/contributors/guide/contributor-cheatsheet/README-pt.md
@@ -332,7 +332,7 @@ fase de uma revisão do PR. Se você não tem certeza se deve efetuar o squashin
 [Guia do Contribuidor]: /contributors/guide/README.md
 [Guia do Desenvolvedor]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [tide dashboard]: https://prow.k8s.io/tide
 [Comandos do Bot]: https://go.k8s.io/bot-commands
 [gitHub labels]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-uk.md
+++ b/contributors/guide/contributor-cheatsheet/README-uk.md
@@ -278,7 +278,7 @@ git checkout -b myfeature
 [Керівництво для контриб'юторів]: /contributors/guide/README.md
 [Керівництво для розробників]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [tide dashboard]: https://prow.k8s.io/tide
 [Команди бота]: https://go.k8s.io/bot-commands
 [GitHub мітки]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README-zh.md
+++ b/contributors/guide/contributor-cheatsheet/README-zh.md
@@ -283,7 +283,7 @@ git checkout -b myfeature
 [贡献者指南]: /contributors/guide/README.md
 [开发者指南]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [tide 仪表盘]: https://prow.k8s.io/tide
 [Bot 命令]: https://go.k8s.io/bot-commands
 [GitHub 标签]: https://go.k8s.io/github-labels

--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -379,7 +379,7 @@ git push --force
 [contributor guide]: /contributors/guide/README.md
 [developer guide]: /contributors/devel/README.md
 [prow]: https://prow.k8s.io
-[tide]: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
+[tide]: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md
 [tide dashboard]: https://prow.k8s.io/tide
 [bot commands]: https://go.k8s.io/bot-commands
 [gitHub labels]: https://go.k8s.io/github-labels


### PR DESCRIPTION
## Change List

- fix broken links in Contributor Cheatsheet (and localized)
    - before: http://git.k8s.io/test-infra/prow/cmd/tide/pr-authors.md
    - after: https://sigs.k8s.io/prow/site/content/en/docs/components/core/tide/pr-authors.md