### PR TITLE
Annual change of membership for Election Subproject

### DIFF
--- a/elections/OWNERS
+++ b/elections/OWNERS
@@ -5,10 +5,11 @@ approvers:
   - committee-steering
   - sig-contributor-experience-leads
   - parispittman
-  - mrbobbytables
-  - nikhita
   - fsmunoz
+  - salaxander
 emeritus_approvers:
   - jdumars
+  - nikhita
+  - mrbobbytables
 labels:
   - committee/steering

--- a/elections/README.md
+++ b/elections/README.md
@@ -44,8 +44,7 @@ choose the slate of Election Officers:
 | Contributor | Affiliation |
 | ---------------- | ------------------- |
 | [Josh Berkus](https://github.com/jberkus) | Red Hat |
-| [Bob Killen](https://github.com/mrbobbytables) | Google |
-| [Nikhita Raghunath](https://github.com/nikhita) | VMware |
+| [Xander Grzywinski](https://github.com/salaxander) | Defense Unicorns |
 | [Paris Pittman](https://github.com/parispittman) | Apple |
 | [Federico Muñoz](https://github.com/fsmunoz) | SAS |
 


### PR DESCRIPTION
Updates the Election Subproject Members for 2024.

This is a prerequisite to choosing the Election Officers for 2024.

Please approve,
@Priyankasaggu11929 @MadhavJivrajani @kaslin @palnabarun 