### PR TITLE
Fixed broken link in sig-node/CONTRIBUTING.md

### DIFF
--- a/sig-node/CONTRIBUTING.md
+++ b/sig-node/CONTRIBUTING.md
@@ -16,7 +16,7 @@ SIG Node enhancements are available in the <https://github.com/kubernetes/enhanc
 
 **Code**:  
 
-For general code organization, read [contributors/devel/README.md](contributors/devel/README.md) for explaining things like
+For general code organization, read [contributors/devel/README.md](../contributors/devel/README.md) for explaining things like
 `vendor/`, `staging`, etc.
 
 * Kubelet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7939
There is a broken link in https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md `contributors/devel/README.md` which redirects to  https://github.com/kubernetes/community/blob/master/sig-node/contributors/devel/README.md which shows the error **404 - page not found**.