### PR TITLE
Add cluster-api-ionoscloud Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -71,6 +71,7 @@ channels:
     archived: true
   - name: cluster-api-gcp
   - name: cluster-api-ibmcloud
+  - name: cluster-api-ionoscloud
   - name: cluster-api-k3s
   - name: cluster-api-kubemark
   - name: cluster-api-kubevirt


### PR DESCRIPTION
This adds a Slack channel for the IONOS Cloud cluster-api provider: https://github.com/ionos-cloud/cluster-api-provider-ionoscloud.
