### PR TITLE
Add Kat Cosgrove as SIG Docs Tech Lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -42,6 +42,7 @@ aliases:
     - palnabarun
   sig-docs-leads:
     - divya-mohan0209
+    - katcosgrove
     - natalisucks
     - reylejano
     - salaxander

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -46,6 +46,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
+* Kat Cosgrove (**[@katcosgrove](https://github.com/katcosgrove)**), Dell
 * Xander Grzywinski (**[@salaxander](https://github.com/salaxander)**), Defense Unicorns
 * Qiming Teng (**[@tengqm](https://github.com/tengqm)**), Sangfor Technologies
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1539,6 +1539,9 @@ sigs:
       name: Rey Lejano
       company: Red Hat
     tech_leads:
+    - github: katcosgrove
+      name: Kat Cosgrove
+      company: Dell
     - github: salaxander
       name: Xander Grzywinski
       company: Defense Unicorns


### PR DESCRIPTION
Add Kat Cosgrove as SIG Docs Tech Lead to sigs.yaml and k/community/sig-docs/README.md
Ran `make generate` which updated OWNERS_ALIASES 

/assign @MadhavJivrajani 
/cc @natalisucks @divya-mohan0209 