### PR TITLE
SIG-Network: Add Subproject Leads responsibilities

### DIFF
--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -90,6 +90,11 @@ The following [subprojects][subproject-definition] are owned by sig-network:
 - **Contact:**
   - Slack: [#external-dns](https://kubernetes.slack.com/messages/external-dns)
 ### gateway-api
+- **Leads:**
+  - Mattia Lavacca (**[@mlavacca](https://github.com/mlavacca)**), Kong
+  - Rob Scott (**[@robscott](https://github.com/robscott)**), Google
+  - Shane Utt (**[@shaneutt](https://github.com/shaneutt)**), Red Hat
+  - Nick Young (**[@youngnick](https://github.com/youngnick)**), Isovalent
 - **Owners:**
   - [kubernetes-sigs/blixt](https://github.com/kubernetes-sigs/blixt/blob/main/OWNERS)
   - [kubernetes-sigs/gateway-api](https://github.com/kubernetes-sigs/gateway-api/blob/master/OWNERS)
@@ -119,6 +124,10 @@ The following [subprojects][subproject-definition] are owned by sig-network:
   - [kubernetes-sigs/multi-network-api](https://github.com/kubernetes-sigs/multi-network-api/blob/main/OWNERS)
   - [kubernetes-sigs/multi-network](https://github.com/kubernetes-sigs/multi-network/blob/main/OWNERS)
 ### network-policy
+- **Leads:**
+  - Andrew Stoycos (**[@astoycos](https://github.com/astoycos)**)
+  - Dan Winship (**[@danwinship](https://github.com/danwinship)**), Red Hat
+  - Yang Ding (**[@dyanngg](https://github.com/dyanngg)**), VMWare
 - **Owners:**
   - [kubernetes-sigs/kube-network-policies](https://github.com/kubernetes-sigs/kube-network-policies/blob/master/OWNERS)
   - [kubernetes-sigs/network-policy-api](https://github.com/kubernetes-sigs/network-policy-api/blob/master/OWNERS)

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -120,9 +120,13 @@ The following [subprojects][subproject-definition] are owned by sig-network:
 - **Owners:**
   - [kubernetes/dns](https://github.com/kubernetes/dns/blob/master/OWNERS)
 ### multi-network
+- **Leads:**
+  - Maciej Skrocki (**[@mskrocki](https://github.com/mskrocki)**), Google
 - **Owners:**
   - [kubernetes-sigs/multi-network-api](https://github.com/kubernetes-sigs/multi-network-api/blob/main/OWNERS)
   - [kubernetes-sigs/multi-network](https://github.com/kubernetes-sigs/multi-network/blob/main/OWNERS)
+- **Contact:**
+  - Slack: [#sig-network-multi-network](https://kubernetes.slack.com/messages/sig-network-multi-network)
 ### network-policy
 - **Leads:**
   - Andrew Stoycos (**[@astoycos](https://github.com/astoycos)**)

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -136,6 +136,31 @@ The following [subprojects][subproject-definition] are owned by sig-network:
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 [working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups
 <!-- BEGIN CUSTOM CONTENT -->
+
+### Subproject Leads
+
+SIG network provides some additional responsibilities for subproject leads beyond what is covered in the [standard subproject definition][subprojects].
+Most of these additional responsibilities relate to communication about their projects within SIG Network, and to the greater community:
+
+- **Transparent Project Planning, Maintenance and Communication:**
+  - Subproject Leads must provide transparent view into their historical and future project plans (eg; using GitHub project boards, KEPs, or custom enhancement proposals (see [GEPs]/[NPEPs])).
+  - Subproject leads must create, maintain and be present in a public [Kubernetes Slack] channel with the easy-to-find naming `#sig-network-<subproject>` for their sub-project.
+  - Subproject leads should create and maintain a regular public [Zoom] sync on the [SIG Network Calendar].
+  - Subproject leads must keep the project in good health through regular issue triaging, PR reviews, CI health monitoring and checking testgrids (delegating this to other members in the community is good!)
+  - Projects that own CRDs in the `k8s.io` group must go through the [API review process](https://github.com/kubernetes/community/blob/master/sig-architecture/api-review-process.md) and Subproject leads are expected to make sure this well defined processes across Kubernetes is followed.
+
+- **Regular Project Updates**
+  - Subproject leads must report on project's status, significant releases/events, interesting developments to the wider SIG-Network community via the [SIG Network Mailing List] on a quarterly basis (or as needed).
+  - Subproject leads should report on project status in the general SIG Network community meetings (in addition to mailing list updates).
+
+[subprojects]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
+[GEPs]: https://github.com/kubernetes-sigs/gateway-api/blob/main/geps/overview.md
+[NPEPs]: https://github.com/kubernetes-sigs/network-policy-api/blob/main/npeps
+[Kubernetes Slack]: https://kubernetes.slack.com
+[Zoom]: https://zoom.us
+[SIG Network Calendar]: https://github.com/kubernetes/community/tree/master/sig-network#meetings
+[SIG Network Mailing List]: https://groups.google.com/g/kubernetes-sig-network
+
 ## Areas of Responsibility
 
 SIG Network is responsible for the following Kubernetes subsystems:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2286,9 +2286,15 @@ sigs:
     owners:
     - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
   - name: multi-network
+    contact:
+      slack: sig-network-multi-network
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/multi-network-api/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/multi-network/main/OWNERS
+    leads:
+    - github: mskrocki
+      name: Maciej Skrocki
+      company: Google
   - name: network-policy
     contact:
       slack: sig-network-policy-api

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2296,6 +2296,15 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes-sigs/kube-network-policies/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
+    leads:
+    - github: astoycos
+      name: Andrew Stoycos
+    - github: danwinship
+      name: Dan Winship
+      company: Red Hat
+    - github: dyanngg
+      name: Yang Ding
+      company: VMWare
   - name: node-ipam-controller
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/node-ipam-controller/main/OWNERS

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2258,6 +2258,19 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/controllers/service/OWNERS
+    leads:
+    - github: mlavacca
+      name: Mattia Lavacca
+      company: Kong
+    - github: robscott
+      name: Rob Scott
+      company: Google
+    - github: shaneutt
+      name: Shane Utt
+      company: Red Hat
+    - github: youngnick
+      name: Nick Young
+      company: Isovalent
   - name: ingress
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/ingress-controller-conformance/master/OWNERS


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

1. Add more structure to what it means to being a sub-project lead.
2. Add sub project leads and owner repos to existing areas
