### PR TITLE
add a period to the end of youtube-admins and zoom-admins descriptions

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -82,7 +82,7 @@ usergroups:
 
   - name: youtube-admins
     long_name: YouTube Admins
-    description: YouTube Admin group. Ping for a YouTube-specific issue
+    description: YouTube Admin group. Ping for a YouTube-specific issue.
     channels:
       - sig-contribex
     members:
@@ -92,7 +92,7 @@ usergroups:
 
   - name: zoom-admins
     long_name: Zoom Admins
-    description: Zoom Admin group. Ping for a Zoom-specific issue
+    description: Zoom Admin group. Ping for a Zoom-specific issue.
     channels:
       - sig-contribex
     members:


### PR DESCRIPTION
This is a trivial change to test https://github.com/kubernetes/test-infra/pull/32928

