### PR TITLE
add hmc to slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -171,6 +171,7 @@ channels:
   - name: hephy-users
     id: C678BMZ89
   - name: hetzner
+  - name: hmc  
   - name: homelab
   - name: hydrophone
   - name: id-events

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -171,7 +171,7 @@ channels:
   - name: hephy-users
     id: C678BMZ89
   - name: hetzner
-  - name: hmc  
+  - name: hmc-dev
   - name: homelab
   - name: hydrophone
   - name: id-events


### PR DESCRIPTION
This adds #hmc to the Kubernetes Slack Channels

**Purpose:**
We at Mirantis are developing a new Hybrid Multi Cloud platform called (HMC) which is leveraging CAPI under the hood. It is developed fully in the open under https://github.com/Mirantis/hmc (currently private, will be public in 2-3 days) in the Apache 2 License. We have already 5+ of our customers that committed to develop and design HMC with us.
For this we are looking for a Slack Channel to communicate with our customers, to prevent that we need to use company slack channels, plus allow the whole k8s community to be part of the discussions (as the project management will also happen in Github fully public)

Happy to provide additional information if needed.