### PR TITLE
Move Jaice to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,13 +5,13 @@ filters:
     approvers:
       - cblecker
       - idvoretskyi
-      - jdumars
       - mrbobbytables
       - nikhita
       - parispittman
       - sig-contributor-experience-leads
       - committee-steering
     emeritus_approvers:
+      - jdumars
       - alisondy
       - castrojo
       - calebamiles

--- a/communication/OWNERS
+++ b/communication/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - jdumars
   - idvoretskyi
   - jeefy
   - mrbobbytables
@@ -10,6 +9,7 @@ approvers:
   - mrbobbytables
   - sig-contributor-experience-leads
 emeritus_approvers:
+  - jdumars
   - castrojo
   - parispittman
 labels:

--- a/elections/steering/OWNERS
+++ b/elections/steering/OWNERS
@@ -2,12 +2,12 @@
 
 approvers:
   - jberkus
-  - jdumars
   - committee-steering
   - sig-contributor-experience-leads
   - coderanger
   - dims
 emeritus_approvers:
   - parispittman
+  - jdumars
 labels:
   - committee/steering


### PR DESCRIPTION
Jaice's current workload does not permit him to contribute currently, and it's not clear when it will.  As such, moving him to emeritus_approvers in all OWNERs files so that he won't be assigned review.