### PR TITLE
Add wg-etcd-operator to Slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -545,6 +545,7 @@ channels:
   - name: wg-apply
     archived: true
   - name: wg-batch
+  - name: wg-etcd-operator
   - name: wg-serving
   - name: wg-component-standard
     archived: true


### PR DESCRIPTION
Following up https://github.com/kubernetes/community/pull/7917 WG etcd-operator has already been approved, now we need to create a slack-channel