### PR TITLE
remove deprecated sig testing groups

### DIFF
--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -63,7 +63,4 @@ restrictions:
       - "^prow"
       - "^testgrid"
       - "^testing"
-    usergroups:
-      - "^test-infra-oncall$"
-      - "^google-build-admin$"
   - path: "**/*" # prevent any other file from containing anything

--- a/communication/slack-config/sig-testing/usergroups.yaml
+++ b/communication/slack-config/sig-testing/usergroups.yaml
@@ -1,8 +1,0 @@
-usergroups:
-  # maintained by https://github.com/kubernetes/test-infra/blob/master/experiment/slack-oncall-updater
-  - name: test-infra-oncall
-    external: true
-
-  # maintained by https://github.com/kubernetes/test-infra/blob/master/experiment/slack-oncall-updater
-  - name: google-build-admin
-    external: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

/kind cleanup
/sig testing

Second part of https://github.com/kubernetes/test-infra/pull/33083

/hold

