### PR TITLE
add slack channel sre-learning-platform

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -502,6 +502,7 @@ channels:
   - name: spark-operator
   - name: spinnaker
   - name: sre
+  - name: sre-learning-platform
   - name: steering-committee
   - name: submariner
   - name: surveys


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Dear Kubernetes Slack Administrators,
Good day! My name is [Viktor](http://www.linkedin.com/in/viktar-mikalayeu-mns). I have developed an [open-source platform](https://github.com/ViktorUJ/cks) dedicated to learning Kubernetes and preparing for certification exams. The platform is designed to support individuals in their journey to understand and master Kubernetes, providing resources and materials beneficial for beginners and advanced users alike.


Considering the potential value it could bring to the community, I am reaching out to inquire if it would be possible to create a dedicated channel within the official Kubernetes Slack for this platform. This channel would serve as a hub for discussions, Q&A, sharing of resources, and support related to the learning platform and Kubernetes education in general.
I believe that such a channel could significantly contribute to the community, fostering a space for learning, collaboration, and growth among Kubernetes enthusiasts and professionals.


Thank you for considering my request. I am looking forward to your positive response and am more than willing to provide any further information or details required.
