### PR TITLE
fix tempelis config

### DIFF
--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -33,7 +33,7 @@ users:
   byako: U03GZBD4J4C
   cahillsf: U04TNKBE92R
   calebamiles: U1ZDD4CUR
-  camilamacedo86: UJDM393EH
+  camilamacedo86: U042UFD8LQK
   castrojo: U1W1Q6PRQ
   catblade: URCV5RDSB
   cblecker: U3EDWR9FV

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -1,7 +1,7 @@
 # This file contains an alphabetically sorted mapping of lowercase GitHub
 # usernames to Kubernetes Slack user IDs.
 users:
-  adheipsingh: T09NY5SBT
+  adheipsingh: U02HS73S804
   adilGhaffarDev: U038BLZPX1S
   adisky: U9YRVLTEH
   adityabhatia: U04N6JTDK39


### PR DESCRIPTION
I noticed in https://github.com/kubernetes/community/pull/7985#issuecomment-2248438016 that we are failing to update some user groups.

By inspecting the logs at https://prow.k8s.io/?job=post-community-tempelis-apply we can see which groups

From there we check the list of members in the group and verify the UIDs for each.

cc @AdheipSingh @camilamacedo86 