### PR TITLE
remove newline from PSC description

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -50,8 +50,7 @@ usergroups:
   - name: product-security-committee
     long_name: Product Security Committee
     description: |-
-      The Product Security Committee (PSC) is responsible for triaging and
-      handling the security issues for Kubernetes.
+      The Product Security Committee (PSC) is responsible for triaging and handling the security issues for Kubernetes.
     channels:
       - release-management
       - sig-release


### PR DESCRIPTION
Hopefully this stops tempelis from attempting to mutate this group every time any changes merge.

previously: https://github.com/kubernetes/community/pull/7990#issuecomment-2248731582