### PR TITLE
2024 Steering Election setup

### DIFF
--- a/elections/steering/2024/README.md
+++ b/elections/steering/2024/README.md
@@ -64,10 +64,10 @@ previous [governance meeting video] which led to this whole process.
 
 Please refer to the [Steering Committee Election Charter] for [Eligibility for candidacy]
 
-Eligibility for voting in 2023 is defined as:
+Eligibility for voting in 2024 is defined as:
 
 * People who had at least 50 contributions to the Kubernetes project over
-  the past year, according to a snapshot taken 2023-08-04 of the data driving
+  the past year, according to a snapshot taken 2024-07-31 of the data driving
   the [devstats developer activity counts dashboard][devstats-dashboard],
   who are also [Org Members].
   Contributions include GitHub events like creating issues, creating PRs,
@@ -75,7 +75,7 @@ Eligibility for voting in 2023 is defined as:
   [the SQL query used by devstats for developer activity counts][devstats-sql].
 
 * Full members of the Code of Conduct Committee (CoCC) and Security Response Committee
-  (SRC), as listed in [SIGs.yaml], at any time between August 2022 and August 2023,
+  (SRC), as listed in [SIGs.yaml], at any time between August 2023 and August 2024,
   regardless of contribution count.
 
 * People who have submitted the [voter exception form] and are accepted by
@@ -117,31 +117,30 @@ Examples of contributions that would NOT be considered:
 
 <!-- While finalizing the dates in the schedule, ensure that:
 - The Steering Committee and candidate Q+A occurs at a public SC meeting
-  (usually a Monday).
+  (usually a Wednesday).
 - Deadline to submit voter exception forms and request a
   replacement ballot is ~3 days before voting closes.
 - Private announcement of results to SC members is at least ~2 days
   before private announcement to all candidates.
 - The interval between private announcement to all candidates and the
-  public announcement is 24-48 hours, ideally during a weekend.
+  public announcement is 24-48 hours.
 -->
 
-**This schedule is not yet final, and is a copy of last year's **
 
 | Date                    | Event                                                                 |
 |:------------------------|:----------------------------------------------------------------------|
-| Wednesday, July 12      | Steering Committee selects Election Committee                         |
-| Tuesday, August 8       | Announcement of Election and publication of voters.md                 |
-| TBD                     | Steering Committee Q+A for the candidates                             |
-| Saturday, August 26     | Candidate nominations due at the end of the day in AoE time           |
-| Sunday, August 27       | All candidate bios due at the end of the day in AoE time              |
-| Tuesday, August 29      | Election Begins                                                       |
-| Saturday, September 23  | Deadline to submit voter exception requests                           |
-| Tuesday, September 26   | Election Closes at the end of the day in AoE time                     |
-| Wednesday, September 27 | Private announcement of Results to SC members not up for election     |
-| Sunday, October 1       | Private announcement of Results to all candidates                     |
-| Monday, October 2       | Public announcement of Results at Public Steering Committee Meeting   |
-| Tuesday, October 3      | Election Retro                                                        |
+| Tuesday, July 9         | Steering Committee selects Election Committee                         |
+| Thursday, August 1      | Announcement of Election and publication of voters.md                 |
+| Wednesday, August 21    | Steering Committee Q+A for the candidates (to be confirmed)           |
+| Saturday, August 24     | Candidate nominations due at the end of the day in AoE time           |
+| Sunday, August 25       | All candidate bios due at the end of the day in AoE time              |
+| Tuesday, August 27      | Election Begins                                                       |
+| Monday, September 23    | Deadline to submit voter exception requests                           |
+| Thursday, September 26  | Election Closes at the end of the day in AoE time                     |
+| Friday, September 27    | Private announcement of Results to SC members not up for election     |
+| Monday, September 30    | Private announcement of Results to all candidates                     |
+| Wednesday, October 2    | Public announcement of Results at Public Steering Committee Meeting   |
+| Wednesday, October 9    | Election Retro                                                        |
 
 Candidate nomination, bio, and election close deadlines will be done using Anywhere on Earth timing, meaning it is still valid to submit new nominations/bios/votes as long as it is still the last day anywhere on the planet (i.e. at the end of that day in UTC-12).
 
@@ -173,7 +172,7 @@ to add their bio (see below). The PR body must contain the text `Fixes #NNN` to
 automatically close the issue once the PR is merged.
 
 5. Create the PR for your bio by copying the `nomination-template.md` file in
-this directory, and creating a new file titled `candidate-githubid.md`.  Fill
+this directory, and creating a new file titled `candidate-yourgithub.md`.  Fill
 out all the fields in the template, but avoid making any format changes.
 
 **Endorsement**
@@ -199,7 +198,7 @@ Election Officers will announce that on the GitHub issue.
 
 Eligible candidates can submit a pull request with a biography in this
 directory with their platform and intent to run. This PR will copy `nomination-template.md`
-to a file named `candidate-YourName.md`.  It will fill out the fields in
+to a file named `candidate-yourgithub.md`.  It will fill out the fields in
 that template.
 
 All biographical statements should be brief and to the point, with a guideline of around
@@ -259,8 +258,8 @@ The Steering Committee has selected the following people as [election officers]:
 In addition, the following contributors are helping with the election:
 
 - Alternate Officers: Rey Lejano, Joseph Sandoval
-- Infra Liaison: TBD
-- Contributor Comms Liaison: TBD
+- Infra Liaison: Mahamed Ali
+- Contributor Comms Liaison: TBD (discussing with contrib comms)
 
 Please direct any questions via email to <election@k8s.io>.
 
@@ -294,7 +293,7 @@ Nominees may be found in the [election app].
 [pledge to recuse]: https://github.com/kubernetes/steering/blob/master/elections.md#steering-committee-and-election-officer-recusal
 
 [Condorcet]: https://en.wikipedia.org/wiki/Condorcet_method
-[prior candidate bios]: https://github.com/kubernetes/community/tree/master/elections/steering/2022
+[prior candidate bios]: https://github.com/kubernetes/community/tree/master/elections/steering/2023
 [election officers]: https://github.com/kubernetes/community/tree/master/elections#recommending-election-officers
 [Kubernetes Community Meeting]: https://github.com/kubernetes/community/blob/master/events/community-meeting.md
 [Kubernetes Blog]: https://kubernetes.io/blog/
@@ -306,8 +305,8 @@ Nominees may be found in the [election app].
 [election app]: https://elections.k8s.io
 [Elekto voting documentation]: https://elekto.dev/docs/voting/
 [voters.yaml]: https://github.com/kubernetes/community/blob/master/elections/steering/2024/voters.yaml
-[election page]: https://elections.k8s.io/app/elections/steering---2023
-[voter exception form]: https://elections.k8s.io/app/elections/steering---2023/exception
+[election page]: https://elections.k8s.io/app/elections/steering---2024
+[voter exception form]: https://elections.k8s.io/app/elections/steering---2024/exception
 [public Steering Committee Meeting]: https://github.com/kubernetes/steering/#meetings
-[Eligible voters]: https://github.com/kubernetes/community/tree/master/elections/steering/2023#eligibility
+[Eligible voters]: https://github.com/kubernetes/community/tree/master/elections/steering/2024#eligibility
 [SIGs.yaml]: https://github.com/kubernetes/community/tree/master/sigs.yaml

--- a/elections/steering/2024/README.md
+++ b/elections/steering/2024/README.md
@@ -259,7 +259,7 @@ In addition, the following contributors are helping with the election:
 
 - Alternate Officers: Rey Lejano, Joseph Sandoval
 - Infra Liaison: Mahamed Ali
-- Contributor Comms Liaison: TBD (discussing with contrib comms)
+- Contributor Comms Liaison: Arpit Agrawal
 
 Please direct any questions via email to <election@k8s.io>.
 

--- a/elections/steering/2024/README.md
+++ b/elections/steering/2024/README.md
@@ -107,7 +107,7 @@ Committee's governance will be considered for voter exception.
 Examples of contributions that would be considered:
 * Slack admins who are not active in GitHub
 * K8s Infra staff doing mostly support
-* Working Group or User Group leads without a lot of GitHub activity
+* Working Group leads without a lot of GitHub activity
 
 Examples of contributions that would NOT be considered:
 * Contributions to ecosystem projects and products

--- a/elections/steering/2024/election.yaml
+++ b/elections/steering/2024/election.yaml
@@ -1,0 +1,20 @@
+name: 2024 Steering Committee Election
+organization: Kubernetes
+# Start of day in UTC for opening: 2023-08-29 00:00:01
+start_datetime: 2024-08-27 00:00:01
+# End of day Anywhere on Earth for closing. Write 2023-09-26 as: 2023-09-27 11:59:59
+end_datetime: 2024-09-27 11:59:59
+no_winners: 3
+allow_no_opinion: True
+delete_after: True
+show_candidate_fields:
+  - employer
+  - slack
+election_officers:
+  - bridgetkromhout
+  - cblecker
+  - Priyankasaggu11929
+eligibility: Kubernetes Org members with 50 or more contributions in the last year can vote.  See [the election guide](https://github.com/kubernetes/community/tree/master/elections/steering/2024)
+exception_description: Not all contributions are measured by DevStats.  If you have contributions that are not so measured, then please request an exception to allow you to vote via the Elekto application.
+# End of day Anywhere on Earth for closing. Write 2023-09-23 as: 2023-09-24 11:59:59
+exception_due: 2024-09-24 11:59:59

--- a/elections/steering/2024/election_desc.md
+++ b/elections/steering/2024/election_desc.md
@@ -1,0 +1,11 @@
+# Vote for the 2024 Steering Committee
+
+As is now customary, the third calendar quarter is [Steering Committee](https://github.com/kubernetes/steering) election season for Kubernetes. Four (4) elected members (@justaugustus, @pacoxu, @pohly, @soltysh) will stay on for the remaining year of their terms, and there will be three (3) positions open for election. Every election term will be 2 years. More complete information on the election may be found [in the voter's guide](https://github.com/kubernetes/community/tree/master/elections/steering/2024).
+
+Instructions on using Elekto can be found [in its docs site](https://elekto.dev/docs/voting/).
+
+If you’d like to vote or run for a seat, all details and next steps are outlined in the [election process doc](https://git.k8s.io/steering/elections.md) and this application. The application will be the single source of truth of information for this cycle. It will be updated live as new bios of candidates get committed.
+
+Please pay attention to the [scheduled dates](https://github.com/kubernetes/community/tree/master/elections/steering/2024#schedule).
+
+Eligibility for voting will be determined by 50 contributions to a Kubernetes project over the past year and [Kubernetes Org membership](https://github.com/kubernetes/community/blob/master/community-membership.md).  Eligible voters will be shown as such by this site when logged in.  If you should be eligible, but are not, you may also [file for an exception](https://elections.k8s.io/app/elections/steering---2024/exception).

--- a/elections/steering/2024/nomination-template.md
+++ b/elections/steering/2024/nomination-template.md
@@ -1,0 +1,23 @@
+-------------------------------------------------------------
+name: 
+ID: GitHubID
+info:
+  - employer: Your Employer or "Independent"
+  - slack: slack handle
+-------------------------------------------------------------
+
+<!-- Please make a copy of this template as "candidate-githubid.md" and save it to
+the election directory -->
+
+## SIGS
+
+- SIGS/WG/UGs you're a member of
+
+## What I have done
+
+## What I'll do
+
+## Resources About Me
+
+- Links to KubeCon or other conference talks or other related material 
+- Links to social media

--- a/elections/steering/2024/nomination-template.md
+++ b/elections/steering/2024/nomination-template.md
@@ -11,7 +11,7 @@ the election directory -->
 
 ## SIGS
 
-- SIGS/WG/UGs you're a member of
+- SIGs/WGs/Teams you're a member of
 
 ## What I have done
 

--- a/elections/steering/2024/voters.yaml
+++ b/elections/steering/2024/voters.yaml
@@ -1,0 +1,15 @@
+# 2024 Steering Committee Election
+##################################
+#
+# The process for determining eligible voters can be found in
+# https://github.com/kubernetes/community/tree/master/elections/steering/2024
+#
+# If you feel you meet the eligibility criteria but do not see your GitHub username
+# below, please fill out an exception request and the elections team will get back to
+# you as quickly as possible: https://elections.k8s.io/app/elections/steering---2024/exception
+#
+# History:
+# Log of changes to the file
+#
+eligible_voters:
+-

--- a/elections/steering/README.md
+++ b/elections/steering/README.md
@@ -8,6 +8,6 @@ The last Steering election, including all directions on eligibility, voting, and
 
 You can also read [documentation] on how to run a Steering Election.
 
-[2023 Election]: /elections/steering/2023/
 [2024 Election]: /elections/steering/2024/
+[2023 Election]: /elections/steering/2023/
 [documentation]: /elections/steering/documentation/

--- a/elections/steering/documentation/README.md
+++ b/elections/steering/documentation/README.md
@@ -340,7 +340,7 @@ Eligible:
 Ineligible without other contributions:
 
 * Writer/maintainers of 3rd party information resources (private/company blogs, personal/company Kubernetes websites, personal video channels)
-* Meetup/User Group organizers
+* Meetup organizers
 * Conference speakers
 * Contributors to other CNCF projects
 * Contributors to Kubernetes distributions

--- a/elections/steering/documentation/template/README.md
+++ b/elections/steering/documentation/template/README.md
@@ -114,7 +114,7 @@ Committee's governance will be considered for voter exception.
 Examples of contributions that would be considered:
 * Slack admins who are not active in GitHub
 * K8s Infra staff doing mostly support
-* Working Group leads without a lot of GitHub activity
+* Working Group or User Group leads without a lot of GitHub activity
 
 Examples of contributions that would NOT be considered:
 * Contributions to ecosystem projects and products
@@ -124,13 +124,13 @@ Examples of contributions that would NOT be considered:
 
 <!-- While finalizing the dates in the schedule, ensure that:
 - The Steering Committee and candidate Q+A occurs at a public SC meeting
-  (usually a Monday).
+  (usually a Wednesday).
 - Deadline to submit voter exception forms and request a
   replacement ballot is ~3 days before voting closes.
 - Private announcement of results to SC members is at least ~2 days
   before private announcement to all candidates.
 - The interval between private announcement to all candidates and the
-  public announcement is 24-48 hours, ideally during a weekend.
+  public announcement is 24-48 hours.
 -->
 
 | Date                    | Event                                                                 |
@@ -178,7 +178,7 @@ to add their bio (see below). The PR body must contain the text `Fixes #NNN` to
 automatically close the issue once the PR is merged.
 
 5. Create the PR for your bio by copying the `nomination-template.md` file in
-this directory, and creating a new file titled `candidate-githubid.md`.  Fill
+this directory, and creating a new file titled `candidate-yourgithub.md`.  Fill
 out all the fields in the template, but avoid making any format changes.
 
 **Endorsement**
@@ -204,7 +204,7 @@ Election Officers will announce that on the GitHub issue.
 
 Eligible candidates can submit a pull request with a biography in this
 directory with their platform and intent to run. This PR will copy `nomination-template.md`
-to a file named `candidate-YourName.md`.  It will fill out the fields in
+to a file named `candidate-yourgithub.md`.  It will fill out the fields in
 that template.
 
 All biographical statements should be brief and to the point, with a guideline of around

--- a/elections/steering/documentation/template/README.md
+++ b/elections/steering/documentation/template/README.md
@@ -114,7 +114,7 @@ Committee's governance will be considered for voter exception.
 Examples of contributions that would be considered:
 * Slack admins who are not active in GitHub
 * K8s Infra staff doing mostly support
-* Working Group or User Group leads without a lot of GitHub activity
+* Working Group leads without a lot of GitHub activity
 
 Examples of contributions that would NOT be considered:
 * Contributions to ecosystem projects and products

--- a/elections/steering/documentation/template/nomination-template.md
+++ b/elections/steering/documentation/template/nomination-template.md
@@ -11,7 +11,7 @@ the election directory -->
 
 ## SIGS
 
-- SIGS/WG/UGs you're a member of
+- SIGs/WGs/Teams you're a member of
 
 ## What I have done
 


### PR DESCRIPTION
This PR sets up the 2024 Steering Election, with Election Officers of @Priyankasaggu11929, @cblecker, and @bridgetkromhout. 

We're seeking approval from Steering for this timeline as well as approval for the voter eligibility criteria (which have not changed from last year).

Notes:
- I also corrected issues with the templates and fixed broken links in the docs.
- We are avoiding requiring action during holidays such as Labor Day (US), Rosh Hashanah, and Yom Kippur.
- I am creating the voters.yaml with an empty list to be populated when the election opens, as was recommended last year.

Holding for the majority of Steering to approve.
/hold