### PR TITLE
Directly give pip command and bash version for etcd

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -323,7 +323,11 @@ different version of Go, please refer to the
 #### PyYAML
 
 Some Kubernetes verification tests use [PyYAML](https://pyyaml.org/) and it therefore needs to be installed to successfully run all verification tests in your local environment. 
-You can use the
+
+``` py
+pip install pyyaml
+```
+Or you can use the
 [PyYAML documentation](https://pyyaml.org/wiki/PyYAMLDocumentation) to
 find the installation instructions for your platform.
 
@@ -341,7 +345,7 @@ To test Kubernetes, you will need to install a recent version of [etcd](https://
 ```sh
 ./hack/install-etcd.sh
 ```
-
+This script requires a minimum bash version of 4.2. 
 This script will instruct you to make a change to your `PATH`. To make
 this permanent, add this to your `.bashrc` or login script:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

- Installing PyYAML section asks to direct to https://pyyaml.org/wiki/PyYAMLDocumentation. It says just to run pip install command. So feels better to give the command directly. So can save some time :-) 
- While running etcd installation steps it will throw error if minimum bash version is not met. It is added as a note

<img width="686" alt="Screenshot 2024-07-28 at 9 15 26 PM" src="https://github.com/user-attachments/assets/8518fe58-34da-4607-ba45-9c61489e309e">


