### PR TITLE
sig-node: remove unavailable node-perf-dash.k8s.io

### DIFF
--- a/sig-node/charter.md
+++ b/sig-node/charter.md
@@ -37,7 +37,7 @@ SIG [readme]
 #### Cross-cutting and Externally Facing Processes
 
 - CRI [validation] and [testing policy]
-- Node [test grid] and [perf dashboard]
+- Node [test grid]
 
 ### Out of scope
 
@@ -69,7 +69,6 @@ SIG Technical Leads
 [validation]: /contributors/devel/sig-node/cri-validation.md
 [testing policy]: /contributors/devel/sig-node/cri-testing-policy.md
 [test grid]: https://testgrid.k8s.io/sig-node#Summary
-[perf dashboard]: http://node-perf-dash.k8s.io/#/builds
 [sig-governance]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md
 [readme]: https://github.com/kubernetes/community/tree/master/sig-node
 [Kubernetes Charter README]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md


### PR DESCRIPTION


https://github.com/kubernetes/community/blob/32d76b26594c5010a2a3ab49576dc62c04d9b4a6/sig-node/charter.md?plain=1#L72
```
[perf dashboard]: http://node-perf-dash.k8s.io/#/builds
```
http://node-perf-dash.k8s.io/#/builds this is not available.

Other node related performance dashboard can be found in https://perf-dash.k8s.io/#/?jobname=containerd-node-throughput&metriccategoryname=E2E&metricname=PodStartup&Metric=run_to_watch.