### PR TITLE
Setting lower-case for Elekto link

### DIFF
--- a/elections/steering/2024/candidate-bentheelder.md
+++ b/elections/steering/2024/candidate-bentheelder.md
@@ -1,6 +1,6 @@
 -------------------------------------------------------------
 name: Benjamin Elder
-ID: BenTheElder
+ID: bentheelder
 info:
   - employer: Google
   - slack: bentheelder


### PR DESCRIPTION
Looks like Elekto has case-sensitivity, unlike GitHub. I'm editing the ID inside the file versus the filename itself, although either would probably work.