### PR TITLE
[steering 2024] add voters from approved exception request - aug 21

### DIFF
--- a/elections/steering/2024/voters.yaml
+++ b/elections/steering/2024/voters.yaml
@@ -13,6 +13,7 @@
 # 2024-08-01 - Initial setup with voters from devstats+org, plus CCoC + SRC
 # 2024-08-01 - Minor correction to fix alpha-sorting of voters list
 # 2024-08-20 - Add voters from approved exception requests
+# 2024-08-21 - Add voters from approved exception requests
 #
 eligible_voters:
 - a-mccarthy
@@ -259,6 +260,7 @@ eligible_voters:
 - ivelichkovich
 - jackfrancis
 - jacobwolfaws
+- JamesLaverack
 - jasonbraganza
 - jayantjain93
 - jayunit100


### PR DESCRIPTION
PR adds voters from approved exception request, as of Aug 21, 2024.

/assign @bridgetkromhout @cblecker

/hold
for review/approval from Election Officers.