### PR TITLE
1.32 release team slack groups

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -51,22 +51,16 @@ usergroups:
       - sig-release
     members:
       - chanieljdan         # 1.32 Docs Lead
-      - cpanato             # SIG Release Technical Lead
       - drewhagen           # 1.32 Release Signal Lead
       - fsmunoz             # 1.32 Release Lead
       - gracenng            # Release Team Subproject Lead
-      - jeremyrickard       # SIG Release Chair
-      - justaugustus        # SIG Release Chair
       - katcosgrove         # 1.32 EA + Release Team Subproject Lead
       - mbianchidev         # 1.32 Communications Lead
       - npolshakova         # 1.32 RT Lead Shadow
-      - puerco              # SIG Release Technical Lead
       - salehsedghpour      # 1.32 RT Lead Shadow
-      - saschagrunert       # SIG Release Chair
       - satyampsoni         # 1.32 Release Notes Lead
       - sreeram-venkitesh   # 1.32 RT Lead Shadow
-      - tjons               # 1.32 Enhancements Lead-
-      - Verolop             # SIG Release Technical Lead
+      - tjons               # 1.32 Enhancements Lead
       - Vyom-Yadav          # 1.32 RT Lead Shadow
 
   # Should match the membership of the following teams at all times:

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -63,6 +63,24 @@ usergroups:
       - tjons               # 1.32 Enhancements Lead
       - Vyom-Yadav          # 1.32 RT Lead Shadow
 
+  # Should match SIG Release Leads at all times:
+  # https://git.k8s.io/community/sig-release/README.md#leadership
+  - name: sig-release-leads
+    long_name: SIG Release Leads
+    description: >-
+      SIG Release Leads. Ping for questions on SIG Release process and escalations.
+    channels:
+      - release-ci-signal
+      - release-management
+      - sig-release
+    members:
+      - cpanato             # SIG Release Technical Lead
+      - jeremyrickard       # SIG Release Chair
+      - justaugustus        # SIG Release Chair
+      - puerco              # SIG Release Technical Lead
+      - saschagrunert       # SIG Release Chair
+      - Verolop             # SIG Release Technical Lead
+
   # Should match the membership of the following teams at all times:
   # - https://git.k8s.io/security/#product-security-committee-psc
   # - https://kubernetes.io/releases/release-managers/#release-managers

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -14,17 +14,19 @@ usergroups:
       - release-management
       - sig-release
     members:
-      - ameukam # Release Manager Associate
-      - cici37 # Release Manager
-      - cpanato # Release Manager
-      - jeremyrickard # Release Manager
-      - jimangel # Release Manager Associate
-      - justaugustus # subproject owner / Release Manager
-      - palnabarun # Release Manager
-      - puerco # Release Manager
-      - saschagrunert # subproject owner / Release Manager
-      - Verolop # Release Manager
-      - xmudrii # Release Manager
+      - ameukam             # Release Manager Associate
+      - cici37              # Release Manager
+      - cpanato             # Release Manager
+      - jeremyrickard       # Release Manager
+      - jimangel            # Release Manager Associate
+      - jrsapi              # Release Manager Associate
+      - justaugustus        # Release Manager
+      - palnabarun          # Release Manager
+      - puerco              # Release Manager
+      - salaxander          # Release Manager Associate
+      - saschagrunert       # Release Manager
+      - Verolop             # Release Manager
+      - xmudrii             # Release Manager
 
   # Should match the membership of the following groups at all times:
   # - Release Team Lead
@@ -32,7 +34,7 @@ usergroups:
   # - Emeritus Adviser
   # - SIG Release leads
   #
-  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.29/release-team.md
+  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.32/release-team.md
   - name: release-team-leads
     long_name: Release Team Leads
     description: >-
@@ -48,36 +50,24 @@ usergroups:
       - release-notes
       - sig-release
     members:
-      - cpanato # SIG Release Technical Lead
-      - jeremyrickard # SIG Release Chair
-      - justaugustus # SIG Release Chair
-      - mehabhalodiya # 1.29 RT Lead Shadow
-      - mickeyboxell # 1.29 RT Lead Shadow
-      - neoaggelos # 1.29 RT Lead Shadow
-      - Priyankasaggu11929 # 1.29 RT Lead
-      - puerco # SIG Release Technical Lead
-      - ramrodo # 1.29 RT Lead Shadow
-      - salaxander # 1.29 Emeritus Adviser
-      - saschagrunert # SIG Release Chair
-      - Verolop # SIG Release Technical Lead
-
-  # Should match SIG Release Leads at all times:
-  # https://git.k8s.io/community/sig-release/README.md#leadership
-  - name: sig-release-leads
-    long_name: SIG Release Leads
-    description: >-
-      SIG Release Leads. Ping for questions on SIG Release process and escalations.
-    channels:
-      - release-ci-signal
-      - release-management
-      - sig-release
-    members:
-      - cpanato # SIG Release Technical Lead
-      - jeremyrickard # SIG Release Chair
-      - justaugustus # SIG Release Chair
-      - puerco # SIG Release Technical Lead
-      - saschagrunert # SIG Release Chair
-      - Verolop # SIG Release Technical Lead
+      - chanieljdan         # 1.32 Docs Lead
+      - cpanato             # SIG Release Technical Lead
+      - drewhagen           # 1.32 Release Signal Lead
+      - fsmunoz             # 1.32 Release Lead
+      - gracenng            # Release Team Subproject Lead
+      - jeremyrickard       # SIG Release Chair
+      - justaugustus        # SIG Release Chair
+      - katcosgrove         # 1.32 EA + Release Team Subproject Lead
+      - mbianchidev         # 1.32 Communications Lead
+      - npolshakova         # 1.32 RT Lead Shadow
+      - puerco              # SIG Release Technical Lead
+      - salehsedghpour      # 1.32 RT Lead Shadow
+      - saschagrunert       # SIG Release Chair
+      - satyampsoni         # 1.32 Release Notes Lead
+      - sreeram-venkitesh   # 1.32 RT Lead Shadow
+      - tjons               # 1.32 Enhancements Lead-
+      - Verolop             # SIG Release Technical Lead
+      - Vyom-Yadav          # 1.32 RT Lead Shadow
 
   # Should match the membership of the following teams at all times:
   # - https://git.k8s.io/security/#product-security-committee-psc

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -42,6 +42,7 @@ users:
   cfryanr: U0188B6J42H
   chadmcrowell: UC4J73YCR
   chandankumar4: U01QKVBNMSL
+  chanieljdan: U04BYV58N87
   chiukapoor: U045T4QQUE6
   chrischdi: UBVL9Q4TB
   chrisshort: U2YGXSD9B
@@ -64,6 +65,7 @@ users:
   divya-mohan0209: UV4J7K97Z
   dntosas: UKT4D74F3
   dougm: U8GG20UE9
+  drewhagen: U01NTKZDPLK
   elezar: ULV21K3CH
   elsony: UCW8323KL
   EmilienM: U01BVTA83D4
@@ -159,6 +161,7 @@ users:
   mattmoyer: U0DRP8H42
   maysunfaisal: U01DEHK2YUB
   mbbroberg: U18JTHMDY
+  mbianchidev: UU1JM5G5A
   mcbenjemaa: UF111SQ4U
   meatballhat: U01QEKCBTBM
   mehabhalodiya: U024HPAQDC1
@@ -185,6 +188,7 @@ users:
   nitishfy: U03AB2YFVGV
   Nivedita-coder: U01H4FQJ3RP
   nkubala: UA90QL2BE
+  npolshakova: U048GQET6MR
   nprokopic: UR434B8TS
   nrb: U7S597E00
   nzoueidi: UBU72MWP2
@@ -226,10 +230,12 @@ users:
   s-urbaniak: U0DT660QM
   sadysnaat: UNQPKAQHE
   salaxander: UDHV1RXB2
+  salehsedghpour: U02GM9ZLELB
   sammy: U8NJFL023
   sandipanpanda: U02A47HJ517
   SaranBalaji90: U6PNPSULW
   saschagrunert: U53SUDBD4
+  satyampsoni: U04DUM62MDY
   savitharaghunathan: UC8U2V3BM
   sayantani11: U028S6XNVSN
   sbueringer: U48TE1L75
@@ -260,6 +266,7 @@ users:
   theishshah: U01891A4TRS
   thejoycekung: U01AY4VHX25
   thepetk: U04NW4PPY8N
+  tjons: U05H23DAZTP
   tobiasgiese: U01C1NM8D8F
   tpepper: U6UB5V4TX
   troy0820: U3D457W7M
@@ -273,6 +280,7 @@ users:
   vincepri: UCD11GCET
   vishalanarase: U02GX4DHBUM
   vladimirmukhin: UHVSCSD4G
+  Vyom-Yadav: U03658QBE1K
   vzhukovs: U030TR1FG85
   wallrj: U1ZMERJF7
   willie-yao: U024EME7SQK


### PR DESCRIPTION
Adds the release team to Slack groups for v1.32 cycle.

xref: 
 - https://github.com/kubernetes/community/pull/7919
 - https://github.com/kubernetes/community/pull/7682

cc: @kubernetes/sig-release-leads @Priyankasaggu11929 @katcosgrove @gracenng 
