### PR TITLE
add kubearchive slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -265,6 +265,7 @@ channels:
   - name: kubeadm
   - name: kubeadm-cn
   - name: kubeapps
+  - name: kubearchive
   - name: kubebuilder
   - name: kubecon
   - name: kubecfg


### PR DESCRIPTION
Adds a #kubearchive channel to the Kubernetes slack 

**Project URL:** [https://github.com/kubearchive/kubearchive](https://github.com/kubearchive/kubearchive)

**Purpose:**

KubeArchive is an open source project, licensed under Apache-2.0, that allows kubernetes users to specify resource(s) on their cluster that they would like to be archive (written to a Postgres database and the object deleted from the cluster) when objects of these resource(s) reach a user specified state and provide an API and CLI for querying and retreiving the archived objects. Think Tekton Results (the inspiration for KubeArchive), but more flexible so that it can operate on everything from Tekton PipelineRuns, to plain old Jobs, to any CR you create yourself. KubeArchive uses Knative Eventing under the hood to find out when objects on the cluster are created/updated. We're growing the KubeArchive community and we are looking for a chat channel where the community can:

- coordinate and plan development on KubeArchive in the open
- provide KubeArchive users a place to talk about how they're using KubeArchive or ask questions
- allow the Kubernetes community to learn more about KubeArchive and get involved

I'm happy to provide additional information if needed.