### PR TITLE
Update CAPI v1.9 release team members

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -244,22 +244,19 @@ usergroups:
     description: Members of the Cluster API Release Team
     members:
       - adilGhaffarDev
+      - cahillsf
       - chandankumar4
-      - chiukapoor
-      - dhij
-      - hackeramitkumar
       - jayesh-srivastava
-      - kperath
-      - meatballhat
-      - Nivedita-coder
       - pravarag
       - rajankumary2k
-      - shipra101
-      - smoshiur1237
+      - SD-13
+      - serngawy
+      - sivchari
       - Sunnatillo
-      - troy0820
+      - tasdikrahman
+      - tormath1
+      - varshasuryawanshi
       - vishalanarase
-      - willie-yao
 
   - name: kcp-devs
     long_name: kcp Development Team

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -234,12 +234,15 @@ users:
   sayantani11: U028S6XNVSN
   sbueringer: U48TE1L75
   scott-seago: UHGD79E78
+  SD-13: U03KA77JSHF
+  serngawy: U42969L5P
   sethmccombs: U92LLUZ8A
   sgtcodfish: U01PQ8N3PM1
   shamus: US7EUUBK8
   shipra101: U06MJ9TT031
   shubham-pampattiwar: U01QW84HBBN
   simplytunde: UAY1NBYHE
+  sivchari: U02PERJF469
   Sladyn Nunes: UQ9J177Q8
   smoshiur1237: UULFDSURY
   soltysh: U0B4CS1GF
@@ -255,12 +258,14 @@ users:
   tabbysable: U01742MGBRT
   tallclair: U64VCBURE
   TaoBeier: UCLDV6MN1
+  tasdikrahman: U65NQJWAF
   tejal29: UACD7R316
   ThatsMrTalbot: U7QBP08LR
   theishshah: U01891A4TRS
   thejoycekung: U01AY4VHX25
   thepetk: U04NW4PPY8N
   tobiasgiese: U01C1NM8D8F
+  tormath1: U03F0AG61JM
   tpepper: U6UB5V4TX
   troy0820: U3D457W7M
   tstromberg: UCSL5SJ8Z
@@ -268,6 +273,7 @@ users:
   typeid: U05M1L6EPS6
   valaparthvi: U016TMJVDAA
   varshaprasad96: UK59YP2DA
+  varshasuryawanshi: U07EPRHR6LQ
   Verolop: U7NNE57PU
   VibhorChinda: U031EALE91D
   vincepri: UCD11GCET


### PR DESCRIPTION
New CAPI v1.9 RT members announced here: https://kubernetes.slack.com/archives/C8TSNPY4T/p1723216277709389

This PR removes old and adds new v1.9 RT members from/to the list in alphabetical order