### PR TITLE
[steering 2024] add voters from approved exception request - aug 26

### DIFF
--- a/elections/steering/2024/voters.yaml
+++ b/elections/steering/2024/voters.yaml
@@ -14,6 +14,7 @@
 # 2024-08-01 - Minor correction to fix alpha-sorting of voters list
 # 2024-08-20 - Add voters from approved exception requests
 # 2024-08-21 - Add voters from approved exception requests
+# 2024-08-26 - Add voters from approved exception requests
 #
 eligible_voters:
 - a-mccarthy
@@ -475,6 +476,7 @@ eligible_voters:
 - pwittrock
 - pwschuurman
 - qbarrand
+- qedrakmar
 - qiujian16
 - Raffo
 - RainbowMango


### PR DESCRIPTION
PR adds voters from approved exception request, as of Aug 26, 2024.

/assign @bridgetkromhout @cblecker

/hold
for review/approval from Election Officers.
