### PR TITLE
[steering 2024] add voters from approved exception request - aug 28

### DIFF
--- a/elections/steering/2024/voters.yaml
+++ b/elections/steering/2024/voters.yaml
@@ -15,6 +15,7 @@
 # 2024-08-20 - Add voters from approved exception requests
 # 2024-08-21 - Add voters from approved exception requests
 # 2024-08-26 - Add voters from approved exception requests
+# 2024-08-28 - Add voters from approved exception requests
 #
 eligible_voters:
 - a-mccarthy
@@ -249,6 +250,7 @@ eligible_voters:
 - huww98
 - huxcrux
 - ialidzhikov
+- IanColdwater
 - iholder101
 - Imtiaz1234
 - inductor
@@ -328,6 +330,7 @@ eligible_voters:
 - kvaps
 - kwiesmueller
 - kwilczynski
+- lachie83
 - laozc
 - lauralorenz
 - leilajal
@@ -464,6 +467,7 @@ eligible_voters:
 - PiotrProkop
 - pjbgf
 - pmalek
+- pnbrown
 - pohly
 - Prajyot-Parab
 - PrasadG193


### PR DESCRIPTION
PR adds following voters from approved exception requests, as of Aug 28, 2024.

- @IanColdwater 
- @lachie83 
- @pnbrown 

---

/assign @bridgetkromhout @cblecker

/hold
for review/approval from Election Officers.