### PR TITLE
Modify the sample link in #sign-the-cla section

### DIFF
--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -69,7 +69,7 @@ Before you get started, you will need to [sign up](http://github.com/signup) for
 
 Before you can contribute to Kubernetes, you will need to sign the
 [Contributor License Agreement].
-The easiest way to do so is to open a PR against the [contributor playground repo](https://github.com/kubernetes-sigs/contributor-playground), you can find an example PR [here](https://github.com/kubernetes-sigs/contributor-playground/pull/1227).
+The easiest way to do so is to open a PR against the [contributor playground repo](https://github.com/kubernetes-sigs/contributor-playground), you can find an example PR [here](https://github.com/kubernetes-sigs/contributor-playground/pull/1389).
 
 ### Code of Conduct
 

--- a/contributors/guide/README.md
+++ b/contributors/guide/README.md
@@ -71,6 +71,8 @@ Before you can contribute to Kubernetes, you will need to sign the
 [Contributor License Agreement].
 The easiest way to do so is to open a PR against the [contributor playground repo](https://github.com/kubernetes-sigs/contributor-playground), you can find an example PR [here](https://github.com/kubernetes-sigs/contributor-playground/pull/1389).
 
+**Note:** [kubernetes-sigs/contributor-playground](https://github.com/kubernetes-sigs/contributor-playground) is a repository for practicing submitting your first PR, not just for CLA registration. When creating and submitting a new PR, please write the PR description according to the provided template. Check the above example PR for reference.
+
 ### Code of Conduct
 
 Please make sure to read and observe the [Code of Conduct] and


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

This PR aims to update the sample link in the [#sign-the-cla](https://www.kubernetes.dev/docs/guide/#sign-the-cla) section.
The current example does not follow the repository’s template, making it a little inconvenient for review. Therefore, I want to update it to adhere to the template.
