### PR TITLE
[steering 2024] add voters from approved exception request - aug 30

### DIFF
--- a/elections/steering/2024/voters.yaml
+++ b/elections/steering/2024/voters.yaml
@@ -16,6 +16,7 @@
 # 2024-08-21 - Add voters from approved exception requests
 # 2024-08-26 - Add voters from approved exception requests
 # 2024-08-28 - Add voters from approved exception requests
+# 2024-08-30 - Add voters from approved exception requests
 #
 eligible_voters:
 - a-mccarthy
@@ -185,6 +186,7 @@ eligible_voters:
 - eddycharly
 - edithturn
 - edsoncelio
+- ehashman
 - electrocucaracha
 - elezar
 - ellistarn


### PR DESCRIPTION
PR adds following voters from approved exception requests, as of Aug 30, 2024.

- @ehashman

---

/assign @bridgetkromhout @cblecker

/hold
for review/approval from Election Officers.