### PR TITLE
Add new cert-manager maintainer erikgb to the slack usergroup

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -306,7 +306,7 @@ usergroups:
       - cert-manager-dev
       - cert-manager
     # To get that list, run the following:
-    #  curl https://raw.githubusercontent.com/cert-manager/cert-manager/master/OWNERS | yq .approvers
+    #  curl https://raw.githubusercontent.com/cert-manager/community/main/maintainers.csv
     # Note that you will then need to find your Slack User ID (look up in Stackoverflow)
     # and copy it to the users.yaml file in this repository.
     members:
@@ -318,6 +318,7 @@ usergroups:
       - sgtcodfish
       - inteon
       - ThatsMrTalbot
+      - erikgb
 
   - name: gophercloud-maintainers
     long_name: Gophercloud Maintainers

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -70,6 +70,7 @@ users:
   elsony: UCW8323KL
   EmilienM: U01BVTA83D4
   enj: U2T4CVDTJ
+  erikgb: U015W0NF962
   erismaster: U0162FJ79LY
   estroz: UKSEANEC9
   ezra: U8UN4DC4T


### PR DESCRIPTION
Adds erikgb to the cert-manager-maintainers usergroup. He is a new cert-manager maintainer (see https://github.com/cert-manager/community/pull/32).