### PR TITLE
slack: add channel kty

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -248,6 +248,7 @@ channels:
   - name: krew
   - name: krex
   - name: krustlet
+  - name: kty
   - name: kuadrant
   - name: kube-aws
   - name: kube-bind


### PR DESCRIPTION
Adds a #kty channel to the Kubernetes slack

Project URL: https://github.com/grampelberg/kty

Purpose:

kty is an open source project, licensed under Apache-2.0, which provides a terminal based interface for Kubernetes users leveraging SSH. We're growing the kty community and looking for a channel where the community can:

- Learn more about kty and get involved.
- Have a space to ask questions and get support.
- Coordinate future development amongst contributors.
