### PR TITLE
Add SimKube to Slack Channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -498,6 +498,7 @@ channels:
     archived: true
   - name: sig-windows
   - name: sig-windows-leads
+  - name: simkube
   - name: skaffold
   - name: slack-admins
   - name: slack-infra


### PR DESCRIPTION
This creates a channel for the [SimKube](https://github.com/acrlabs/simkube) project, which is a Kubernetes simulation environment.  SimKube recently announced its [1.0 release](https://blog.appliedcomputing.io/p/announcing-simkube-v10) and I'd like to provide a place for users to come ask questions/report bugs/discuss issues.  

SimKube is an open-source, MIT-licensed project by [Applied Computing Research Labs](https://appliedcomputing.io).
