### PR TITLE
Add k0s-users and k0s-dev to slack channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -199,6 +199,8 @@ channels:
   - name: jsonnet
   - name: carvel
     id: CH8KCCKA5
+  - name: k0s-dev
+  - name: k0s-users
   - name: kalm
   - name: kaniko
   - name: karpenter


### PR DESCRIPTION
This adds #k0s-users and #k0s-dev to the Kubernetes Slack Channels

**Purpose:**
The k0s community is growing and we are working on multiple things that would make it much easier to have two slack channels about k0s

1. k0s has been maintained by Mirantis employees so far, recently we added additional Maintainers from other companies to k0s (https://github.com/k0sproject/k0s/blob/main/MAINTAINERS.md) and would need a place to talk about PRs, issues, etc. - hence we would like to add #k0s-dev
2. k0s has a growing community of users and right now there is no slack channel for k0s users to talk about it we would like to do this in the CNCF slack - hence we would like to add #k0s-users
3. k0s is working on becoming a Sandbox project: https://github.com/cncf/sandbox/issues/125

**About k0s:**
- k0s is a fully open source Kubernetes Distribution: https://k0sproject.io/ https://github.com/k0sproject/k0s
- k0s is actively used in the CNCF ecosystem, see https://github.com/cncf/sandbox/issues/125