### PR TITLE
wg-serving: add links to sponsored subprojects

### DIFF
--- a/wg-serving/README.md
+++ b/wg-serving/README.md
@@ -51,6 +51,11 @@ The WG Serving will operate in several workstreams with different areas of focus
 - [Orchestration](https://docs.google.com/document/d/1hbEx3ZEqdXCqWH9RL3uy9FIy35B8pFJ5KiK3HsOz2FE/edit?usp=sharing)
 - [DRA](https://github.com/kubernetes/community/tree/master/wg-device-management)
 
+## Sponsored Subprojects
+
+* [LLM Instance Gateway](https://github.com/kubernetes-sigs/llm-instance-gateway)
+* [Serving Catalog](https://github.com/kubernetes-sigs/wg-serving/tree/main/serving-catalog)
+
 
 ## How to ...
 


### PR DESCRIPTION
Just added these in custom content in the markdown file directly for now for easy access.