### PR TITLE
doc(e2e-node-tests): fix gcloud list images cmd

### DIFF
--- a/contributors/devel/sig-node/e2e-node-tests.md
+++ b/contributors/devel/sig-node/e2e-node-tests.md
@@ -96,7 +96,7 @@ provided by the default image.
 List the available test images using gcloud.
 
 ```sh
-make test-e2e-node LIST_IMAGES=true
+gcloud compute images list --project="cos-cloud" --no-standard-images --filter="name ~ 'cos-beta.*'"
 ```
 
 This will output a list of the available images for the default image project.


### PR DESCRIPTION
/kind bug


**Which issue(s) this PR fixes**:
the command specified on "List the available test images using gcloud." is outdated since the LIST_IMAGES option was [removed ](https://github.com/kubernetes/kubernetes/pull/109606/files  ) from hack/make-rules/test-e2e-node.sh file.  


#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes https://github.com/kubernetes/community/issues/8083  .
