### PR TITLE
doc(test-e2e): support custom network and subnet on remote e2e mode

### DIFF
--- a/contributors/devel/sig-node/e2e-node-tests.md
+++ b/contributors/devel/sig-node/e2e-node-tests.md
@@ -115,6 +115,14 @@ This is useful if you have an host instance running already and want to run the 
 make test-e2e-node REMOTE=true HOSTS="<comma-separated-list-of-hostnames>"
 ```
 
+## Run tests against a different network and subnet (not the default)
+
+This is useful if you want to run tests on a non-default network and subnet.
+
+```sh
+make test-e2e-node REMOTE=true NETWORK="<network> SUBNET="<subnet>"
+```
+
 ## Delete instance after tests run
 
 This is useful if you want recreate the instance for each test run to trigger flakes related to starting the instance.


### PR DESCRIPTION
/kind feature
/kind doc


**Which issue(s) this PR fixes**:
doc: Support specifying a custom network parameter when running e2e-node-tests with the remote option.


#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes https://github.com/kubernetes/community/issues/8089  .
