### PR TITLE
REQUEST: New Slack kubectl.nvim to the channel.yaml

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -269,6 +269,7 @@ channels:
   - name: kubebuilder
   - name: kubecon
   - name: kubecfg
+  - name: kubectl-nvim
   - name: kubectl-trace
   - name: kubectl-validate
   - name: kubedb


### PR DESCRIPTION
Adds kubectl-nvim channel intended for [kubectl.nvim](https://github.com/Ramilito/kubectl.nvim)