### PR TITLE
Add election results of 2024 Steering Committee election

### DIFF
--- a/elections/steering/2024/ballots.csv
+++ b/elections/steering/2024/ballots.csv
@@ -1,0 +1,234 @@
+aojea,katcosgrove,natalisucks,bentheelder,xmudrii,palnabarun,saschagrunert
+4,6,1,3,7,2,5
+2,No opinion,No opinion,1,No opinion,No opinion,No opinion
+2,No opinion,3,1,No opinion,4,No opinion
+5,6,2,1,7,4,3
+7,2,1,7,7,7,7
+7,7,7,7,7,1,2
+4,2,7,3,7,7,1
+2,7,7,3,5,1,4
+7,7,7,7,7,7,7
+5,4,1,2,7,6,3
+7,7,1,7,7,7,7
+3,2,7,1,6,5,3
+1,7,5,2,6,4,3
+5,1,2,3,7,4,6
+No opinion,No opinion,No opinion,No opinion,1,2,No opinion
+3,5,6,4,7,2,1
+2,No opinion,No opinion,3,No opinion,No opinion,1
+1,7,5,3,6,4,2
+3,2,2,4,7,7,1
+3,7,4,3,6,2,5
+2,7,5,1,6,4,3
+2,6,6,1,4,4,3
+2,7,7,1,4,3,7
+1,3,3,7,3,2,2
+3,No opinion,No opinion,7,No opinion,No opinion,No opinion
+7,2,1,4,7,3,7
+1,No opinion,No opinion,1,1,No opinion,1
+4,5,6,2,1,No opinion,3
+1,3,4,2,No opinion,No opinion,No opinion
+1,3,No opinion,2,No opinion,No opinion,No opinion
+1,No opinion,No opinion,2,3,2,1
+7,7,7,7,7,7,7
+2,4,7,2,7,2,4
+7,3,4,6,2,5,1
+7,2,1,7,7,7,7
+2,1,4,6,5,7,3
+1,7,6,2,5,3,4
+4,3,4,2,2,1,2
+No opinion,No opinion,3,No opinion,1,No opinion,2
+3,2,7,4,6,1,5
+7,2,1,4,5,3,6
+5,2,1,7,4,3,6
+7,7,1,1,7,7,1
+No opinion,1,1,No opinion,No opinion,No opinion,No opinion
+7,4,1,6,5,3,2
+1,7,7,2,7,7,7
+4,2,1,4,3,4,No opinion
+2,7,3,1,7,7,7
+1,3,6,2,7,4,5
+3,2,No opinion,1,No opinion,4,No opinion
+1,7,7,2,7,7,7
+1,4,No opinion,3,No opinion,No opinion,2
+1,4,No opinion,2,3,No opinion,No opinion
+4,2,1,7,3,5,6
+4,7,2,1,6,5,3
+7,7,1,2,7,7,7
+1,7,7,1,7,7,7
+2,3,7,1,7,7,7
+3,5,2,1,6,5,5
+1,7,6,2,4,5,3
+4,1,2,3,5,5,7
+1,5,3,4,6,2,7
+1,7,7,2,5,7,7
+No opinion,No opinion,No opinion,1,No opinion,No opinion,2
+5,4,1,3,7,2,6
+7,1,2,6,5,3,4
+1,7,4,3,7,7,2
+1,7,7,2,7,7,3
+6,3,1,2,5,7,5
+1,7,7,2,7,7,3
+2,1,7,3,5,4,6
+1,7,6,2,5,3,4
+2,3,7,1,7,7,3
+2,3,7,1,4,7,7
+1,7,7,7,7,7,7
+3,1,No opinion,4,No opinion,No opinion,2
+7,7,7,1,7,7,1
+2,4,3,1,7,5,6
+6,1,4,2,3,5,7
+3,7,4,7,2,7,1
+2,1,7,3,5,4,6
+2,3,6,1,5,7,4
+2,7,6,1,4,5,3
+1,1,1,2,1,1,3
+7,3,6,5,1,2,4
+7,7,7,7,7,7,7
+2,1,3,4,7,5,6
+7,2,1,7,7,7,6
+No opinion,1,2,No opinion,No opinion,No opinion,No opinion
+4,2,1,3,6,7,5
+1,No opinion,7,1,3,7,2
+5,4,1,3,6,2,7
+4,2,7,3,6,1,5
+7,4,1,2,7,3,7
+1,3,No opinion,2,4,5,No opinion
+2,7,5,1,4,3,5
+5,1,5,5,4,4,5
+6,4,3,2,5,1,7
+5,6,3,2,7,1,4
+7,7,7,7,7,7,1
+6,4,No opinion,5,No opinion,No opinion,7
+1,5,1,2,4,2,3
+1,7,7,2,7,4,2
+1,4,6,2,5,7,3
+4,3,6,2,1,7,5
+2,No opinion,No opinion,No opinion,No opinion,1,No opinion
+2,7,1,3,7,7,7
+1,3,5,2,4,6,7
+4,5,6,2,1,7,3
+2,6,1,5,4,7,3
+6,1,2,3,7,4,5
+3,2,1,4,No opinion,No opinion,No opinion
+2,6,7,1,4,3,5
+4,6,1,3,7,5,2
+1,4,6,2,5,7,3
+7,3,7,2,7,7,1
+1,No opinion,No opinion,1,No opinion,No opinion,No opinion
+7,2,3,7,7,7,1
+5,6,7,2,4,1,3
+6,1,3,4,7,2,5
+2,No opinion,No opinion,1,3,No opinion,No opinion
+1,7,7,2,7,7,7
+1,7,7,1,7,1,7
+1,4,7,2,6,5,3
+7,2,3,7,7,7,1
+6,2,1,3,7,5,4
+2,No opinion,No opinion,1,4,No opinion,4
+No opinion,No opinion,No opinion,2,No opinion,1,No opinion
+No opinion,1,No opinion,2,No opinion,No opinion,No opinion
+5,2,1,3,7,6,4
+4,7,1,4,2,4,3
+2,3,1,2,3,1,2
+No opinion,No opinion,No opinion,5,No opinion,No opinion,1
+1,2,4,1,2,1,3
+1,No opinion,No opinion,3,2,4,No opinion
+3,2,2,1,4,4,1
+7,4,1,5,6,3,2
+1,7,2,3,7,7,7
+7,2,3,7,1,7,4
+3,7,4,1,5,6,2
+5,7,6,2,4,1,3
+1,No opinion,No opinion,1,No opinion,No opinion,No opinion
+4,2,5,1,3,7,6
+2,1,1,4,7,3,7
+6,5,2,3,1,4,7
+5,2,1,3,7,4,6
+7,4,1,1,4,7,1
+2,4,3,1,4,4,4
+1,7,3,2,5,4,6
+7,2,3,7,7,7,1
+1,3,5,2,4,6,7
+7,1,2,7,7,7,3
+1,4,5,2,7,6,3
+1,4,7,3,4,7,5
+7,7,7,1,7,7,7
+6,1,2,3,7,5,4
+7,7,7,7,7,7,7
+6,2,1,3,4,5,7
+2,7,7,7,7,7,1
+No opinion,2,No opinion,1,3,No opinion,No opinion
+3,4,6,5,1,7,2
+3,1,2,6,7,5,4
+No opinion,No opinion,No opinion,No opinion,No opinion,1,No opinion
+7,2,1,5,7,7,7
+1,6,5,2,3,5,4
+2,No opinion,No opinion,1,No opinion,No opinion,No opinion
+No opinion,7,6,No opinion,No opinion,No opinion,No opinion
+1,7,7,3,7,2,7
+2,3,7,4,7,7,1
+1,7,5,5,4,3,2
+3,7,5,2,6,1,4
+No opinion,7,7,1,3,2,7
+1,No opinion,No opinion,No opinion,No opinion,No opinion,2
+2,7,5,4,6,1,3
+4,3,3,1,7,2,6
+1,6,5,2,4,7,3
+6,7,7,7,2,1,2
+7,7,7,7,7,7,1
+6,1,4,5,2,7,3
+4,2,3,1,7,6,5
+4,2,3,1,5,7,6
+3,4,2,1,7,6,5
+4,3,No opinion,2,No opinion,No opinion,1
+4,2,3,1,7,6,5
+1,7,3,2,6,5,4
+2,3,7,1,7,7,7
+7,7,7,7,7,7,7
+7,2,5,7,4,3,1
+4,1,2,No opinion,No opinion,3,No opinion
+3,7,1,4,2,6,5
+2,4,3,1,7,5,6
+7,1,1,7,2,5,6
+3,5,4,1,2,7,6
+No opinion,No opinion,2,3,1,No opinion,No opinion
+7,7,7,7,7,7,7
+2,7,5,1,4,6,3
+7,2,4,1,6,5,3
+3,1,5,2,7,6,4
+1,3,2,6,7,4,5
+1,3,7,2,7,7,7
+1,3,7,2,4,7,7
+2,No opinion,No opinion,No opinion,No opinion,No opinion,1
+4,7,2,5,7,3,1
+3,7,7,7,7,1,2
+3,6,7,4,2,5,1
+No opinion,No opinion,No opinion,No opinion,No opinion,1,No opinion
+2,7,7,5,1,4,3
+7,3,1,7,3,7,2
+4,5,5,2,7,3,1
+2,7,5,1,6,3,4
+2,7,5,1,6,3,4
+No opinion,1,No opinion,No opinion,No opinion,No opinion,No opinion
+1,7,2,7,7,3,7
+5,7,1,6,4,3,2
+6,5,2,6,4,5,5
+7,7,7,7,7,1,7
+3,5,6,4,7,1,2
+1,7,7,7,7,7,7
+2,5,6,1,4,7,3
+7,7,7,2,7,3,1
+6,1,1,3,5,7,4
+7,7,7,7,7,7,7
+1,7,7,2,7,7,7
+1,No opinion,3,2,No opinion,No opinion,No opinion
+7,7,7,7,7,1,7
+2,7,7,1,7,7,7
+2,3,7,1,7,7,7
+2,5,1,4,6,3,7
+1,7,7,2,7,3,7
+2,4,3,1,5,7,6
+7,4,7,1,2,3,7
+No opinion,3,1,2,No opinion,No opinion,2
+2,No opinion,No opinion,1,5,4,3

--- a/elections/steering/2024/results.md
+++ b/elections/steering/2024/results.md
@@ -1,0 +1,22 @@
+# Results of the 2024 Steering Committee Election
+
+- Number of seats open: 3 (2 year term)
+- Number of eligible voters: 660
+- Number of votes cast: 233
+- Turnout: 35.30%
+
+## Winners
+
+The winners of the open seats are as follows for their two year term:
+
+1. [Benjamin Elder](https://github.com/bentheelder)
+2. [Antonio Ojea](https://github.com/aojea)
+3. [Sascha Grunert](https://github.com/saschagrunert)
+
+The rest of the candidates were placed as follows:
+4. [Natali Vlatko](https://github.com/natalisucks)
+5. [Kat Cosgrove](https://github.com/katcosgrove)
+6. [Nabarun Pal](https://github.com/palnabarun)
+7. [Marko Mudrinić](https://github.com/xmudrii)
+
+Proportional representation limits were not invoked for this election.

--- a/elections/steering/2024/voters.yaml
+++ b/elections/steering/2024/voters.yaml
@@ -679,4 +679,4 @@ eligible_voters:
 - zetaab
 - zhanggbj
 - ziyi-xie
-- zwpaper 
+- zwpaper


### PR DESCRIPTION
This PR adds the formal results of the 2024 Kubernetes Steering Committee election.