### PR TITLE
Simplify contributor setup by removing GOPATH dependency

### DIFF
--- a/contributors/guide/github-workflow.md
+++ b/contributors/guide/github-workflow.md
@@ -17,22 +17,13 @@ description: |
 
 ## 2. Clone fork to local storage
 
-Per Go's [workspace instructions][go-workspace], place Kubernetes' code on your
-`GOPATH` using the following cloning procedure.
+In your shell, define a local working directory as `working_dir`.
 
-[go-workspace]: https://golang.org/doc/code.html#Workspaces
-
-In your shell, define a local working directory as `working_dir`. If your `GOPATH` has multiple paths, pick
-just one and use it instead of `$GOPATH`. You must follow exactly this pattern,
-neither `$GOPATH/src/github.com/${your github profile name}/`
-nor any other pattern will work.
+[GO Modules]: https://go.dev/blog/using-go-modules
 
 ```sh
-export working_dir="$(go env GOPATH)/src/k8s.io"
+export working_dir="${HOME}/src/k8s.io" # Change to your preferred location for source code
 ```
-
-If you already do Go development on github, the `k8s.io` directory
-will be a sibling to your existing `github.com` directory.
 
 Set `user` to match your github profile name:
 


### PR DESCRIPTION
Updates the contributor guide to reflect the shift to Go Modules as the default build system from Go 1.13 onwards. Contributors are no longer required to clone the repository within their GOPATH, simplifying the setup process.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
