### PR TITLE
Archive three disused channels.

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -379,6 +379,7 @@ channels:
   - name: navigator
     archived: true
   - name: ncw-staff
+    archived: true
   - name: netmaker
   - name: nl-users
   - name: node-feature-discovery
@@ -515,6 +516,7 @@ channels:
   - name: summit-staff
   - name: suse-caasp
   - name: talk-proposals
+    archived: true
   - name: tanzu-community-edition
     archived: true
   - name: tanzu-streaming-runtimes
@@ -569,6 +571,7 @@ channels:
     archived: true
   - name: wg-multitenancy
   - name: wg-naming
+    archived: true
   - name: wg-onprem
     archived: true
   - name: wg-policy


### PR DESCRIPTION
Archiving three disused channels.

`#ncw-staff` was for the old New Contributor Workshop and hasn't been used since 2020

`wg-naming` was for the Naming Working Group which was dissolved in 2021

`talk-proposals` never really fulfilled its purpose, and has been inactive since 2019 (tag @castrojo)

/sig contributor-experience
/area slack-management


