### PR TITLE
archive zarf-dev slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -589,4 +589,5 @@ channels:
   - name: yaml-overlay-tool
   - name: zarf
   - name: zarf-dev
+    archived: true
   - name: krkn


### PR DESCRIPTION
Currently there are 2 channels for the Zarf project. We've decided to archive #zarf-dev in favor of the #zarf channel