### PR TITLE
Add room proctor instructions

### DIFF
--- a/events/events-team/operations/mainroom-room-proctor.md
+++ b/events/events-team/operations/mainroom-room-proctor.md
@@ -1,0 +1,16 @@
+# Contributor Summit General Sessions in the Main Presentation Room: Moderator Instructions
+
+Thanks for volunteering to moderate a general session in the main presentation room! 
+Your contribution will make sure everyone can share knowledge and collaborate.
+The general sessions in the main presentation room include things like the introductions, the Steering Q&A, and the Awards. Unlike all other kinds of sessions, they will be staffed by other members of the Summit Staff, including the Summit Leads and Content staff. As such, the room proctors for these are there to supplement these other staff, and may do any of the following as needed:
+
+* Arrive at least 5 minutes before the session is scheduled to start
+* Timekeeping is valuable to make sure the day's schedule goes as planned. Make sure the session both begins and ends on time. Ask the presenter/moderator if they would like a time check. If so, provide a time check with a visual cue at 5 minutes before the session is scheduled to end. At the latest, ensure you end 3 minutes before the start of the next session block.
+* Usher attendees to seats
+* Help run mics to contributors during Q&A sessions
+* Troubleshooting AV and running AV issues to AV staff
+* Other tasks as needed by other staff
+* Keep an eye on the summit slack channels
+
+Thank you once again for your help and support. We hope you enjoy taking part in the Contributor Summit!
+

--- a/events/events-team/operations/presentation-session-room-proctor.md
+++ b/events/events-team/operations/presentation-session-room-proctor.md
@@ -1,0 +1,19 @@
+# Contributor Summit Presentation Sessions Moderator Instructions
+
+Thanks for volunteering to moderate one of the presentation sessions! 
+Presentation sessions are 30 minute sessions in which a speaker is making a slide presentation to the contributors.  
+Your contribution will make sure everyone can share knowledge and collaborate.
+
+To be a successful moderator, you’ll complete the following tasks:
+
+* Arrive at least 5 minutes before the session is scheduled to start
+* Make sure the speaker shows up -- hopefully a few minutes early to setup 
+* Verify AV is working: sound, projection, recording (if applicable), check if there is a second microphone for Q&A. Help troubleshoot any problems with AV, facilities, or event staff.
+* It's best if you sit in the front row
+* Introduce the speaker and session
+* Timekeeping is valuable to make sure the day's schedule goes as planned. Make sure the session both begins and ends on time. Provide a time check with a visual cue at 5 minutes before the session is scheduled to end. At the latest, ensure you end 3 minutes before the start of the next session block.
+* If there is time for Q&A, facilatate the Q&A.
+* Keep an eye on the summit slack channels
+
+Thank you once again for your help and support. We hope you enjoy taking part in the Contributor Summit!
+

--- a/events/events-team/operations/presentation-session-room-proctor.md
+++ b/events/events-team/operations/presentation-session-room-proctor.md
@@ -1,4 +1,4 @@
-# Contributor Summit Presentation Sessions Moderator Instructions
+# Contributor Summit Presentation Sessions Room Proctor Instructions
 
 Thanks for volunteering to moderate one of the presentation sessions! 
 Presentation sessions are 30 minute sessions in which a speaker is making a slide presentation to the contributors.  
@@ -6,14 +6,14 @@ Your contribution will make sure everyone can share knowledge and collaborate.
 
 To be a successful moderator, you’ll complete the following tasks:
 
-* Arrive at least 5 minutes before the session is scheduled to start
-* Make sure the speaker shows up -- hopefully a few minutes early to setup 
+* Arrive at least 5 minutes before the session is scheduled to start.
+* Make sure the speaker shows up -- hopefully a few minutes early to setup.
 * Verify AV is working: sound, projection, recording (if applicable), check if there is a second microphone for Q&A. Help troubleshoot any problems with AV, facilities, or event staff.
-* It's best if you sit in the front row
-* Introduce the speaker and session
+* It's best if you sit in the front row.
+* Introduce the speaker and session.
 * Timekeeping is valuable to make sure the day's schedule goes as planned. Make sure the session both begins and ends on time. Provide a time check with a visual cue at 5 minutes before the session is scheduled to end. At the latest, ensure you end 3 minutes before the start of the next session block.
-* If there is time for Q&A, facilatate the Q&A.
-* Keep an eye on the summit slack channels
+* If there is time for Q&A, facilitate the Q&A.  Take the handheld mic, if available, and bring it to folks who have questions.  Make sure that several people get to ask their questions, rather than allowing one person to dominate Q&A. Exception: sometimes Q&A will become a discussion between the presenter and relevant SIG leads; you should allow this to proceed.  
+* Keep an eye on the summit slack channels.
 
 Thank you once again for your help and support. We hope you enjoy taking part in the Contributor Summit!
 

--- a/events/events-team/operations/presentation-session-room-proctor.md
+++ b/events/events-team/operations/presentation-session-room-proctor.md
@@ -1,6 +1,6 @@
 # Contributor Summit Presentation Sessions Room Proctor Instructions
 
-Thanks for volunteering to moderate one of the presentation sessions! 
+Thanks for volunteering to be a room proctor for one of the presentation sessions! 
 Presentation sessions are 30 minute sessions in which a speaker is making a slide presentation to the contributors.  
 Your contribution will make sure everyone can share knowledge and collaborate.
 

--- a/events/events-team/operations/sig-meeting-room-proctor.md
+++ b/events/events-team/operations/sig-meeting-room-proctor.md
@@ -1,0 +1,18 @@
+# Contributor Summit SIG Meeting Moderator Instructions
+
+Thanks for volunteering to moderate a general session in the main presentation room! 
+Your contribution will make sure everyone can share knowledge and collaborate.
+SIGs can reserve a room for a SIG meeting and discussion at the Contributor Summit.
+
+To be a successful moderator, you’ll complete the following tasks:
+
+* Arrive at least 5 minutes before the session is scheduled to start
+* Ask the SIG if they would requested any AV and verify AV is working like microphone(s) or projector. Help troubleshoot any problems with AV, facilities, or event staff.
+* Timekeeping is valuable to make sure the day's schedule goes as planned. Make sure the session both begins and ends on time. Provide a time check to the session leader at 5/2/1 minute warnings (before the session is scheduled to end). At the latest, ensure you end 3 minutes before the start of the next session block.
+* Make sure the room has appropriate supplies e.g. pens, paper, etc
+* As a SIG meeting may be an official SIG meeting, SIGs should facilitate note taking if applicable
+* When it comes to crowd participation, don't let one person monopolize the conversation – pay attention to the discussion and politely encourage and highlight other people who have may have things to add
+* Keep an eye on the summit slack channels
+
+Thank you once again for your help and support. We hope you enjoy taking part in the Contributor Summit!
+

--- a/events/events-team/operations/sig-meeting-room-proctor.md
+++ b/events/events-team/operations/sig-meeting-room-proctor.md
@@ -1,18 +1,18 @@
 # Contributor Summit SIG Meeting Room Proctor Instructions
 
-Thanks for volunteering to moderate a general session in the main presentation room! 
+Thanks for volunteering to be a room proctor for a general session in the main presentation room! 
 Your contribution will make sure everyone can share knowledge and collaborate.
 SIGs can reserve a room for a SIG meeting and discussion at the Contributor Summit.
 
 To be a successful moderator, you’ll complete the following tasks:
 
-* Arrive at least 5 minutes before the session is scheduled to start
+* Arrive at least 5 minutes before the session is scheduled to start.
 * Find out who is running the SIG meeting, and make sure they're ready and present.  If the SIG lead does not show, help SIG members decide on someone else to lead the meeting.
 * Ask the SIG if they would requested any AV and verify AV is working like microphone(s) or projector. Help troubleshoot any problems with AV, facilities, or event staff.
 * Timekeeping is valuable to make sure the day's schedule goes as planned. Make sure the session both begins and ends on time. Provide a time check to the session leader at 5/2/1 minute warnings (before the session is scheduled to end). At the latest, ensure you end 3 minutes before the start of the next session block.
-* Make sure the room has appropriate supplies e.g. pens, paper, etc
-* As a SIG meeting may be an official SIG meeting, SIGs should facilitate note taking if applicable
-* Keep an eye on the summit slack channels
+* Make sure the room has appropriate supplies e.g. pens, paper, etc.
+* As a SIG meeting may be an official SIG meeting, SIGs should facilitate note taking if applicable.
+* Keep an eye on the summit slack channels.
 
 Thank you once again for your help and support. We hope you enjoy taking part in the Contributor Summit!
 

--- a/events/events-team/operations/sig-meeting-room-proctor.md
+++ b/events/events-team/operations/sig-meeting-room-proctor.md
@@ -1,4 +1,4 @@
-# Contributor Summit SIG Meeting Moderator Instructions
+# Contributor Summit SIG Meeting Room Proctor Instructions
 
 Thanks for volunteering to moderate a general session in the main presentation room! 
 Your contribution will make sure everyone can share knowledge and collaborate.
@@ -7,11 +7,11 @@ SIGs can reserve a room for a SIG meeting and discussion at the Contributor Summ
 To be a successful moderator, you’ll complete the following tasks:
 
 * Arrive at least 5 minutes before the session is scheduled to start
+* Find out who is running the SIG meeting, and make sure they're ready and present.  If the SIG lead does not show, help SIG members decide on someone else to lead the meeting.
 * Ask the SIG if they would requested any AV and verify AV is working like microphone(s) or projector. Help troubleshoot any problems with AV, facilities, or event staff.
 * Timekeeping is valuable to make sure the day's schedule goes as planned. Make sure the session both begins and ends on time. Provide a time check to the session leader at 5/2/1 minute warnings (before the session is scheduled to end). At the latest, ensure you end 3 minutes before the start of the next session block.
 * Make sure the room has appropriate supplies e.g. pens, paper, etc
 * As a SIG meeting may be an official SIG meeting, SIGs should facilitate note taking if applicable
-* When it comes to crowd participation, don't let one person monopolize the conversation – pay attention to the discussion and politely encourage and highlight other people who have may have things to add
 * Keep an eye on the summit slack channels
 
 Thank you once again for your help and support. We hope you enjoy taking part in the Contributor Summit!

--- a/events/events-team/operations/unconference-room-proctor.md
+++ b/events/events-team/operations/unconference-room-proctor.md
@@ -1,0 +1,17 @@
+# Contributor Summit Unconference Sessions Moderator Instructions
+
+Thanks for volunteering to moderate one of our unconference sessions! Your contribution will make sure everyone can share knowledge and collaborate.
+
+To be a successful moderator, you’ll complete the following tasks:
+
+* Arrive at least 5 minutes before the unconference session is scheduled to start
+* Make sure the room has appropriate supplies e.g. pens, paper, etc
+* Find a volunteer notekeeper or two and have them take notes in the shared Google Drive folder: https://k8s.dev/summit/notes. You will also find this link in the #contributor-summit Slack channel. The Google Drive folder contains the notes template needed
+* Each unconference block should have one (1) notes document, named for the room name and session (Unconference) your unconference block is happening in. If a notes document already exists for your room, continue note-taking there. Share this document in the #contributor-summit Slack channel for attendees to find and access
+* When it comes to crowd participation, don't let one person monopolize the conversation – pay attention to the discussion and politely encourage and highlight other people who have may have things to add
+* “Has everyone who wants to say something had a chance to do so?" – this is a great phrase to use to encourage more people to share their thoughts!
+* You’ll need to conduct time checks at the 10 minute and 5 minute mark, ensuring you end 3 minutes before the start of the next session block – visual cues for speakers are best. All sessions must end on time so that contributors can rely on our shared schedule and participate accordingly
+
+
+Thank you again for your help and support. We hope you enjoy taking part in the Contributor Summit and the unconference sessions!
+

--- a/events/events-team/operations/unconference-room-proctor.md
+++ b/events/events-team/operations/unconference-room-proctor.md
@@ -1,16 +1,17 @@
-# Contributor Summit Unconference Sessions Moderator Instructions
+# Contributor Summit Unconference Sessions Room Proctor Instructions
 
 Thanks for volunteering to moderate one of our unconference sessions! Your contribution will make sure everyone can share knowledge and collaborate.
 
 To be a successful moderator, you’ll complete the following tasks:
 
 * Arrive at least 5 minutes before the unconference session is scheduled to start
-* Make sure the room has appropriate supplies e.g. pens, paper, etc
-* Find a volunteer notekeeper or two and have them take notes in the shared Google Drive folder: https://k8s.dev/summit/notes. You will also find this link in the #contributor-summit Slack channel. The Google Drive folder contains the notes template needed
-* Each unconference block should have one (1) notes document, named for the room name and session (Unconference) your unconference block is happening in. If a notes document already exists for your room, continue note-taking there. Share this document in the #contributor-summit Slack channel for attendees to find and access
-* When it comes to crowd participation, don't let one person monopolize the conversation – pay attention to the discussion and politely encourage and highlight other people who have may have things to add
+* Make sure the room has appropriate supplies e.g. pens, paper, etc.
+* Help the group decide on a discussion leader.  In most cases, this is the person who proposed the session, but sometimes they are unavailable or uncomfortable with leading it.
+* Find a volunteer notekeeper or two and have them take notes in the shared Google Drive folder: https://k8s.dev/summit/notes. You will also find this link in the #contributor-summit Slack channel. The Google Drive folder contains the notes template needed.
+* Each unconference block should have one (1) notes document, named for the room name and session (Unconference) your unconference block is happening in. If a notes document already exists for your room, continue note-taking there. Share this document in the #contributor-summit Slack channel for attendees to find and access.
+* When it comes to crowd participation, don't let one person monopolize the conversation – pay attention to the discussion and politely encourage and highlight other people who have may have things to add.
 * “Has everyone who wants to say something had a chance to do so?" – this is a great phrase to use to encourage more people to share their thoughts!
-* You’ll need to conduct time checks at the 10 minute and 5 minute mark, ensuring you end 3 minutes before the start of the next session block – visual cues for speakers are best. All sessions must end on time so that contributors can rely on our shared schedule and participate accordingly
+* You’ll need to conduct time checks at the 10 minute and 5 minute mark, ensuring you end 3 minutes before the start of the next session block – visual cues for speakers are best. All sessions must end on time so that contributors can rely on our shared schedule and participate accordingly.
 
 
 Thank you again for your help and support. We hope you enjoy taking part in the Contributor Summit and the unconference sessions!

--- a/events/events-team/operations/unconference-room-proctor.md
+++ b/events/events-team/operations/unconference-room-proctor.md
@@ -1,8 +1,8 @@
 # Contributor Summit Unconference Sessions Room Proctor Instructions
 
-Thanks for volunteering to moderate one of our unconference sessions! Your contribution will make sure everyone can share knowledge and collaborate.
+Thanks for volunteering to be a room proctor for one of our unconference sessions! Your contribution will make sure everyone can share knowledge and collaborate.
 
-To be a successful moderator, you’ll complete the following tasks:
+To be a successful room proctor, you’ll complete the following tasks:
 
 * Arrive at least 5 minutes before the unconference session is scheduled to start
 * Make sure the room has appropriate supplies e.g. pens, paper, etc.


### PR DESCRIPTION
This PR adds KCS room proctor instructions for moderators for unconference sessions, the main room, general presentation, and SIG meetings.
Separate files are used instead of adding to volunteers.md since these instructions are intended to be printed and provided to room proctors.

The unconference room proctor instructions came from @mfahlandt 's Google Doc: https://docs.google.com/document/d/1V2Eoqulktul_i-UqJTd3svbODxulm5n7RV7m_rJg9P0/edit?usp=sharing