### PR TITLE
create e2e-framework slack channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -115,6 +115,8 @@ channels:
   - name: draft-dev
   - name: draft-users
   - name: druid-operator
+  - name: e2e-framework-dev
+  - name: e2e-framework-users
   - name: ebpf
   - name: educates
   - name: eks


### PR DESCRIPTION
create slack channels for the e2e-framework project

one for the development and the other for users support and general requests/topics


/assign @jberkus @mrbobbytables @harshanarayana @vladimirvivien 