### PR TITLE
Code of Conduct Committee Elections — 2025

### DIFF
--- a/elections/code-of-conduct/2023/OWNERS
+++ b/elections/code-of-conduct/2023/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-  - committee-steering
-labels:
-  - committee/steering

--- a/elections/code-of-conduct/2025/README.md
+++ b/elections/code-of-conduct/2025/README.md
@@ -29,7 +29,7 @@ member will serve a two (2) year term.
 
 ## Election Platform
 
-We will be using [Elekto] to conduct the election. Elekto relies entirely on GitHub Oauth for
+We will be using [Elekto] to conduct the election. Elekto relies entirely on GitHub OAuth for
 voting, and as such does not use email at all. Elekto also handles exceptions,
 eligibility checks, and other aspects of the election. See the [Elekto voting documentation]
 for how to use it.

--- a/elections/code-of-conduct/2025/README.md
+++ b/elections/code-of-conduct/2025/README.md
@@ -47,15 +47,15 @@ for how to use it.
 ### Schedule
 
 <!-- TODO(cocc): Fix election dates -->
-| Date                    | Event                                             |
-|:------------------------|:--------------------------------------------------|
-| July 25                 | Nominations Open                                  |
-| Friday, August 4        | Nominations Close                                 |
-| Monday, August 7        | Steering to confirm candidacy                     |
-| Friday, August 11       | Election Begins                                   |
-| Thursday, August 17     | Election Closes                                   |
-| Friday, August 18       | Announcement of results                           |
-| Wednesday, August 23    | CoCC to hold onboarding sessions for new members  |
+| Date | Event |
+| --- | --- |
+| Monday, December 2 | Nominations Open |
+| Friday, January 31 | Nominations Close |
+| Monday, February 3 | Steering to confirm candidacy |
+| Monday, February 10 | Election Begins |
+| Monday, February 17 | Election Closes |
+| Tuesday, February 18 | Announcement of results |
+| Thursday, February 20 | CoCC to hold onboarding sessions for new members |
 
 Candidate nomination, bio, and election close deadlines will be done using Anywhere on Earth timing, meaning it is still valid to submit new nominations/bios/votes as long as it is still the last day anywhere on the planet (i.e. at the end of that day in UTC-12).
 

--- a/elections/code-of-conduct/2025/README.md
+++ b/elections/code-of-conduct/2025/README.md
@@ -1,0 +1,84 @@
+# 2025 VOTERS GUIDE - KUBERNETES CODE OF CONDUCT ELECTIONS
+
+## Important Links
+
+- [Kubernetes Code of Conduct Committee]
+- [election app]
+- [election page]
+- [schedule](#schedule)
+
+## Table of Contents
+
+- [Important Links](#important-links)
+- [Table of Contents](#table-of-contents)
+- [Purpose](#purpose)
+- [Election Platform](#election-platform)
+- [Eligibility](#eligibility)
+  - [Schedule](#schedule)
+- [Candidacy Process](#candidacy-process)
+- [Voters](#voters)
+- [Nominees](#nominees)
+
+## Purpose
+
+The role of this election is to fill out the three (3) seats open for election
+this year on the [Kubernetes Code of Conduct Committee]. Each elected
+member will serve a two (2) year term.
+
+<!-- TODO(cocc): Add blurb about election timing -->
+
+## Election Platform
+
+We will be using [Elekto] to conduct the election. Elekto relies entirely on GitHub Oauth for
+voting, and as such does not use email at all. Elekto also handles exceptions,
+eligibility checks, and other aspects of the election. See the [Elekto voting documentation]
+for how to use it.
+
+## Eligibility
+
+- Candidate commits to putting the interests of the community above the interests of their employer for all Code of Conduct Committee activities.
+- Is generally a responsible human
+- Does not have to be part of the Kubernetes or CNCF community
+- Characteristics which would be nice in any nominations:
+  - Previous experience on an Ethics Committee or Code of Conduct Committee is appreciated
+  - Has demonstrated integrity, professionalism, and positive influence within the community is appreciated
+  - Experience with the tools which we use to communicate (Zoom, Slack, GitHub, etc.) within the Kubernetes community is appreciated
+
+### Schedule
+
+<!-- TODO(cocc): Fix election dates -->
+| Date                    | Event                                             |
+|:------------------------|:--------------------------------------------------|
+| July 25                 | Nominations Open                                  |
+| Friday, August 4        | Nominations Close                                 |
+| Monday, August 7        | Steering to confirm candidacy                     |
+| Friday, August 11       | Election Begins                                   |
+| Thursday, August 17     | Election Closes                                   |
+| Friday, August 18       | Announcement of results                           |
+| Wednesday, August 23    | CoCC to hold onboarding sessions for new members  |
+
+Candidate nomination, bio, and election close deadlines will be done using Anywhere on Earth timing, meaning it is still valid to submit new nominations/bios/votes as long as it is still the last day anywhere on the planet (i.e. at the end of that day in UTC-12).
+
+## Candidacy Process
+
+<!-- TODO(cocc): Fix election dates -->
+Candidate nominations were accepted through a [Google Form] open from July 25, 2025 to August 4, 2025.
+
+For more details about the candidacy and the voting process, see the [CoCC Election Charter].
+
+## Voters
+
+<!-- TODO(cocc): Fix election dates -->
+Only the Kubernetes Steering Committee members as of August 8, 2025 will be eligible voters for the election.
+
+## Nominees
+
+Nominees may be found in the [election app].
+
+[Kubernetes Code of Conduct Committee]: https://github.com/kubernetes/community/blob/master/committee-code-of-conduct
+[election app]: https://elections.k8s.io
+[election page]: https://elections.k8s.io/app/elections/code-of-conduct---2025
+[Elekto]: https://elekto.dev
+[Elekto voting documentation]: https://elekto.dev/docs/voting/
+[Google Form]: https://forms.gle/YQvofRb14Jbu2mjc6 <!-- TODO(cocc): Generate new candidate submission form -->
+[CoCC Election Charter]: https://github.com/kubernetes/community/blob/master/committee-code-of-conduct/election.md

--- a/elections/code-of-conduct/2025/README.md
+++ b/elections/code-of-conduct/2025/README.md
@@ -46,7 +46,6 @@ for how to use it.
 
 ### Schedule
 
-<!-- TODO(cocc): Fix election dates -->
 | Date | Event |
 | --- | --- |
 | Monday, December 2 | Nominations Open |
@@ -61,15 +60,13 @@ Candidate nomination, bio, and election close deadlines will be done using Anywh
 
 ## Candidacy Process
 
-<!-- TODO(cocc): Fix election dates -->
-Candidate nominations were accepted through a [Google Form] open from July 25, 2025 to August 4, 2025.
+Candidate nominations were accepted through a [Google Form] open during the above stated [nomination period](#schedule).
 
 For more details about the candidacy and the voting process, see the [CoCC Election Charter].
 
 ## Voters
 
-<!-- TODO(cocc): Fix election dates -->
-Only the Kubernetes Steering Committee members as of August 8, 2025 will be eligible voters for the election.
+Only the Kubernetes Steering Committee members as of February 4, 2025 will be eligible voters for the election.
 
 ## Nominees
 

--- a/elections/code-of-conduct/2025/README.md
+++ b/elections/code-of-conduct/2025/README.md
@@ -25,7 +25,11 @@ The role of this election is to fill out the three (3) seats open for election
 this year on the [Kubernetes Code of Conduct Committee]. Each elected
 member will serve a two (2) year term.
 
-<!-- TODO(cocc): Add blurb about election timing -->
+*In an effort to deconflict between Steering and Code of Conduct Committee
+election timing and provide new Steering Committee members sufficient time to
+onboard (3+ months), the Steering Committee has made the decision to move the
+Code of Conduct Committee elections to follow the 2024 Steering elections,
+instead of preceding them.*
 
 ## Election Platform
 

--- a/elections/code-of-conduct/2025/election.yaml
+++ b/elections/code-of-conduct/2025/election.yaml
@@ -1,8 +1,7 @@
 name: 2025 Kubernetes Code of Conduct Committee Election
 organization: Kubernetes
-# TODO(cocc): Fix election dates
-start_datetime: 2025-08-11 00:00:01
-end_datetime: 2025-08-18 11:59:59
+start_datetime: 2025-02-10 00:00:01
+end_datetime: 2025-02-17 11:59:59
 no_winners: 3
 allow_no_opinion: True
 delete_after: True
@@ -16,7 +15,6 @@ election_officers:
   - soltysh
 eligibility: Eligibility is limited to the [current Steering Committee Members](https://github.com/kubernetes/steering/blob/45c016ebe5c08cb3852240751382b02afc0aa4f3/README.md#members)
 exception_description: No exception requests accepted for this election.
-# TODO(cocc): Fix election dates
-exception_due: 2025-08-08 00:00:01
+exception_due: 2025-02-04 00:00:01
 show_candidate_fields:
   - 

--- a/elections/code-of-conduct/2025/election.yaml
+++ b/elections/code-of-conduct/2025/election.yaml
@@ -1,0 +1,22 @@
+name: 2025 Kubernetes Code of Conduct Committee Election
+organization: Kubernetes
+# TODO(cocc): Fix election dates
+start_datetime: 2025-08-11 00:00:01
+end_datetime: 2025-08-18 11:59:59
+no_winners: 3
+allow_no_opinion: True
+delete_after: True
+election_officers:
+  - BenTheElder
+  - aojea
+  - justaugustus
+  - pacoxu
+  - pohly
+  - saschagrunert
+  - soltysh
+eligibility: Eligibility is limited to the [current Steering Committee Members](https://github.com/kubernetes/steering/blob/45c016ebe5c08cb3852240751382b02afc0aa4f3/README.md#members)
+exception_description: No exception requests accepted for this election.
+# TODO(cocc): Fix election dates
+exception_due: 2025-08-08 00:00:01
+show_candidate_fields:
+  - 

--- a/elections/code-of-conduct/2025/election_desc.md
+++ b/elections/code-of-conduct/2025/election_desc.md
@@ -1,0 +1,4 @@
+# Vote for the Kubernetes Code of Conduct Committee
+
+<!-- TODO(cocc): Fix election dates -->
+Please complete your voting by the end of 2025/08/17.

--- a/elections/code-of-conduct/2025/election_desc.md
+++ b/elections/code-of-conduct/2025/election_desc.md
@@ -1,4 +1,3 @@
 # Vote for the Kubernetes Code of Conduct Committee
 
-<!-- TODO(cocc): Fix election dates -->
-Please complete your voting by the end of 2025/08/17.
+Please complete your voting by the end of 2025-02-17.

--- a/elections/code-of-conduct/2025/results.md
+++ b/elections/code-of-conduct/2025/results.md
@@ -1,0 +1,12 @@
+# Results of the 2025 Kubernetes Code of Conduct Committee Elections
+
+- Number of seats open: 3 (2 year term)
+- Number of eligible voters: 7
+- Number of votes cast: TBD
+- Turnout: TBD
+
+## Winners
+
+- TBD
+- TBD
+- TBD

--- a/elections/code-of-conduct/2025/voters.yaml
+++ b/elections/code-of-conduct/2025/voters.yaml
@@ -1,0 +1,17 @@
+# 2025 Code of Conduct Committee Election
+##################################
+#
+# The eligible voters for the elections is the Kubernetes Steering Committee as of 2025-01-31
+#
+# History:
+# Log of changes to the file
+# 2024-11-06 - Add eligible voters
+#
+eligible_voters:
+- BenTheElder
+- aojea
+- justaugustus
+- pacoxu
+- pohly
+- saschagrunert
+- soltysh

--- a/elections/code-of-conduct/OWNERS
+++ b/elections/code-of-conduct/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+options:
+  no_parent_owners: true
+approvers:
+  - committee-steering
+labels:
+  - committee/conduct
+  - committee/steering


### PR DESCRIPTION
*In an effort to deconflict between Steering and Code of Conduct Committee
election timing and provide new Steering Committee members sufficient time to
onboard (3+ months), the Steering Committee has made the decision to move the
Code of Conduct Committee elections to follow the 2024 Steering elections,
instead of preceding them.*

I am proposing the following timeline for the 2025 Code of Conduct Committee elections:

| Date | Event |
| --- | --- |
| Monday, December 2 | Nominations Open |
| Friday, January 31 | Nominations Close |
| Monday, February 3 | Steering to confirm candidacy |
| Monday, February 10 | Election Begins |
| Monday, February 17 | Election Closes |
| Tuesday, February 18 | Announcement of results |
| Thursday, February 20 | CoCC to hold onboarding sessions for new members |

As a point of reference, the last CoCC election that we held had approximately the following timeline:

- Nominations period: 2 weeks
- Steering confirms candidacy: 1 day after nomination close
- Election begins: 1 week after candidacy confirmation
- Election closes: 1 week after election opens
- Announcement: 1 day after election closes
- Onboarding: 3 days after election announcement

tl;dr — the biggest changes here are:

- the actual election dates
- how long the nominations period is open for (2 months, instead of 2 weeks, to accommodate holiday schedules and multiple notifications)