### PR TITLE
add email to lead metadata

### DIFF
--- a/generator/app.go
+++ b/generator/app.go
@@ -217,6 +217,10 @@ type Person struct {
 	GitHub  string
 	Name    string
 	Company string `yaml:"company,omitempty"`
+	// NOTE: this isn't displayed in the markdown files by design
+	// We collect this info for purposes like the leads@kubernetes.io list
+	// You should reach out to SIGs via the group mailinglists, slack, and github
+	Email string `yaml:"email,omitempty"`
 }
 
 // Meeting represents a regular meeting for a group.

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1932,6 +1932,7 @@ sigs:
     - github: BenTheElder
       name: Benjamin Elder
       company: Google
+      email: bentheelder@google.com
     - github: ameukam
       name: Arnaud Meukam
       company: Independent
@@ -3015,6 +3016,7 @@ sigs:
     - github: BenTheElder
       name: Benjamin Elder
       company: Google
+      email: bentheelder@google.com
     - github: alvaroaleman
       name: Alvaro Aleman
       company: Red Hat


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

This is for https://github.com/kubernetes/steering/issues/281, and may also be useful for populating the leads mailinglist.

It is not intended to surface the leads's emails for other purposes and therefore the generator is not extended to display it in the SIG/WG markdown files.
