### PR TITLE
Add project `kro` to slack channels

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -247,6 +247,7 @@ channels:
   - name: kraken
   - name: krane
   - name: krator
+  - name: kro
   - name: krew
   - name: krex
   - name: krustlet


### PR DESCRIPTION
Add a new slack channel 'kro' to facilitate discussions around Kube Resource Orchestrator implementation and usage.

Link: https://kro.run/