### PR TITLE
update sig-cloud-provider emails in sigs.yaml

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -825,16 +825,20 @@ sigs:
     - github: bridgetkromhout
       name: Bridget Kromhout
       company: Microsoft
+      email: bridget@kromhout.org
     - github: elmiko
       name: Michael McCune
       company: Red Hat
+      email: msm@opbstudios.com
     tech_leads:
     - github: cheftako
       name: Walter Fender
       company: Google
+      email: wfender@google.com
     - github: elmiko
       name: Michael McCune
       company: Red Hat
+      email: msm@opbstudios.com
     emeritus_leads:
     - github: andrewsykim
       name: Andrew Sy Kim


### PR DESCRIPTION
this change adds email addresses for the chairs and tech leads.
