### PR TITLE
add emails for wg-batch leads on sigs list

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3303,15 +3303,19 @@ workinggroups:
     - github: kannon92
       name: Kevin Hannon
       company: Red Hat
+      email: kehannon@redhat.com
     - github: mwielgus
       name: Marcin Wielgus
       company: Google
+      email: mwielgus@google.com
     - github: soltysh
       name: Maciej Szulik
       company: Defense Unicorns
+      email: soltysh@gmail.com
     - github: swatisehgal
       name: Swati Sehgal
       company: Red Hat
+      email: swati.tcd@gmail.com
     emeritus_leads:
     - github: Huang-Wei
       name: Wei Huang


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:

Add emails for wg-batch leads. I used https://github.com/kubernetes/k8s.io/blob/main/groups/wg-batch/groups.yaml as the source of truth here.

Refer to https://groups.google.com/a/kubernetes.io/g/leads/c/3A2d1_onI3o

cc @soltysh @swatisehgal @mwielgus 
