### PR TITLE
add emails for sig-node leadership

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2351,22 +2351,28 @@ sigs:
     - github: SergeyKanzhelev
       name: Sergey Kanzhelev
       company: Google
+      email: s.kanzhelev@gmail.com
     - github: haircommander
       name: Peter Hunt
       company: Red Hat
+      email: pehunt@redhat.com
     - github: mrunalp
       name: Mrunal Patel
       company: Red Hat
+      email: mpatel@redhat.com
     tech_leads:
     - github: dchen1107
       name: Dawn Chen
       company: Google
+      email: dawnchen@google.com
     - github: derekwaynecarr
       name: Derek Carr
       company: Red Hat
+      email: decarr@redhat.com
     - github: mrunalp
       name: Mrunal Patel
       company: Red Hat
+      email: mpatel@redhat.com
   meetings:
   - description: Main SIG Meeting
     day: Tuesday


### PR DESCRIPTION
Added emails for sig-node leadership and I used https://github.com/kubernetes/k8s.io/blob/main/groups/sig-node/groups.yaml as the source of truth.