### PR TITLE
Update SIG Release leads emails and affiliations - 2024

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -34,9 +34,9 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
-* Verónica López (**[@Verolop](https://github.com/Verolop)**), PlanetScale
+* Verónica López (**[@Verolop](https://github.com/Verolop)**), AuthZed
 * Carlos Tadeu Panato Jr. (**[@cpanato](https://github.com/cpanato)**), Chainguard, Inc
-* Adolfo García Veytia (**[@puerco](https://github.com/puerco)**), Chainguard, Inc
+* Adolfo García Veytia (**[@puerco](https://github.com/puerco)**), Stacklok
 
 ## Emeritus Leads
 
@@ -106,8 +106,8 @@ The Release Engineering subproject is responsible for the [process/procedures](h
 ### Release Team
 The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
 - **Leads:**
-  - Grace Nguyen (**[@gracenng](https://github.com/gracenng)**)
-  - Kat Cosgrove (**[@katcosgrove](https://github.com/katcosgrove)**), Dell
+  - Grace Nguyen (**[@gracenng](https://github.com/gracenng)**), Notion
+  - Kat Cosgrove (**[@katcosgrove](https://github.com/katcosgrove)**), Independent
 - **Owners:**
   - [kubernetes-sigs/release-team-shadow-stats](https://github.com/kubernetes-sigs/release-team-shadow-stats/blob/main/OWNERS)
   - [kubernetes/sig-release/release-team](https://github.com/kubernetes/sig-release/blob/master/release-team/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2477,23 +2477,28 @@ sigs:
     - github: jeremyrickard
       name: Jeremy Rickard
       company: Microsoft
+      email: jeremy.r.rickard@gmail.com
     - github: justaugustus
       name: Stephen Augustus
       company: Cisco
+      email: k8s@auggie.dev
     - github: saschagrunert
       name: Sascha Grunert
       company: Red Hat
+      email: saschagrunert@gmail.com
     tech_leads:
     - github: Verolop
       name: Verónica López
-      company: PlanetScale
+      company: AuthZed
+      email: gveronicalg@gmail.com
     - github: cpanato
       name: Carlos Tadeu Panato Jr.
       company: Chainguard, Inc
       email: ctadeu@gmail.com
     - github: puerco
       name: Adolfo García Veytia
-      company: Chainguard, Inc
+      company: Stacklok
+      email: adolfo.garcia@uservers.net
     emeritus_leads:
     - github: alejandrox1
       name: Jorge Alarcon Ochoa
@@ -2581,6 +2586,7 @@ sigs:
     - github: xmudrii
       name: Marko Mudrinić
       company: Kubermatic
+      email: mudrinic.mare@gmail.com
   - name: Release Team
     description: |
       The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
@@ -2603,9 +2609,12 @@ sigs:
     leads:
     - github: gracenng
       name: Grace Nguyen
+      company: Notion
+      email: nng.grace@gmail.com
     - github: katcosgrove
       name: Kat Cosgrove
-      company: Dell
+      company: Independent
+      email: kat.cosgrove@gmail.com
   - name: SIG Release Process Documentation
     description: |
       Documents and processes related to SIG Release


### PR DESCRIPTION
This PR updates the lead data for the SIG release leads.

Hold while collecting everyone's info
/hold

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
