### PR TITLE
remove inaccurate representation of subprojects

### DIFF
--- a/wg-serving/README.md
+++ b/wg-serving/README.md
@@ -51,12 +51,6 @@ The WG Serving will operate in several workstreams with different areas of focus
 - [Orchestration](https://docs.google.com/document/d/1hbEx3ZEqdXCqWH9RL3uy9FIy35B8pFJ5KiK3HsOz2FE/edit?usp=sharing)
 - [DRA](https://github.com/kubernetes/community/tree/master/wg-device-management)
 
-## Sponsored Subprojects
-
-* [LLM Instance Gateway](https://github.com/kubernetes-sigs/llm-instance-gateway)
-* [Serving Catalog](https://github.com/kubernetes-sigs/wg-serving/tree/main/serving-catalog)
-
-
 ## How to ...
 
 ### subscribe to WG events


### PR DESCRIPTION
Work groups CANNOT sponsor subprojects, only suggest and participate in them. work groups are discussion groups for interests that potentially cross sigs.

Also, subprojects are tracked in sigs.yaml in a standardized format with specific metadata required.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


/assign @kubernetes/steering-committee 

FYI @ArangoGutierrez @Jeffwan @SergeyKanzhelev @terrytangyuan
