### PR TITLE
add emails for pohly and wg-device-management

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3080,6 +3080,7 @@ sigs:
     - github: pohly
       name: Patrick Ohly
       company: Intel
+      email: patrick.ohly@intel.com
     emeritus_leads:
     - github: fejta
       name: Erick Fejta
@@ -3442,9 +3443,11 @@ workinggroups:
     - github: klueska
       name: Kevin Klues
       company: NVIDIA
+      email: klueska@gmail.com
     - github: pohly
       name: Patrick Ohly
       company: Intel
+      email: patrick.ohly@intel.com
   meetings:
   - description: Regular WG Meeting
     day: Tuesday
@@ -3840,6 +3843,7 @@ committees:
     - github: pohly
       name: Patrick Ohly
       company: Intel
+      email: patrick.ohly@intel.com
     - github: saschagrunert
       name: Sascha Grunert
       company: Red Hat


### PR DESCRIPTION
Email for @klueska is from
https://github.com/kubernetes/k8s.io/blob/ab454c582cd8aa08187da5d9ec95926a4b48fa66/groups/wg-device-management/groups.yaml#L17C9-L17C26

**Which issue(s) this PR fixes**:
Related-to: https://github.com/kubernetes/steering/issues/281

/assign @BenTheElder @klueska 