### PR TITLE
sig-architecture: document wg-device-management repo

### DIFF
--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -112,6 +112,12 @@ Snooping on the Kubernetes OpenAPI communications
   - [kubernetes/community/sig-architecture](https://github.com/kubernetes/community/blob/master/sig-architecture/OWNERS)
 - **Contact:**
   - Slack: [#prod-readiness](https://kubernetes.slack.com/messages/prod-readiness)
+### wg-device-management
+Contains prototype code for future work driven by WG Device Management
+- **Owners:**
+  - [kubernetes-sigs/wg-device-management](https://github.com/kubernetes-sigs/wg-device-management/blob/main/OWNERS)
+- **Contact:**
+  - Slack: [#wg-device-management](https://kubernetes.slack.com/messages/wg-device-management)
 ### wg-serving
 - **Owners:**
   - [kubernetes-sigs/wg-serving](https://github.com/kubernetes-sigs/wg-serving/blob/main/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -413,6 +413,12 @@ sigs:
       slack: prod-readiness
     owners:
     - https://raw.githubusercontent.com/kubernetes/community/master/sig-architecture/OWNERS
+  - name: wg-device-management
+    description: Contains prototype code for future work driven by WG Device Management
+    contact:
+      slack: wg-device-management
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/wg-device-management/main/OWNERS
   - name: wg-serving
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/wg-serving/main/OWNERS


### PR DESCRIPTION
The repo was created based on https://github.com/kubernetes/org/issues/4886 with SIG Architecture as owner, so it should be documented under that SIG.

**Which issue(s) this PR fixes**:
Fixes https://kubernetes.slack.com/archives/G6LUC4J7M/p1732278914037949?thread_ts=1732231045.231229&cid=G6LUC4J7M

/assign @johnbelamaric 
