### PR TITLE
sig-storage: remove cosi-provisioner-sidecar, cosi-controller, cosi-spec repos from kubernetes-cosi subproject

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -84,9 +84,6 @@ The following [subprojects][subproject-definition] are owned by sig-storage:
 ### kubernetes-cosi
 - **Owners:**
   - [kubernetes-sigs/container-object-storage-interface-api](https://github.com/kubernetes-sigs/container-object-storage-interface-api/blob/master/OWNERS)
-  - [kubernetes-sigs/container-object-storage-interface-controller](https://github.com/kubernetes-sigs/container-object-storage-interface-controller/blob/master/OWNERS)
-  - [kubernetes-sigs/container-object-storage-interface-provisioner-sidecar](https://github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/blob/master/OWNERS)
-  - [kubernetes-sigs/container-object-storage-interface-spec](https://github.com/kubernetes-sigs/container-object-storage-interface-spec/blob/master/OWNERS)
   - [kubernetes-sigs/container-object-storage-interface](https://github.com/kubernetes-sigs/container-object-storage-interface/blob/main/OWNERS)
   - [kubernetes-sigs/cosi-driver-sample](https://github.com/kubernetes-sigs/cosi-driver-sample/blob/master/OWNERS)
 - **Contact:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3018,9 +3018,6 @@ sigs:
       slack: sig-storage-cosi
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-controller/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/master/OWNERS
-    - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-spec/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/cosi-driver-sample/master/OWNERS
   - name: kubernetes-csi


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5238

cc: @kubernetes/owners

/assign @kubernetes/sig-storage-leads