### PR TITLE
sig-storage: remove container-object-storage-interface-api subproject repo

### DIFF
--- a/sig-storage/README.md
+++ b/sig-storage/README.md
@@ -83,7 +83,6 @@ The following [subprojects][subproject-definition] are owned by sig-storage:
   - [kubernetes-sigs/gluster-file-external-provisioner](https://github.com/kubernetes-sigs/gluster-file-external-provisioner/blob/master/OWNERS)
 ### kubernetes-cosi
 - **Owners:**
-  - [kubernetes-sigs/container-object-storage-interface-api](https://github.com/kubernetes-sigs/container-object-storage-interface-api/blob/master/OWNERS)
   - [kubernetes-sigs/container-object-storage-interface](https://github.com/kubernetes-sigs/container-object-storage-interface/blob/main/OWNERS)
   - [kubernetes-sigs/cosi-driver-sample](https://github.com/kubernetes-sigs/cosi-driver-sample/blob/master/OWNERS)
 - **Contact:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3029,7 +3029,6 @@ sigs:
     contact:
       slack: sig-storage-cosi
     owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/cosi-driver-sample/master/OWNERS
   - name: kubernetes-csi


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5238

cc: @kubernetes/owners 

/assign @kubernetes/sig-storage-leads 