### PR TITLE
Moving Instance Gateway to SIG-Network and renaming it

### DIFF
--- a/sig-apps/README.md
+++ b/sig-apps/README.md
@@ -83,10 +83,6 @@ Application metadata descriptor CRD
   - [kubernetes/kompose](https://github.com/kubernetes/kompose/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#kompose](https://kubernetes.slack.com/messages/kompose)
-### llm-instance-gateway
-LLM Instance gateway implementation
-- **Owners:**
-  - [kubernetes-sigs/llm-instance-gateway](https://github.com/kubernetes-sigs/llm-instance-gateway/blob/main/OWNERS)
 ### workloads-api
 The core workloads API, which is composed of the CronJob, DaemonSet, Deployment, Job, ReplicaSet, ReplicationController, PodDisruptionBudget and StatefulSet kinds
 - **Owners:**

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -105,6 +105,10 @@ The following [subprojects][subproject-definition] are owned by sig-network:
   - [kubernetes/kubernetes/staging/src/k8s.io/cloud-provider/controllers/service](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cloud-provider/controllers/service/OWNERS)
 - **Contact:**
   - Slack: [#sig-network-gateway-api](https://kubernetes.slack.com/messages/sig-network-gateway-api)
+### gateway-api-inference-extension
+Gateway API Inference Extension
+- **Owners:**
+  - [kubernetes-sigs/llm-instance-gateway](https://github.com/kubernetes-sigs/llm-instance-gateway/blob/main/OWNERS)
 ### ingate
 - **Owners:**
   - [kubernetes-sigs/ingate/heads/main](https://github.com/kubernetes-sigs/ingate/blob/refs/heads/main/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -249,10 +249,6 @@ sigs:
       slack: kompose
     owners:
     - https://raw.githubusercontent.com/kubernetes/kompose/master/OWNERS
-  - name: llm-instance-gateway
-    description: LLM Instance gateway implementation
-    owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/llm-instance-gateway/main/OWNERS
   - name: workloads-api
     description: The core workloads API, which is composed of the CronJob, DaemonSet,
       Deployment, Job, ReplicaSet, ReplicationController, PodDisruptionBudget and
@@ -2324,6 +2320,10 @@ sigs:
     - github: youngnick
       name: Nick Young
       company: Isovalent
+  - name: gateway-api-inference-extension
+    description: Gateway API Inference Extension
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/llm-instance-gateway/main/OWNERS
   - name: ingate
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/ingate/refs/heads/main/OWNERS


### PR DESCRIPTION
New name will be gateway-api-inference-extension.

**Which issue(s) this PR fixes**:
None in this repo, but addresses https://github.com/kubernetes-sigs/llm-instance-gateway/issues/41.

For more context on the name change, refer to the original [proposal](https://docs.google.com/document/d/1gLYe9zPNeMuxKWolcu5MRm_Sq2xoZBXn100e-fZ6fX4/edit?tab=t.0) which has previously been discussed in SIG-Network, Instance Gateway, and Gateway API community meetings, as well as WG-Serving Slack and mailing list. 
  
Looking for LGTM from representatives from each of the following groups:

SIG Apps Leads:
/cc @janetkuo @kow3ns @soltysh 

SIG Net Leads:
/cc @aojea @danwinship @MikeZappa87 @shaneutt @thockin 

WG Serving Leads:
/cc @ArangoGutierrez @Jeffwan @SergeyKanzhelev @terrytangyuan

/hold for consensus