### PR TITLE
Fix google groups link

### DIFF
--- a/communication/README.md
+++ b/communication/README.md
@@ -180,7 +180,7 @@ place!
 [events]: https://www.cncf.io/events/
 [file an issue]: https://github.com/kubernetes/kubernetes/issues/new
 [kubernetes-announce]: https://groups.google.com/forum/#!forum/kubernetes-announce
-[kubernetes-dev]: https://groups.google.com/forum/#!forum/kubernetes-dev
+[kubernetes-dev]: https://groups.google.com/a/kubernetes.io/g/dev
 [Discuss Kubernetes]: https://discuss.kubernetes.io
 [Join]: http://slack.k8s.io
 [Slack Guidelines]: /communication/slack-guidelines.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # NA


When following the older link it was showing a deprecation notice

> As of January 2, 2022, this group will be sunset in favor of dev@[kubernetes.io](http://kubernetes.io/). Please join that one if it's not already in your list. https://groups.google.com/a/kubernetes.io/group/dev

This PR fixes the link and points it to  https://groups.google.com/a/kubernetes.io/group/dev as said above ^^