### PR TITLE
Create new vertical-pod-autoscaler channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -548,6 +548,7 @@ channels:
   - name: velero-dev
   - name: velero-users
     id: C6VCGP4MT
+  - name: vertical-pod-autoscaler
   - name: virtlet
   - name: virtual-kubelet
   - name: virtualization

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -67,9 +67,13 @@ The following [subprojects][subproject-definition] are owned by sig-autoscaling:
 ### karpenter
 - **Owners:**
   - [kubernetes-sigs/karpenter](https://github.com/kubernetes-sigs/karpenter/blob/main/OWNERS)
+- **Contact:**
+  - Slack: [#karpenter](https://kubernetes.slack.com/messages/karpenter)
 ### vertical-pod-autoscaler
 - **Owners:**
   - [kubernetes/autoscaler/vertical-pod-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/OWNERS)
+- **Contact:**
+  - Slack: [#vertical-pod-autoscaler](https://kubernetes.slack.com/messages/vertical-pod-autoscaler)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 [working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -683,9 +683,13 @@ sigs:
     - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
     - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
   - name: karpenter
+    contact:
+      slack: karpenter
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/karpenter/main/OWNERS
   - name: vertical-pod-autoscaler
+    contact:
+      slack: vertical-pod-autoscaler
     owners:
     - https://raw.githubusercontent.com/kubernetes/autoscaler/master/vertical-pod-autoscaler/OWNERS
 - dir: sig-cli


### PR DESCRIPTION
vertical-pod-autoscaler is a big enough subproject in sig-autoscaling
that it needs a dedicated channel.

I also noticed that the karpenter channel wasn't listed, so I added
that.


cc @gjtempleton (The sig-autoscaling chair)