### PR TITLE
CAPI: Update v1.10 release team members

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -240,20 +240,22 @@ usergroups:
     long_name: Cluster API Release Team
     description: Members of the Cluster API Release Team
     members:
-      - adilGhaffarDev
+      - AttyXY
+      - blind3dd
       - cahillsf
       - chandankumar4
-      - jayesh-srivastava
-      - pravarag
-      - rajankumary2k
-      - SD-13
+      - cprivitere
+      - hackeramitkumar
+      - mboersma
+      - mbrow137
+      - pratik-mahalle
+      - ramessesii2
+      - RansherSingh
       - serngawy
-      - sivchari
+      - shecodesmagic
+      - sreeram-venkitesh
       - Sunnatillo
-      - tasdikrahman
-      - tormath1
-      - varshasuryawanshi
-      - vishalanarase
+      - wendy-ha18
 
   - name: kcp-devs
     long_name: kcp Development Team

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -21,6 +21,7 @@ users:
   aravindputrevu: U1G27SDU6
   asmacdo: UNVH7RY9J
   Atharva-Shinde: U028J67T478
+  AttyXY: U07KSK513NW
   AvineshTripathi: U029U44P26B
   bai: U4XAULHL3
   Bart Farrell: U01DZM7PJDT
@@ -29,6 +30,7 @@ users:
   benoitf: UCQC3DNUA
   bentheelder: U1P7T516X
   bhumijgupta: U022JUBM3B4
+  blind3dd: UC7GPBQB1
   briandealwis: UAZKM38JV
   bubblemelon: U7K9C643G
   byako: U03GZBD4J4C
@@ -53,6 +55,7 @@ users:
   cji: U5YSRC21J
   clubanderson: U0462LN24QJ
   cpanato: U8DFY4TTK
+  cprivitere: UEXCRF7EK
   csams: U02B6A9GF55
   Dave Smith-Uchida: UDZDED8G2
   david-martin: ULMJ41U73
@@ -164,6 +167,8 @@ users:
   maysunfaisal: U01DEHK2YUB
   mbbroberg: U18JTHMDY
   mbianchidev: UU1JM5G5A
+  mboersma: U5PL62ULA
+  mbrow137: U07HN4TUNKS
   mcbenjemaa: UF111SQ4U
   meatballhat: U01QEKCBTBM
   mehabhalodiya: U024HPAQDC1
@@ -210,6 +215,7 @@ users:
   pnbrown: U011JJTQVGF
   pohly: U91901TMF
   prajyot-parab: U02MVRCN8CX
+  pratik-mahalle: U06P66FAHPU
   pravarag: UFA5V59J5
   prietyc123: U01D4MBLM52
   Priyankasaggu11929: U012EE74CU8
@@ -219,7 +225,9 @@ users:
   r-lawton: U019CNHR2E6
   rajankumary2k: U011YM87GQK
   rajula96reddy: U7K9EK1HC
+  ramessesii2: U0359S5LUDR
   ramrodo: UU74ZC2RX
+  RansherSingh: U05MZREAE2Y
   rashmigottipati: U013T1DD3PW
   razashahid107: U05FB1L2YM8
   reylejano: U01GDNJL5MW
@@ -248,6 +256,7 @@ users:
   sethmccombs: U92LLUZ8A
   sgtcodfish: U01PQ8N3PM1
   shamus: US7EUUBK8
+  shecodesmagic: U0592U4JQA3
   shipra101: U06MJ9TT031
   shubham-pampattiwar: U01QW84HBBN
   simplytunde: UAY1NBYHE
@@ -292,6 +301,7 @@ users:
   Vyom-Yadav: U03658QBE1K
   vzhukovs: U030TR1FG85
   wallrj: U1ZMERJF7
+  wendy-ha18: U072Q1ZPVA7
   willie-yao: U024EME7SQK
   wilsonehusin: U0100068GF2
   wurbanski: URX7CMK97


### PR DESCRIPTION
This PR syncs up the Slack `cluster-api-release-team` with its current v1.10-release members.

**Which issue(s) this PR fixes**:

Refs kubernetes-sigs/cluster-api#11648
