### PR TITLE
add: SIG-Scheduling annual report

### DIFF
--- a/sig-scheduling/annual-report-2024.md
+++ b/sig-scheduling/annual-report-2024.md
@@ -20,7 +20,7 @@
 
 2. Are there any areas and/or subprojects that your group needs help with (e.g. fewer than 2 active OWNERS)?
 
-None.
+- [scheduler-plugins](https://github.com/kubernetes-sigs/scheduler-plugins/)
 
 3. Did you have community-wide updates in 2024 (e.g. KubeCon talks)?
 

--- a/sig-scheduling/annual-report-2024.md
+++ b/sig-scheduling/annual-report-2024.md
@@ -12,11 +12,11 @@
    - Governance and leadership changes
 -->
 
-- **The performance improvement**
-  - Have put a lot of effort into QueueingHint ([KEP-4247](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4247-queueinghint)), which enhances the scheduler's retrying efficiency.
-  - Introduced the asynchronous preemption ([KEP-4832](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4832-async-preemption)), which improves the scheduling throughput with the preemption.
-  - Improved [the internal scheduling performance test (scheduler-perf)](https://github.com/kubernetes/kubernetes/tree/master/test/integration/scheduler_perf) to cover more scenarios and alert us when the degradation is introduced.
-- **DRA**: Improved the DRA scheduling with the structured parameters ([KEP-4381](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4381-dra-structured-parameters#kube-scheduler)).
+- **Performance improvement**
+  - Iterated on QueueingHints towards re-enabling the feature. ([KEP-4247](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4247-queueinghint))
+  - Introduced asynchronous preemption ([KEP-4832](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4832-async-preemption)) when there are pods to be preempted.
+  - Improved [the internal scheduling performance test suite (scheduler-perf)](https://github.com/kubernetes/kubernetes/tree/master/test/integration/scheduler_perf) to cover more scenarios and alert us when the degradation is introduced.
+- **DRA**: Added DRA scheduling with the structured parameters, replacing classic DRA ([KEP-4381](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4381-dra-structured-parameters#kube-scheduler)).
 
 2. Are there any areas and/or subprojects that your group needs help with (e.g. fewer than 2 active OWNERS)?
 

--- a/sig-scheduling/annual-report-2024.md
+++ b/sig-scheduling/annual-report-2024.md
@@ -12,8 +12,15 @@
    - Governance and leadership changes
 -->
 
+- **The performance improvement**
+  - Have put a lot of effort into QueueingHint ([KEP-4247](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4247-queueinghint)), which enhances the scheduler's retrying efficiency.
+  - Introduced the asynchronous preemption ([KEP-4832](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4832-async-preemption)), which improves the scheduling throughput with the preemption.
+  - Improved [the internal scheduling performance test (scheduler-perf)](https://github.com/kubernetes/kubernetes/tree/master/test/integration/scheduler_perf) to cover more scenarios and alert us when the degradation is introduced.
+- **DRA**: Improved the DRA scheduling with the structured parameters ([KEP-4381](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4381-dra-structured-parameters#kube-scheduler)).
+
 2. Are there any areas and/or subprojects that your group needs help with (e.g. fewer than 2 active OWNERS)?
 
+None.
 
 3. Did you have community-wide updates in 2024 (e.g. KubeCon talks)?
 
@@ -21,27 +28,23 @@
   Examples include links to email, slides, or recordings.
 -->
 
+- [Kubecon EU 2024: SIG_Scheduling Intro & Deep Dive](https://sched.co/1YhjR)
+- [Kubecon NA 2024: SIG_Scheduling Intro & Updates](https://sched.co/1hovV)
+
 4. KEP work in 2024 (v1.30, v1.31, v1.32):
-<!--
-   TODO: Uncomment the following auto-generated list of KEPs, once reviewed & updated for correction.
 
-   Note: This list is generated from the KEP metadata in kubernetes/enhancements repository.
-      If you find any discrepancy in the generated list here, please check the KEP metadata.
-      Please raise an issue in kubernetes/community, if the KEP metadata is correct but the generated list is incorrect.
--->
-
-<!-- 
   - Alpha
     - [4816 - DRA Prioritized List](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4816-dra-prioritized-list) - v1.32
     - [4832 - Asynchronous Preemption](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4832-async-preemption) - v1.32
 
   - Beta
     - [3633 - Introduce MatchLabelKeys and MismatchLabelKeys to PodAffinity and PodAntiAffinity](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3633-matchlabelkeys-to-podaffinity) - v1.31
+    - [4247 - Per-plugin callback functions for efficient requeueing in the scheduling queue](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4247-queueinghint/README.md) - v1.32
 
   - Stable
     - [3022 - Tuning the number of domains in PodTopologySpread](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3022-min-domains-in-pod-topology-spread) - v1.30
     - [3521 - Pod Scheduling Readiness](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3521-pod-scheduling-readiness) - v1.30
-    - [3838 - Pod Mutable Scheduling Directives](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3838-pod-mutable-scheduling-directives) - v1.30 -->
+    - [3838 - Pod Mutable Scheduling Directives](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3838-pod-mutable-scheduling-directives) - v1.30 
 
 ## [Subprojects](https://git.k8s.io/community/sig-scheduling#subprojects)
 
@@ -69,12 +72,12 @@
 ## Operational
 
 Operational tasks in [sig-governance.md]:
-- [ ] [README.md] reviewed for accuracy and updated if needed
-- [ ] [CONTRIBUTING.md] reviewed for accuracy and updated if needed
-- [ ] Other contributing docs (e.g. in devel dir or contributor guide) reviewed for accuracy and updated if needed
+- [x] [README.md] reviewed for accuracy and updated if needed
+- [x] [CONTRIBUTING.md] reviewed for accuracy and updated if needed
+- [x] Other contributing docs (e.g. in devel dir or contributor guide) reviewed for accuracy and updated if needed
 - [ ] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
-- [ ] SIG leaders (chairs, tech leads, and subproject leads) in [sigs.yaml] are accurate and active, and updated if needed
-- [ ] Meeting notes and recordings for 2024 are linked from [README.md] and updated/uploaded if needed
+- [x] SIG leaders (chairs, tech leads, and subproject leads) in [sigs.yaml] are accurate and active, and updated if needed
+- [x] Meeting notes and recordings for 2024 are linked from [README.md] and updated/uploaded if needed
 
 
 [CONTRIBUTING.md]: https://git.k8s.io/community/sig-scheduling/CONTRIBUTING.md

--- a/sig-scheduling/annual-report-2024.md
+++ b/sig-scheduling/annual-report-2024.md
@@ -21,6 +21,7 @@
 2. Are there any areas and/or subprojects that your group needs help with (e.g. fewer than 2 active OWNERS)?
 
 - [scheduler-plugins](https://github.com/kubernetes-sigs/scheduler-plugins/)
+- [kwok](https://github.com/kubernetes-sigs/kwok)
 
 3. Did you have community-wide updates in 2024 (e.g. KubeCon talks)?
 

--- a/sig-scheduling/annual-report-2024.md
+++ b/sig-scheduling/annual-report-2024.md
@@ -74,8 +74,8 @@ None.
 Operational tasks in [sig-governance.md]:
 - [x] [README.md] reviewed for accuracy and updated if needed
 - [x] [CONTRIBUTING.md] reviewed for accuracy and updated if needed
-- [x] Other contributing docs (e.g. in devel dir or contributor guide) reviewed for accuracy and updated if needed
-- [ ] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
+- [ ] Other contributing docs (e.g. in devel dir or contributor guide) reviewed for accuracy and updated if needed
+- [x] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
 - [x] SIG leaders (chairs, tech leads, and subproject leads) in [sigs.yaml] are accurate and active, and updated if needed
 - [x] Meeting notes and recordings for 2024 are linked from [README.md] and updated/uploaded if needed
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

/cc @kubernetes/sig-scheduling-misc @macsko @dom4ha @AxeZhan 

Added the 2024 annual report for SIG-Scheduling.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8271
