### PR TITLE
slack-config: Add cluster-api-release channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -82,6 +82,7 @@ channels:
   - name: cluster-api-operator
   - name: cluster-api-packet
   - name: cluster-api-proxmox
+  - name: cluster-api-release
   - name: cluster-api-vsphere
   - name: cn-dev
   - name: cn-events


### PR DESCRIPTION
Adds a new Slack channel named "cluster-api-release" for the Cluster API SIG to use for coordinating Cluster API releases and release team responsibilities.