### PR TITLE
WG-Etcd Operator annual report

### DIFF
--- a/sig-etcd/README.md
+++ b/sig-etcd/README.md
@@ -90,6 +90,10 @@ Distributed reliable key-value store for the most critical data of a distributed
 etcd manager
 - **Owners:**
   - [kubernetes-sigs/etcd-manager](https://github.com/kubernetes-sigs/etcd-manager/blob/main/OWNERS)
+### etcd-operator
+future site of the new etcd operator, currently used for wg-etcd-operator artifacts
+- **Owners:**
+  - [etcd-io/etcd-operator](https://github.com/etcd-io/etcd-operator/blob/main/OWNERS)
 ### etcd-play
 etcd playground
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1805,6 +1805,11 @@ sigs:
     description: etcd manager
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/etcd-manager/main/OWNERS
+  - name: etcd-operator
+    description: future site of the new etcd operator, currently used for wg-etcd-operator
+      artifacts
+    owners:
+    - https://raw.githubusercontent.com/etcd-io/etcd-operator/main/OWNERS
   - name: etcd-play
     description: etcd playground
     owners:
@@ -3516,6 +3521,9 @@ workinggroups:
 
     Note: the etcd clusters, to be managed by the etcd-operator, are to support applications
     instead of Kubernetes itself.
+
+    In addition to the slack channel, mailing list, and meetings, you can join our
+    discussion through issues and PRs in [the etcd-operator repo](https://github.com/etcd-io/etcd-operator/)
 
   charter_link: charter.md
   stakeholder_sigs:

--- a/wg-etcd-operator/README.md
+++ b/wg-etcd-operator/README.md
@@ -10,6 +10,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 The working group is dedicated to enabling automatic and efficient operation of etcd clusters in Kubernetes using an etcd-operator. The working group will discuss the requirement and use cases of such an etcd-operator. It will also try to create a roadmap to develop such an etcd-operator.
 Note: the etcd clusters, to be managed by the etcd-operator, are to support applications instead of Kubernetes itself.
+In addition to the slack channel, mailing list, and meetings, you can join our discussion through issues and PRs in [the etcd-operator repo](https://github.com/etcd-io/etcd-operator/)
 
 The [charter](charter.md) defines the scope and governance of the etcd Operator Working Group.
 

--- a/wg-etcd-operator/annual-report-2024.md
+++ b/wg-etcd-operator/annual-report-2024.md
@@ -18,7 +18,7 @@ Not yet.
 
 Operational tasks in [wg-governance.md]:
 
-- [ ] [README.md] reviewed for accuracy and updated if needed
+- [X] [README.md] reviewed for accuracy and updated if needed
 - [X] WG leaders in [sigs.yaml] are accurate and active, and updated if needed
 - [X] Meeting notes and recordings for 2024 are linked from [README.md] and updated/uploaded if needed
 - [ ] Updates provided to sponsoring SIGs in 2024

--- a/wg-etcd-operator/annual-report-2024.md
+++ b/wg-etcd-operator/annual-report-2024.md
@@ -2,26 +2,25 @@
 
 ## Current initiatives and Project Health
 
-
 1. What work did the WG do this year that should be highlighted?
 
-<!--
-   Some example items that might be worth highlighting:
-   - artifacts
-   - reports
-   - white papers
-   - work not tracked in KEPs
--->
+* We launched the WG, and [recruited contributors](https://github.com/etcd-io/etcd-operator/graphs/contributors) from multiple prior operators
+* Completed [review of leading existing operators](https://github.com/etcd-io/etcd-operator/blob/main/docs/wg/evaluation/evaluation.pdf)
+* [Surveyed potential users](https://github.com/etcd-io/etcd-operator/blob/main/docs/wg/survey/2024-operator-survey.md) and determined [operator development roadmap](https://github.com/etcd-io/etcd-operator/blob/main/docs/roadmap.md)
+* Created initial [operator workflow]()
+* Started work on [version 0.1](https://github.com/etcd-io/etcd-operator/milestone/1), about 30% completed
 
 2. Are there any areas and/or subprojects that your group needs help with (e.g. fewer than 2 active OWNERS)?
+
+Not yet.
 
 ## Operational
 
 Operational tasks in [wg-governance.md]:
 
 - [ ] [README.md] reviewed for accuracy and updated if needed
-- [ ] WG leaders in [sigs.yaml] are accurate and active, and updated if needed
-- [ ] Meeting notes and recordings for 2024 are linked from [README.md] and updated/uploaded if needed
+- [X] WG leaders in [sigs.yaml] are accurate and active, and updated if needed
+- [X] Meeting notes and recordings for 2024 are linked from [README.md] and updated/uploaded if needed
 - [ ] Updates provided to sponsoring SIGs in 2024
       - [$sig-name](https://git.k8s.io/community/$sig-id/)
         - links to email, meeting notes, slides, or recordings, etc

--- a/wg-etcd-operator/annual-report-2024.md
+++ b/wg-etcd-operator/annual-report-2024.md
@@ -7,7 +7,7 @@
 * We launched the WG, and [recruited contributors](https://github.com/etcd-io/etcd-operator/graphs/contributors) from multiple prior operators
 * Completed [review of leading existing operators](https://github.com/etcd-io/etcd-operator/blob/main/docs/wg/evaluation/evaluation.pdf)
 * [Surveyed potential users](https://github.com/etcd-io/etcd-operator/blob/main/docs/wg/survey/2024-operator-survey.md) and determined [operator development roadmap](https://github.com/etcd-io/etcd-operator/blob/main/docs/roadmap.md)
-* Created initial [operator workflow]()
+* Created initial [operator reconciliation workflow](https://github.com/etcd-io/etcd-operator/blob/main/docs/design/reconcile_loop_v0.1.0.png)
 * Started work on [version 0.1](https://github.com/etcd-io/etcd-operator/milestone/1), about 30% completed
 
 2. Are there any areas and/or subprojects that your group needs help with (e.g. fewer than 2 active OWNERS)?
@@ -21,12 +21,8 @@ Operational tasks in [wg-governance.md]:
 - [X] [README.md] reviewed for accuracy and updated if needed
 - [X] WG leaders in [sigs.yaml] are accurate and active, and updated if needed
 - [X] Meeting notes and recordings for 2024 are linked from [README.md] and updated/uploaded if needed
-- [ ] Updates provided to sponsoring SIGs in 2024
-      - [$sig-name](https://git.k8s.io/community/$sig-id/)
-        - links to email, meeting notes, slides, or recordings, etc
-      - [$sig-name](https://git.k8s.io/community/$sig-id/)
-        - links to email, meeting notes, slides, or recordings, etc
-      -
+- [X] Updates provided to sponsoring SIGs in 2024
+      - None, since the WG has existed for less than one year.
 
 [wg-governance.md]: https://git.k8s.io/community/committee-steering/governance/wg-governance.md
 [README.md]: https://git.k8s.io/community/wg-etcd-operator/README.md


### PR DESCRIPTION
Most of the annual report for Etcd Operator working group.  A few things missing:

1. Where can I put a link to our repository in sigs.yaml?  I don't see a field for repos.
2. Since our WG was created in 2024, do we need to have status meetings with our sponsoring SIGs?
3. I couldn't find the Operator Workflow doc, @ahrtr link to that?

attn: @soltysh @justinsb @jmhbnz 