### PR TITLE
Add #syself slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -522,6 +522,7 @@ channels:
   - name: surveys
   - name: summit-staff
   - name: suse-caasp
+  - name: syself
   - name: talk-proposals
     archived: true
   - name: tanzu-community-edition


### PR DESCRIPTION
This requests a new channel for Syself, a platform for managing Kubernetes clusters on Hetzner.

Syself is maintaining a lot of Kubernetes-related projects, such as the Cluster API Provider for Hetzner, helm charts, and a fork of the Hetzner Cloud Controller Manager.

The goal of this channel is to centralize communication around Syself open source projects, and provide a better way of supporting users of the Cluster API Provider Hetzner.
