### PR TITLE
remove critest page from community repository

### DIFF
--- a/contributors/devel/README.md
+++ b/contributors/devel/README.md
@@ -173,8 +173,6 @@ See the [kubernetes/release](https://github.com/kubernetes/release) repository f
 
 * **Container Runtime Interface: Container Metrics** [cri-container-stats.md](sig-node/cri-container-stats.md)
 
-* **Container Runtime Interface (CRI) Validation Testing** [cri-validation.md](sig-node/cri-validation.md)
-
 * **Node End-To-End tests** [e2e-node-tests.md](sig-node/e2e-node-tests.md)
 
 * **Container Runtime Interface: Testing Policy** [cri-testing-policy.md](sig-node/cri-testing-policy.md)

--- a/contributors/devel/sig-node/cri-validation.md
+++ b/contributors/devel/sig-node/cri-validation.md
@@ -1,53 +1,5 @@
 # Container Runtime Interface (CRI) Validation Testing
 
-CRI validation testing provides a test framework and a suite of tests to validate that the Container Runtime Interface (CRI) server implementation meets all the requirements. This allows the CRI runtime developers to verify that their runtime conforms to CRI, without needing to set up Kubernetes components or run Kubernetes end-to-end tests.
+This page is DEPRECATED and WILL BE REMOVED.
 
-CRI validation testing is GA since v1.11.0 and is hosted at the [cri-tools](https://github.com/kubernetes-sigs/cri-tools) repository. We encourage the CRI developers to report bugs or help extend the test coverage by adding more tests.
-
-## Install
-
-The test suites can be downloaded from cri-tools [release page](https://github.com/kubernetes-sigs/cri-tools/releases):
-
-```sh
-VERSION="v1.11.0"
-wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/critest-$VERSION-linux-amd64.tar.gz
-sudo tar zxvf critest-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
-rm -f critest-$VERSION-linux-amd64.tar.gz
-```
-
-critest requires [ginkgo](https://github.com/onsi/ginkgo) to run parallel tests. It could be installed by
-
-```sh
-go get -u github.com/onsi/ginkgo/ginkgo
-```
-
-*Note: ensure GO is installed and GOPATH is set before installing ginkgo.*
-
-## Running tests
-
-### Prerequisite
-
-Before running the test, you need to _ensure that the CRI server under test is running and listening on a Unix socket_. Because the validation tests are designed to request changes (e.g., create/delete) to the containers and verify that correct status is reported, it expects to be the only user of the CRI server. Please make sure that 1) there are no existing CRI-managed containers running on the node, and 2) no other processes (e.g., Kubelet) will interfere with the tests.
-
-### Run
-
-```sh
-critest
-```
-
-This will
-
-- Connect to the shim of CRI container runtime
-- Run the tests using `ginkgo`
-- Output the test results to STDOUT
-
-critest connects to `unix:///var/run/dockershim.sock` by default. For other runtimes, the endpoint can be set by flags `-runtime-endpoint` and `-image-endpoint`.
-
-## Additional options
-
-- `-ginkgo.focus`: Only run the tests that match the regular expression.
-- `-image-endpoint`: Set the endpoint of image service. Same with runtime-endpoint if not specified.
-- `-runtime-endpoint`: Set the endpoint of runtime service. Default to `unix:///var/run/dockershim.sock`.
-- `-ginkgo.skip`: Skip the tests that match the regular expression.
-- `-parallel`: The number of parallel test nodes to run (default 1). ginkgo must be installed to run parallel tests.
-- `-h`: Show help and all supported options.
+Content of the page was moved to https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md.

--- a/sig-node/charter.md
+++ b/sig-node/charter.md
@@ -66,7 +66,6 @@ None
 SIG Technical Leads
 
 
-[validation]: /contributors/devel/sig-node/cri-validation.md
 [testing policy]: /contributors/devel/sig-node/cri-testing-policy.md
 [test grid]: https://testgrid.k8s.io/sig-node#Summary
 [sig-governance]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

/sig node

See also: https://github.com/kubernetes-sigs/cri-tools/pull/1761

This page belongs to cri-tools repo. And it is alredy referenced from https://www.kubernetes.dev/docs/code/cri-api-version-skew-policy/#feature-testing

All CRI docs pages can and should be moved to the contributing website.