### PR TITLE
make sig-architecture-approvers to be approvers of devel

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -199,6 +199,10 @@ aliases:
   provider-vmware:
     - cantbewong
     - frapposelli
+  sig-architecture-approvers:
+    - dims
+    - derekwaynecarr
+    - johnbelamaric
   sig-release-subproject-leads:
     - gracenng
     - katcosgrove

--- a/contributors/devel/OWNERS
+++ b/contributors/devel/OWNERS
@@ -11,6 +11,7 @@ approvers:
   - lavalamp
   - spiffxp
   - thockin
+  - sig-architecture-approvers
 emeritus_approvers:
 - calebamiles
 - Phillels


### PR DESCRIPTION
It looks logical to match this folder to https://github.com/kubernetes/contributor-site/blob/master/content/en/docs/code/OWNERS.

Many articles here may be better suited for contributor site as well.

Discovered this OWNER file when was looking at old CRI documentation like this: https://github.com/kubernetes/community/pull/8305