### PR TITLE
add link to contributor awards site

### DIFF
--- a/events/awards/README.md
+++ b/events/awards/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Contributor Awards
 
-The awards can be see in [contributor site](https://www.kubernetes.dev/community/awards/), and recipients is maintained in https://github.com/kubernetes/contributor-site/tree/master/content/en/community/awards.
+The awards can be see in [contributor site](https://www.kubernetes.dev/community/awards/), and recipients is maintained in the [contributor-site repository](https://github.com/kubernetes/contributor-site/tree/master/content/en/community/awards).
 
 Every year, the Kubernetes Contributor Community recognizes and awards their peers for
 outstanding contributions to the project for the year.

--- a/events/awards/README.md
+++ b/events/awards/README.md
@@ -1,5 +1,7 @@
 # Kubernetes Contributor Awards
 
+The awards can be see in [contributor site](https://www.kubernetes.dev/community/awards/), and recipients is maintained in https://github.com/kubernetes/contributor-site/tree/master/content/en/community/awards.
+
 Every year, the Kubernetes Contributor Community recognizes and awards their peers for
 outstanding contributions to the project for the year.
 These awards are handed out during the end-of-year Contributor Summit.

--- a/events/awards/README.md
+++ b/events/awards/README.md
@@ -10,11 +10,17 @@ These awards are handed out during the end-of-year Contributor Summit.
 
 ## Contributor Award Recipients
 
+- [2024 Contributor Award Recipients][2024-awards-recipients]
+- [2023 Contributor Award Recipients][2023-awards-recipients]
+- [2022 Contributor Award Recipients][2022-awards-recipients]
 - [2021 Contributor Award Recipients][2021-awards-recipients]
 - [2020 Contributor Award Recipients][2020-awards-recipients]
 - [2019 Contributor Award Recipients][2019-awards-recipients]
 
 [playbook]: ./README.md
-[2021-awards-recipients]: ./award-recipients/2021-award-recipients.md
-[2020-awards-recipients]: ./award-recipients/2020-award-recipients.md
-[2019-awards-recipients]: ./award-recipients/2019-award-recipients.md
+[2024-awards-recipients]: https://www.kubernetes.dev/community/awards/2024/
+[2023-awards-recipients]: https://www.kubernetes.dev/community/awards/2023/
+[2022-awards-recipients]: https://www.kubernetes.dev/community/awards/2022/
+[2021-awards-recipients]: https://www.kubernetes.dev/community/awards/2021/
+[2020-awards-recipients]: https://www.kubernetes.dev/community/awards/2020/
+[2019-awards-recipients]: https://www.kubernetes.dev/community/awards/2019/


### PR DESCRIPTION
before we synced things like https://github.com/kubernetes/community/pull/6759#issuecomment-1195778361.

We may merely maintain the award recipient in the contributor site.