### PR TITLE
Add Spegel Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -516,6 +516,7 @@ channels:
   - name: solr-operator
   - name: sonobuoy
   - name: spark-operator
+  - name: spegel
   - name: spinnaker
   - name: sre
   - name: steering-committee


### PR DESCRIPTION
I would like to add a Slack channel for my project Spegel, which is a stateless cluster local OCI registry mirror built for Kubernetes.

https://github.com/spegel-org/spegel

I read through the Slack guidelines and did not see any explicit requirements for adding project channels so hopefully this is ok.