### PR TITLE
SIG Testing annual report 2024

### DIFF
--- a/sig-testing/annual-report-2024.md
+++ b/sig-testing/annual-report-2024.md
@@ -3,7 +3,12 @@
 ## Current initiatives and Project Health
 
 1. What work did the SIG do this year that should be highlighted?
-
+- (Together with SIG K8s Infra) Migration of the Prow control plane (and related resources) from Google-owned infra to community-owned infra, including:
+  - Notifying the community about the migration (and work needed beforehand)
+  - Identifying and migrating jobs blocking the migration
+  - Adding new logs/image locations and updating references to them
+  - Updating tools (Kettle, TestGrid, etc.) to use the new Prow instance
+- Moved Prow code from k8s/test-infra into its own repository at [k8s-sigs/prow](https://github.com/kubernetes-sigs/prow)
 <!--
    Some example items that might be worth highlighting:
    - Major KEP advancement
@@ -13,33 +18,28 @@
 -->
 
 2. Are there any areas and/or subprojects that your group needs help with (e.g. fewer than 2 active OWNERS)?
-
+Yup! SIG Testing covers a large variety of subprojects and is generally in need of contributors and maintainers.
+- Important:
+  - Prow: We still need more contributors and maintainers for Prow, especially folks who can focus on the Kubernetes project's use of Prow in particular.
+  - Hydrophone: Feedback and help enabling adoption of new conformance testing tools for end users.
+- Useful:
+  - TestGrid
+  - Boskos
+  - Kettle
 
 3. Did you have community-wide updates in 2024 (e.g. KubeCon talks)?
+- KubeCon NA 2024: "Achieving and Maintaining a Healthy CI with Zero Test Flakes"
+  - Event: https://sched.co/1hoxc
+  - Recording: https://youtu.be/hl3jjCTTL50 
 
-<!--
-  Examples include links to email, slides, or recordings.
--->
-
-4. KEP work in 2024 (v1.30, v1.31, v1.32):
-<!--
-   TODO: Uncomment the following auto-generated list of KEPs, once reviewed & updated for correction.
-
-   Note: This list is generated from the KEP metadata in kubernetes/enhancements repository.
-      If you find any discrepancy in the generated list here, please check the KEP metadata.
-      Please raise an issue in kubernetes/community, if the KEP metadata is correct but the generated list is incorrect.
--->
-
-<!-- 
-
- -->
+4. KEP work in 2024 (v1.30, v1.31, v1.32): N/A
 
 ## [Subprojects](https://git.k8s.io/community/sig-testing#subprojects)
-
 
 **New in 2024:**
   - hydrophone
   - testgrid
+
 **Continuing:**
   - Cloud Provider for KIND
   - boskos
@@ -59,12 +59,12 @@
 ## Operational
 
 Operational tasks in [sig-governance.md]:
-- [ ] [README.md] reviewed for accuracy and updated if needed
-- [ ] [CONTRIBUTING.md] reviewed for accuracy and updated if needed
-- [ ] Other contributing docs (e.g. in devel dir or contributor guide) reviewed for accuracy and updated if needed
-- [ ] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
-- [ ] SIG leaders (chairs, tech leads, and subproject leads) in [sigs.yaml] are accurate and active, and updated if needed
-- [ ] Meeting notes and recordings for 2024 are linked from [README.md] and updated/uploaded if needed
+- [x] [README.md] reviewed for accuracy and updated if needed
+- [x] [CONTRIBUTING.md] reviewed for accuracy and updated if needed
+- [x] Other contributing docs (e.g. in devel dir or contributor guide) reviewed for accuracy and updated if needed
+- [x] Subprojects list and linked OWNERS files in [sigs.yaml] reviewed for accuracy and updated if needed
+- [x] SIG leaders (chairs, tech leads, and subproject leads) in [sigs.yaml] are accurate and active, and updated if needed
+- [x] Meeting notes and recordings for 2024 are linked from [README.md] and updated/uploaded if needed
 
 
 [CONTRIBUTING.md]: https://git.k8s.io/community/sig-testing/CONTRIBUTING.md


### PR DESCRIPTION
Adding an initial draft for the annual report for 2024 (apologies for the delay!).

Ref #8274