### PR TITLE
fix: remove removed teams from the "Contact" lists

### DIFF
--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -53,13 +53,8 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling)
 - [Open Community Issues/PRs](https://github.com/kubernetes/community/labels/sig%2Fscheduling)
 - GitHub Teams:
-    - [@kubernetes/sig-scheduling-api-reviews](https://github.com/orgs/kubernetes/teams/sig-scheduling-api-reviews) - API Changes and Reviews
-    - [@kubernetes/sig-scheduling-bugs](https://github.com/orgs/kubernetes/teams/sig-scheduling-bugs) - Bug Triage and Troubleshooting
-    - [@kubernetes/sig-scheduling-feature-requests](https://github.com/orgs/kubernetes/teams/sig-scheduling-feature-requests) - Feature Requests
+    - [@kubernetes/sig-scheduling-leads](https://github.com/orgs/kubernetes/teams/sig-scheduling-leads) - SIG Scheduling leads
     - [@kubernetes/sig-scheduling-misc](https://github.com/orgs/kubernetes/teams/sig-scheduling-misc) - General Discussion
-    - [@kubernetes/sig-scheduling-pr-reviews](https://github.com/orgs/kubernetes/teams/sig-scheduling-pr-reviews) - PR Reviews
-    - [@kubernetes/sig-scheduling-proposals](https://github.com/orgs/kubernetes/teams/sig-scheduling-proposals) - Design Proposals
-    - [@kubernetes/sig-scheduling-test-failures](https://github.com/orgs/kubernetes/teams/sig-scheduling-test-failures) - Test Failures and Triage
 - Steering Committee Liaison: Benjamin Elder (**[@BenTheElder](https://github.com/BenTheElder)**)
 
 ## Working Groups

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2857,20 +2857,10 @@ sigs:
     slack: sig-scheduling
     mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling
     teams:
-    - name: sig-scheduling-api-reviews
-      description: API Changes and Reviews
-    - name: sig-scheduling-bugs
-      description: Bug Triage and Troubleshooting
-    - name: sig-scheduling-feature-requests
-      description: Feature Requests
+    - name: sig-scheduling-leads
+      description: SIG Scheduling leads
     - name: sig-scheduling-misc
       description: General Discussion
-    - name: sig-scheduling-pr-reviews
-      description: PR Reviews
-    - name: sig-scheduling-proposals
-      description: Design Proposals
-    - name: sig-scheduling-test-failures
-      description: Test Failures and Triage
     liaison:
       github: BenTheElder
       name: Benjamin Elder


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

We removed some teams, but forgot updating the list here.