### PR TITLE
update youtube-admins slack user group

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -86,7 +86,7 @@ usergroups:
       - pnbrown
       - CIPHERTron
       - chadmcrowell
-      - Hii-Arpit
+      - hii-arpit
       - kaslin
 
   - name: zoom-admins


### PR DESCRIPTION
Postsubmit  [post-community-tempelis-apply](https://testgrid.k8s.io/sig-contribex-slack-infra#post-community-tempelis-apply) job is failing after changes in https://github.com/kubernetes/community/pull/8361


IIUC, it is because the new added user `Hii-Arpit` to the `youtube-admins` group didn't have a corresponding entry in `communication/slack-config/users.yaml`.

We do have an entry for `hii-arpit` :
https://github.com/kubernetes/community/blob/d1d75b0720a20a44a4c7dec2e608935760d14d33/communication/slack-config/users.yaml#L101

So, PR is updating the `youtube-admins` groups to instead add `hii-arpit`, in an attempt to fix the failing tempelis job.


cc: @chris-short @kaslin 