### PR TITLE
sig-contribex: retire contributor-katacoda repo

### DIFF
--- a/sig-contributor-experience/README.md
+++ b/sig-contributor-experience/README.md
@@ -123,7 +123,6 @@ Manages and controls Github permissions, repos, and groups, including Org Member
 ### mentoring
 Oversees and develops programs for helping contributors ascend the contributor ladder, including the New Contributor Workshops, and other programs.
 - **Owners:**
-  - [kubernetes-sigs/contributor-katacoda](https://github.com/kubernetes-sigs/contributor-katacoda/blob/main/OWNERS)
   - [kubernetes-sigs/contributor-playground](https://github.com/kubernetes-sigs/contributor-playground/blob/master/OWNERS)
   - [kubernetes/community/mentoring](https://github.com/kubernetes/community/blob/master/mentoring/OWNERS)
 ### sigs-github-actions

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1544,7 +1544,6 @@ sigs:
     description: Oversees and develops programs for helping contributors ascend the
       contributor ladder, including the New Contributor Workshops, and other programs.
     owners:
-    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-katacoda/main/OWNERS
     - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
     - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
   - name: sigs-github-actions


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/5437


/assign @kubernetes/sig-contributor-experience-leads 