### PR TITLE
sig-testing: add subproject - randfill

### DIFF
--- a/sig-testing/README.md
+++ b/sig-testing/README.md
@@ -115,6 +115,12 @@ Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action 
   - [kubernetes-sigs/prow](https://github.com/kubernetes-sigs/prow/blob/main/OWNERS)
 - **Contact:**
   - Slack: [#prow](https://kubernetes.slack.com/messages/prow)
+### randfill
+Utility functions for filling types with randomized data (for kubernetes testing use).
+- **Leads:**
+  - Tim Hockin (**[@thockin](https://github.com/thockin)**), Google
+- **Owners:**
+  - [kubernetes-sigs/randfill](https://github.com/kubernetes-sigs/randfill/blob/main/OWNERS)
 ### sig-testing
 Home for SIG Testing discussion and documents.
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3295,6 +3295,16 @@ sigs:
       name: Petr Muller
       company: Red Hat
       email: muller@redhat.com
+  - name: randfill
+    description: |
+      Utility functions for filling types with randomized data (for kubernetes testing use).
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/randfill/main/OWNERS
+    leads:
+    - github: thockin
+      name: Tim Hockin
+      company: Google
+      email: thockin@google.com
   - name: sig-testing
     description: |
       Home for SIG Testing discussion and documents.


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/5414

/assign @kubernetes/sig-testing-leads 

cc: @kubernetes/owners 