### PR TITLE
Remove zpages as subproject from sig-instrumentation

### DIFF
--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -105,9 +105,6 @@ Organization of SIG Instrumentation subprojects
 ### usage-metrics-collector
 - **Owners:**
   - [kubernetes-sigs/usage-metrics-collector](https://github.com/kubernetes-sigs/usage-metrics-collector/blob/main/OWNERS)
-### zpages
-- **Owners:**
-  - [kubernetes/kubernetes/staging/src/k8s.io/component-base/zpages](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/zpages/OWNERS)
 
 [subproject-definition]: https://github.com/kubernetes/community/blob/master/governance.md#subprojects
 [working-group-definition]: https://github.com/kubernetes/community/blob/master/governance.md#working-groups

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1968,9 +1968,6 @@ sigs:
   - name: usage-metrics-collector
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/usage-metrics-collector/main/OWNERS
-  - name: zpages
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/zpages/OWNERS
 - dir: sig-k8s-infra
   name: K8s Infra
   mission_statement: >


### PR DESCRIPTION
Updates list of sub-projects under sig-instrumentation

Apologies for the back and forth on this, we actually decided against stating zpages as a subproject [later on](https://github.com/kubernetes/community/pull/8327#discussion_r1974068328) 

Issue #https://github.com/kubernetes/community/issues/8264
