### PR TITLE
Fixed the Hyperlink of DNS.

### DIFF
--- a/contributors/devel/running-locally.md
+++ b/contributors/devel/running-locally.md
@@ -187,7 +187,7 @@ KUBE_DNS_SERVER_IP="10.0.0.10"
 KUBE_DNS_NAME="cluster.local"
 ```
 
-To know more on DNS service you can check out the [docs](http://kubernetes.io/docs/admin/dns/).
+To know more on DNS service you can check out the [docs](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
 
 ### All pod fail to start with a cgroups error of `expected cgroupsPath to be of format "slice:prefix:name" for systemd cgroups`
 


### PR DESCRIPTION
This PR fixed the Hyperlink of dns docs under the [The pods fail to connect to the services by host names](https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md#the-pods-fail-to-connect-to-the-services-by-host-names) in [running-locally.md](https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md)

**Which issue(s) this PR fixes**:
Fixes #8360
