### PR TITLE
sig-multicluster: add subproject for kubernetes-sigs/multicluster-runtime

### DIFF
--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -63,6 +63,9 @@ The following [subprojects][subproject-definition] are owned by sig-multicluster
 ### mcs-api
 - **Owners:**
   - [kubernetes-sigs/mcs-api](https://github.com/kubernetes-sigs/mcs-api/blob/master/OWNERS)
+### multicluster-runtime
+- **Owners:**
+  - [kubernetes-sigs/multicluster-runtime](https://github.com/kubernetes-sigs/multicluster-runtime/blob/main/OWNERS)
 ### sig-multicluster-site
 - **Owners:**
   - [kubernetes-sigs/sig-multicluster-site](https://github.com/kubernetes-sigs/sig-multicluster-site/blob/main/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2204,6 +2204,9 @@ sigs:
   - name: mcs-api
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/master/OWNERS
+  - name: multicluster-runtime
+    owners:
+    - https://github.com/kubernetes-sigs/multicluster-runtime/blob/main/OWNERS
   - name: sig-multicluster-site
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/sig-multicluster-site/main/OWNERS


### PR DESCRIPTION
For https://github.com/kubernetes/org/issues/5457

/assign @kubernetes/sig-multicluster-leads 