### PR TITLE
Update generator owners

### DIFF
--- a/generator/OWNERS
+++ b/generator/OWNERS
@@ -2,7 +2,8 @@
 
 approvers:
   - cblecker
-  - nikhita
-  - spiffxp
 labels:
   - sig/contributor-experience
+emeritus_approvers:
+  - nikhita
+  - spiffxp

--- a/generator/OWNERS
+++ b/generator/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
   - cblecker
+  - sig-contributor-experience-leads
 labels:
   - sig/contributor-experience
 emeritus_approvers:


### PR DESCRIPTION
Follow up from https://github.com/kubernetes/community/pull/8377#issuecomment-2716010345

Changes:

- add @kubernetes/sig-contributor-experience-leads as approvers for generator tool
- add @nikhita @spiffxp as emeritus approvers


/assign @kubernetes/sig-contributor-experience-leads 