### PR TITLE
Remove add gnu bins to path

### DIFF
--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -162,14 +162,11 @@ You will want to include this block or something similar at the end of
 your `.bashrc` or shell init script:
 
 ```sh
-GNUBINS="$(find `brew --prefix`/opt -type d -follow -name gnubin -print)"
-
+GNUBINS=($(find `brew --prefix`/opt -type d -follow -name gnubin -print))
 for bindir in ${GNUBINS[@]}
 do
-  export PATH=$bindir:$PATH
+  export PATH="$bindir:$PATH"
 done
-
-export PATH
 ```
 
 This ensures that the GNU tools are found first in your path. Note

--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -158,21 +158,6 @@ In particular, this command installs the necessary packages:
 brew install coreutils ed findutils gawk gnu-sed gnu-tar grep make jq
 ```
 
-You will want to include this block or something similar at the end of
-your `.zshrc` or shell init script:
-
-```sh
-GNUBINS=($(find `brew --prefix`/opt -type d -follow -name gnubin -print))
-for bindir in ${GNUBINS[@]}
-do
-  export PATH="$bindir:$PATH"
-done
-```
-
-This ensures that the GNU tools are found first in your path. Note
-that shell init scripts work a little differently for
-macOS. [This article can help you figure out what changes to make.](https://scriptingosx.com/2017/04/about-bash_profile-and-bashrc-on-macos/)
-
 ### Installing Required Software
 
 #### GNU Development Tools 

--- a/contributors/devel/development.md
+++ b/contributors/devel/development.md
@@ -159,7 +159,7 @@ brew install coreutils ed findutils gawk gnu-sed gnu-tar grep make jq
 ```
 
 You will want to include this block or something similar at the end of
-your `.bashrc` or shell init script:
+your `.zshrc` or shell init script:
 
 ```sh
 GNUBINS=($(find `brew --prefix`/opt -type d -follow -name gnubin -print))


### PR DESCRIPTION
This removes adding the gnu bin utils to the path on macOS.
This is handled by `homebrew` in most cases.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8391
