### PR TITLE
Sunset SIG Security Self-Assessments subproject

### DIFF
--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -45,12 +45,6 @@ The following [working groups][working-group-definition] are sponsored by sig-se
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-security:
-### security-assessments
-Security self assessments for upstream projects
-- **Owners:**
-  - [kubernetes/sig-security/sig-security-assessments](https://github.com/kubernetes/sig-security/blob/main/sig-security-assessments/OWNERS)
-- **Contact:**
-  - Slack: [#sig-security-assessments](https://kubernetes.slack.com/messages/sig-security-assessments)
 ### security-audit
 Third Party Security Audit
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2969,12 +2969,6 @@ sigs:
       github: justaugustus
       name: Stephen Augustus
   subprojects:
-  - name: security-assessments
-    description: Security self assessments for upstream projects
-    contact:
-      slack: sig-security-assessments
-    owners:
-    - https://raw.githubusercontent.com/kubernetes/sig-security/main/sig-security-assessments/OWNERS
   - name: security-audit
     description: Third Party Security Audit
     owners:


### PR DESCRIPTION
Per longstanding discussion in SIG Security meetings and slack, retire SIG Security Self-Assessments subproject.

See also https://groups.google.com/g/kubernetes-sig-security/c/-f_yguXvop8/m/uwlsLfeQAgAJ