### PR TITLE
correct guidance for building e2e.test with debug symbols

### DIFF
--- a/contributors/devel/sig-testing/e2e-tests.md
+++ b/contributors/devel/sig-testing/e2e-tests.md
@@ -282,9 +282,9 @@ For this example we'll debug a [sig-storage test that will provision storage fro
 First, compile the E2E test suite with additional compiler flags
 
 ```sh
-# -N Disable optimizations.
-# -l Disable inlining.
-make WHAT=test/e2e/e2e.test GOGCFLAGS="all=-N -l" GOLDFLAGS=""
+# DBG=1 enables necessary debug options and disables stripping binaries
+# see the makefile upstream, or use UBE_VERBOSE=3 to get the actual build commands
+make WHAT=test/e2e/e2e.test DBG=1
 ```
 
 Then set the env var `E2E_TEST_DEBUG_TOOL=delve` and then run the test with `./hack/ginkgo.sh` instead of `kubetest`, you should see the delve command line prompt

--- a/contributors/devel/sig-testing/e2e-tests.md
+++ b/contributors/devel/sig-testing/e2e-tests.md
@@ -283,7 +283,7 @@ First, compile the E2E test suite with additional compiler flags
 
 ```sh
 # DBG=1 enables necessary debug options and disables stripping binaries
-# see the makefile upstream, or use UBE_VERBOSE=3 to get the actual build commands
+# see the makefile upstream, or use KUBE_VERBOSE=3 to get the actual build commands
 make WHAT=test/e2e/e2e.test DBG=1
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # N/A

DBG=1 enables these settings and also disables stripping the binaries. The current instructions do not produce a debuggable binary.

NOTE: this change does produce a binary that can be debugged, the next bit about using it with "ginkgo.sh" is also wrong but I'm not done iterating on that part. I filed this to avoid forgetting fixing the part which I know the correct fix for already.

/cc @pohly @aojea 