### PR TITLE
sig-auth: add subproject leads for secrets-store (csi driver and sync-controller)

### DIFF
--- a/sig-auth/README.md
+++ b/sig-auth/README.md
@@ -151,6 +151,9 @@ API validation and policies enforced during admission, such as PodSecurityPolicy
   - [kubernetes/pod-security-admission](https://github.com/kubernetes/pod-security-admission/blob/master/OWNERS)
 ### secrets-store-csi-driver
 Integrates secrets stores with Kubernetes via a CSI volume.
+- **Leads:**
+  - Anish Ramasekar (**[@aramase](https://github.com/aramase)**), Microsoft
+  - Rita Zhang (**[@ritazh](https://github.com/ritazh)**), Microsoft
 - **Owners:**
   - [kubernetes-sigs/secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/OWNERS)
 - **Contact:**
@@ -158,6 +161,9 @@ Integrates secrets stores with Kubernetes via a CSI volume.
   - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-secrets-store-csi-driver)
 ### secrets-store-sync-controller
 This is a Kubernetes controller that watches for changes to a custom resource and syncs the secrets from external secrets-store as Kubernetes secret.
+- **Leads:**
+  - Anish Ramasekar (**[@aramase](https://github.com/aramase)**), Microsoft
+  - Mo Khan (**[@enj](https://github.com/enj)**), Microsoft
 - **Owners:**
   - [kubernetes-sigs/secrets-store-sync-controller](https://github.com/kubernetes-sigs/secrets-store-sync-controller/blob/main/OWNERS)
 ### service-accounts

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -607,11 +607,29 @@ sigs:
       mailing_list: https://groups.google.com/forum/#!forum/kubernetes-secrets-store-csi-driver
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/OWNERS
+    leads:
+    - github: aramase
+      name: Anish Ramasekar
+      company: Microsoft
+      email: anish.ramasekar@gmail.com
+    - github: ritazh
+      name: Rita Zhang
+      company: Microsoft
+      email: ritazh@microsoft.com
   - name: secrets-store-sync-controller
     description: |
       This is a Kubernetes controller that watches for changes to a custom resource and syncs the secrets from external secrets-store as Kubernetes secret.
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-sync-controller/main/OWNERS
+    leads:
+    - github: aramase
+      name: Anish Ramasekar
+      company: Microsoft
+      email: anish.ramasekar@gmail.com
+    - github: enj
+      name: Mo Khan
+      company: Microsoft
+      email: i@monis.app
   - name: service-accounts
     description: |
       Infrastructure implementing Kubernetes service account based workload identity.


### PR DESCRIPTION
/sig auth
/assign enj