### PR TITLE
Update e2e-node-tests.md to include KUBE_ROOT

### DIFF
--- a/contributors/devel/sig-node/e2e-node-tests.md
+++ b/contributors/devel/sig-node/e2e-node-tests.md
@@ -7,6 +7,9 @@ Node e2e tests are component tests meant for testing the Kubelet code on a custo
 *Note: There is no scheduler running. The e2e tests have to do manual scheduling, e.g. by using `framework.PodClient`.*
 
 # Running tests
+To ensure node e2e test build can locate the Kubernetes source code, please take one of the following actions:
+- *Set the `KUBE_ROOT` environment variable* to the absolute path of the directory where the Kubernetes repository has been cloned.
+- *Clone the Kubernetes repository* into the default location: `~/k8s.io/kubernetes`.
 
 ## Locally
 


### PR DESCRIPTION
KUBE_ROOT environment variable is used while building node e2e tests. Failing to set this variable will result in the error:
```
I0327 08:36:58.617691    1793 build.go:59] Building k8s binaries...
make: Entering directory '/home/ubuntu/go/k8s.io/kubernetes'
make: *** No targets specified and no makefile found.  Stop.
make: Leaving directory '/home/ubuntu/go/k8s.io/kubernetes'
F0327 08:36:58.627303    1793 run_local.go:51] Failed to build the dependencies: unable to build cgo targets : failed to build go packages exit status 2
exit status 255
```
while running `make test-e2e-node` using the local or the remote method. The environment variable KUBE_ROOT is used [here](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/builder/build.go#L60)

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
