### PR TITLE
charter for CI testing subgroup of SIG Node

### DIFF
--- a/sig-node/CONTRIBUTING.md
+++ b/sig-node/CONTRIBUTING.md
@@ -212,7 +212,39 @@ Running a local cluster
 
 Note: Task 5 requires Linux OS
 
+## Subgroups
+
+### CI testing
+
+CI testing subgroup of SIG Node provides a great way to get started with the SIG.
+CI testing concentrate on  reliability and ongoing issues, see the [charter](sig-node/sig-node-ci-testing-group-charter.md) for details.
+
+There are many ways to participate:
+
+1. Bring a topic for the discussion at a weekly (see "How to..." section below).
+  Topic must be aligned with the group charter.
+2. Participate in test issues, PRs, and bugs triage during the meeting.
+  Expertise in various areas is needed when triaging.
+  So YOUR expertise may be very valuable for some of the topics discussed.
+3. Host a section of a meeting. Once you attended a meeting a few times,
+  you may be ready to host the section of a meeting. It will include
+  presenting your screen and applying needed labels to the issues.
+
 ## How to ...
+
+### add agenda item to the meeting
+
+This applies to both, SIG Node weekly meeting and CI testing subgroup weekly meeting.
+
+1. Find the meeting invite and notes document.
+2. Join the group sig-node@kubernetes.io for edit permissions.
+3. Add you topic to the end of the list, prefixed with your alias, to the agenda of the next meeting.
+4. Show up at the meeting to present your agenda item or find a delegate to present it.
+
+There is generally no restrictions on topics, and topics are added on first come, first served basis.
+Chair who host the meeting will try to allocate time and fit as many topics as possible.
+However declared order is not guaranteed. Also topics may be moved to the next meeting
+if other things like KEP planning must be prioritized.
 
 ### upload meeting recording to YouTube (for chairs)
 

--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -150,4 +150,9 @@ The following topics fall under scope of this SIG.
 * Host OS and/or kernel interactions (to a limited extent)
 
 We also work closely with [sig-storage](../sig-storage) and [sig-network](../sig-network). As you can see, this is a very cross-functional team!
+
+## Subgroups
+
+Read the CI testing subgroup [charter](sig-node-ci-testing-group-charter.md).
+
 <!-- END CUSTOM CONTENT -->

--- a/sig-node/sig-node-ci-testing-group-charter.md
+++ b/sig-node/sig-node-ci-testing-group-charter.md
@@ -1,0 +1,68 @@
+# SIG Node CI testing subgroup charters
+
+- **Created:**  Jul 24, 2020
+- **Last Updated:** Mar 27, 2025
+
+## Overview
+
+SIG Node CI Group is proposed and formed by volunteers from the [SIG Node](charter.md) community.
+SIG Node owns a broad range of [code, binaries, and services](charter.md#code-binaries-and-services)
+which are fundamental to the success of Kubernetes.
+To ensure high quality of these components, SIG Node community has developed a large number of
+[end-to-end (e2e) test cases](https://testgrid.k8s.io/sig-node) over the past several years.
+With new PR requests merged every day, OS distros being updated,
+it has become more and more challenging to maintain these tests and to keep them up to date with new changes.
+In order to maintain tests and keep up with the incoming bugs triage, the CI subproject was formed.
+The progress of this group can be viewed in the [meeting notes](https://docs.google.com/document/d/1fb-ugvgdSVIkkuJ388_nhp2pBTy_4HEVg5848Xy7n5U/edit#heading=h.badwgoqn6j9e).
+
+## Goal
+
+The goal of this group is to keep a high quality bar for SIG Node and to enable continuous integration of node features of Kubernetes.
+More specifically, this group drives all aspects of [SIG Node e2e tests](https://testgrid.k8s.io/sig-node),
+and aims to achieve the following goals:
+
+- Maintaining existing node e2e tests healthiness
+  - Triage and fix failing tests (especially release-blocking tests) in a timely manner
+  - Remove deprecated tests
+  - Enhanced test failure troubleshooting and diagnostics tooling and documentation
+
+- Improving test code quality
+  - Identify and reduce flaky behavior in tests
+  - Review new e2e test code
+
+- Improving test coverage
+  - Identify areas missing test coverage, and work with owners to add e2e tests
+
+- OS Image and dependencies support
+  - Make sure the representative set of OS images are being tested
+  - Make sure the representative set of container runtime versions are being tested
+
+- Test resource utilization and cost optimization
+  - Increase ROI of SIG Node tests
+  - Help spread tests for different clouds for better usage of cloud credits
+
+- Make sure timely response for critical bugs
+  - Triage bugs regularly
+  - Identify critical issue and ensure timely follow up
+  - Review high priority bugs before each release
+
+## Execution Plan
+
+- Regular meet-ups for discussion and triage
+  - Triage test failures
+  - Review test related Pull requests and issues backlog
+  - Triage bugs
+  - Periodically summarize test coverage (flakes, failures etc) in sig-node meeting for broader visibility
+
+- Image Support
+  - Maintain owners for supported OS images.
+  - Process/documentation on lifecycle of OS images used by SIG Node tests.  
+  - Ensure a process and/or automation exists for OS image upgrading process.
+
+- Group Sustainability
+  - Identify, document release-blocking tests  
+  - Grow node e2e test reviewers and approvers
+
+## History
+
+- Original [charter document](https://docs.google.com/document/d/1yS-XoUl6GjZdjrwxInEZVHhxxLXlTIX2CeWOARmD8tY/)


### PR DESCRIPTION
This is an update for the charter (from  https://docs.google.com/document/d/1yS-XoUl6GjZdjrwxInEZVHhxxLXlTIX2CeWOARmD8tY/) with some mentions in how to contribute.

/sig node

/cc @haircommander 
