### PR TITLE
fix validation for company affiliation and email must be set for leads

### DIFF
--- a/generator/app.go
+++ b/generator/app.go
@@ -469,7 +469,7 @@ func (c *Context) Validate() []error {
 								errors = append(errors, fmt.Errorf("%s: %s company: %q does not match other entries %q", group.Dir, val.GitHub, val.Company, person.Company))
 							}
 						}
-						// all entries should have github + name, emeritus or not
+						// all entries should have matching github + name, emeritus or not
 						if val.Name != person.Name {
 							errors = append(errors, fmt.Errorf("%s: %s: expected person: %v, got: %v", group.Dir, prefix, val, person))
 						}
@@ -482,6 +482,9 @@ func (c *Context) Validate() []error {
 						if person.Company == "" {
 							errors = append(errors, fmt.Errorf("%s: %s: company is empty but should be set", group.Dir, person.GitHub))
 						}
+					}
+					if person.Name == "" {
+						errors = append(errors, fmt.Errorf("%s: %s: name is empty but should be set", group.Dir, person.GitHub))
 					}
 
 					if prefix == "emeritus_lead" && person.Company != "" {

--- a/generator/app.go
+++ b/generator/app.go
@@ -461,16 +461,11 @@ func (c *Context) Validate() []error {
 					if val, ok := people[person.GitHub]; ok {
 						// non-emeritus must have email and company set
 						if prefix != "emeritus_lead" {
-							// email must be set and consistent
-							if val.Email == "" {
-								errors = append(errors, fmt.Errorf("%s: %s: email is empty but should be set", group.Dir, val.GitHub))
-							} else if val.Email != person.Email {
+							// email and company must match across groups
+							if val.Email != person.Email {
 								errors = append(errors, fmt.Errorf("%s: %s email: %q does not match other entries %q", group.Dir, val.GitHub, val.Email, person.Email))
 							}
-							// company must be set and consistent
-							if val.Company == "" {
-								errors = append(errors, fmt.Errorf("%s: %s: company is empty but should be set", group.Dir, val.Company))
-							} else if val.Company != person.Company {
+							if val.Company != person.Company {
 								errors = append(errors, fmt.Errorf("%s: %s company: %q does not match other entries %q", group.Dir, val.GitHub, val.Company, person.Company))
 							}
 						}
@@ -480,6 +475,13 @@ func (c *Context) Validate() []error {
 						}
 					} else if prefix != "emeritus_lead" {
 						people[person.GitHub] = person
+						// email and company must be set for leads
+						if person.Email == "" {
+							errors = append(errors, fmt.Errorf("%s: %s: email is empty but should be set", group.Dir, person.GitHub))
+						}
+						if person.Company == "" {
+							errors = append(errors, fmt.Errorf("%s: %s: company is empty but should be set", group.Dir, person.GitHub))
+						}
 					}
 
 					if prefix == "emeritus_lead" && person.Company != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

xref: https://github.com/kubernetes/steering/issues/281

NOTE: This will fail because some emails are missing currently.
I have PRs in flight for the emails.