### PR TITLE
add missing emails for code of conduct committee

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3922,6 +3922,7 @@ committees:
     - github: AnaMMedina21
       name: Ana Margarita Medina
       company: Upbound
+      email: AnaMMedina21@gmail.com
     - github: divya-mohan0209
       name: Divya Mohan
       company: SUSE
@@ -3929,6 +3930,7 @@ committees:
     - github: endocrimes
       name: Danielle Lancashire
       company: Fermyon
+      email: lancashiredanielle@gmail.com
     - github: jeremyrickard
       name: Jeremy Rickard
       company: Microsoft
@@ -3936,6 +3938,7 @@ committees:
     - github: stmcginnis
       name: Sean McGinnis
       company: Lambda, Inc
+      email: sean.mcginnis@gmail.com
     emeritus_leads:
     - github: AevaOnline
       name: Aeva Black


### PR DESCRIPTION
pulled from https://github.com/kubernetes/k8s.io/blob/main/groups/committee-code-of-conduct/groups.yaml

this will make it easier to validate that all leads have this field set, in the future we can drive the email lists from this source of truth ...

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Blocks https://github.com/kubernetes/community/pull/8421
