### PR TITLE
Fixed link to SIG Node CI charter doc

### DIFF
--- a/sig-node/CONTRIBUTING.md
+++ b/sig-node/CONTRIBUTING.md
@@ -217,7 +217,7 @@ Note: Task 5 requires Linux OS
 ### CI testing
 
 CI testing subgroup of SIG Node provides a great way to get started with the SIG.
-CI testing concentrate on  reliability and ongoing issues, see the [charter](sig-node/sig-node-ci-testing-group-charter.md) for details.
+CI testing concentrate on  reliability and ongoing issues, see the [charter](sig-node-ci-testing-group-charter.md) for details.
 
 There are many ways to participate:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes a broken link to the SIG Node CI charter doc from the SIG Node CONTRIBUTING.md file.
