### PR TITLE
new: add kubetail and its usergroup

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -318,6 +318,7 @@ channels:
   - name: kubespray
   - name: kubespray-dev
   - name: kubevirt-dev
+  - name: kubetail
   - name: kubewarden
   - name: kubewarden-dev
   - name: kubicorn

--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -331,3 +331,12 @@ usergroups:
       - kayrus
       - mandre
       - pierreprinetti
+
+  - name: kubetail-maintainers
+    long_name: kubetail Maintainers
+    description: kubetail Maintainers group of kubetail.com
+    channels:
+      - kubetail
+    members:
+      - amorey
+      - rxinui

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -11,6 +11,7 @@ users:
   alexander-demicev: UR7UCR7RV
   AlexB138: U3JA3MDGV
   alisondy: U9CBCBLCV
+  amorey: D08CF0BPYGG
   ameukam: U68KPQ448
   anandrkskd: U01DRS3V0R2
   aniruddha2000: U02BU1RP41H
@@ -240,6 +241,7 @@ users:
   rnapoles-rh: U01KDAMSWJD
   robshelly: U01LL4P09SR
   rtaniwa: U03K27HLHKN
+  rxinui: D08G3DBM3UN
   rytswd: ULUBQ9DFA
   s-urbaniak: U0DT660QM
   sadysnaat: UNQPKAQHE


### PR DESCRIPTION
In accordance with the [Slack guidelines](https://www.kubernetes.dev/docs/comms/slack/#requesting-a-channel), we, the maintainers of kubetail, @amorey and myself, are respectfully requesting the creation of a channel for the kubetail project.

## Project Overview

Kubetail is a real-time logging dashboard designed for Kubernetes. As an open-source project under the Apache License Version 2.0, our community is expanding. To mark our milestone of achieving +1000🌟 on github, we aim to grow and centralize our community on the Kubernetes Slack platform. This will facilitate easier access for new contributors, as a significant portion of the Kubernetes community is already active on this Slack.

- Website: [kubetail.com](https://www.kubetail.com/)
- GitHub: [kubetail-org/kubetail](https://github.com/kubetail-org/kubetail)
- GitHub Community: [kubetail-org](https://github.com/kubetail-org)

