### PR TITLE
[tempelis] add slack member id for gh user natherz97

### DIFF
--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -189,6 +189,7 @@ users:
   munnerz: U0EC03FTN
   natalisucks: U01S4LGP3P1
   nate-double-u: U01AWL6BD62
+  natherz97: U04DKBRL7H8
   nawazkh: U03HJN1C81W
   ncdc: U0A4MJ62V
   neoaggelos: U02GE88D3SQ


### PR DESCRIPTION
Follow up: https://github.com/kubernetes/community/pull/8411

---

To fix failing tempelis job - https://storage.googleapis.com/kubernetes-ci-logs/logs/post-community-tempelis-apply/1920490705503916032/build-log.txt

```
2025/05/08 14:47:30 Error 1: Product Security Committee: unknown user names: natherz97.
```