### PR TITLE
Add permissions for v1.34 release team leads and subteam leads

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -34,7 +34,7 @@ usergroups:
   # - Emeritus Adviser
   # - SIG Release leads
   #
-  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.33/release-team.md
+  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.34/release-team.md
   - name: release-team-leads
     long_name: Release Team Leads
     description: >-
@@ -50,19 +50,19 @@ usergroups:
       - release-notes
       - sig-release
     members:
-      - chanieljdan         # 1.33 Release Lead Shadow
-      - dipesh-rawat        # 1.33 Enhancements Lead
+      - aibarbetta          # v1.34 Comms Lead
+      - chanieljdan         # v1.34 RT Lead Shadow
+      - fsmunoz             # v1.34 EA
       - gracenng            # Release Team Subproject Lead
-      - katcosgrove         # Release Team Subproject Lead
-      - neoaggelos          # 1.33 Emeritus Advisor
-      - mbianchidev         # 1.33 Release Lead Shadow
-      - npolshakova         # 1.33 Release Lead
-      - rashansmith         # 1.33 Release Lead Shadow
-      - rayandas            # 1.33 Docs Lead
-      - rytswd              # 1.33 Communications Lead
-      - sanchita-07         # 1.33 Release Lead Shadow
-      - Vyom-Yadav          # 1.33 Release Lead Shadow
-      - wendy-ha18          # 1.33 Release Signal Lead
+      - jenshu              # v1.34 Enhancements Lead
+      - katcosgrove         # v1.32 EA + Release Team Subproject Lead
+      - michellengnx        # v1.34 Docs Lead
+      - Rajalakshmi-Girish  # v1.34 Release Signal Lead
+      - rytswd              # v1.34 RT Lead Shadow
+      - sreeram-venkitesh   # v1.34 RT Lead Shadow
+      - Vyom-Yadav          # v1.34 RT Lead
+      - wendy-ha18          # v1.34 RT Lead Shadow
+
   # Should match SIG Release Leads at all times:
   # https://git.k8s.io/community/sig-release/README.md#leadership
   - name: sig-release-leads

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -5,6 +5,7 @@ users:
   adilGhaffarDev: U038BLZPX1S
   adisky: U9YRVLTEH
   adityabhatia: U04N6JTDK39
+  aibarbetta: U02GQ3GEQV8
   akshay196: U0254QBGAAY
   alejandrox1: U6AS37R50
   aleksandra-malinowska: U357LUPHS
@@ -118,6 +119,7 @@ users:
   Jdubrick: U068JS25A03
   jdumars: U0YJS6LHL
   jeefy: U5MCFK468
+  jenshu: U07FYLCQD40
   jeremyrickard: U72ESU398
   jiangd: UFS2C9JEA
   jimangel: U4HSVFA5U
@@ -176,6 +178,7 @@ users:
   mfahlandt: U01RR6BFC9Y
   micahhausler: U1WJ1BZA5
   michael-valdron: U03LXKVS0SX
+  michellengnx: U06AE3PKP37
   mickeyboxell: UH0K0EC6S
   microwavables: UAF606ESE
   mik-dass: UCUULSG1W
@@ -230,6 +233,7 @@ users:
   ramessesii2: U0359S5LUDR
   ramrodo: UU74ZC2RX
   rashansmith: U054U4V3A3V
+  Rajalakshmi-Girish: U01B200MPM5
   RansherSingh: U05MZREAE2Y
   rashmigottipati: U013T1DD3PW
   rayandas: UPLGYMV6D


### PR DESCRIPTION
Update `release-team-leads` slack group and user.yaml to reflect the v1.34 release team. 