### PR TITLE
Create #inference-perf slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -186,6 +186,7 @@ channels:
   - name: in-dev
   - name: in-events
   - name: in-users
+  - name: inference-perf
   - name: ingate-dev
   - name: ingate-users
   - name: ingress-nginx-dev


### PR DESCRIPTION
This change adds a slack channel for the inference-perf project (https://github.com/kubernetes-sigs/inference-perf) since we have quite a few topics to discuss on a regular basis.

cc @terrytangyuan @wangchen615 @SachinVarghese
