### PR TITLE
CAPI: Update v1.11 release team members

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -245,22 +245,20 @@ usergroups:
     long_name: Cluster API Release Team
     description: Members of the Cluster API Release Team
     members:
-      - AttyXY
-      - blind3dd
-      - cahillsf
+      - adilGhaffarDev
+      - alimaazamat
       - chandankumar4
+      - chiukapoor
       - cprivitere
       - hackeramitkumar
       - mboersma
       - mbrow137
-      - pratik-mahalle
-      - ramessesii2
+      - natitomattis
+      - neoaggelos
       - RansherSingh
-      - serngawy
       - shecodesmagic
-      - sreeram-venkitesh
-      - Sunnatillo
-      - wendy-ha18
+      - swastik959
+      - tsuzu
 
   - name: kcp-devs
     long_name: kcp Development Team

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -11,9 +11,10 @@ users:
   aleksandra-malinowska: U357LUPHS
   alexander-demicev: UR7UCR7RV
   AlexB138: U3JA3MDGV
+  alimaazamat: U08HKJQCUPK
   alisondy: U9CBCBLCV
-  amorey: D08CF0BPYGG
   ameukam: U68KPQ448
+  amorey: D08CF0BPYGG
   anandrkskd: U01DRS3V0R2
   aniruddha2000: U02BU1RP41H
   anjaltelang: U028B09KZ5X
@@ -85,8 +86,8 @@ users:
   Fedosin: U9Q7EGB7Y
   feiskyer: U0ASA4398
   feloy: UFG7CN85U
-  furkatgofurov7: UV31DL3CG
   fsmunoz: U03DL8UAEMQ
+  furkatgofurov7: UV31DL3CG
   fykaa: U04RHLECJGZ
   g-gaston: U01SS3GFELV
   gianarb: U0FSCELCR
@@ -194,6 +195,7 @@ users:
   natalisucks: U01S4LGP3P1
   nate-double-u: U01AWL6BD62
   natherz97: U04DKBRL7H8
+  natitomattis: U087G7F46BY
   nawazkh: U03HJN1C81W
   ncdc: U0A4MJ62V
   neoaggelos: U02GE88D3SQ
@@ -229,13 +231,13 @@ users:
   PurneswarPrasad: U027CFKVAB0
   pweil-: U0AL6882X
   r-lawton: U019CNHR2E6
+  Rajalakshmi-Girish: U01B200MPM5
   rajankumary2k: U011YM87GQK
   rajula96reddy: U7K9EK1HC
   ramessesii2: U0359S5LUDR
   ramrodo: UU74ZC2RX
-  rashansmith: U054U4V3A3V
-  Rajalakshmi-Girish: U01B200MPM5
   RansherSingh: U05MZREAE2Y
+  rashansmith: U054U4V3A3V
   rashmigottipati: U013T1DD3PW
   rayandas: UPLGYMV6D
   razashahid107: U05FB1L2YM8
@@ -254,8 +256,8 @@ users:
   salehsedghpour: U02GM9ZLELB
   sammy: U8NJFL023
   sanchita-07: U04BT49MD5W
-  sandipanpanda: U02A47HJ517
   sandeepkanabar: U042H6CU0BW
+  sandipanpanda: U02A47HJ517
   SaranBalaji90: U6PNPSULW
   saschagrunert: U53SUDBD4
   satyampsoni: U04DUM62MDY
@@ -285,6 +287,7 @@ users:
   sumitranr: UCQN13L9H
   Sunnatillo: U0261DHJ1Q8
   swamymsft: UHU7ZNXH8
+  swastik959: U04HY2PUN65
   tabbysable: U01742MGBRT
   tallclair: U64VCBURE
   TaoBeier: UCLDV6MN1
@@ -300,6 +303,7 @@ users:
   tpepper: U6UB5V4TX
   troy0820: U3D457W7M
   tstromberg: UCSL5SJ8Z
+  tsuzu: UP5JBA094
   Tunde: UAY977ENN
   typeid: U05M1L6EPS6
   valaparthvi: U016TMJVDAA


### PR DESCRIPTION
This PR syncs up the Slack cluster-api-release-team with its current v1.11-release members.

Also moved a couple aliases in the users.yaml file to proper alphabetical position.

Which issue(s) this PR fixes:

Refs kubernetes-sigs/cluster-api#12150
