### PR TITLE
add ai-gateway channel to slack

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -3,6 +3,7 @@
 
 channels:
   - name: africa-dev
+  - name: ai-gateway
   - name: airflow-operator
   - name: akri
   - name: azure-aks


### PR DESCRIPTION
This adds a channel to discuss "AI Gateway" technologies. "AI Gateway" in this context is meant to encompass proxy technologies and API management capabilities that relate to AI/ML workloads and AI Inference on Kubernetes clusters.