### PR TITLE
fix: update Release Notes Handbook link to correct URL

### DIFF
--- a/contributors/guide/release-notes.md
+++ b/contributors/guide/release-notes.md
@@ -159,4 +159,4 @@ In any other case the release note should be fine.
 * [Behind The Scenes: Kubernetes Release Notes Tips & Tricks - Mike Arpaia, Kolide (KubeCon 2018 Lightning Talk)](https://www.youtube.com/watch?v=n62oPohOyYs)
 
 [kubernetes-repository]: https://git.k8s.io/kubernetes/
-[Release Notes Handbook]: https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes
+[Release Notes Handbook]: https://github.com/kubernetes/sig-release/blob/master/release-engineering/release-notes.md


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the "Release Notes Handbook" link in `contributors/guide/release-notes.md` to point to the correct location of the handbook on GitHub.  
The previous link was broken and resulted in a 404 error.

**Which issue(s) this PR fixes**:
Fixes #8509

**Special notes for your reviewer**:
- No other content was changed.
- The new link is: https://github.com/kubernetes/sig-release/blob/master/release-engineering/release-notes.md