### PR TITLE
Fix link to large-or-automatic-edits

### DIFF
--- a/contributors/guide/pull-requests.md
+++ b/contributors/guide/pull-requests.md
@@ -271,7 +271,7 @@ are generally the people who are the most busy and hardest to get reviews from, 
 when you're a new contributor with no connections within the community yet.)
 
 The effort required to review such sweeping changes might not be worth it, see
-["large or automatic edits")[#large-or-automatic-edits] below.
+["large or automatic edits"](#large-or-automatic-edits) below.
 
 If you really want to try to get such a PR merged, your best bet is to break up the PR
 into separate PRs for each SIG whose code it touches. You can look at the `OWNERS` files


### PR DESCRIPTION
Currently it doesn't render correctly as a link, and the text is just `The effort required to review such sweeping changes might not be worth it, see [“large or automatic edits”)[#large-or-automatic-edits] below`

<img width="762" alt="image" src="https://github.com/user-attachments/assets/5bb89fbf-0ffe-4c97-b5c6-ddd27e10d0bf" />



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
