### PR TITLE
scl/image-builder: updated link to meeting notes and agenda doc

### DIFF
--- a/sig-cluster-lifecycle/README.md
+++ b/sig-cluster-lifecycle/README.md
@@ -216,7 +216,7 @@ A collection of cross-provider Kubernetes virtual machine image building utiliti
   - [Mailing List](https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle)
 - **Meetings:**
   - Image Builder office hours: [Mondays at 08:30 PT (Pacific Time)](https://zoom.us/j/807524571?pwd=WEFTeDJzeWU3bVFkcWQ0UEdZRkRCdz09) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=08%3A30&tz=PT%20%28Pacific%20Time%29).
-    - [Meeting notes and Agenda](https://docs.google.com/document/d/1YIOD0Nnid_0h6rKlDxcbfJaoIRNO6mQd9Or5vKRNxaU/edit).
+    - [Meeting notes and Agenda](https://docs.google.com/document/d/100uv2GmlgWyLBVP65W6ABNJ_EqbvVYTYtTilCLbnVYI/edit).
     - [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4).
 ### kOps
 A tool for creating, destroying, upgrading and maintaining production-grade, highly available, Kubernetes cluster that also provisions infrastructure

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1355,7 +1355,7 @@ sigs:
       tz: PT (Pacific Time)
       frequency: biweekly
       url: https://zoom.us/j/807524571?pwd=WEFTeDJzeWU3bVFkcWQ0UEdZRkRCdz09
-      archive_url: https://docs.google.com/document/d/1YIOD0Nnid_0h6rKlDxcbfJaoIRNO6mQd9Or5vKRNxaU/edit
+      archive_url: https://docs.google.com/document/d/100uv2GmlgWyLBVP65W6ABNJ_EqbvVYTYtTilCLbnVYI/edit
       recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
   - name: kOps
     description: A tool for creating, destroying, upgrading and maintaining production-grade,


### PR DESCRIPTION
Updates the link to sig-cluster-lifecycle image-builder's agenda document to the correct one.

**Which issue(s) this PR fixes**:

N/A