### PR TITLE
Fix: broken GitHub project board links in triage

### DIFF
--- a/contributors/guide/issue-triage.md
+++ b/contributors/guide/issue-triage.md
@@ -96,12 +96,12 @@ Its features include:
 
 ### GitHub Project Boards
 
-GitHub offers project boards, set up like [kanban boards](https://en.wikipedia.org/wiki/Kanban), to help teams organize and track their workflow in order to get work done. The Release Team has come to depend on [their project board](https://github.com/orgs/kubernetes/projects/29) for planning new Kubernetes releases; they also use it as an archive to show the work done for past releases.
+GitHub offers project boards, set up like [kanban boards](https://en.wikipedia.org/wiki/Kanban), to help teams organize and track their workflow in order to get work done. The Release Team has come to depend on [their project board](https://github.com/orgs/kubernetes/projects/68) for planning new Kubernetes releases; they also use it as an archive to show the work done for past releases.
 
 Other SIGs are also using project boards:
-- [Contributor Experience](https://github.com/orgs/kubernetes/projects/1)
-- [Network](https://github.com/orgs/kubernetes/projects/10)
-- [Windows](https://github.com/orgs/kubernetes/projects/8)
+- [Apps](https://github.com/orgs/kubernetes/projects/167)
+- [Auth](https://github.com/orgs/kubernetes/projects/116)
+- [Scheduling](https://github.com/orgs/kubernetes/projects/165)
 
 We encourage more SIGs to use project boards to enhance visibility and tracking. If you'd like some help getting started, visit [GitHub's documentation](https://help.github.com/en/github/managing-your-work-on-github/about-project-boards) or reach out to [SIG Contributor Experience](/sig-contributor-experience/README.md#contact).
 


### PR DESCRIPTION
- Update Release Team project board link to current working URL
- Replace broken SIG project board links (Contributor Experience, Network, Windows) with currently active project boards (Apps, Auth, Scheduling).
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
