### PR TITLE
root OWNERS: match charter.md case-insensitive, require steering instead of only labeling

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -23,6 +23,10 @@ filters:
     labels:
       - area/annual-reports
   # label charter changes for review by steering
-  "charter.md":
+  "(?i)charter.md":
+    required_reviewers:
+      - kubernetes/steering-committee
+    approvers:
+      - committee-steering
     labels:
       - committee/steering


### PR DESCRIPTION
/committee steering
/assign @kubernetes/steering-committee 
