### PR TITLE
Fixing my email in Node Lifecycle WG Chairs

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -3830,7 +3830,7 @@ workinggroups:
     - github: intUnderflow
       name: Lucy Sweet
       company: Uber
-      email: kubernetes.github.com@lucy.sh
+      email: lucysweet@uber.com
     - github: kwilczynski
       name: Krzysztof Wilczyński
       company: Independent


### PR DESCRIPTION
The email in sigs.yaml doesn't have a google account so can't use google groups. Using my work email instead so I can access the Google Group for leads.