### PR TITLE
tempelis: add slack user id - embik, mjudeikis, scheeles, xrstf

### DIFF
--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -75,6 +75,7 @@ users:
   drewhagen: U01NTKZDPLK
   elezar: ULV21K3CH
   elsony: UCW8323KL
+  embik: UAAG3U09H
   EmilienM: U01BVTA83D4
   enj: U2T4CVDTJ
   erikgb: U015W0NF962
@@ -185,6 +186,7 @@ users:
   mik-dass: UCUULSG1W
   ming-qiu: U02JVSL5550
   mjlshen: UN08SUPPD
+  mjudeikis: U36J4T2JC
   mkorbi: UEBLUUA0P
   mohammedzee1000: U3PFFE8CD
   MonzElmasry: U018U96HYDQ
@@ -263,6 +265,7 @@ users:
   sayantani11: U028S6XNVSN
   sbueringer: U48TE1L75
   scott-seago: UHGD79E78
+  scheeles: U0DT4RJ72
   SD-13: U03KA77JSHF
   serngawy: U42969L5P
   sethmccombs: U92LLUZ8A
@@ -319,6 +322,7 @@ users:
   wurbanski: URX7CMK97
   Xander: UDHV1RXB2
   xmudrii: U4Q2TNGVD
+  xrstf: UNP602J64
   xun-jiang: U02J0QC1VKJ
   yangcao77: U01D1VCNJQ3
   yinw: UMVD1GDCY


### PR DESCRIPTION
Follow up - https://github.com/kubernetes/community/pull/8527

Fix for failing `post-community-tempelis-apply` job 

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-community-tempelis-apply/1949857509816668160

```
2025/07/28 15:40:40 This configuration cannot be applied against the current reality:
2025/07/28 15:40:40 Error 1: kcp Development Team: unknown user names: embik, mjudeikis, scheeles, xrstf.
2025/07/28 15:40:40 We will not execute anything due to errors, but this what we would've done:
2025/07/28 15:40:40 Step 1: Rename channel C021U8WSAFK from kcp-dev to kcp-users. 
```