### PR TITLE
Add basic terminology page for SIG-MC.

### DIFF
--- a/sig-multicluster/terminology.md
+++ b/sig-multicluster/terminology.md
@@ -17,11 +17,6 @@ For more information, see individual subprojects and documents, or the SIG-Multi
 
 ## ClusterProfile API
 
-### Previously known as:
-
-- Cluster Inventory
-
-
 ## ClusterSet
 
 

--- a/sig-multicluster/terminology.md
+++ b/sig-multicluster/terminology.md
@@ -6,9 +6,13 @@ For more information, see individual subprojects and documents, or the SIG-Multi
 
 ## About API
 
+### Also known as:
+
+- ClusterProperty
+
 ### Previously known as:
 
--  ClusterProperty API
+-  ClusterClaim API
 
 
 ## ClusterProfile API

--- a/sig-multicluster/terminology.md
+++ b/sig-multicluster/terminology.md
@@ -1,0 +1,35 @@
+# Terminology
+
+This file contains terminology in common use by the SIG-Multicluster community, as well as aliases those terms may be used by past or present.
+
+For more information, see individual subprojects and documents, or the SIG-Multicluster website at https://multicluster.sigs.k8s.io/.
+
+## About API
+
+### Previously known as:
+
+-  ClusterProperty API
+
+
+## ClusterProfile API
+
+### Previously known as:
+
+- Cluster Inventory
+
+
+## ClusterSet
+
+
+## Multicluster Services API
+
+### Also known as:
+
+- MCS
+- MCS API
+
+
+## Namespace Sameness
+
+
+## Work API


### PR DESCRIPTION
Add a `terminology.md` page in the community repo for SIG-Multicluster that gives a bare-bones list of terminology and their alternate names, and provides a link out to the website for more information.

**Which issue(s) this PR fixes**:

No issue, but based off of conversation in https://github.com/kubernetes/community/pull/8210#issuecomment-3012304521.