### PR TITLE
Add WG AI Integration Slack Channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -563,7 +563,8 @@ channels:
   - name: virtualization
   - name: vsphere
     archived: true
-  - name: wg-ai-conformance  
+  - name: wg-ai-conformance
+  - name: wg-ai-integration
   - name: wg-app-def
     archived: true
   - name: wg-api-expression


### PR DESCRIPTION
New working group WG AI Integration has been approved in https://github.com/kubernetes/community/pull/8519. This PR adds the definition of dedicated slack channel for this WG.

`#wg-ai-integration`