### PR TITLE
sig-instrumentation: add resource-state-metrics subproject

### DIFF
--- a/sig-instrumentation/README.md
+++ b/sig-instrumentation/README.md
@@ -98,6 +98,9 @@ Organization of SIG Instrumentation subprojects
 ### prometheus-adapter
 - **Owners:**
   - [kubernetes-sigs/prometheus-adapter](https://github.com/kubernetes-sigs/prometheus-adapter/blob/master/OWNERS)
+### resource-state-metrics
+- **Owners:**
+  - [kubernetes-sigs/resource-state-metrics](https://github.com/kubernetes-sigs/resource-state-metrics/blob/main/OWNERS)
 ### structured-logging
 - **Owners:**
   - [kubernetes-sigs/logtools](https://github.com/kubernetes-sigs/logtools/blob/main/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2011,6 +2011,9 @@ sigs:
   - name: prometheus-adapter
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/prometheus-adapter/master/OWNERS
+  - name: resource-state-metrics
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/resource-state-metrics/main/OWNERS
   - name: structured-logging
     owners:
     - https://raw.githubusercontent.com/kubernetes-sigs/logtools/main/OWNERS


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5740

/assign @kubernetes/sig-instrumentation-leads 

cc: @kubernetes/owners