### PR TITLE
2025 Steering Elections: Added election.yaml and election_desc.md

### DIFF
--- a/elections/steering/2025/election.yaml
+++ b/elections/steering/2025/election.yaml
@@ -1,0 +1,20 @@
+name: 2025 Steering Committee Election
+organization: Kubernetes
+# Start of day in UTC for opening: 2023-08-29 00:00:01
+start_datetime: 2025-09-11 00:00:01
+# End of day Anywhere on Earth for closing. Write 2023-09-26 as: 2023-09-27 11:59:59
+end_datetime: 2025-10-25 11:59:59
+no_winners: 4
+allow_no_opinion: True
+delete_after: True
+show_candidate_fields:
+  - employer
+  - slack
+election_officers:
+  - cblecker
+  - npolshakova
+  - sreeram-venkitesh
+eligibility: Kubernetes Org members with 50 or more contributions in the last year can vote.  See [the election guide](https://github.com/kubernetes/community/tree/master/elections/steering/2025)
+exception_description: Not all contributions are measured by DevStats.  If you have contributions that are not so measured, then please request an exception to allow you to vote via the Elekto application.
+# End of day Anywhere on Earth for closing. Write 2023-09-23 as: 2023-09-24 11:59:59
+exception_due: 2025-10-25 11:59:59

--- a/elections/steering/2025/election.yaml
+++ b/elections/steering/2025/election.yaml
@@ -1,7 +1,7 @@
 name: 2025 Steering Committee Election
 organization: Kubernetes
 # Start of day in UTC for opening: 2023-08-29 00:00:01
-start_datetime: 2025-09-11 00:00:01
+start_datetime: 2025-09-10 00:00:01
 # End of day Anywhere on Earth for closing. Write 2023-09-26 as: 2023-09-27 11:59:59
 end_datetime: 2025-10-25 11:59:59
 no_winners: 4
@@ -17,4 +17,4 @@ election_officers:
 eligibility: Kubernetes Org members with 50 or more contributions in the last year can vote.  See [the election guide](https://github.com/kubernetes/community/tree/master/elections/steering/2025)
 exception_description: Not all contributions are measured by DevStats.  If you have contributions that are not so measured, then please request an exception to allow you to vote via the Elekto application.
 # End of day Anywhere on Earth for closing. Write 2023-09-23 as: 2023-09-24 11:59:59
-exception_due: 2025-10-25 11:59:59
+exception_due: 2025-10-23 11:59:59

--- a/elections/steering/2025/election_desc.md
+++ b/elections/steering/2025/election_desc.md
@@ -1,0 +1,11 @@
+# Vote for the 2025 Steering Committee
+
+As is now customary, the third calendar quarter is [Steering Committee](https://github.com/kubernetes/steering) election season for Kubernetes. Three (3) elected members (@bentheelder, @aojea, @saschagrunert) will stay on for the remaining year of their terms, and there will be four (4) positions open for election. Every election term will be 2 years. More complete information on the election may be found [in the voter's guide](https://github.com/kubernetes/community/tree/master/elections/steering/2025).
+
+Instructions on using Elekto can be found [in its docs site](https://elekto.dev/docs/voting/).
+
+If you’d like to vote or run for a seat, all details and next steps are outlined in the [election process doc](https://git.k8s.io/steering/elections.md) and this application. The application will be the single source of truth of information for this cycle. It will be updated live as new bios of candidates get committed.
+
+Please pay attention to the [scheduled dates](https://github.com/kubernetes/community/tree/master/elections/steering/2025#schedule).
+
+Eligibility for voting will be determined by 50 contributions to a Kubernetes project over the past year and [Kubernetes Org membership](https://github.com/kubernetes/community/blob/master/community-membership.md).  Eligible voters will be shown as such by this site when logged in.  If you should be eligible, but are not, you may also [file for an exception](https://elections.k8s.io/app/elections/steering---2025/exception).

--- a/elections/steering/2025/voters.yaml
+++ b/elections/steering/2025/voters.yaml
@@ -1,0 +1,15 @@
+# 2025 Steering Committee Election
+##################################
+#
+# The process for determining eligible voters can be found in
+# https://github.com/kubernetes/community/tree/master/elections/steering/2025
+#
+# If you feel you meet the eligibility criteria but do not see your GitHub username
+# below, please fill out an exception request and the elections team will get back to
+# you as quickly as possible: https://elections.k8s.io/app/elections/steering---2025/exception
+#
+# History:
+# Log of changes to the file
+#
+eligible_voters:
+-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Adds the election.yaml and election_desc.md required to setup the election in Elekto. Also adds the template for voters.yaml although this still needs to be populated with the list of eligible voters.

/committee steering
/sig contributor-experience
/area elections
/hold
