### PR TITLE
Add an optional leads mailing list address

### DIFF
--- a/generator/app.go
+++ b/generator/app.go
@@ -263,9 +263,10 @@ type Subproject struct {
 
 // LeadershipGroup represents the different groups of leaders within a group
 type LeadershipGroup struct {
-	Chairs         []Person
-	TechnicalLeads []Person `yaml:"tech_leads,omitempty"`
-	EmeritusLeads  []Person `yaml:"emeritus_leads,omitempty"`
+	MailingListEmail string `yaml:"mailing_list_email,omitempty"`
+	Chairs           []Person
+	TechnicalLeads   []Person `yaml:"tech_leads,omitempty"`
+	EmeritusLeads    []Person `yaml:"emeritus_leads,omitempty"`
 }
 
 // PrefixToPersonMap returns a map of prefix to persons, useful for iteration over all persons

--- a/generator/sig_readme.tmpl
+++ b/generator/sig_readme.tmpl
@@ -26,6 +26,9 @@ The [charter]({{.CharterLink}}) defines the scope and governance of the {{.Name}
 {{- if .Leadership }}
 
 ## Leadership
+{{- if .Leadership.MailingListEmail }}
+To contact all the leads, email `{{.Leadership.MailingListEmail}}`.
+{{- end }}
 {{- if .Leadership.Chairs }}
 
 ### Chairs

--- a/sig-multicluster/README.md
+++ b/sig-multicluster/README.md
@@ -22,6 +22,7 @@ The [charter](charter.md) defines the scope and governance of the Multicluster S
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0HqgyqTby6HlDEz7i1mb0-).
 
 ## Leadership
+To contact all the leads, email `kubernetes-sig-multicluster-leads at googlegroups.com`.
 
 ### Chairs
 The Chairs of the SIG run operations and processes governing the SIG.

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2193,6 +2193,7 @@ sigs:
   charter_link: charter.md
   label: multicluster
   leadership:
+    mailing_list_email: kubernetes-sig-multicluster-leads at googlegroups.com
     chairs:
     - github: jeremyot
       name: Jeremy Olmsted-Thompson


### PR DESCRIPTION
This was inspired by a SIG-Multicluster discussion; there are leads mailing lists that can be used to contact all the leads of a given SIG, but they aren't advertised. This adds a field, a template entry, and the information for SIG-MC.

Since the mailing list is only useful as an email address, the entry is supposed to be an email address (or slight anti-spam variant thereof), rather than the web link commonly used for open mailing lists.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
