### PR TITLE
Fixing typo about number of seats in election

### DIFF
--- a/elections/steering/2025/README.md
+++ b/elections/steering/2025/README.md
@@ -25,7 +25,7 @@
 
 ## Purpose
 
-The role of this election is to fill out the three (3) seats due for
+The role of this election is to fill out the four (4) seats due for
 reelection this year on the [Kubernetes Steering Committee]. Each elected
 member will serve a two (2) year term.
 


### PR DESCRIPTION
Looks like we accidentally repeated the number of open seats from last year's election README instead of adjusting it to match the correct number for this year. Based on https://elections.k8s.io/app/elections/steering---2025 there are 4 open seats (which makes sense, as it was 3 open seats in 2024 and 4 open seats in 2023.)