### PR TITLE
Update the meetings link to use an absolute URL

### DIFF
--- a/sig-docs/blog-subproject/README.md
+++ b/sig-docs/blog-subproject/README.md
@@ -6,7 +6,7 @@ This section covers documentation, processes, and roles for the [Kubernetes blog
 
 ## Meetings
 
-See [meetings](/kubernetes/community/tree/master/sig-docs#meetings) for SIG Docs
+See [meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meetings) for SIG Docs
 
 
 ## Subproject contributors


### PR DESCRIPTION
Update the meetings link in sig-docs to use an absolute URL.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
