### PR TITLE
fix Kubernetes slack invitation link in new contributor resources

### DIFF
--- a/mentoring/new-contributor-orientation/new-contributor-resources.md
+++ b/mentoring/new-contributor-orientation/new-contributor-resources.md
@@ -4,7 +4,7 @@
 
 - Join the Kubernetes Developer Google Group (k-dev): [https://groups.google.com/a/kubernetes.io/g/dev](https://groups.google.com/a/kubernetes.io/g/dev)
 - Check out [kubernetes/community](https://github.com/kubernetes/community) for an overview of our community.
-- Come join us in the [Kubernetes Slack](https://www.slack.k8s.io):
+- Come join us in the [Kubernetes Slack](https://slack.k8s.io):
   - Join the #kubernetes-new-contributors channel
   - Join the channels of 1 or more SIGs you're interested in
 - Participate in the [New Contributor Orientation](./README.md) to get an introduction to Kubernetes development and the community.


### PR DESCRIPTION
Changed Slack invitation URL from "www.slack.k8s.io" to "slack.k8s.io"

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8575
