### PR TITLE
Fixup labels for elections directories

### DIFF
--- a/elections/OWNERS
+++ b/elections/OWNERS
@@ -12,4 +12,5 @@ emeritus_approvers:
   - nikhita
   - mrbobbytables
 labels:
-  - committee/steering
+  - area/elections
+  - sig/contributor-experience

--- a/elections/steering/2025/OWNERS
+++ b/elections/steering/2025/OWNERS
@@ -6,5 +6,3 @@ approvers:
   - cblecker
   - npolshakova
   - sreeram-venkitesh
-labels:
-  - committee/steering

--- a/elections/steering/OWNERS
+++ b/elections/steering/OWNERS
@@ -1,5 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
+options:
+  no_parent_owners: true
 approvers:
   - jberkus
   - committee-steering
@@ -10,4 +11,5 @@ emeritus_approvers:
   - parispittman
   - jdumars
 labels:
+  - area/elections
   - committee/steering


### PR DESCRIPTION
- Ensures that `area/elections` is added to elections/ dir stuff
- Uses `no_parent_owners` to prevent contribex stuff from applying to steering stuff