### PR TITLE
Updating year from 2024 to 2025

### DIFF
--- a/elections/steering/README.md
+++ b/elections/steering/README.md
@@ -2,12 +2,12 @@
 
 This folder contains information on the Kubernetes Steering elections since 2017.
 
-The current Steering election, including all directions on eligibility, voting, and candidates, can be found here: [2024 Election]
+The current Steering election, including all directions on eligibility, voting, and candidates, can be found here: [2025 Election]
 
-The last Steering election, including all directions on eligibility, voting, and candidates, can be found here: [2023 Election]
+The last Steering election, including all directions on eligibility, voting, and candidates, can be found here: [2024 Election]
 
 You can also read [documentation] on how to run a Steering Election.
 
+[2025 Election]: /elections/steering/2025/
 [2024 Election]: /elections/steering/2024/
-[2023 Election]: /elections/steering/2023/
 [documentation]: /elections/steering/documentation/


### PR DESCRIPTION
I noticed that the base README for all elections still pointed to last year; this updates it.