### PR TITLE
Add WG AI Gateway Slack Channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -566,6 +566,7 @@ channels:
   - name: vsphere
     archived: true
   - name: wg-ai-conformance
+  - name: wg-ai-gateway
   - name: wg-ai-integration
   - name: wg-app-def
     archived: true


### PR DESCRIPTION
This adds the Slack channel for the new AI Gateway Working Group.

Ref https://github.com/kubernetes/community/pull/8521