### PR TITLE
Delay 2025 election start

### DIFF
--- a/elections/steering/2025/README.md
+++ b/elections/steering/2025/README.md
@@ -143,7 +143,7 @@ Examples of contributions that would NOT be considered:
 | Wednesday, September 3  | Steering Committee Q+A for the candidates (to be confirmed)           |
 | Monday, September 8     | Candidate nominations due at the end of the day in AoE time           |
 | Tuesday, September 9    | All candidate bios due at the end of the day in AoE time              |
-| Wednesday, September 10 | Election Begins                                                       |
+| Friday, September 12    | Election Begins                                                       |
 | Wednesday, October 22   | Deadline to submit voter exception requests                           |
 | Friday, October 24      | Election Closes at the end of the day in AoE time                     |
 | Monday, October 27      | Private announcement of Results to SC members not up for election     |

--- a/elections/steering/2025/election.yaml
+++ b/elections/steering/2025/election.yaml
@@ -1,7 +1,7 @@
 name: 2025 Steering Committee Election
 organization: Kubernetes
 # Start of day in UTC for opening: 2023-08-29 00:00:01
-start_datetime: 2025-09-10 00:00:01
+start_datetime: 2025-09-12 00:00:01
 # End of day Anywhere on Earth for closing. Write 2023-09-26 as: 2023-09-27 11:59:59
 end_datetime: 2025-10-25 11:59:59
 no_winners: 4


### PR DESCRIPTION
Delays the start of the 2025 election as there was a slight delay in getting bios merged.