### PR TITLE
updates members in release-team-leads for 1.35 release cycle

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -34,7 +34,7 @@ usergroups:
   # - Emeritus Adviser
   # - SIG Release leads
   #
-  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.34/release-team.md
+  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.35/release-team.md
   - name: release-team-leads
     long_name: Release Team Leads
     description: >-
@@ -50,18 +50,16 @@ usergroups:
       - release-notes
       - sig-release
     members:
-      - aibarbetta          # v1.34 Comms Lead
-      - chanieljdan         # v1.34 RT Lead Shadow
-      - fsmunoz             # v1.34 EA
-      - gracenng            # Release Team Subproject Lead
-      - jenshu              # v1.34 Enhancements Lead
-      - katcosgrove         # v1.32 EA + Release Team Subproject Lead
-      - michellengnx        # v1.34 Docs Lead
-      - Rajalakshmi-Girish  # v1.34 Release Signal Lead
-      - rytswd              # v1.34 RT Lead Shadow
-      - sreeram-venkitesh   # v1.34 RT Lead Shadow
-      - Vyom-Yadav          # v1.34 RT Lead
-      - wendy-ha18          # v1.34 RT Lead Shadow
+      - dipesh-rawat        # v1.35 RT Lead Shadow
+      - drewhagen           # v1.35 Lead
+      - graz-dev            # v1.35 Comms Lead
+      - jenshu              # v1.35 RT Lead Shadow
+      - katcosgrove         # Release Team Subproject Lead
+      - Rajalakshmi-Girish  # v1.35 RT Lead Shadow
+      - rayandas            # v1.35 Enhancements Lead
+      - rytswd              # v1.35 RT Lead Shadow
+      - tico88612           # v1.35 Release Signal Lead
+      - Urvashi0109         # v1.35 Docs Lead
 
   # Should match SIG Release Leads at all times:
   # https://git.k8s.io/community/sig-release/README.md#leadership

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -94,6 +94,7 @@ users:
   gianarb: U0FSCELCR
   girishramnani: U9M4K75EU
   gracenng: U01GX18N6H3
+  graz-dev: U071WP8D3JB
   grdryn: U017628HJL8
   gsquared94: U0131C0PJBU
   guineveresaenger: U4H2QU3DW
@@ -300,6 +301,7 @@ users:
   theishshah: U01891A4TRS
   thejoycekung: U01AY4VHX25
   thepetk: U04NW4PPY8N
+  tico88612: U03M6SD7CLE
   tjons: U05H23DAZTP
   tobiasgiese: U01C1NM8D8F
   tormath1: U03F0AG61JM
@@ -310,6 +312,7 @@ users:
   Tunde: UAY977ENN
   typeid: U05M1L6EPS6
   upodroid: U01FLMDKY3B
+  Urvashi0109: U087802UFHA
   valaparthvi: U016TMJVDAA
   varshaprasad96: UK59YP2DA
   varshasuryawanshi: U07EPRHR6LQ


### PR DESCRIPTION
Update release-team-leads slack group and user.yaml to reflect the v1.35 release team.