### PR TITLE
chore: add new slack channel for CAPI working group

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -85,6 +85,7 @@ channels:
   - name: cluster-api-proxmox
   - name: cluster-api-release
   - name: cluster-api-vsphere
+  - name: cluster-api-wg-machinepools
   - name: cn-dev
   - name: cn-events
   - name: cn-users


### PR DESCRIPTION
This adds a new slack channel to be used for a working group focused on machine pools in cluster api.

