### PR TITLE
docs: fix archive_url for Declarative APIs and Linters subproject meeting

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -15,7 +15,7 @@ The [charter](charter.md) defines the scope and governance of the API Machinery 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery) for the group will typically add invites for the following meetings to your calendar.*
 * Declarative APIs and Linters Meeting: [Tuesdays at 9:00 PT (Pacific Time)]() (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9%3A00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1GbSkHAxIaFTm2fL92z3WeWrCtnIjXfr7gNZSySLHhmk/edit?usp=sharing).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1cYXfDHZpalzoew-PKfgh1XHQB_6JjiEsidsM4zYGAzc/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0SOaFeA9f3dwdCNECEKkX3).
 * Kubebuilder Meeting: [Thursdays at 11:00 PT (Pacific Time)]() (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11%3A00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1GbSkHAxIaFTm2fL92z3WeWrCtnIjXfr7gNZSySLHhmk/edit?usp=sharing).

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -35,7 +35,7 @@ sigs:
         time: "9:00"
         tz: PT (Pacific Time)
         frequency: biweekly
-        archive_url: https://docs.google.com/document/d/1GbSkHAxIaFTm2fL92z3WeWrCtnIjXfr7gNZSySLHhmk/edit?usp=sharing
+        archive_url: https://docs.google.com/document/d/1cYXfDHZpalzoew-PKfgh1XHQB_6JjiEsidsM4zYGAzc/edit?usp=sharing
         recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP0SOaFeA9f3dwdCNECEKkX3
       - description: Kubebuilder Meeting
         day: Thursday


### PR DESCRIPTION
This PR fixes the archive_url for the recently added Declarative APIs and Linters subproject meeting setting it to the appropriate file (currently it points to the Kubebuilder meeting archive_url)