### PR TITLE
docs: update declarative apis and linters meeting recordings url

### DIFF
--- a/sig-api-machinery/README.md
+++ b/sig-api-machinery/README.md
@@ -16,7 +16,7 @@ The [charter](charter.md) defines the scope and governance of the API Machinery 
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery) for the group will typically add invites for the following meetings to your calendar.*
 * Declarative APIs and Linters Meeting: [Tuesdays at 9:00 PT (Pacific Time)]() (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=9%3A00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1cYXfDHZpalzoew-PKfgh1XHQB_6JjiEsidsM4zYGAzc/edit?usp=sharing).
-  * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0SOaFeA9f3dwdCNECEKkX3).
+  * [Meeting recordings](https://www.youtube.com/playlist?list=PL--jPUI8HA10IosS6xSbUstXIG05IiHkz).
 * Kubebuilder Meeting: [Thursdays at 11:00 PT (Pacific Time)]() (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=11%3A00&tz=PT%20%28Pacific%20Time%29).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1GbSkHAxIaFTm2fL92z3WeWrCtnIjXfr7gNZSySLHhmk/edit?usp=sharing).
   * [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP0SOaFeA9f3dwdCNECEKkX3).

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -36,7 +36,7 @@ sigs:
         tz: PT (Pacific Time)
         frequency: biweekly
         archive_url: https://docs.google.com/document/d/1cYXfDHZpalzoew-PKfgh1XHQB_6JjiEsidsM4zYGAzc/edit?usp=sharing
-        recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP0SOaFeA9f3dwdCNECEKkX3
+        recordings_url: https://www.youtube.com/playlist?list=PL--jPUI8HA10IosS6xSbUstXIG05IiHkz
       - description: Kubebuilder Meeting
         day: Thursday
         time: "11:00"


### PR DESCRIPTION
Updates the recordings url to be correct for the SIG API Machinery Suproject Meeting - Declarative APIs and Linters