### PR TITLE
Update SIG-Autoscaling TL to adrianmoisey

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,9 +20,9 @@ aliases:
     - micahhausler
     - ritazh
   sig-autoscaling-leads:
+    - adrianmoisey
     - gjtempleton
     - jackfrancis
-    - raywainman
     - towca
   sig-cli-leads:
     - ardaguclu

--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -29,13 +29,14 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
+* Adrian Moisey (**[@adrianmoisey](https://github.com/adrianmoisey)**), SalesLoft
 * Jack Francis (**[@jackfrancis](https://github.com/jackfrancis)**), Microsoft
-* Ray Wainman (**[@raywainman](https://github.com/raywainman)**), Google
 
 ## Emeritus Leads
 
 * Maciek Pytel (**[@maciekpytel](https://github.com/maciekpytel)**)
 * Marcin Wielgus (**[@mwielgus](https://github.com/mwielgus)**)
+* Ray Wainman (**[@raywainman](https://github.com/raywainman)**)
 
 ## Contact
 - Slack: [#sig-autoscaling](https://kubernetes.slack.com/messages/sig-autoscaling)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -668,19 +668,21 @@ sigs:
           company: Google
           email: jtuznik@google.com
       tech_leads:
+        - github: adrianmoisey
+          name: Adrian Moisey
+          company: SalesLoft
+          email: adrian@changeover.za.net
         - github: jackfrancis
           name: Jack Francis
           company: Microsoft
           email: jack.francis@microsoft.com
-        - github: raywainman
-          name: Ray Wainman
-          company: Google
-          email: rwainman@google.com
       emeritus_leads:
         - github: maciekpytel
           name: Maciek Pytel
         - github: mwielgus
           name: Marcin Wielgus
+        - github: raywainman
+          name: Ray Wainman
     meetings:
       - description: Regular SIG Meeting
         day: Thursday


### PR DESCRIPTION
Updates SIG Autoscaling TL from myself to @adrianmoisey per [this announcement](https://groups.google.com/g/kubernetes-sig-autoscaling/c/VH_Dj1nWCUw/m/ulj2jMCuAQAJ).

Updated info in `sigs.yaml` and ran `make generate`.

**Which issue(s) this PR fixes**:

See https://github.com/kubernetes/community/issues/8629.