### PR TITLE
Retire channels related to self-assessment projects that have completed

### DIFF
--- a/communication/slack-config/sig-security/config.yaml
+++ b/communication/slack-config/sig-security/config.yaml
@@ -1,8 +1,9 @@
 channels:
   - name: sig-security
-  - name: sig-security-assess-capi
   - name: sig-security-docs
   - name: sig-security-tooling
   - name: sig-security-assessments
   - name: sig-security-assess-etcd
-  - name: sig-security-assess-vsphere-csi-driver
+# Retired channels noted for future reference
+#  - name: sig-security-assess-vsphere-csi-driver
+#  - name: sig-security-assess-capi


### PR DESCRIPTION
To reduce future confusion, close Slack channels that were created for SIG Security Self-Assessements projects that have completed.