### PR TITLE
Add documentation for re-opened SIG Security Self-Assessments subproj…

### DIFF
--- a/sig-security/README.md
+++ b/sig-security/README.md
@@ -55,6 +55,12 @@ Security Documents and Documentation
   - [kubernetes/sig-security/sig-security-docs](https://github.com/kubernetes/sig-security/blob/main/sig-security-docs/OWNERS)
 - **Contact:**
   - Slack: [#sig-security-docs](https://kubernetes.slack.com/messages/sig-security-docs)
+### security-self-assessments
+Security self-assessments for K8s subprojects
+- **Owners:**
+  - [kubernetes/sig-security/sig-security-assessments](https://github.com/kubernetes/sig-security/blob/main/sig-security-assessments/OWNERS)
+- **Contact:**
+  - Slack: [#sig-security-assessments](https://kubernetes.slack.com/messages/sig-security-assessments)
 ### security-tooling
 Development and Enhancements of Security Tooling
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2963,6 +2963,12 @@ sigs:
           slack: sig-security-docs
         owners:
           - https://raw.githubusercontent.com/kubernetes/sig-security/main/sig-security-docs/OWNERS
+      - name: security-self-assessments
+        description: Security self-assessments for K8s subprojects
+        contact:
+          slack: sig-security-assessments
+        owners:
+          - https://raw.githubusercontent.com/kubernetes/sig-security/main/sig-security-assessments/OWNERS
       - name: security-tooling
         description: Development and Enhancements of Security Tooling
         contact:


### PR DESCRIPTION
SIG Security Self-Assessments has re-opened in May 2025; re-add it to the documentation