### PR TITLE
[fix:tempelis] archive sig-security-assess* slack channels

### DIFF
--- a/communication/slack-config/sig-security/config.yaml
+++ b/communication/slack-config/sig-security/config.yaml
@@ -4,6 +4,8 @@ channels:
   - name: sig-security-tooling
   - name: sig-security-assessments
   - name: sig-security-assess-etcd
-# Retired channels noted for future reference
-#  - name: sig-security-assess-vsphere-csi-driver
-#  - name: sig-security-assess-capi
+  # Retired channels noted for future reference
+  - name: sig-security-assess-vsphere-csi-driver
+    archived: true
+  - name: sig-security-assess-capi
+    arhcived: true


### PR DESCRIPTION
Fix for the failing `post-community-tempelis-apply` job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-community-tempelis-apply/1975546920612925440

```
 2025/10/07 13:01:13 This configuration cannot be applied against the current reality:
2025/10/07 13:01:13 Error 1: channel sig-security-assess-capi (C022K4F2W4W) not referenced in config.
2025/10/07 13:01:13 Error 2: channel sig-security-assess-vsphere-csi-driver (C04M4MFTJ6R) not referenced in config.
2025/10/07 13:01:13 We will not execute anything due to errors, but this what we would've done:
2025/10/07 13:01:13 Step 1: Set members of usergroup kubetail-maintainers (S08SBCW9U91) to [D08CF0BPYGG D08G3DBM3UN].
2025/10/07 13:01:13 Reconciliation failed: there were configuration errors 
```

Follow up https://github.com/kubernetes/community/pull/8645

cc: @tabbysable (for review)

