### PR TITLE
sig-autoscaling: add karpenter-provider-ibm-cloud repo to karpenter subproject

### DIFF
--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -76,6 +76,7 @@ The following [subprojects][subproject-definition] are owned by sig-autoscaling:
   - [kubernetes/kubernetes/pkg/controller/podautoscaler](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/podautoscaler/OWNERS)
 ### karpenter
 - **Owners:**
+  - [kubernetes-sigs/karpenter-provider-ibm-cloud](https://github.com/kubernetes-sigs/karpenter-provider-ibm-cloud/blob/main/OWNERS)
   - [kubernetes-sigs/karpenter](https://github.com/kubernetes-sigs/karpenter/blob/main/OWNERS)
 - **Contact:**
   - Slack: [#karpenter](https://kubernetes.slack.com/messages/karpenter)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -727,6 +727,7 @@ sigs:
         contact:
           slack: karpenter
         owners:
+          - https://raw.githubusercontent.com/kubernetes-sigs/karpenter-provider-ibm-cloud/main/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/karpenter/main/OWNERS
       - name: vertical-pod-autoscaler
         contact:


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5836

/assign @kubernetes/sig-autoscaling-leads

cc: @kubernetes/owners