### PR TITLE
Archive spark-operator Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -524,6 +524,7 @@ channels:
   - name: solr-operator
   - name: sonobuoy
   - name: spark-operator
+    archived: true
   - name: spegel
   - name: spinnaker
   - name: sre


### PR DESCRIPTION
`spark-operator` Kubernetes Slack channel has been deprecated since September 2024.
The new channel is in CNCF Slack: `kubeflow-spark-operator`: https://cloud-native.slack.com/archives/C074588U7EG

cc @jacobsalway @vara-bonthu @ChenYi015 @nabuskey

/assign   @jeefy @mrbobbytables @alejandrox1 @coderanger @munnerz @DylanGraham @jberkus
