### PR TITLE
[tempelis] fix typo in sig-security config.yaml

### DIFF
--- a/communication/slack-config/sig-security/config.yaml
+++ b/communication/slack-config/sig-security/config.yaml
@@ -8,4 +8,4 @@ channels:
   - name: sig-security-assess-vsphere-csi-driver
     archived: true
   - name: sig-security-assess-capi
-    arhcived: true
+    archived: true


### PR DESCRIPTION
fix https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-community-tempelis-apply/1978751796494995456

```
2025/10/16 09:16:14 Failed to load config: failed to parse communication/slack-config/sig-security/config.yaml: failed to parse yaml: error unmarshaling JSON: while decoding JSON: json: unknown field "arhcived"
```

ref: https://github.com/kubernetes/community/pull/8647