### PR TITLE
[Steering 2025] Add voters from approved exception requests - Oct 24

### DIFF
--- a/elections/steering/2025/voters.yaml
+++ b/elections/steering/2025/voters.yaml
@@ -184,6 +184,7 @@ eligible_voters:
 - droslean
 - EandrewJones
 - Eason1118
+- eddiezane
 - edsoncelio
 - Edwinhr716
 - elbehery
@@ -261,6 +262,7 @@ eligible_voters:
 - hwdef
 - hzxuzhonghu
 - ialidzhikov
+- IanColdwater
 - ianychoi
 - ichekrygin
 - iholder101


### PR DESCRIPTION
This PR adds following voters from approved exception requests, as of October 24, 2025.

@eddiezane 
@IanColdwater 

/assign @cblecker @sreeram-venkitesh 

/hold

for review and approval from Election Officers. Thanks!
