### PR TITLE
sig-node: add node-readiness-controller subproject

### DIFF
--- a/sig-node/README.md
+++ b/sig-node/README.md
@@ -110,6 +110,9 @@ The following [subprojects][subproject-definition] are owned by sig-node:
   - [kubernetes/test-infra/config/jobs/kubernetes/node-problem-detector](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/node-problem-detector/OWNERS)
 - **Contact:**
   - Slack: [#node-problem-detector](https://kubernetes.slack.com/messages/node-problem-detector)
+### node-readiness-controller
+- **Owners:**
+  - [kubernetes-sigs/node-readiness-controller](https://github.com/kubernetes-sigs/node-readiness-controller/blob/main/OWNERS)
 ### resource-management
 - **Owners:**
   - [kubernetes-sigs/dra-example-driver](https://github.com/kubernetes-sigs/dra-example-driver/blob/main/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2550,6 +2550,9 @@ sigs:
         owners:
           - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
           - https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/node-problem-detector/OWNERS
+      - name: node-readiness-controller
+        owners:
+          - https://raw.githubusercontent.com/kubernetes-sigs/node-readiness-controller/main/OWNERS
       - name: resource-management
         owners:
           - https://raw.githubusercontent.com/kubernetes-sigs/dra-example-driver/main/OWNERS


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5906

/assign @kubernetes/sig-node-leads

cc: @kubernetes/owners