### PR TITLE
sig-release: add signalhound repo under release-team subproject

### DIFF
--- a/sig-release/README.md
+++ b/sig-release/README.md
@@ -107,6 +107,7 @@ The Kubernetes Release Team is responsible for the day-to-day work required to s
   - Kat Cosgrove (**[@katcosgrove](https://github.com/katcosgrove)**), Independent
 - **Owners:**
   - [kubernetes-sigs/release-team-shadow-stats](https://github.com/kubernetes-sigs/release-team-shadow-stats/blob/main/OWNERS)
+  - [kubernetes-sigs/signalhound](https://github.com/kubernetes-sigs/signalhound/blob/main/OWNERS)
   - [kubernetes/sig-release/release-team](https://github.com/kubernetes/sig-release/blob/master/release-team/OWNERS)
 - **Contact:**
   - [Mailing List](https://groups.google.com/a/kubernetes.io/g/release-team)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2703,6 +2703,7 @@ sigs:
             - name: release-team-release-notes
         owners:
           - https://raw.githubusercontent.com/kubernetes-sigs/release-team-shadow-stats/main/OWNERS
+          - https://raw.githubusercontent.com/kubernetes-sigs/signalhound/main/OWNERS
           - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
         leads:
           - github: gracenng


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5960

/assign @kubernetes/sig-release-leads 

cc: @kubernetes/owners