### PR TITLE
Add WG Checkpoint Restore Slack Channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -582,6 +582,7 @@ channels:
     archived: true
   - name: wg-batch
   - name: wg-serving
+  - name: wg-checkpoint-restore
   - name: wg-component-standard
     archived: true
   - name: wg-component-standard-mentorship


### PR DESCRIPTION
New working group WG Checkpoint Restore has been approved in https://github.com/kubernetes/community/pull/8508. This PR adds the definition of dedicated slack channel for this WG.

#wg-checkpoint-restore