### PR TITLE
Add Slack channel for tofu-controller

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -549,6 +549,7 @@ channels:
   - name: test-failures
   - name: tilt
   - name: tn-users
+  - name: tofu-controller
   - name: topology-aware-scheduling
   - name: tor-controller
   - name: tr-events


### PR DESCRIPTION
This PR creates a new Slack Channel for the [Tofu Controller](https://flux-iac.github.io/tofu-controller/) project.

Website: https://flux-iac.github.io/tofu-controller/
GitHub: https://github.com/flux-iac/tofu-controller