### PR TITLE
provide path to meeting note access

### DIFF
--- a/wg-ai-conformance/README.md
+++ b/wg-ai-conformance/README.md
@@ -19,7 +19,7 @@ The [charter](charter.md) defines the scope and governance of the AI Conformance
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/a/kubernetes.io/g/wg-ai-conformance) for the group will typically add invites for the following meetings to your calendar.*
 * Regular WG Meeting ([calendar](https://calendar.google.com/calendar/embed?src=a574542f85d51cb4624145f13307810c9e23bc9096cfbb83f6205cc7acee34b6%40group.calendar.google.com)): [Thursdays at 10:00 PT (Pacific Time)](https://zoom.us/j/95480364337) (biweekly). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10%3A00&tz=PT%20%28Pacific%20Time%29).
-  * [Meeting notes and Agenda](https://docs.google.com/document/d/1qlW1LkibOoiMio-hbJucRjOYeKT8mNaQ4awwzf0bi8M/edit).
+  * [Meeting notes and Agenda](https://docs.google.com/document/d/1qlW1LkibOoiMio-hbJucRjOYeKT8mNaQ4awwzf0bi8M/edit). (Join mailing list for access)
 
 ## Organizers
 


### PR DESCRIPTION
I was able to view the meeting notes with the Google account that joined the Google group (mailing list), but not anonymously or from other Google accounts. 

Perhaps the best path is instead to make view access public to anyone, and write access only for group members?

FYI: Currently anyone who joins the mailing list gets immediate edit access to this doc. I noticed the Architecture SIG uses "suggesting mode" for broader contributors, which might be a good model for us to consider.