### PR TITLE
Add sig-network-ingress2gateway channel to YAML

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -507,6 +507,7 @@ channels:
   - name: sig-multicluster
   - name: sig-network
   - name: sig-network-agentic-networking
+  - name: sig-network-ingress2gateway
   - name: sig-network-kni
   - name: sig-network-multi-network
   # sig-node channels are defined in sig-node/


### PR DESCRIPTION
This adds the Slack channel to discuss ingress2gateway. There is a lot of work planned for this given the ingress nginx deprecation, and it nice to have a place to chat about it and not DOS the gateway api channel
