### PR TITLE
create slack channel for node-readiness-controller

### DIFF
--- a/communication/slack-config/sig-node/config.yaml
+++ b/communication/slack-config/sig-node/config.yaml
@@ -11,3 +11,4 @@ channels:
   - name: sig-node-sidecar
   - name: sig-node-swap
   - name: sig-node-wranglers
+  - name: sig-node-readiness-controller


### PR DESCRIPTION
Creating a discussion channel for [node-readiness-controller](https://github.com/kubernetes-sigs/node-readiness-controller) project.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/community/issues/8691

/sig node