### PR TITLE
Add documentation for Node Declared Features (KEP-5328)

### DIFF
--- a/contributors/devel/sig-architecture/api_changes.md
+++ b/contributors/devel/sig-architecture/api_changes.md
@@ -42,6 +42,7 @@ found at [API Conventions](api-conventions.md).
     - [Ratcheting validation](#ratcheting-validation)
     - [New enum value in existing field](#new-enum-value-in-existing-field)
     - [New alpha API version](#new-alpha-api-version)
+    - [Managing Version Skew](#managing-version-skew)
 
 ## So you want to change the API?
 
@@ -1496,3 +1497,16 @@ client which uses the other version. Therefore, this is not a preferred option.
 A related issue is how a cluster manager can roll back from a new version
 with a new feature, that is already being used by users. See
 https://github.com/kubernetes/kubernetes/issues/4855.
+
+#### Managing Version Skew
+
+The **Node Declared Features** framework can be used to manage version skew
+for node-level features where the control plane must be aware of whether each node
+supports this feature to ensure compatibility while scheduling or admitting workloads.
+
+This framework allows nodes to advertise their capabilities, preventing the
+scheduler from placing pods on incompatible nodes and enabling admission
+control to validate API operations.
+
+For more details on how the framework operates and how to integrate
+with it, see [Node Declared Features](feature-gates.md#node-declared-features).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->
This PR introduces documentation for the Node Declared Features framework (KEP-5328) into the contributor guides. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
