### PR TITLE
Add OWNERS file for WG Checkpoint Restore

### DIFF
--- a/wg-checkpoint-restore/OWNERS
+++ b/wg-checkpoint-restore/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- wg-checkpoint-restore-leads
+reviewers:
+- wg-checkpoint-restore-leads
+
+labels:
+- wg/checkpoint-restore


### PR DESCRIPTION
The OWNERS file allows to designate responsibilities of reviewing and approving changes. The `wg-checkpoint-restore-leads` alias was introduced with https://github.com/kubernetes/community/commit/cef6a0df5b9c24e3f70f5ba4699073babbf9e16b.

This PR adds an OWNERS file containing the `wg-checkpoint-restore-leads` alias so that the working group leads can be referenced for review and approval.