### PR TITLE
Update a couple of ContribEx Slack usergroups

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -298,6 +298,7 @@ usergroups:
     description: Administrators of the Kubernetes GitHub organisations
     members:
       - cblecker
+      - jasonbraganza
       - MadhavJivrajani
       - mrbobbytables
       - nikhita

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -118,6 +118,7 @@ users:
   IsaacPD: U01B0C1R9NZ
   jakexks: U0AKBM9EC
   JamesLaverack: U9MK7274Y
+  jasonbraganza: U03ADRCSW23
   Jason: UB272379N
   jasperchui: U01DRL00ES3
   jayesh-srivastava: U023B885W9M


### PR DESCRIPTION
- Add a new contribex-leads Slack usergroup
- Add Chad and Nabarun to zoom-admins Slack usergroup
- Add Jason to github-admins

/assign @kubernetes/sig-contributor-experience-leads 
/kind documentation
/priority important-longterm