### PR TITLE
Fixed broken link in contributor-cheatsheet page

### DIFF
--- a/contributors/guide/contributor-cheatsheet/README.md
+++ b/contributors/guide/contributor-cheatsheet/README.md
@@ -420,4 +420,4 @@ git push --force
 [Security and Disclosure Information]: https://kubernetes.io/docs/reference/issues-security/security/
 [approve]: https://prow.k8s.io/command-help#approve
 [GitHub Administration Team]: /github-management#github-administration-team
-[Kubernetes Patch Release]: https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md
+[Kubernetes Patch Release]: https://kubernetes.io/releases/patch-releases/


### PR DESCRIPTION
The existing link for the "Kubernetes patch releases" was broken (404 error)  on web page https://www.kubernetes.dev/docs/contributor-cheatsheet/

Current (broken) link: https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md
Updated (working) link: https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md