### PR TITLE
Clarify that options can be set outside filters in OWNERS files

### DIFF
--- a/contributors/guide/owners.md
+++ b/contributors/guide/owners.md
@@ -78,6 +78,9 @@ filters:
 ```
 
 If you set `filters` you must not set a [simple OWNERS configuration](#owners) outside of `filters`.
+
+**Note:** The `options` key (e.g., `no_parent_owners`) is an exception and may be set at the top level even when using `filters`. All other owner-related keys such as `approvers`, `reviewers`, `labels`, and `emeritus_approvers` must be defined inside `filters`.
+
 For example:
 
 ```yaml


### PR DESCRIPTION
The Filters section previously said that simple OWNERS configurations must not be set outside filters. This made it seem like "options" (like "no_parent_owners") could not be set at the top level.  Added a note clarifying that "options" are allowed outside filters.

Fixes #8484
