### PR TITLE
docs: docs: add rikatz as gateway-api maintainer

### DIFF
--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -96,8 +96,8 @@ The following [subprojects][subproject-definition] are owned by sig-network:
   - Slack: [#external-dns](https://kubernetes.slack.com/messages/external-dns)
 ### gateway-api
 - **Leads:**
+  - Ricardo Katz (**[@rikatz](https://github.com/rikatz)**), Red Hat
   - Rob Scott (**[@robscott](https://github.com/robscott)**), Google
-  - Shane Utt (**[@shaneutt](https://github.com/shaneutt)**), Red Hat
   - Nick Young (**[@youngnick](https://github.com/youngnick)**), Isovalent
 - **Owners:**
   - [kubernetes-sigs/gateway-api](https://github.com/kubernetes-sigs/gateway-api/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2355,12 +2355,12 @@ sigs:
           - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
           - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/controllers/service/OWNERS
         leads:
+          - github: rikatz
+            name: Ricardo Katz
+            company: Red Hat
           - github: robscott
             name: Rob Scott
             company: Google
-          - github: shaneutt
-            name: Shane Utt
-            company: Red Hat
           - github: youngnick
             name: Nick Young
             company: Isovalent


### PR DESCRIPTION
As per https://groups.google.com/g/kubernetes-sig-network/c/Yg4leTItyFE, this PR promotes rikatz to maintainer of [Gateway API](https://github.com/kubernetes-sigs/gateway-api).