### PR TITLE
docs: add Declarative Validation Native (DV Native) to api-conventions.md and api_changes.md

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -1982,6 +1982,13 @@ type definitions, or manually, by writing validation functions. For all new
 APIs, declarative validation is the preferred approach for the validation rules
 it supports.  For more information see the
 [declarative validation documentation](api_changes.md#declarative-validation).
+
+Additionally, "Declarative Validation Native" (DV Native) is a mode that allows 
+net-new API fields and their validations to be defined exclusively using Go 
+comment tags, without requiring a parallel hand-written implementation in Go. 
+See the [DV Native documentation](api_changes.md#declarative-validation-native-dv-native) 
+for more details.
+
 Validation errors are flagged and returned to the caller in a `Failure` status,
 usually with `reason` set to `Invalid`.
 


### PR DESCRIPTION
This PR updates the API development guidelines to include documentation for **Declarative Validation Native (DV Native)**.

DV Native is a mode for the declarative validation framework that allows new API fields to use Declarative Validation (DV) exclusively, removing the need for parallel hand-written Go validation logic (speeding up dev and review! ⚡ ).

### Changes:
- **`contributors/devel/sig-architecture/api_changes.md`**: Added a detailed section on DV Native covering:
    - The `+k8s:declarativeValidationNative` opt-in tag.
    - Stability level enforcement (requiring `stable` tags by default).
    - Required strategy changes using `rest.WithDeclarativeNative()`.
    - Testing requirements using `.MarkDeclarativeNative()`.
- **`contributors/devel/sig-architecture/api-conventions.md`**: Added a brief introduction and link to the DV Native documentation within the Validation section.

This PR is adapted from the dev-branch doc PR here: 
- https://github.com/jpbetz/validation-gen/pull/232
