### PR TITLE
Add Dipesh Rawat as SIG Docs Tech Lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -46,6 +46,7 @@ aliases:
     - mfahlandt
     - palnabarun
   sig-docs-leads:
+    - dipesh-rawat
     - divya-mohan0209
     - katcosgrove
     - natalisucks

--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -46,6 +46,7 @@ The Chairs of the SIG run operations and processes governing the SIG.
 The Technical Leads of the SIG establish new subprojects, decommission existing
 subprojects, and resolve cross-subproject technical issues and decisions.
 
+* Dipesh Rawat (**[@dipesh-rawat](https://github.com/dipesh-rawat)**), IBM
 * Kat Cosgrove (**[@katcosgrove](https://github.com/katcosgrove)**), Minimus
 * Xander Grzywinski (**[@salaxander](https://github.com/salaxander)**), Independent
 * Qiming Teng (**[@tengqm](https://github.com/tengqm)**), Sangfor Technologies

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1581,6 +1581,10 @@ sigs:
           company: Red Hat
           email: rlejano@gmail.com
       tech_leads:
+        - github: dipesh-rawat
+          name: Dipesh Rawat
+          company: IBM
+          email: rawat.dipesh@gmail.com
         - github: katcosgrove
           name: Kat Cosgrove
           company: Minimus


### PR DESCRIPTION
Adding myself as SIG Docs tech lead!

I updated `sigs.yaml` and ran `make generate`, which automatically refreshed _OWNERS_ALIASES_ and the _README_.

cc @natalisucks @divya-mohan0209 @reylejano