### PR TITLE
Fix v1.36 release team user entries to unblock CI validation

### DIFF
--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -229,7 +229,7 @@ users:
   pierreprinetti: ULU8K49S5
   pnbrown: U011JJTQVGF
   pohly: U91901TMF
-  prajyot-parab: U02MVRCN8CX
+  Prajyot-Parab: U02MVRCN8CX
   pratik-mahalle: U06P66FAHPU
   pravarag: UFA5V59J5
   prietyc123: U01D4MBLM52
@@ -269,6 +269,7 @@ users:
   saschagrunert: U53SUDBD4
   satyampsoni: U04DUM62MDY
   savitharaghunathan: UC8U2V3BM
+  sayanchowdhury: U6ERE5YQL
   sayantani11: U028S6XNVSN
   sbueringer: U48TE1L75
   scott-seago: UHGD79E78


### PR DESCRIPTION
### Description

This change resolves the CI failure caused by mismatched and missing v1.36 release team user entries highlighted in https://github.com/kubernetes/community/pull/8742#discussion_r2693251572.

It updates the casing for Prajyot Parab to match the existing the github user name (@Prajyot-Parab) and adds Sayan Chowdhury (@sayanchowdhury) to the users list.

cc @rytswd @Priyankasaggu11929 