### PR TITLE
Update dashboard project status and add Headlamp

### DIFF
--- a/sig-ui/charter.md
+++ b/sig-ui/charter.md
@@ -8,7 +8,8 @@ SIG-UI covers GUI-related aspects of the Kubernetes project. Efforts are centere
 
 #### Code, Binaries and Services
 
-- [Kubernetes Dashboard](https://github.com/kubernetes/dashboard)
+- [Kubernetes Dashboard](https://github.com/kubernetes/dashboard) (Archived)
+- [Headlamp](https://github.com/kubernetes-sigs/headlamp)
 
 #### Cross-cutting and Externally Facing Processes
 


### PR DESCRIPTION
Updated the charter to reflect the archived status of the Kubernetes Dashboard and added Headlamp as a new project.

There are probably more changes to be made, but this is a first step, since Headlamp has been moved under the SIG-UI

sigs.yaml is properly updated, but I guess the charter requires manual updating.
