### PR TITLE
fix: remove reference to weekly community meeting

### DIFF
--- a/sig-list.md
+++ b/sig-list.md
@@ -18,8 +18,7 @@ sigs.yaml file in the project root.
 To understand how this file is generated, see https://git.k8s.io/community/generator/README.md
 --->
 
-Most community activity is organized into Special Interest Groups (SIGs),
-time bounded Working Groups, and the [community meeting](communication/README.md#weekly-meeting).
+Most community activity is organized into Special Interest Groups (SIGs) and time bounded Working Groups (WGs)
 
 SIGs follow these [guidelines](governance.md) although each of these groups may operate a little differently
 depending on their needs and workflow.


### PR DESCRIPTION
The weekly community meeting hasn't been a thing in a REALLY long time.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
