### PR TITLE
Add Rey Lejano as SIG Docs TL

### DIFF
--- a/sig-docs/README.md
+++ b/sig-docs/README.md
@@ -48,6 +48,7 @@ subprojects, and resolve cross-subproject technical issues and decisions.
 
 * Dipesh Rawat (**[@dipesh-rawat](https://github.com/dipesh-rawat)**), IBM
 * Kat Cosgrove (**[@katcosgrove](https://github.com/katcosgrove)**), Minimus
+* Rey Lejano (**[@reylejano](https://github.com/reylejano)**), Red Hat
 * Xander Grzywinski (**[@salaxander](https://github.com/salaxander)**), Independent
 * Qiming Teng (**[@tengqm](https://github.com/tengqm)**), Sangfor Technologies
 

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1589,6 +1589,10 @@ sigs:
           name: Kat Cosgrove
           company: Minimus
           email: kat.cosgrove@gmail.com
+        - github: reylejano
+          name: Rey Lejano
+          company: Red Hat
+          email: rlejano@gmail.com
         - github: salaxander
           name: Xander Grzywinski
           company: Independent


### PR DESCRIPTION
Add Rey Lejano as SIG Docs TL per email to dev@kubernetes.io with the subject "SIG Docs Leadership Updates" originally sent to on December 18, 2025  https://groups.google.com/a/kubernetes.io/g/dev/c/_9Qip-oLFe8/m/JKCE4CvTCQAJ 

/assign @divya-mohan0209 @natalisucks 