### PR TITLE
Delete sig-scheduling slack channels from main channel file

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -512,7 +512,7 @@ channels:
   - name: sig-network-multi-network
   # sig-node channels are defined in sig-node/
   - name: sig-scalability
-  - name: sig-scheduling
+  # sig-scheduling channels are defined in sig-scheduling/
   # sig-security* channels are defined in sig-security/
   - name: sig-service-catalog
     archived: true
@@ -616,7 +616,6 @@ channels:
     archived: true
   - name: windows-containerd
   - name: workshop-chat
-  - name: workload-aware-scheduling
   - name: yaml-overlay-tool
   - name: zarf
   - name: zarf-dev

--- a/communication/slack-config/sig-scheduling/config.yaml
+++ b/communication/slack-config/sig-scheduling/config.yaml
@@ -1,2 +1,3 @@
 channels:
+  - name: sig-scheduling
   - name: workload-aware-scheduling


### PR DESCRIPTION
In order to fix error `couldn't merge channels: cannot define channel`, we needed to remove channel names from `channel.yaml`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
