### PR TITLE
finish offboarding cji user from sig-release usergroups.yaml causing slack-config jobs to fail

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -93,7 +93,6 @@ usergroups:
       - sig-release
     members:
       - cjcullen # Product Security Committee
-      - cji # Product Security Committee
       - cici37 # Release Manager
       - cpanato # subproject owner / Release Manager
       - enj # Produce Security Committee


### PR DESCRIPTION
@cji appears to have offboarded himself from various Slack configs. However, the usergroups.yaml for sig-release was not modified to remove cji (simple mistake; nbd). But, this omission is causing slack-config jobs to fail: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-community-tempelis-apply/2027422866235985920

Removing `cji` from the Security Release Team is the last step in the offboarding process needed to correct the error causing slack-config jobs to fail.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
