### PR TITLE
Update slack ids for @kubetail-maintainers

### DIFF
--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -14,7 +14,7 @@ users:
   alimaazamat: U08HKJQCUPK
   alisondy: U9CBCBLCV
   ameukam: U68KPQ448
-  amorey: D08CF0BPYGG
+  amorey: U08C4S3HNRX
   anandrkskd: U01DRS3V0R2
   aniruddha2000: U02BU1RP41H
   anjaltelang: U028B09KZ5X
@@ -255,7 +255,7 @@ users:
   rnapoles-rh: U01KDAMSWJD
   robshelly: U01LL4P09SR
   rtaniwa: U03K27HLHKN
-  rxinui: D08G3DBM3UN
+  rxinui: U08G3DBHXSA
   rytswd: ULUBQ9DFA
   s-urbaniak: U0DT660QM
   sadysnaat: UNQPKAQHE


### PR DESCRIPTION
This PR updates the slack config to use the correct ids for @kubetail-maintainers. It resolves this Prow failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-community-tempelis-apply/2028861813478658048#1:build-log.txt%3A5. We were alerted to the issue by @chris-short.
