### PR TITLE
add admission-policies subproject to sig-architecture

### DIFF
--- a/sig-architecture/README.md
+++ b/sig-architecture/README.md
@@ -65,6 +65,10 @@ The following [working groups][working-group-definition] are sponsored by sig-ar
 ## Subprojects
 
 The following [subprojects][subproject-definition] are owned by sig-architecture:
+### admission-policies
+Mutating and Validating Admission Policies published by the Kubernetes project.
+- **Owners:**
+  - [kubernetes-sigs/admission-policies](https://github.com/kubernetes-sigs/admission-policies/blob/main/OWNERS)
 ### ai-conformance
 Proposals and tests for AI Conformance
 - **Leads:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -391,6 +391,10 @@ sigs:
         github: BenTheElder
         name: Benjamin Elder
     subprojects:
+      - name: admission-policies
+        description: Mutating and Validating Admission Policies published by the Kubernetes project.
+        owners:
+          - https://raw.githubusercontent.com/kubernetes-sigs/admission-policies/main/OWNERS
       - name: ai-conformance
         description: Proposals and tests for AI Conformance
         contact:


### PR DESCRIPTION
see: https://github.com/kubernetes/org/issues/5408

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Completes https://github.com/kubernetes/org/issues/5408

/cc @dims @johnbelamaric 
