### PR TITLE
sig-scheduling: add new subproject - scheduler-library

### DIFF
--- a/sig-scheduling/README.md
+++ b/sig-scheduling/README.md
@@ -99,6 +99,9 @@ The following [subprojects][subproject-definition] are owned by sig-scheduling:
 - **Owners:**
   - [kubernetes/kubernetes/cmd/kube-scheduler](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-scheduler/OWNERS)
   - [kubernetes/kubernetes/pkg/scheduler](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/OWNERS)
+### scheduler-library
+- **Owners:**
+  - [kubernetes-sigs/scheduler-library](https://github.com/kubernetes-sigs/scheduler-library/blob/main/OWNERS)
 ### scheduler-plugins
 - **Owners:**
   - [kubernetes-sigs/scheduler-plugins](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/OWNERS)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2968,6 +2968,9 @@ sigs:
         owners:
           - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-scheduler/OWNERS
           - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/scheduler/OWNERS
+      - name: scheduler-library
+        owners:
+          - https://raw.githubusercontent.com/kubernetes-sigs/scheduler-library/main/OWNERS
       - name: scheduler-plugins
         owners:
           - https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/master/OWNERS


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/6273

/assign @kubernetes/sig-scheduling-leads

cc: @kubernetes/owners