### PR TITLE
Add example disclosure to AI guidance

### DIFF
--- a/contributors/guide/pull-requests.md
+++ b/contributors/guide/pull-requests.md
@@ -627,7 +627,9 @@ the Pull Request provides.
 
 Using AI tools to help write your PR is acceptable, but as the author, you are responsible for 
 understanding every change. If you used AI tools in preparing your PR, you must disclose this in the 
-description of your PR. Listing AI tooling as a co-author, co-signing commits using an AI tool, or using 
+description of your PR. For example, including "This PR was written in part with the assistance of generative AI," in the PR description is sufficient.
+
+Listing AI tooling as a co-author, co-signing commits using an AI tool, or using 
 the `assisted-by`, `co-developed` or similar commit trailer is not allowed.
 
 All contributions must follow the [contributions policies](/contributors/guide/contributing.md) and use 


### PR DESCRIPTION
This PR adds an example of acceptable disclosure to the AI guidance.

/hold

cc: @kubernetes/steering-committee @tabbysable 