### PR TITLE
Adds style guidance for graduation stages

### DIFF
--- a/contributors/guide/style-guide.md
+++ b/contributors/guide/style-guide.md
@@ -308,6 +308,9 @@ external appearance.
   - Use `code` style for API objects or object parameters.
     - **Good example:** A `Deployment` contains a `DeploymentSpec`.
     - **Bad example:**  A Deployment contains a DeploymentSpec.
+- Capitalize the first letter of enhancement graduation stages.
+  - **Good example:** Dynamic Resource Allocation (DRA) is Beta.
+  - **Bad example:** Dynamic Resource Allocation (DRA) is beta.
 - Use angle brackets (`<` and `>`) to surround a placeholder references.
   - **Good example:** `kubectl describe pod <pod-name>`
   - **Bad example:** `kubectl describe pod pod-name`


### PR DESCRIPTION
The Release Team standardized on capitalizing the first letter of graduation stages when writing blogs some time ago and feature gate documentation uses the same convention, but it was never added to the style guide. This update formalizes the convention.

/hold for @kubernetes/sig-docs-leads approval.