### PR TITLE
Add #karpenter-gcp Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -221,6 +221,7 @@ channels:
   - name: kaniko
   - name: karpenter
   - name: karpenter-dev
+  - name: karpenter-gcp
   - name: k8s-ai-conformance
     id: C09813W8DC2
   - name: k8s-dual-stack


### PR DESCRIPTION
## Purpose

Add a new `#karpenter-gcp` channel for the [karpenter-provider-gcp](https://github.com/cloudpilot-ai/karpenter-provider-gcp) project — a Google Cloud Karpenter Provider that enables Karpenter-based node provisioning on GCP.

## Why a separate channel

The existing `#karpenter` channel is focused on the upstream Karpenter project (AWS). A dedicated `#karpenter-gcp` channel will give GCP-specific Karpenter users and contributors a focused space to discuss:
- GCP-specific node provisioning and configuration
- Issues and development of the karpenter-provider-gcp project
- Community coordination around the GCP provider

## Supporting resources

- Project repository: https://github.com/cloudpilot-ai/karpenter-provider-gcp
- The project is open source and Kubernetes-ecosystem focused

## Channel details

- **Channel name:** `karpenter-gcp` (12 characters, within 21-character limit)
- **Visibility:** Public