### PR TITLE
sig-autoscaling: update cluster-autoscaler subproject with new repo

### DIFF
--- a/sig-autoscaling/README.md
+++ b/sig-autoscaling/README.md
@@ -68,6 +68,7 @@ The following [subprojects][subproject-definition] are owned by sig-autoscaling:
   - [kubernetes/autoscaler/addon-resizer](https://github.com/kubernetes/autoscaler/blob/master/addon-resizer/OWNERS)
 ### cluster-autoscaler
 - **Owners:**
+  - [kubernetes-sigs/cluster-autoscaler](https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/OWNERS)
   - [kubernetes/autoscaler/cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/OWNERS)
 ### horizontal-pod-autoscaler
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -754,6 +754,7 @@ sigs:
           - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
       - name: cluster-autoscaler
         owners:
+          - https://raw.githubusercontent.com/kubernetes-sigs/cluster-autoscaler/main/OWNERS
           - https://raw.githubusercontent.com/kubernetes/autoscaler/master/cluster-autoscaler/OWNERS
       - name: horizontal-pod-autoscaler
         owners:


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/6221

/assign @kubernetes/sig-autoscaling-leads

cc: @kubernetes/owners