### PR TITLE
doc: add #careers vetting criteria and link to README

### DIFF
--- a/communication/README.md
+++ b/communication/README.md
@@ -79,7 +79,7 @@ We talk a lot, too.
 Our real-time platform with Kubernetes enthusiasts spread across 250+ channels.
 Owned and operated by sig-contributor-experience.
 
-[Join] | [Slack Guidelines] | [slack moderators] | [#kubernetes-contributors]
+[Join] | [Slack Guidelines] | [slack moderators] | [#kubernetes-contributors] | [Job Posting Vetting Criteria](./slack-job-posting-policy.md)
 
 Pro-tip: If you want to add a new channel, simply file a request following
 [these instructions].

--- a/communication/slack-job-posting-policy.md
+++ b/communication/slack-job-posting-policy.md
@@ -1,0 +1,51 @@
+---
+title: "Kubernetes-careers Moderation & Vetting Criteria"
+description: |
+  Guidelines and policies for posting jobs and resumes in the Kubernetes
+  Slack #careers channel.
+---
+
+<!-- overview -->
+
+This document outlines the vetting guidelines used by Kubernetes Slack moderators to manage the `#kubernetes-careers` channel.
+We maintain these standards to create a safe, trustworthy space for job seekers and employers in the Kubernetes community.
+
+<!-- body -->
+
+## 1. Acceptance Criteria:
+
+Posts that meet these criteria are approved and shared in `#kubernetes-careers` channel:
+
+- **Cloud-native & ecosystem alignment:** Roles must involve Kubernetes, CNCF technologies, or DevOps/SRE practices that serve the cloud-native ecosystem.
+- **Legitimate organizations:** Posts should reference verifiable company websites, established recruiting agencies, or recognized firms with demonstrable online presence.
+- **Complete information:** Job posts must include a meaningful description and link to an official career portal. "DM for details" or submissions with insufficient information will be rejected.
+- **Individual resumes only:** Community members may post personal resumes; however, third-party recruitment services, talent farming, and bulk resume dumps are not permitted.
+
+## 2. Rejection Flags:
+
+Posts matching these criteria are rejected:
+
+- **Security threats:** URL shorteners (such as bit.ly, tinyurl) that mask destinations; links to known phishing or typosquatting domains, or suspicious links of any kind.
+- **Spam or bot activity:** Automated posts, generic mass-posting templates, or identical posts repeated across channels or time periods.
+- **Off-topic content:** Cryptocurrency mining, generic "work from home" virtual assistant positions, or roles with no technical connection to Kubernetes or cloud-native technologies.
+- **Incomplete submissions:** Posts missing critical details such as company name, job title, or clear application instructions.
+
+## 3. Gray Areas:
+
+Some submissions fall into ambiguous categories and require moderator judgment. Generally this will mean removing the post and messaging the poster to clarify their intent or identity.
+
+- **Emerging companies:** Early-stage startups with limited online presence may require verification (LinkedIn profile, domain age, or other verification signals) to confirm legitimacy.
+- **High-volume posters:** Legitimate recruiting agencies and firms that post frequently may need guidance to avoid cluttering the channel.
+
+## 4. Security & Enforcement:
+
+Submissions identified as malicious will be handled with immediate enforcement:
+
+- **Identity theft, phishing, or scam attempts:** Posts will be deleted immediately, and the user will be banned from the Slack workspace.
+
+## 5. Feedback & Appeals
+
+We maintain transparency and fairness in our moderation process:
+
+- **Rejection notifications:** Users whose posts are rejected receive a clear explanation citing the specific criteria that resulted in rejection.
+- **Appeal process:** Users who believe a post was rejected in error may reach out to `#slack-admins` for manual review. If the rejection resulted in a ban, the user will need to file an issue in the `kubernetes/community` repository.


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #8943

**What this PR does / why we need it**:
Implements a formal triage process and vetting criteria for `#kubernetes-careers` channel to prevent scams and malicious postings. 

The goal is to establish a clear source of truth for moderation and ensure community safety.

/cc @jberkus @priyankasaggu11929