### PR TITLE
Update slack moderators list

### DIFF
--- a/communication/moderators.md
+++ b/communication/moderators.md
@@ -184,33 +184,18 @@ Moderators seats: 10
 
 | Name                | Kubernetes Slack ID | Region   | Timezone                                                |
 | ------------------- | ------------------- | -------- | ------------------------------------------------------- |
-| Jorge Castro        | @castrojo           | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Jeffrey Sica        | @jeefy              | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
 | Bob Killen          | @mrbobbytables      | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
-| Jorge Alarcon       | @alejandrox1        | Americas | [ET - Eastern Time (US East Coast)](https://time.is/ET) |
-| Katharine Berry     | @Katharine          | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
-| Jaice Singer DuMars | @jdumars            | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Noah Kantrowitz     | @coderanger         | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
 | Ihor Dvoretskyi     | @ihor.dvoretskyi    | EMEA     | [EET - Eastern European Time](https://time.is/EET)      |
-| Yang Li             | @idealhack          | APAC     | [JST - Japan Standard Time](https://time.is/Japan)      |
 | Josh Berkus         | @jberkus            | Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
-| Marky Jackson       | @markyjackson-taulia| Americas | [PT - Pacific Time (US West Coast)](https://time.is/PT) |
-| _Open_              | _Open_              |          |                                                         |
-
-### Moderators Pro Tempore
-
-Moderators pro tempore seats: 10
-
-| Name                    | Kubernetes Slack ID | Region | Timezone                                                   |
-| ----------------------- | ------------------- | ------ | ---------------------------------------------------------- |
 | Dylan Graham            | @DylanGraham        | APAC   | [AET - Australian Eastern Time](https://time.is/Australia) |
-| Angus Lees              | @anguslees          | APAC   | [AET - Australian Eastern Time](https://time.is/Australia) |
-| Aditya Konarde          | @aditya-konarde     | APAC   | [IST - Indian Standard Time](https://time.is/IST)          |
+| Angus Lees              | @guslees          | APAC   | [AET - Australian Eastern Time](https://time.is/Australia) |
 | Manjunath Kumatagi      | @mkumatag           | APAC   | [IST - Indian Standard Time](https://time.is/IST)          |
-| Pandiyaraja Ramamoorthy | @pontiya            | APAC   | [IST - Indian Standard Time](https://time.is/IST)          |
 | Puja Abbassi            | @puja108            | EMEA   | [CET - Central European Time](https://time.is/CET)         |
 | James Munnelly          | @munnerz            | EMEA   | [GMT - Greenwich Mean Time](https://time.is/GMT)           |
 | Joel Speed              | @JoelSpeed          | EMEA   | [GMT - Greenwich Mean Time](https://time.is/GMT)           |
+| Simon Essien            | @Champbreed         | AF     | [WAT - West Africa Time](https://time.is/WAT)           |
 
 ## Zoom
 

--- a/communication/slack-config/OWNERS
+++ b/communication/slack-config/OWNERS
@@ -4,17 +4,20 @@
 approvers:
   - jeefy
   - mrbobbytables
-  - alejandrox1
   - coderanger
   - munnerz
   - DylanGraham
   - jberkus
+  - idvoretskyi
+  - mkumatag
+reviewers:
+  - JoelSpeed
 emeritus_approvers:
   - parispitmann
-  - idvoretskyi
   - katharine
   - castrojo
   - jdumars
   - idealhack
+  - alejandrox1
 labels:
   - area/slack-management


### PR DESCRIPTION
Update the list of Slack moderators.  This includes the following changes:

* Removing several former moderators who have not been active in more than 6 months and did not respond to a message about continuing as a moderator.
* Adding @Champbreed as a moderator, primarily to implement the job announcement approval queue #8943 
* Folding "Moderators pro tempore" into just "moderators", since the distinction never meant anything anyways.
* Syncing list of moderators with list of approvers/reviewers in OWNERS.  Three moderators need to apply/revive their Org memberships, at which point they will be added.

Fixes #8944

/sig contributor-experience
/area slack-management
