### PR TITLE
Ensure only slack-admins can approve new channels

### DIFF
--- a/communication/slack-config/OWNERS
+++ b/communication/slack-config/OWNERS
@@ -1,5 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
+options:
+  no_parent_owners: true
 # These are the primary slack moderators.
 approvers:
   - jeefy


### PR DESCRIPTION
This came out of a discussion with Josh.

/assign @jberkus 