### PR TITLE
Add sig-autoscaling slack config, WAS channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -486,7 +486,6 @@ channels:
   - name: sig-auth-kms-dev
   - name: sig-auth-triage
   # sig-autoscaling channels are defined in sig-autoscaling/
-  - name: sig-autoscaling-api
   - name: sig-cli
   - name: sig-cli-krm-functions
     archived: true

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -488,7 +488,7 @@ channels:
   - name: sig-auth-certificates-dev
   - name: sig-auth-kms-dev
   - name: sig-auth-triage
-  - name: sig-autoscaling
+  # sig-autoscaling channels are defined in sig-autoscaling/
   - name: sig-autoscaling-api
   - name: sig-cli
   - name: sig-cli-krm-functions

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -219,9 +219,6 @@ channels:
   - name: k0s-users
   - name: kalm
   - name: kaniko
-  - name: karpenter
-  - name: karpenter-dev
-  - name: karpenter-gcp
   - name: k8s-ai-conformance
     id: C09813W8DC2
   - name: k8s-dual-stack

--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -19,6 +19,10 @@ restrictions:
       - "^prod-readiness$"
     usergroups:
       - "^enhancements-owners$"
+  - path: "sig-autoscaling/*.yaml"
+    channels:
+      - "^sig-autoscaling"
+      - "^scheduler-driven-autoscaling"
   - path: "sig-docs/*.yaml"
     channels:
       - "^kubernetes-docs-[a-z]{2}(-[a-z]{2})?(-maintainers)?$"

--- a/communication/slack-config/restrictions.yaml
+++ b/communication/slack-config/restrictions.yaml
@@ -23,6 +23,9 @@ restrictions:
     channels:
       - "^sig-autoscaling"
       - "^scheduler-driven-autoscaling"
+      - "^karpenter"
+      - "^karpenter-dev"
+      - "^karpenter-gcp"
   - path: "sig-docs/*.yaml"
     channels:
       - "^kubernetes-docs-[a-z]{2}(-[a-z]{2})?(-maintainers)?$"

--- a/communication/slack-config/sig-autoscaling/OWNERS
+++ b/communication/slack-config/sig-autoscaling/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-autoscaling-leads
+approvers:
+  - sig-autoscaling-leads
+labels:
+  - sig/autoscaling

--- a/communication/slack-config/sig-autoscaling/config.yaml
+++ b/communication/slack-config/sig-autoscaling/config.yaml
@@ -1,0 +1,3 @@
+channels:
+  - name: sig-autoscaling
+  - name: scheduler-driven-autoscaling

--- a/communication/slack-config/sig-autoscaling/config.yaml
+++ b/communication/slack-config/sig-autoscaling/config.yaml
@@ -4,3 +4,5 @@ channels:
   - name: karpenter
   - name: karpenter-dev
   - name: karpenter-gcp
+  - name: sig-autoscaling-api
+    archived: true

--- a/communication/slack-config/sig-autoscaling/config.yaml
+++ b/communication/slack-config/sig-autoscaling/config.yaml
@@ -1,3 +1,6 @@
 channels:
   - name: sig-autoscaling
   - name: scheduler-driven-autoscaling
+  - name: karpenter
+  - name: karpenter-dev
+  - name: karpenter-gcp


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

This PR adds a dedicated sig-autoscaling config file for slack, and adds a new "scheduler-driven-autoscaling" channel to coordinate Workload Aware Scheduling-downstream efforts.
