### PR TITLE
feat: add #kubara community channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -271,6 +271,7 @@ channels:
   - name: krex
   - name: krustlet
   - name: kuadrant
+  - name: kubara
   - name: kube-aws
   - name: kube-bind
   - name: kube-burner


### PR DESCRIPTION
We would like to open a new community channel for our Kubernetes Platform tool kubara

https://github.com/kubara-io/kubara
https://kubara.io/
https://docs.kubara.io/