### PR TITLE
slack-config: Jenkins X changes name to JayeX

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -205,8 +205,10 @@ channels:
   - name: it-users
   - name: java
   - name: jenkins-ci
-  - name: jenkins-x-dev
-  - name: jenkins-x-user
+  - name: jayex-dev
+    id: C9LTHT2BB
+  - name: jayex-user
+    id: C9MBGQJRH
   - name: jp-dev
   - name: jp-events
   - name: jp-mentoring


### PR DESCRIPTION
I’m a maintainer of the JayeX project which just changed name from Jenkins X. We have 2 channels, jenkins-x-dev and jenkins-x-user. Could we get these renamed to jayex-dev and jayex-user respectively? The cause for the name change was confusion with the Jenkins project, which has been apparent also with a fair number of posts in the jenkins-x-user channel.

References:

https://jenkins-x.io/blog/2026/03/19/jayex/
https://cd.foundation/blog/2026/04/16/announcing-jayex/