### PR TITLE
docs: fix "Cillium" → "Cilium" typo in sig-etcd vision

### DIFF
--- a/sig-etcd/vision.md
+++ b/sig-etcd/vision.md
@@ -53,7 +53,7 @@ The most important design principle of Kubernetes,
 the reconciliation protocol, is not something unique to it.
 
 Reconciliation can be implemented solely on etcd,
-as has been shown by projects like Cillium,
+as has been shown by projects like Cilium,
 Calico Typha that support etcd-based control planes.
 The reason why this idea has not propagated further is
 the amount of work that was put into making 


### PR DESCRIPTION
/kind documentation

**What this PR does**:
Fixes a small spelling typo in `sig-etcd/vision.md`: the project name `Cillium` should be `Cilium`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Single-character documentation fix; no other content was modified.

```release-note
NONE
```