### PR TITLE
sig-autoscaling: remove SIG Governance disclaimer

### DIFF
--- a/sig-autoscaling/charter.md
+++ b/sig-autoscaling/charter.md
@@ -69,11 +69,6 @@ component autoscaling, and autoscaling of Kubernetes clusters themselves.
 This sig follows adheres to the Roles and Organization Management outlined in [sig-governance]
 and opts-in to updates and modifications to [sig-governance].
 
-### Deviations from [sig-governance]
-
-- SIG Autoscaling does not have chairs as a separate entity from tech
-  leads.  The tech leads have the responsibility of chairs.
-
 ### Subproject Creation
 
 SIG Technical Leads


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

When the original SIG Autoscaling charter shipped it was made explicit that TLs == Chairs. Going forward, there is no reason for the SIG to have its own governance model apart from that defined by the official SIG Governance charter.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
