### PR TITLE
docs(slack): add user guide for new careers channel triage process

### DIFF
--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -108,6 +108,8 @@ include:
     started contributing to Kubernetes.
 -   `kubernetes-org-members` - Discussion by and for organization members and
     established contributors.
+-   `#surveys` - Cloud native community wide surveys. Posts must be ecosystem
+    related.
 -   `#kubernetes-careers` - Job openings for positions working with/on/around
     Kubernetes. These must be postings for specific jobs, not "cattle calls"
     for general tech hiring. To maintain community safety and combat fraudulent
@@ -122,19 +124,19 @@ include:
     -   **Need More Information**: If a job listing is missing mandatory fields,
         additional information will be needed for approval.
 
-        Submissions require a direct corporate portal, official ATS, or accessible
-        portfolio URL; a matching corporate domain email (public domains such as
-        @gmail.com will be rejected); explicit geographic constraints
-        for `Hybrid` or `On-site` roles and direct, unshortened resume links. Third-party
-        URL shorteners are not permitted.
+submissions require a direct corporate portal, official ATS, or accessible portfolio URL; a matching corporate domain email (public domains such as @gmail.com will be rejected); explicit geographic constraints for `Hybrid` or `On-site` roles and direct, unshortened resume links. Third-party URL shorteners are not permitted.
 
-        Job posting will be rejected for missing, broken, or permission-locked links;
-        mismatched business email domains; anonymous or unverified recruitment agency postings;
-        or any content related to cryptocurrency, investment schemes, or unrelated topics.
-        If your post does not appear within 48 hours reach out in `#slack-admins` for a status
-        update. For full moderation criteria see the [Job Posting Vetting Policy](./slack-job-posting-policy.md).
--   `#surveys` - Cloud native community wide surveys. Posts must be ecosystem
-    related.
+Job posting will be rejected for missing, broken, or permission-locked links; mismatched business email domains; anonymous or unverified recruitment agency postings; or any content related to cryptocurrency, investment schemes, or unrelated topics. If your post does not appear within 48 hours reach out in `#slack-admins` for a status update.
+
+**Resume Submission:** Candidates must demonstrate experience with Kubernetes, CNCF 
+technologies, or DevOps/SRE practices that serve the cloud-native ecosystem. 
+Provide your full name, professional contact information, and a direct resume link 
+(Google Drive, GitHub, or personal website), along with a brief description of your 
+background and relevant experience. Direct, unshortened links only; URL shorteners 
+will result in immediate rejection. Resume submissions follow the same vetting 
+process and moderation standards as job postings to maintain community safety.
+For full moderation criteria see the [Job Posting Vetting Policy](./slack-job-posting-policy.md).
+
 
 ### Reporting a Problem
 

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -124,7 +124,7 @@ include:
     -   **Need More Information**: If a job listing is missing mandatory fields,
         additional information will be needed for approval.
 
-submissions require a direct corporate portal, official ATS, or accessible portfolio URL; a matching corporate domain email (public domains such as @gmail.com will be rejected); explicit geographic constraints for `Hybrid` or `On-site` roles and direct, unshortened resume links. Third-party URL shorteners are not permitted.
+Job opening submissions require a direct corporate portal, official ATS, or accessible portfolio URL; a matching corporate domain email (public domains such as @gmail.com will be rejected); explicit geographic constraints for `Hybrid` or `On-site` roles and direct, unshortened resume links. Third-party URL shorteners are not permitted.
 
 Job posting will be rejected for missing, broken, or permission-locked links; mismatched business email domains; anonymous or unverified recruitment agency postings; or any content related to cryptocurrency, investment schemes, or unrelated topics. If your post does not appear within 48 hours reach out in `#slack-admins` for a status update.
 

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -110,11 +110,29 @@ include:
     established contributors.
 -   `#kubernetes-careers` - Job openings for positions working with/on/around
     Kubernetes. These must be postings for specific jobs, not "cattle calls"
-    for general tech hiring. You may also post resumes if you are looking
-    to be hired. Job postings must include:
-    -   A link to the posting or job description.
-    -   The business name that will employ the Kubernetes hire.
-    -   The location of the role or if remote is OK.
+    for general tech hiring. To maintain community safety and combat fraudulent
+    listings, all posts now require a structured form submission and pass through
+    a moderated triage queue before becoming visible to the community.
+    -   **Form Submission**: Complete either the `Job Posting Form`
+        or the `Resume Form` inside Slack based on your intent.
+    -   **Triage Queue**: Submissions do not appear instantly. They are
+        routed to a private administrative review space.
+    -   **Manual Vetting**: Channel moderators review submissions to
+        screen out malicious links, fake profiles, and scams.
+    -   **Need More Information**: If a job listing is missing mandatory fields,
+        additional information will be needed for approval.
+
+        Submissions require a direct corporate portal, official ATS, or accessible
+        portfolio URL; a matching corporate domain email (public domains such as
+        @gmail.com will be rejected); explicit geographic constraints
+        for `Hybrid` or `On-site` roles and direct, unshortened resume links. Third-party
+        URL shorteners are not permitted.
+
+        Job posting will be rejected for missing, broken, or permission-locked links;
+        mismatched business email domains; anonymous or unverified recruitment agency postings;
+        or any content related to cryptocurrency, investment schemes, or unrelated topics.
+        If your post does not appear within 48 hours reach out in `#slack-admins` for a status
+        update. For full moderation criteria see the [Job Posting Vetting Policy](./slack-job-posting-policy.md).
 -   `#surveys` - Cloud native community wide surveys. Posts must be ecosystem
     related.
 


### PR DESCRIPTION

This PR rolls out the user guide for our new `#kubernetes-careers` channel submission workflow, so recruiters know exactly how the new form system works and what to expect during review.

### Key Changes
- **Process Steps**: Adds explicit sections detailing Form Submission, Triage Queue, Manual Vetting, and Need More Information.
- **Validation Criteria**: Outlines core formatting expectations for recruiters, including corporate domain matching and the prohibition of third-party URL shorteners.

/sig contributor-experience
/area slack-management
/area community-management
