### PR TITLE
Update "release-team-leads" Slack group members for v1.37 release cycle

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -34,7 +34,7 @@ usergroups:
   # - Emeritus Adviser
   # - SIG Release leads
   #
-  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.35/release-team.md
+  # Current release cycle: https://git.k8s.io/sig-release/releases/release-1.37/release-team.md
   - name: release-team-leads
     long_name: Release Team Leads
     description: >-
@@ -50,17 +50,17 @@ usergroups:
       - release-notes
       - sig-release
     members:
-      - aibarbetta          # v1.36 RT Lead Shadow
-      - chadmcrowell        # v1.36 Comms Lead
-      - dipesh-rawat        # v1.36 RT Lead Shadow
+      - adilGhaffarDev      # v1.37 Release Signal Lead
+      - aibarbetta          # v1.37 RT Lead Shadow
+      - dipesh-rawat        # v1.37 RT Lead
       - fsmunoz             # Release Team Subproject Lead
-      - jenshu              # v1.36 RT Lead Shadow
-      - jmickey             # v1.36 Enhancements Lead
       - katcosgrove         # Release Team Subproject Lead
-      - Prajyot-Parab       # v1.36 Release Signal Lead
-      - rayandas            # v1.36 RT Lead Shadow
-      - rytswd              # v1.36 Lead
-      - sayanchowdhury      # v1.36 docs Lead
+      - kernel-kun          # v1.37 Docs Lead
+      - Prajyot-Parab       # v1.37 RT Lead Shadow
+      - rayandas            # v1.37 RT Lead Shadow
+      - sayanchowdhury      # v1.37 RT Lead Shadow
+      - SwathiR03           # v1.37 Comms Lead
+      - whtssub             # v1.37 Enhancements Lead
 
   # Should match SIG Release Leads at all times:
   # https://git.k8s.io/community/sig-release/README.md#leadership

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -151,6 +151,7 @@ users:
   katcosgrove: U01GDERGEHF
   katharine: UBTBNJ6GL
   kayrus: U20RS7A72
+  kernel-kun: U09E646UPE3
   kikisdeliveryservice: U9HFFRFT2
   killianmuldoon: UGW727X6Z
   kim-tsao: U02U1LDH4T1
@@ -299,6 +300,7 @@ users:
   Sunnatillo: U0261DHJ1Q8
   swamymsft: UHU7ZNXH8
   swastik959: U04HY2PUN65
+  SwathiR03: U065E2S9C6P
   tabbysable: U01742MGBRT
   tallclair: U64VCBURE
   TaoBeier: UCLDV6MN1
@@ -333,6 +335,7 @@ users:
   vzhukovs: U030TR1FG85
   wallrj: U1ZMERJF7
   wendy-ha18: U072Q1ZPVA7
+  whtssub: U01Q16YA35J
   willie-yao: U024EME7SQK
   wilsonehusin: U0100068GF2
   wurbanski: URX7CMK97


### PR DESCRIPTION
Updates the membership of the release-team-leads Slack group for v1.37 release cycle.

Ref: https://github.com/kubernetes/sig-release/issues/3015