### PR TITLE
Add #trusted-execution-clusters Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -563,6 +563,7 @@ channels:
   - name: tr-users
   - name: traefik
   - name: travis-ci
+  - name: trusted-execution-clusters
   - name: tw-users
   - name: ug-big-data
     id: C0ELB338T


### PR DESCRIPTION
Add #trusted-execution-clusters channel to the Kubernetes Slack workspace for the [Trusted Execution Clusters](https://github.com/trusted-execution-clusters) project — an open-source project focused on integrating hardware-based confidential computing technology (such as AMD SEV-SNP and Intel TDX) directly into Kubernetes clusters. The project provides an end-to-end solution that isolates clusters from the underlying infrastructure by running nodes on confidential virtual machines (cVMs) in public cloud infrastructure. It ensures strict data-in-use confidentiality and leverages remote attestation to verify a node's authenticity before it is permitted to join the cluster and access secrets.

Fixes #8956