### PR TITLE
2026 Steering Election setup

### DIFF
--- a/elections/steering/2026/README.md
+++ b/elections/steering/2026/README.md
@@ -139,7 +139,7 @@ Examples of contributions that would NOT be considered:
 | Date                    | Event                                                                 |
 |:------------------------|:----------------------------------------------------------------------|
 | Wednesday, May 20       | Steering Committee selects Election Committee                         |
-| Wednesday, July 1       | Announcement of Election and publication of voters.md                 |
+| Wednesday, July 1       | Announcement of Election and publication of voters.yaml                 |
 | Wednesday, July 29      | Steering Committee Q+A for the candidates (to be confirmed)           |
 | Monday, August 3        | Candidate nominations due at the end of the day in AoE time           |
 | Tuesday, August 4       | All candidate bios due at the end of the day in AoE time              |

--- a/elections/steering/2026/README.md
+++ b/elections/steering/2026/README.md
@@ -260,8 +260,8 @@ The Steering Committee has selected the following people as [election officers]:
 In addition, the following contributors are helping with the election:
 
 - Alternate Officers: Xander Grzywinski, Christopher Tineo
-- Infra Liaison: TBD
-- Contributor Comms Liaison: TBD
+- Infra Liaison: Mahamed Ali (@upodroid)
+- Contributor Comms Liaison: Christopher Tineo (@TineoC)
 
 Please direct any questions via email to <election@k8s.io>.
 

--- a/elections/steering/2026/README.md
+++ b/elections/steering/2026/README.md
@@ -1,7 +1,5 @@
 # 2026 VOTERS GUIDE - KUBERNETES STEERING COMMITTEE ELECTION
 
-## *WORK IN PROGRESS, NOT YET READY*
-
 ## Important Links
 
 * [Kubernetes Steering Committee]
@@ -140,18 +138,18 @@ Examples of contributions that would NOT be considered:
 
 | Date                    | Event                                                                 |
 |:------------------------|:----------------------------------------------------------------------|
-| Wednesday, July 23      | Steering Committee selects Election Committee                         |
-| Monday, August 25       | Announcement of Election and publication of voters.md                 |
-| Wednesday, September 3  | Steering Committee Q+A for the candidates (to be confirmed)           |
-| Monday, September 8     | Candidate nominations due at the end of the day in AoE time           |
-| Tuesday, September 9    | All candidate bios due at the end of the day in AoE time              |
-| Friday, September 12    | Election Begins                                                       |
-| Wednesday, October 22   | Deadline to submit voter exception requests                           |
-| Friday, October 24      | Election Closes at the end of the day in AoE time                     |
-| Monday, October 27      | Private announcement of Results to SC members not up for election     |
-| Tuesday, October 28     | Private announcement of Results to all candidates                     |
-| Wednesday, November 5   | Public announcement of Results at Public Steering Committee Meeting   |
-| Thursday, November 19   | Election Retro                                                        |
+| Wednesday, May 20       | Steering Committee selects Election Committee                         |
+| Wednesday, July 1       | Announcement of Election and publication of voters.md                 |
+| Wednesday, July 29      | Steering Committee Q+A for the candidates (to be confirmed)           |
+| Monday, August 3        | Candidate nominations due at the end of the day in AoE time           |
+| Tuesday, August 4       | All candidate bios due at the end of the day in AoE time              |
+| Friday, August 14       | Election Begins                                                       |
+| Tuesday, September 29   | Deadline to submit voter exception requests                           |
+| Thursday, October 1     | Election Closes at the end of the day in AoE time                     |
+| Friday, October 2       | Private announcement of Results to SC members not up for election     |
+| Monday, October 5       | Private announcement of Results to all candidates                     |
+| Wednesday, October 7    | Public announcement of Results at Public Steering Committee Meeting   |
+| Thursday, October 15    | Election Retro                                                        |
 
 Candidate nomination, bio, and election close deadlines will be done using Anywhere on Earth timing, meaning it is still valid to submit new nominations/bios/votes as long as it is still the last day anywhere on the planet (i.e. at the end of that day in UTC-12).
 

--- a/elections/steering/2026/README.md
+++ b/elections/steering/2026/README.md
@@ -139,7 +139,7 @@ Examples of contributions that would NOT be considered:
 | Date                    | Event                                                                 |
 |:------------------------|:----------------------------------------------------------------------|
 | Wednesday, May 20       | Steering Committee selects Election Committee                         |
-| Wednesday, July 1       | Announcement of Election and publication of voters.yaml                 |
+| Monday, June 15         | Announcement of Election and publication of voters.yaml                 |
 | Wednesday, July 29      | Steering Committee Q+A for the candidates (to be confirmed)           |
 | Monday, August 3        | Candidate nominations due at the end of the day in AoE time           |
 | Tuesday, August 4       | All candidate bios due at the end of the day in AoE time              |

--- a/elections/steering/2026/election.yaml
+++ b/elections/steering/2026/election.yaml
@@ -17,4 +17,4 @@ election_officers:
 eligibility: Kubernetes Org members with 50 or more contributions in the last year can vote.  See [the election guide](https://github.com/kubernetes/community/tree/master/elections/steering/2026)
 exception_description: Not all contributions are measured by DevStats.  If you have contributions that are not so measured, then please request an exception to allow you to vote via the Elekto application.
 # End of day Anywhere on Earth for closing. Write 2023-09-23 as: 2023-09-24 11:59:59
-exception_due: 2026-09-29 11:59:59
+exception_due: 2026-09-30 11:59:59

--- a/elections/steering/2026/election.yaml
+++ b/elections/steering/2026/election.yaml
@@ -1,0 +1,20 @@
+name: 2026 Steering Committee Election
+organization: Kubernetes
+# Start of day in UTC for opening: 2023-08-29 00:00:01
+start_datetime: 2026-08-14 00:00:01
+# End of day Anywhere on Earth for closing. Write 2023-09-26 as: 2023-09-27 11:59:59
+end_datetime: 2026-10-02 11:59:59
+no_winners: 3
+allow_no_opinion: True
+delete_after: True
+show_candidate_fields:
+  - employer
+  - slack
+election_officers:
+  - npolshakova
+  - reylejano
+  - sreeram-venkitesh
+eligibility: Kubernetes Org members with 50 or more contributions in the last year can vote.  See [the election guide](https://github.com/kubernetes/community/tree/master/elections/steering/2026)
+exception_description: Not all contributions are measured by DevStats.  If you have contributions that are not so measured, then please request an exception to allow you to vote via the Elekto application.
+# End of day Anywhere on Earth for closing. Write 2023-09-23 as: 2023-09-24 11:59:59
+exception_due: 2026-09-29 11:59:59

--- a/elections/steering/2026/election_desc.md
+++ b/elections/steering/2026/election_desc.md
@@ -1,0 +1,11 @@
+# Vote for the 2026 Steering Committee
+
+As is now customary, the third calendar quarter is [Steering Committee](https://github.com/kubernetes/steering) election season for Kubernetes. Four (4) elected members (@katcosgrove, @pacoxu, @ritazh, @soltysh) will stay on for the remaining year of their terms, and there will be three (3) positions open for election. Every election term will be 2 years. More complete information on the election may be found [in the voter's guide](https://github.com/kubernetes/community/tree/master/elections/steering/2026).
+
+Instructions on using Elekto can be found [in its docs site](https://elekto.dev/docs/voting/).
+
+If you’d like to vote or run for a seat, all details and next steps are outlined in the [election process doc](https://git.k8s.io/steering/elections.md) and this application. The application will be the single source of truth of information for this cycle. It will be updated live as new bios of candidates get committed.
+
+Please pay attention to the [scheduled dates](https://github.com/kubernetes/community/tree/master/elections/steering/2026#schedule).
+
+Eligibility for voting will be determined by 50 contributions to a Kubernetes project over the past year and [Kubernetes Org membership](https://github.com/kubernetes/community/blob/master/community-membership.md).  Eligible voters will be shown as such by this site when logged in.  If you should be eligible, but are not, you may also [file for an exception](https://elections.k8s.io/app/elections/steering---2026/exception).

--- a/elections/steering/2026/nomination-template.md
+++ b/elections/steering/2026/nomination-template.md
@@ -1,0 +1,23 @@
+-------------------------------------------------------------
+name: 
+ID: GitHubID
+info:
+  employer: Your Employer or "Independent"
+  slack: slack handle
+-------------------------------------------------------------
+
+<!-- Please make a copy of this template as "candidate-githubid.md" and save it to
+the election directory -->
+
+## SIGS
+
+- SIGs/WGs/Teams you're a member of
+
+## What I have done
+
+## What I'll do
+
+## Resources About Me
+
+- Links to KubeCon or other conference talks or other related material 
+- Links to social media

--- a/elections/steering/2026/voters.yaml
+++ b/elections/steering/2026/voters.yaml
@@ -1,0 +1,15 @@
+# 2026 Steering Committee Election
+##################################
+#
+# The process for determining eligible voters can be found in
+# https://github.com/kubernetes/community/tree/master/elections/steering/2026
+#
+# If you feel you meet the eligibility criteria but do not see your GitHub username
+# below, please fill out an exception request and the elections team will get back to
+# you as quickly as possible: https://elections.k8s.io/app/elections/steering---2026/exception
+#
+# History:
+# Log of changes to the file
+#
+eligible_voters:
+-

--- a/elections/steering/README.md
+++ b/elections/steering/README.md
@@ -2,12 +2,12 @@
 
 This folder contains information on the Kubernetes Steering elections since 2017.
 
-The current Steering election, including all directions on eligibility, voting, and candidates, can be found here: [2025 Election]
+The current Steering election, including all directions on eligibility, voting, and candidates, can be found here: [2026 Election]
 
-The last Steering election, including all directions on eligibility, voting, and candidates, can be found here: [2024 Election]
+The last Steering election, including all directions on eligibility, voting, and candidates, can be found here: [2025 Election]
 
 You can also read [documentation] on how to run a Steering Election.
 
+[2026 Election]: /elections/steering/2026/
 [2025 Election]: /elections/steering/2025/
-[2024 Election]: /elections/steering/2024/
 [documentation]: /elections/steering/documentation/


### PR DESCRIPTION
Election officers for the 2026 Steering election are @npolshakova , @reylejano , and @sreeram-venkitesh.

This PR adds the following to be approved by Steering
- updated README.md with the proposed schedule for the 2026 steering election 
- updated README.md with Infra and Contributor Comms liaisons
- election_desc.md
- election.yaml
- nomination-template.md
- voters.yaml with an empty list to be populated when the election opens

We're seeking approval from the Steering Committee for the 2026 Steering election schedule, along with the above-mentioned files.

Holding for the majority of Steering to approve.

/committee steering
/sig contributor-experience
/area elections
/hold