### PR TITLE
Fix seat count in 2026 steering election voter guide: 4 → 3

### DIFF
--- a/elections/steering/2026/README.md
+++ b/elections/steering/2026/README.md
@@ -25,7 +25,7 @@
 
 ## Purpose
 
-The role of this election is to fill out the four (4) seats due for
+The role of this election is to fill out the three (3) seats due for
 reelection this year on the [Kubernetes Steering Committee]. Each elected
 member will serve a two (2) year term.
 


### PR DESCRIPTION
Fix: 2026 has 3 open seats, confirmed by [election.yaml no_winners: 3](https://github.com/kubernetes/community/blob/main/elections/steering/2026/election.yaml#L7).