### PR TITLE
Add #modelplane Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -392,6 +392,7 @@ channels:
   - name: microk8s
   - name: minikube
   - name: minikube-dev
+  - name: modelplane
   - name: monitoring-mixins
   - name: monolith
     archived: true


### PR DESCRIPTION
This PR requests a new `#modelplane` Slack channel.

Modelplane is an Apache 2.0 open source control plane for running AI models across a fleet of GPU Kubernetes clusters. Platform teams declare inference clusters and hardware classes as Kubernetes custom resources. Developers declare a model and get back a unified, OpenAI-compatible endpoint. Modelplane schedules deployments onto clusters with matching capacity, scales replicas, and routes traffic through a gateway on the control plane.

We'd use the channel to support users, gather bug reports and feature requests, and coordinate development. Our users run on Kubernetes, so Kubernetes Slack is where they already are.

Resources:
- Website: https://modelplane.ai
- Documentation: https://docs.modelplane.ai
- Repository: https://github.com/modelplaneai/modelplane ~(public as of Tue Jun 23)~

Channel name: `modelplane`. Visibility: public.

Edit: We just made the repo and site public now.