### PR TITLE
Updated sig-docs blog subproject readme

### DIFF
--- a/sig-docs/blog-subproject/README.md
+++ b/sig-docs/blog-subproject/README.md
@@ -21,6 +21,8 @@ See [meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meet
 
 - **Blog shadow editors:** _no contributors_
 
+- **Blog writing buddies:** _open role :  see [Helping as a blog writing buddy](https://kubernetes.io/docs/contribute/blog/writing-buddy/) to get involved_
+
 ✨ Could **you** join the blog editorial team?
 
 ## Contact

--- a/sig-docs/blog-subproject/role-handbooks/blog-community-manager.md
+++ b/sig-docs/blog-subproject/role-handbooks/blog-community-manager.md
@@ -19,7 +19,7 @@ The Blog Community Manager ensures that the editorial process is transparent, co
 
 ## Activities
 
-* Attending and participating in biweekly editorial meetings.
+* Attending and participating in [SIG Docs meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meetings).
 * Providing a review of all blog posts to ensure they meet the content guidelines and best interests of the community.
 * Work with the editorial leads to maintain transparency in the review process and proposing any necessary updates to the blog guidelines.
 * Advocating for the blog as a place for contributors to get involved and share educational content with the community. 

--- a/sig-docs/blog-subproject/role-handbooks/copy-editor.md
+++ b/sig-docs/blog-subproject/role-handbooks/copy-editor.md
@@ -19,7 +19,7 @@ The copy editor is the expert in spelling, grammar, and flow to ensure that all 
 
 ## Activities
 
-* Attending and participating in biweekly editorial meetings
+* Attending and participating in [SIG Docs meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meetings).
 * Providing a copy review on all blog posts.
 
 ## Time Commitments

--- a/sig-docs/blog-subproject/role-handbooks/editorial-lead.md
+++ b/sig-docs/blog-subproject/role-handbooks/editorial-lead.md
@@ -23,7 +23,7 @@ The Editorial Lead is responsible for the day-to-day management of the Kubernete
 
 ## Activities
 
-* Scheduling and running biweekly editorial meetings.
+* Participating in [SIG Docs meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meetings).
 * Reviewing, assigning, and scheduling blog posts.
 * Final approval on blog posts.
 * Maintain blog documentation and process guidelines.

--- a/sig-docs/blog-subproject/role-handbooks/technical-editor.md
+++ b/sig-docs/blog-subproject/role-handbooks/technical-editor.md
@@ -18,7 +18,7 @@ The technical editor is the subject matter expert to ensure the technical accura
 
 ## Activities
 
-* Attending and participating in biweekly editorial meetings.
+* Attending and participating in [SIG Docs meetings](https://github.com/kubernetes/community/tree/master/sig-docs#meetings).
 * Providing a technical review on all blog posts.
 
 ## Time Commitments


### PR DESCRIPTION
Updated  Blog subproject README : 

- **Meetings:** Replaced outdated reference to biweekly/fortnightly editorial meetings (which no longer take place) with a pointer to the existing SIG Docs meetings
- **Writing buddies:** Added the Blog writing buddies role with a link to the official documentation
- **Shadow roles:** Kept shadow approver and shadow editor roles as-is ,  they are currently unfilled but preserved in case someone wants to pick them up in future

Reference : Based on the discussion : [sig-docs-blog](https://kubernetes.slack.com/archives/CJDHVD54J/p1781837613613499)