### PR TITLE
Reorganize SIG Network subprojects

### DIFF
--- a/generator/testdata/sigs.yaml
+++ b/generator/testdata/sigs.yaml
@@ -23,3 +23,10 @@ workinggroups:
     label: baz
     stakeholder_sigs:
     - Foo
+gb_rep:
+  github: cblecker
+  name: Christoph Blecker
+  company: Red Hat
+  email: cblecker@gmail.com
+
+

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -81,15 +81,15 @@ The following [subprojects][subproject-definition] are owned by sig-network:
 ### cluster-proportional-autoscaler
 - **Owners:**
   - [kubernetes-sigs/cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/blob/master/OWNERS)
-### cluster-proportional-vertical-autoscaler
-- **Owners:**
   - [kubernetes-sigs/cluster-proportional-vertical-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler/blob/master/OWNERS)
 ### external-dns
+Configures external DNS servers (like AWS Route53, Google Cloud DNS) based on Kubernetes Services and Ingresses.
 - **Owners:**
   - [kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns/blob/master/OWNERS)
 - **Contact:**
   - Slack: [#external-dns](https://kubernetes.slack.com/messages/external-dns)
 ### gateway-api
+APIS for Service networking in Kubernetes.
 - **Leads:**
   - Ricardo Katz (**[@rikatz](https://github.com/rikatz)**), Red Hat
   - Rob Scott (**[@robscott](https://github.com/robscott)**), Google
@@ -111,34 +111,25 @@ Gateway API Inference Extension
 - **Contact:**
   - Slack: [#gateway-api-inference-extension](https://kubernetes.slack.com/messages/gateway-api-inference-extension)
 ### ingress
+Ingress controllers and conformance test suites.
 - **Owners:**
   - [kubernetes-sigs/ingress-controller-conformance](https://github.com/kubernetes-sigs/ingress-controller-conformance/blob/master/OWNERS)
   - [kubernetes/ingress-gce](https://github.com/kubernetes/ingress-gce/blob/master/OWNERS)
   - [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/master/OWNERS)
-### iptables-wrappers
-- **Owners:**
-  - [kubernetes-sigs/iptables-wrappers](https://github.com/kubernetes-sigs/iptables-wrappers/blob/master/OWNERS)
-### kindnet
-- **Owners:**
-  - [kubernetes-sigs/kindnet](https://github.com/kubernetes-sigs/kindnet/blob/main/OWNERS)
-### knftables
-- **Owners:**
-  - [kubernetes-sigs/knftables](https://github.com/kubernetes-sigs/knftables/blob/master/OWNERS)
 ### kube-agentic-networking
+Sandbox for exploring agentic networking and AI capabilities in Kubernetes.
 - **Owners:**
   - [kubernetes-sigs/kube-agentic-networking](https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/OWNERS)
-### kube-dns
-kube-dns was the original implementation of Kubernetes Service DNS. It is now deprecated, though there may be new releases to fix CVEs up until Kubernetes 1.40. Most Kubernetes clusters now use [CoreDNS](https://coredns.io) for Service DNS.
-- **Owners:**
-  - [kubernetes-sigs/node-local-dns](https://github.com/kubernetes-sigs/node-local-dns/blob/master/OWNERS)
-  - [kubernetes/dns](https://github.com/kubernetes/dns/blob/master/OWNERS)
 ### kubernetes-network-drivers
+Dynamic Resource Allocation (DRA) network drivers and related plugins.
 - **Owners:**
+  - [kubernetes-sigs/cni-dra-driver](https://github.com/kubernetes-sigs/cni-dra-driver/blob/main/OWNERS)
   - [kubernetes-sigs/dranet](https://github.com/kubernetes-sigs/dranet/blob/main/OWNERS)
   - [kubernetes-sigs/kubernetes-network-drivers](https://github.com/kubernetes-sigs/kubernetes-network-drivers/blob/main/OWNERS)
 - **Contact:**
   - Slack: [#sig-network-dranet](https://kubernetes.slack.com/messages/sig-network-dranet)
 ### multi-network
+API definitions and implementations for supporting multiple networks per Pod.
 - **Leads:**
   - Lionel Jouin (**[@LionelJouin](https://github.com/LionelJouin)**), Red Hat
   - Maciej Skrocki (**[@mskrocki](https://github.com/mskrocki)**), Google
@@ -147,7 +138,13 @@ kube-dns was the original implementation of Kubernetes Service DNS. It is now de
   - [kubernetes-sigs/multi-network](https://github.com/kubernetes-sigs/multi-network/blob/main/OWNERS)
 - **Contact:**
   - Slack: [#sig-network-multi-network](https://kubernetes.slack.com/messages/sig-network-multi-network)
+### netfilter-tooling
+Libraries and utility tools for interacting with Linux netfilter (iptables, nftables).
+- **Owners:**
+  - [kubernetes-sigs/iptables-wrappers](https://github.com/kubernetes-sigs/iptables-wrappers/blob/master/OWNERS)
+  - [kubernetes-sigs/knftables](https://github.com/kubernetes-sigs/knftables/blob/master/OWNERS)
 ### network-policy
+Kubernetes Network Policy API and evolution.
 - **Leads:**
   - Dan Winship (**[@danwinship](https://github.com/danwinship)**), Red Hat
   - Nadia Pinaeva (**[@npinaeva](https://github.com/npinaeva)**), NVIDIA
@@ -159,17 +156,15 @@ kube-dns was the original implementation of Kubernetes Service DNS. It is now de
   - [kubernetes/api/networking](https://github.com/kubernetes/api/blob/master/networking/OWNERS)
 - **Contact:**
   - Slack: [#sig-network-policy-api](https://kubernetes.slack.com/messages/sig-network-policy-api)
-### node-ipam-controller
-- **Owners:**
-  - [kubernetes-sigs/node-ipam-controller](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/OWNERS)
-### node-local-dns
-- **Owners:**
-  - [kubernetes-sigs/node-local-dns](https://github.com/kubernetes-sigs/node-local-dns/blob/master/OWNERS)
 ### pod-networking
+Components and utilities for managing pod-to-pod networking, CNI plugins, node local DNS services, and IPAM.
 - **Owners:**
-  - [kubernetes-sigs/cni-dra-driver](https://github.com/kubernetes-sigs/cni-dra-driver/blob/main/OWNERS)
   - [kubernetes-sigs/ip-masq-agent](https://github.com/kubernetes-sigs/ip-masq-agent/blob/master/OWNERS)
+  - [kubernetes-sigs/kindnet](https://github.com/kubernetes-sigs/kindnet/blob/main/OWNERS)
   - [kubernetes-sigs/nat64](https://github.com/kubernetes-sigs/nat64/blob/main/OWNERS)
+  - [kubernetes-sigs/node-ipam-controller](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/OWNERS)
+  - [kubernetes-sigs/node-local-dns](https://github.com/kubernetes-sigs/node-local-dns/blob/master/OWNERS)
+  - [kubernetes/dns](https://github.com/kubernetes/dns/blob/master/OWNERS)
   - [kubernetes/kubernetes/pkg/kubelet/network](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/OWNERS)
 ### wg-ai-gateway
 Proposals and discussions for the AI Gateway Working Group

--- a/sig-network/README.md
+++ b/sig-network/README.md
@@ -99,9 +99,6 @@ APIS for Service networking in Kubernetes.
   - [kubernetes-sigs/gateway-api](https://github.com/kubernetes-sigs/gateway-api/blob/master/OWNERS)
   - [kubernetes-sigs/gwctl](https://github.com/kubernetes-sigs/gwctl/blob/main/OWNERS)
   - [kubernetes-sigs/ingress2gateway](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/OWNERS)
-  - [kubernetes/kubernetes/pkg/controller/endpoint](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/endpoint/OWNERS)
-  - [kubernetes/kubernetes/pkg/proxy](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/OWNERS)
-  - [kubernetes/kubernetes/staging/src/k8s.io/cloud-provider/controllers/service](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cloud-provider/controllers/service/OWNERS)
 - **Contact:**
   - Slack: [#sig-network-gateway-api](https://kubernetes.slack.com/messages/sig-network-gateway-api)
 ### gateway-api-inference-extension
@@ -153,7 +150,6 @@ Kubernetes Network Policy API and evolution.
   - [kubernetes-sigs/kube-network-policies](https://github.com/kubernetes-sigs/kube-network-policies/blob/master/OWNERS)
   - [kubernetes-sigs/network-policy-api](https://github.com/kubernetes-sigs/network-policy-api/blob/master/OWNERS)
   - [kubernetes-sigs/network-policy-finalizer](https://github.com/kubernetes-sigs/network-policy-finalizer/blob/main/OWNERS)
-  - [kubernetes/api/networking](https://github.com/kubernetes/api/blob/master/networking/OWNERS)
 - **Contact:**
   - Slack: [#sig-network-policy-api](https://kubernetes.slack.com/messages/sig-network-policy-api)
 ### pod-networking
@@ -165,7 +161,6 @@ Components and utilities for managing pod-to-pod networking, CNI plugins, node l
   - [kubernetes-sigs/node-ipam-controller](https://github.com/kubernetes-sigs/node-ipam-controller/blob/main/OWNERS)
   - [kubernetes-sigs/node-local-dns](https://github.com/kubernetes-sigs/node-local-dns/blob/master/OWNERS)
   - [kubernetes/dns](https://github.com/kubernetes/dns/blob/master/OWNERS)
-  - [kubernetes/kubernetes/pkg/kubelet/network](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/OWNERS)
 ### wg-ai-gateway
 Proposals and discussions for the AI Gateway Working Group
 - **Owners:**

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2386,15 +2386,15 @@ sigs:
       - name: cluster-proportional-autoscaler
         owners:
           - https://raw.githubusercontent.com/kubernetes-sigs/cluster-proportional-autoscaler/master/OWNERS
-      - name: cluster-proportional-vertical-autoscaler
-        owners:
           - https://raw.githubusercontent.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler/master/OWNERS
       - name: external-dns
+        description: Configures external DNS servers (like AWS Route53, Google Cloud DNS) based on Kubernetes Services and Ingresses.
         contact:
           slack: external-dns
         owners:
           - https://raw.githubusercontent.com/kubernetes-sigs/external-dns/master/OWNERS
       - name: gateway-api
+        description: APIS for Service networking in Kubernetes.
         contact:
           slack: sig-network-gateway-api
         owners:
@@ -2422,34 +2422,25 @@ sigs:
         owners:
           - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/main/OWNERS
       - name: ingress
+        description: Ingress controllers and conformance test suites.
         owners:
           - https://raw.githubusercontent.com/kubernetes-sigs/ingress-controller-conformance/master/OWNERS
           - https://raw.githubusercontent.com/kubernetes/ingress-gce/master/OWNERS
           - https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/OWNERS
-      - name: iptables-wrappers
-        owners:
-          - https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/master/OWNERS
-      - name: kindnet
-        owners:
-          - https://raw.githubusercontent.com/kubernetes-sigs/kindnet/main/OWNERS
-      - name: knftables
-        owners:
-          - https://raw.githubusercontent.com/kubernetes-sigs/knftables/master/OWNERS
       - name: kube-agentic-networking
+        description: Sandbox for exploring agentic networking and AI capabilities in Kubernetes.
         owners:
           - https://raw.githubusercontent.com/kubernetes-sigs/kube-agentic-networking/main/OWNERS
-      - name: kube-dns
-        description: kube-dns was the original implementation of Kubernetes Service DNS. It is now deprecated, though there may be new releases to fix CVEs up until Kubernetes 1.40. Most Kubernetes clusters now use [CoreDNS](https://coredns.io) for Service DNS.
-        owners:
-          - https://raw.githubusercontent.com/kubernetes-sigs/node-local-dns/master/OWNERS
-          - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
       - name: kubernetes-network-drivers
+        description: Dynamic Resource Allocation (DRA) network drivers and related plugins.
         contact:
           slack: sig-network-dranet
         owners:
+          - https://raw.githubusercontent.com/kubernetes-sigs/cni-dra-driver/main/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/dranet/main/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/kubernetes-network-drivers/main/OWNERS
       - name: multi-network
+        description: API definitions and implementations for supporting multiple networks per Pod.
         contact:
           slack: sig-network-multi-network
         owners:
@@ -2462,7 +2453,13 @@ sigs:
           - github: mskrocki
             name: Maciej Skrocki
             company: Google
+      - name: netfilter-tooling
+        description: Libraries and utility tools for interacting with Linux netfilter (iptables, nftables).
+        owners:
+          - https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/master/OWNERS
+          - https://raw.githubusercontent.com/kubernetes-sigs/knftables/master/OWNERS
       - name: network-policy
+        description: Kubernetes Network Policy API and evolution.
         contact:
           slack: sig-network-policy-api
         owners:
@@ -2480,17 +2477,15 @@ sigs:
           - github: tssurya
             name: Surya Seetharaman
             company: Red Hat
-      - name: node-ipam-controller
-        owners:
-          - https://raw.githubusercontent.com/kubernetes-sigs/node-ipam-controller/main/OWNERS
-      - name: node-local-dns
-        owners:
-          - https://raw.githubusercontent.com/kubernetes-sigs/node-local-dns/master/OWNERS
       - name: pod-networking
+        description: Components and utilities for managing pod-to-pod networking, CNI plugins, node local DNS services, and IPAM.
         owners:
-          - https://raw.githubusercontent.com/kubernetes-sigs/cni-dra-driver/main/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/ip-masq-agent/master/OWNERS
+          - https://raw.githubusercontent.com/kubernetes-sigs/kindnet/main/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/nat64/main/OWNERS
+          - https://raw.githubusercontent.com/kubernetes-sigs/node-ipam-controller/main/OWNERS
+          - https://raw.githubusercontent.com/kubernetes-sigs/node-local-dns/master/OWNERS
+          - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
           - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
       - name: wg-ai-gateway
         description: Proposals and discussions for the AI Gateway Working Group

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -2402,9 +2402,6 @@ sigs:
           - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/master/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/gwctl/main/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/ingress2gateway/main/OWNERS
-          - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
-          - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
-          - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/controllers/service/OWNERS
         leads:
           - github: rikatz
             name: Ricardo Katz
@@ -2466,7 +2463,6 @@ sigs:
           - https://raw.githubusercontent.com/kubernetes-sigs/kube-network-policies/master/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/master/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/network-policy-finalizer/main/OWNERS
-          - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
         leads:
           - github: danwinship
             name: Dan Winship
@@ -2486,7 +2482,6 @@ sigs:
           - https://raw.githubusercontent.com/kubernetes-sigs/node-ipam-controller/main/OWNERS
           - https://raw.githubusercontent.com/kubernetes-sigs/node-local-dns/master/OWNERS
           - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
-          - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
       - name: wg-ai-gateway
         description: Proposals and discussions for the AI Gateway Working Group
         owners:


### PR DESCRIPTION
- Consolidate cluster-proportional-vertical-autoscaler into cluster-proportional-autoscaler
- Consolidate kindnet, node-ipam-controller, node-local-dns, and kube-dns into pod-networking
- Consolidate iptables-wrappers and knftables into netfilter-tooling
- Fix generator testdata to include gb_rep
