### PR TITLE
communication: name the `No Solicitation policy` and link to it from each platform guideline

### DIFF
--- a/communication/README.md
+++ b/communication/README.md
@@ -36,7 +36,7 @@ devoted to the Kubernetes project. Please check the guidelines and any relevant
 chat/conversation history before posting. Spam and sales pitches are not tolerated
 on these platforms.
 
-### Appropriate Content for Community Resources
+### No Solicitation
 
 All communications properties are under the [Kubernetes code of conduct].
 Additionally, these resources are for the contributors and users of Kubernetes; commercial usage of these properties is heavily moderated.
@@ -51,6 +51,10 @@ Examples of appropriate content:
 - Asking about commercial products in an appropriate channel. For example most clouds have a channel in Slack, asking how to use GKE on the GKE channel or AKS on the Azure channels is fine.
 - "Does anyone have experience with project foo?" is fine
 - Some OSS projects are also hosted on the Kubernetes Slack that also have a commercial offering, these are allowed.
+
+This policy applies to every platform listed on this page; the platform-specific
+guidelines below implement and extend it. Report violations to that platform's
+[moderators], who enforce it per the [moderation guidelines].
 
 ## Decisions Are Made Here
 
@@ -214,6 +218,7 @@ place!
 [submit a blog post]: https://kubernetes.io/docs/contribute/start/#write-a-blog-post
 [zoom guidelines]: ./zoom-guidelines.md
 [moderators]: ./moderators.md
+[moderation guidelines]: ./moderation.md
 [slack moderators]: ./moderators.md#slack
 [#kubernetes-contributors]: https://app.slack.com/client/T09NY5SBT/C09R23FHP
 [#sig-contribex]: https://app.slack.com/client/T09NY5SBT/C1TU9EB9S

--- a/communication/calendar-guidelines.md
+++ b/communication/calendar-guidelines.md
@@ -15,6 +15,10 @@ practices.
 
 Please feel free to PR in your favorite tips and tricks that may help others.
 
+Calendar events and meeting invites are covered by the community-wide
+[No Solicitation] policy: do not use them to promote commercial products
+or services.
+
 - [Calendar Guidelines](#calendar-guidelines)
   - [Establishing a New Meeting](#establishing-a-new-meeting)
     - [Testing Permissions](#testing-permissions)
@@ -176,6 +180,7 @@ to refresh invites sent to the group.
 
 
 [gsuite]: https://github.com/kubernetes/community/issues/3362
+[No Solicitation]: ./README.md#no-solicitation
 [doodle]: https://doodle.com
 [testing permissions]: #testing-permissions
 [new shared calendar]: https://support.google.com/calendar/answer/37095?hl=en

--- a/communication/discuss-guidelines.md
+++ b/communication/discuss-guidelines.md
@@ -63,6 +63,9 @@ If there is an issue with the platform itself, please use the
 
 ## General communication guidelines
 
+The community-wide [No Solicitation] policy applies on Discuss: do not post
+unsolicited commercial or promotional content, in topics or in private messages.
+
 ### PM (Private Message) conversations
 
 Please do not engage in proprietary company specific conversations in the
@@ -201,6 +204,7 @@ list with the new region, the moderators and their timezone.
 
 
 [Discourse]: https://discourse.org
+[No Solicitation]: ./README.md#no-solicitation
 [A community forum for Kubernetes KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-contributor-experience/0000-community-forum
 [archive k-users]: https://github.com/kubernetes/community/issues/2492
 [Kubernetes Code of Conduct]: /code-of-conduct.md

--- a/communication/mailing-list-guidelines.md
+++ b/communication/mailing-list-guidelines.md
@@ -63,7 +63,8 @@ Moderation of the SIG/WG/subproject lists is up to that individual
 SIG/WG/subproject. The admins are there to help facilitate leadership changes, 
 or various other administrative functions.
 
-Users who are violating the [Code of Conduct] or other negative activities
+Users who are violating the [Code of Conduct], the community-wide
+[No Solicitation] policy, or engaging in other negative activities
 (like spamming) should be moderated.
 - [Lock the thread immediately] so that people cannot reply to the thread.
 - [Delete the post].
@@ -283,6 +284,7 @@ To archive a mailing list, use the below procedure.
 [moderation queue]: #create-moderation-queue
 [sig-list]: /sig-list.md
 [Code of Conduct]: /code-of-conduct.md
+[No Solicitation]: ./README.md#no-solicitation
 [admins]: ./moderators.md#mailing-lists
 [sig contributor experience mailing list]: https://groups.google.com/forum/#!forum/kubernetes-sig-contribex
 [moderation guidelines]: ./moderation.md

--- a/communication/moderation.md
+++ b/communication/moderation.md
@@ -132,7 +132,9 @@ Moderators _MUST_:
     appropriately.
 - Become familiar with the [Kubernetes Community Values].
 - Take care of spam as soon as possible, which may mean taking action by
-  removing a member from that resource.
+  removing a member from that resource. The community-wide
+  [No Solicitation] policy is the reference for what counts as
+  unsolicited commercial content.
 - Foster a safe and productive environment by being aware of potential multiple
   cultural differences between Kubernetes community members.
 - Understand that you might be contacted by moderators, community managers, and
@@ -282,6 +284,7 @@ guidelines:
 [charter]: /sig-contributor-experience/charter.md#code-binaries-and-services
 [moderators]: ./moderators.md
 [Code of Conduct]: /code-of-conduct.md
+[No Solicitation]: ./README.md#no-solicitation
 [Kubernetes Community Values]: /values.md
 [stages of burnout]: https://opensource.com/business/15/12/avoid-burnout-live-happy
 [Code of Conduct Committee]: /committee-code-of-conduct/README.md

--- a/communication/slack-guidelines.md
+++ b/communication/slack-guidelines.md
@@ -63,6 +63,8 @@ in warnings, deletion of posts, restrictions on posting, temporary or
 permanent deactivation of user accounts, and even restrictions on entire
 organizations.  We rely on our community to report prohibited behavior to
 the Slack admins; if you see any of the below, please use the [Message Reporter].
+These rules implement the community-wide [No Solicitation] policy, which
+applies to all Kubernetes communication platforms.
 
 * Violations of the **[Code of Conduct][coc]**
 * Posting **Spam**: you may not post commercial, promotional messages anywhere in
@@ -368,3 +370,4 @@ discussed in Slack itself.
 [GitHub Issue]: https://github.com/kubernetes/community/issues/new/choose
 [Slack's policy on inactivated accounts]: https://get.slack.help/hc/en-us/articles/204475027-Deactivate-a-member-s-account
 [Message Reporter]: #reporting-a-problem
+[No Solicitation]: ./README.md#no-solicitation

--- a/communication/zoom-guidelines.md
+++ b/communication/zoom-guidelines.md
@@ -23,6 +23,9 @@ and general moderation guidelines.
 The Kubernetes project adheres to the [Kubernetes Code of Conduct]
 throughout all platforms and includes all communication mediums.
 
+The community-wide [No Solicitation] policy also applies: unsolicited
+pitching of commercial products has no place in community meetings.
+
 ## Zoom license management
 
 Zoom licenses are managed by the [CNCF Service Desk] through the
@@ -194,6 +197,7 @@ Thanks for making Kubernetes meetings work great!
 [SIG/WG meetings]: /sig-list.md
 [Kubernetes code of conduct]: /code-of-conduct.md
 [moderation]: ./moderation.md
+[No Solicitation]: ./README.md#no-solicitation
 [CNCF Service Desk]: https://github.com/cncf/servicedesk
 [Zoom Admins]: ./moderators.md#zoom
 [centralized list of administrators]: ./moderators.md


### PR DESCRIPTION
The community rule about unsolicited commercial content lives in
communication/README.md under the heading "Appropriate Content for
Community Resources". That heading is hard to cite, and nothing else in
the repo points to it. The Slack guidelines state their own detailed
version of the same rule. The guidelines for Discuss, mailing lists,
Zoom, and the shared calendar do not mention it at all.

This PR makes the existing policy easy to find and to cite. It does not
change any rules. It does the following:

- Rename the section in communication/README.md to "No Solicitation".
  Add a closing note that says the policy applies to every platform and
  that moderators enforce it.
- Add one line to the Slack, Discuss, mailing list, Zoom, and calendar
  guidelines that points to the renamed section.
- Add a pointer in moderation.md so moderators on any platform have
  policy text to cite when they remove spam.

Nothing linked to the old heading anchor, so the rename does not break
any existing links. hack/verify-spelling.sh passes.

/sig contributor-experience
/area community-management
