### PR TITLE
Add SaranBalaji90 to Security Response Committee emeritus_leads

### DIFF
--- a/committee-security-response/README.md
+++ b/committee-security-response/README.md
@@ -26,6 +26,7 @@ The Kubernetes Security Response Committee is the body that is responsible for r
 
 ## Emeritus Members
 
+* Sri Saran Balaji (**[@SaranBalaji90](https://github.com/SaranBalaji90)**)
 * Craig Ingram (**[@cji](https://github.com/cji)**)
 * Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**)
 * Rita Zhang (**[@ritazh](https://github.com/ritazh)**)

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -4066,6 +4066,8 @@ committees:
           company: Google
           email: vinayakankugoyal@gmail.com
       emeritus_leads:
+        - github: SaranBalaji90
+          name: Sri Saran Balaji
         - github: cji
           name: Craig Ingram
         - github: lukehinds


### PR DESCRIPTION
## Summary

- Add @SaranBalaji90 to the Security Response Committee `emeritus_leads` in sigs.yaml.

This was part of the offboarding in January 2026 (kubernetes/committee-security-response@f01aec4) but the sigs.yaml update was missed. The emeritus.md in the committee repo already lists the entry.

## References

- Emeritus listing: https://github.com/kubernetes/committee-security-response/blob/main/emeritus.md
- Offboarding commit: https://github.com/kubernetes/committee-security-response/commit/f01aec4055bd7ae001929b70ae434c738570ad62
- Offboarding process doc (lists sigs.yaml as a required step): https://github.com/kubernetes/committee-security-response/blob/main/src-onboarding-offboarding.md

/sig security-response
/area community-management