### PR TITLE
docs: remove stale NCO Google Calendar TEMPLATE links

### DIFF
--- a/mentoring/new-contributor-orientation/README.md
+++ b/mentoring/new-contributor-orientation/README.md
@@ -21,13 +21,14 @@ NCO Meetings are held in *two sessions* on the *third Tuesday of every month*. E
 
 Typically, the timings for the two monthly sessions are as follows:
 
-* [**EMEA/APAC-friendly**: 1:30 PT / 8:30 UTC / 10:30 CET / 14:00 IST](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NXVpdGhoMWRyMGhpMDZjdWxqYzhwajloYXVfMjAyNDA5MTdUMDgzMDAwWiBjOGJhZmVmMDRzMTJyYTBna3FxbDZmY2hqY0Bn&tmsrc=c8bafef04s12ra0gkqql6fchjc%40group.calendar.google.com&scp=ALL)
-* [**AMER-friendly**: 8:30 PT / 15:30 UTC / 17:30 CET / 21:00 IST](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MnZqMXVmazZhNWJ2aTNldmE3Y2FvYnRkZTBfMjAyNDA5MTdUMTUzMDAwWiBjOGJhZmVmMDRzMTJyYTBna3FxbDZmY2hqY0Bn&tmsrc=c8bafef04s12ra0gkqql6fchjc%40group.calendar.google.com&scp=ALL)
+* **EMEA/APAC-friendly**: 1:30 PT / 8:30 UTC / 10:30 CET / 14:00 IST
+* **AMER-friendly**: 8:30 PT / 15:30 UTC / 17:30 CET / 21:00 IST
+
 **Note:** Due to Daylight Saving Time (DST), IST timings may shift.
 EMEA sessions align with CET, and AMER sessions align with PT.
 Please check the [community calendar](https://www.kubernetes.dev/resources/calendar/) for the most accurate time in your timezone.
 
-Joining the [SIG-ContribEx mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-contribex) will typically add invites for the NCO meetings, and all other SIG ContribEx meetings, to your calendar. You may also add the meetings to your calendar using the links below, or by finding them on [k8s.dev/calendar](https://k8s.dev/calendar)
+Joining the [SIG-ContribEx mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-contribex) will typically add invites for the NCO meetings, and all other SIG ContribEx meetings, to your calendar. You may also find confirmed sessions on [k8s.dev/calendar](https://k8s.dev/calendar).
 
 As with all meetings in the Kubernetes community, NCO meetings follow the [Kubernetes Community Code of Conduct](https://kubernetes.io/community/code-of-conduct/).
 


### PR DESCRIPTION
## Summary
- Remove Sep 2024 Google Calendar `TEMPLATE` links from the New Contributor Orientation README.
- Keep typical EMEA/AMER timing text and point people at the live community calendar (`k8s.dev/calendar` / kubernetes.dev calendar) for confirmed sessions.

Companion to https://github.com/kubernetes/contributor-site/pull/782 — orientation `_index.md` on the contributor site is synced from this file via `gen-content`.

## Test plan
- [ ] Confirm Meetings section no longer links to `calendar.google.com/...TEMPLATE...20240917`
- [ ] Confirm typical session times and calendar/mailing-list guidance remain readable
- [ ] After merge + contributor-site content sync, orientation page no longer shows stale TEMPLATE hrefs below the live NCO card