### PR TITLE
Add cluster-api-kubeswift Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -77,6 +77,7 @@ channels:
   - name: cluster-api-ionoscloud
   - name: cluster-api-k3s
   - name: cluster-api-kubemark
+  - name: cluster-api-kubeswift
   - name: cluster-api-kubevirt
   - name: cluster-api-nested
   - name: cluster-api-nutanix


### PR DESCRIPTION
Channel for the cluster-api-provider-kubeswift (CAPKS) subproject, a Cluster API infrastructure provider. It was added to the clusterctl built-in provider list and the provider docs in kubernetes-sigs/cluster-api#13946 and #13947.

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A
Fixes # N/A
