### PR TITLE
Add @release-comms Slack usergroup (Part A)

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -108,3 +108,17 @@ usergroups:
       - tabbysable # Product Security Committee
       - xmudrii # Release Manager
       - Verolop # subproject owner / Release Manager
+  - name: release-comms
+    long_name: Release Communications
+    description: >-
+      Release Communications team for the current Kubernetes release cycle.
+      Members are updated each cycle by the Comms Lead.
+      Has access to the slack-post-message bot for broadcasting to SIG channels.
+    channels:
+      - release-comms
+      - sig-release
+    members:
+      - SwathiR03
+      - dipesh-rawat
+      - fsmunzo
+


### PR DESCRIPTION
Adds the release-comms usergroup definition per #9042 Phase 1.

 - Added @release-comms entry to sig-release/usergroups.yaml
 - Verified standing members exist in users.yaml