### PR TITLE
Add #kubeaid Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -288,6 +288,7 @@ channels:
   - name: kube-vip
   - name: kubeadm
   - name: kubeadm-cn
+  - name: kubeaid
   - name: kubeapps
   - name: kubearchive
   - name: kubebuilder


### PR DESCRIPTION
## New Channel: #kubeaid

**Purpose:** Support and discussion for KubeAid  questions, setup help, and dev discussion.

**What is KubeAid?**
KubeAid is a GitOps-based platform for deploying and running production
Kubernetes clusters, managed end-to-end through ArgoCD. It handles
infrastructure provisioning, monitoring, security, networking, and storage
as one stack instead of stitching tools together yourself.

- Runs on AWS, Azure, Hetzner (cloud + bare metal), and on-prem bare metal via Cluster API
- 180+ Helm charts, auto-updated weekly
- Monitoring built on kube-prometheus
- Access management through Netbird
- Built with ISO 27001:2022, GDPR, and NIS2 compliance in mind

**Project:** https://github.com/Obmondo/KubeAid
**Website:** https://kubeaid.io
**License:** AGPL-3.0

Channel will cover setup/config questions from users and dev discussion for contributors.