### PR TITLE
Add github status channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -159,6 +159,7 @@ channels:
   - name: github
     archived: true
   - name: github-management
+  - name: github-status
   - name: gitkube
   - name: gitops
   - name: gke


### PR DESCRIPTION
The status updates were too noisy in the main channel; creating a dedicated channel for them.

cc @cblecker 