### PR TITLE
Add #openperouter slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -425,6 +425,7 @@ channels:
   - name: openebs
   - name: openebs-dev
   - name: openkruise
+  - name: openperouter
   - name: openshift-dev
     archived: true
   - name: openshift-users


### PR DESCRIPTION
This PR requests a new #openperouter public Slack channel.

OpenPERouter is an open implementation of a Provider Edge (PE) router, designed to terminate multiple VPN protocols on Kubernetes nodes and expose a BGP interface to the host network.

The project is opensource and licensed under Apache 2.0 license.
We'd like to have a channel to interact with users for supporting them and gathering requests, and also to coordinate the development across the contributors in an open and neutral venue.

Resources:

    Website: https://openperouter.github.io
    Repository: https://github.com/openperouter/openperouter/