### PR TITLE
Update nomination-template in documentation dir with 2026 version

### DIFF
--- a/elections/steering/documentation/template/nomination-template.md
+++ b/elections/steering/documentation/template/nomination-template.md
@@ -2,8 +2,8 @@
 name: 
 ID: GitHubID
 info:
-  - employer: Your Employer or "Independent"
-  - slack: slack handle
+  employer: Your Employer or "Independent"
+  slack: slack handle
 -------------------------------------------------------------
 
 <!-- Please make a copy of this template as "candidate-githubid.md" and save it to


### PR DESCRIPTION
This PR updates \documentation\nomination-template.md with the 2026\nomination-template.md with removing bullets in the header otherwise the bullets fails a check
