### PR TITLE
Add kueue release management channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -635,3 +635,4 @@ channels:
   - name: zarf-dev
     archived: true
   - name: krkn
+  - name: kueue-release-management

--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -338,6 +338,7 @@ channels:
   - name: kubewarden-dev
   - name: kubicorn
   - name: kudo
+  - name: kueue-release-management
   - name: kurl
   - name: kustomize
   - name: kwok
@@ -635,4 +636,3 @@ channels:
   - name: zarf-dev
     archived: true
   - name: krkn
-  - name: kueue-release-management


### PR DESCRIPTION
Related issue: https://github.com/kubernetes/community/issues/9110

Adds a new channel to coordinate kueue release efforts within the kueue release team.
