### PR TITLE
Update candidate bios format

### DIFF
--- a/elections/steering/2026/candidate-elmiko.md
+++ b/elections/steering/2026/candidate-elmiko.md
@@ -2,8 +2,8 @@
 name: Michael McCune
 ID: elmiko
 info:
-  employer: Red Hat
-  slack: elmiko
+  - employer: Red Hat
+  - slack: elmiko
 -------------------------------------------------------------
 
 ## SIGS

--- a/elections/steering/2026/candidate-jackfrancis.md
+++ b/elections/steering/2026/candidate-jackfrancis.md
@@ -2,8 +2,8 @@
 name: Jack Francis
 ID: jackfrancis
 info:
-  employer: Microsoft
-  slack: jackfrancis
+  - employer: Microsoft
+  - slack: jackfrancis
 -------------------------------------------------------------
 
 ## SIGS

--- a/elections/steering/2026/candidate-janetkuo.md
+++ b/elections/steering/2026/candidate-janetkuo.md
@@ -2,8 +2,8 @@
 name: Janet Kuo
 ID: janetkuo
 info:
-  employer: Google
-  slack: janetkuo
+  - employer: Google
+  - slack: janetkuo
 -------------------------------------------------------------
 
 ## SIGS

--- a/elections/steering/2026/candidate-kaslin.md
+++ b/elections/steering/2026/candidate-kaslin.md
@@ -2,8 +2,8 @@
 name: Kaslin Fields
 ID: kaslin
 info:
-  employer: Google
-  slack: kaslin
+  - employer: Google
+  - slack: kaslin
 -------------------------------------------------------------
 
 ## SIGS

--- a/elections/steering/2026/candidate-priyankasaggu11929.md
+++ b/elections/steering/2026/candidate-priyankasaggu11929.md
@@ -2,8 +2,8 @@
 name: Priyanka Saggu
 ID: priyankasaggu11929
 info:
-  employer: SUSE
-  slack: psaggu
+  - employer: SUSE
+  - slack: psaggu
 -------------------------------------------------------------
 
 ## SIGS

--- a/elections/steering/2026/candidate-stmcginnis.md
+++ b/elections/steering/2026/candidate-stmcginnis.md
@@ -2,8 +2,8 @@
 name: Sean McGinnis
 ID: stmcginnis
 info:
-  employer: Lambda
-  slack: Sean McGinnis
+  - employer: Lambda
+  - slack: Sean McGinnis
 -------------------------------------------------------------
 
 ## SIGS

--- a/hack/verify-steering-election-tool.go
+++ b/hack/verify-steering-election-tool.go
@@ -33,6 +33,8 @@ const (
 	startYear            = 2026
 )
 
+var yamlHeaderRegex = regexp.MustCompile(`(?s)^-{61}\s*\n(.*?)\n-{61}\s*\n`)
+
 type ValidationError struct {
 	File    string
 	Message string
@@ -44,11 +46,40 @@ type CandidateHeader struct {
 	Info InfoData `yaml:"info"`
 }
 
-type InfoData struct {
-	Employer string `yaml:"employer"`
-	Slack    string `yaml:"slack"`
+type ElectionConfig struct {
+	ShowCandidateFields []string `yaml:"show_candidate_fields"`
 }
 
+// TODO: Have Elekto accept both mapping and sequence forms for candidate info
+// so compatibility is enforced at the application boundary as well as here.
+type InfoData map[string]string
+
+func (i *InfoData) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.MappingNode:
+		var info map[string]string
+		if err := value.Decode(&info); err != nil {
+			return err
+		}
+		*i = InfoData(info)
+		return nil
+	case yaml.SequenceNode:
+		var entries []map[string]string
+		if err := value.Decode(&entries); err != nil {
+			return err
+		}
+		info := make(InfoData)
+		for _, entry := range entries {
+			for field, fieldValue := range entry {
+				info[field] = fieldValue
+			}
+		}
+		*i = info
+		return nil
+	default:
+		return fmt.Errorf("info must be a mapping or sequence")
+	}
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -89,8 +120,17 @@ func main() {
 			})
 		}
 
+		candidateFields, err := loadShowCandidateFields(bioFile)
+		if err != nil {
+			errors = append(errors, ValidationError{
+				File:    bioFile,
+				Message: err.Error(),
+			})
+			continue
+		}
+
 		// Check template compliance
-		if err := validateTemplateCompliance(bioFile); err != nil {
+		if err := validateTemplateCompliance(bioFile, candidateFields); err != nil {
 			errors = append(errors, ValidationError{
 				File:    bioFile,
 				Message: err.Error(),
@@ -111,6 +151,21 @@ func main() {
 		fmt.Printf("%s\n", separator)
 		os.Exit(1)
 	}
+}
+
+func loadShowCandidateFields(filename string) ([]string, error) {
+	electionPath := filepath.Join(filepath.Dir(filename), "election.yaml")
+	content, err := os.ReadFile(electionPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading election configuration: %v", err)
+	}
+
+	var config ElectionConfig
+	if err := yaml.Unmarshal(content, &config); err != nil {
+		return nil, fmt.Errorf("error parsing election configuration: %v", err)
+	}
+
+	return config.ShowCandidateFields, nil
 }
 
 // findBioFiles finds all steering committee candidate bio files from 2025 forward
@@ -165,6 +220,8 @@ func countWords(filename string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	content = yamlHeaderRegex.ReplaceAll(content, nil)
 
 	// Split by whitespace and count non-empty strings
 	words := regexp.MustCompile(`\s+`).Split(string(content), -1)
@@ -230,7 +287,7 @@ func validateFileNameAndGitHubID(filename string) error {
 }
 
 // validateTemplateCompliance checks if the bio follows the required template structure
-func validateTemplateCompliance(filename string) error {
+func validateTemplateCompliance(filename string, candidateFields []string) error {
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("error reading file: %v", err)
@@ -257,11 +314,10 @@ func validateTemplateCompliance(filename string) error {
 	if header.ID == "" {
 		return fmt.Errorf("missing required field: ID")
 	}
-	if header.Info.Employer == "" {
-		return fmt.Errorf("missing required field: info.employer")
-	}
-	if header.Info.Slack == "" {
-		return fmt.Errorf("missing required field: info.slack")
+	for _, field := range candidateFields {
+		if header.Info[field] == "" {
+			return fmt.Errorf("missing required field: info.%s", field)
+		}
 	}
 
 	// Check for required sections
@@ -292,8 +348,7 @@ func validateTemplateCompliance(filename string) error {
 // The format requires exactly 61 dashes for consistency
 func extractYAMLHeader(content string) (string, error) {
 	// Find the YAML header between exactly 61 dashes
-	dashRegex := regexp.MustCompile(`(?s)^-{61}\s*\n(.*?)\n-{61}\s*\n`)
-	matches := dashRegex.FindStringSubmatch(content)
+	matches := yamlHeaderRegex.FindStringSubmatch(content)
 	if len(matches) != 2 {
 		return "", fmt.Errorf("could not find YAML header between dashes")
 	}

--- a/hack/verify-steering-election-tool_test.go
+++ b/hack/verify-steering-election-tool_test.go
@@ -121,6 +121,18 @@ func TestCountWords(t *testing.T) {
 			content: "Hello, world! This is a test.",
 			want:    6,
 		},
+		{
+			name: "YAML header is excluded",
+			content: strings.Repeat("-", 61) + "\n" +
+				"name: Test User\n" +
+				"ID: testuser\n" +
+				"info:\n" +
+				"  - employer: Test Corp\n" +
+				"  - slack: '@testuser'\n" +
+				strings.Repeat("-", 61) + "\n" +
+				"Biography has four words.\n",
+			want: 4,
+		},
 	}
 
 	for _, tt := range tests {
@@ -236,6 +248,7 @@ func TestValidateFileNameAndGitHubID(t *testing.T) {
 }
 
 func TestValidateTemplateCompliance(t *testing.T) {
+	candidateFields := []string{"employer", "slack"}
 	validContent := strings.Repeat("-", 61) + "\n" +
 		"name: Test User\n" +
 		"ID: testuser\n" +
@@ -253,15 +266,52 @@ func TestValidateTemplateCompliance(t *testing.T) {
 		"Links and info\n"
 
 	tests := []struct {
-		name        string
-		content     string
-		wantErr     bool
-		errContains string
+		name            string
+		content         string
+		candidateFields []string
+		wantErr         bool
+		errContains     string
 	}{
 		{
 			name:    "valid template compliance",
 			content: validContent,
 			wantErr: false,
+		},
+		{
+			name: "valid template compliance with list info",
+			content: strings.Repeat("-", 61) + "\n" +
+				"name: Test User\n" +
+				"ID: testuser\n" +
+				"info:\n" +
+				"  - employer: Test Corp\n" +
+				"  - slack: '@testuser'\n" +
+				strings.Repeat("-", 61) + "\n" +
+				"## What I have done\n## What I'll do\n## SIGS\n## Resources About Me\n",
+			wantErr: false,
+		},
+		{
+			name: "valid configurable candidate fields",
+			content: strings.Repeat("-", 61) + "\n" +
+				"name: Test User\n" +
+				"ID: testuser\n" +
+				"info:\n" +
+				"  organization: Test Foundation\n" +
+				"  matrix: '@testuser:example.org'\n" +
+				strings.Repeat("-", 61) + "\n" +
+				"## What I have done\n## What I'll do\n## SIGS\n## Resources About Me\n",
+			candidateFields: []string{"organization", "matrix"},
+			wantErr:         false,
+		},
+		{
+			name: "invalid info type",
+			content: strings.Repeat("-", 61) + "\n" +
+				"name: Test User\n" +
+				"ID: testuser\n" +
+				"info: invalid\n" +
+				strings.Repeat("-", 61) + "\n" +
+				"## What I have done\n## What I'll do\n## SIGS\n## Resources About Me\n",
+			wantErr:     true,
+			errContains: "info must be a mapping or sequence",
 		},
 		{
 			name: "missing required field - name",
@@ -300,6 +350,18 @@ func TestValidateTemplateCompliance(t *testing.T) {
 				"## What I have done\n## What I'll do\n## SIGs\n## Resources About Me\n",
 			wantErr: false,
 		},
+		{
+			name: "missing configured candidate field",
+			content: strings.Repeat("-", 61) + "\n" +
+				"name: Test User\n" +
+				"ID: testuser\n" +
+				"info:\n" +
+				"  employer: Test Corp\n" +
+				strings.Repeat("-", 61) + "\n" +
+				"## What I have done\n## What I'll do\n## SIGS\n## Resources About Me\n",
+			wantErr:     true,
+			errContains: "missing required field: info.slack",
+		},
 	}
 
 	for _, tt := range tests {
@@ -315,7 +377,11 @@ func TestValidateTemplateCompliance(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = validateTemplateCompliance(tmpfile.Name())
+			fields := tt.candidateFields
+			if fields == nil {
+				fields = candidateFields
+			}
+			err = validateTemplateCompliance(tmpfile.Name(), fields)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateTemplateCompliance() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -324,6 +390,35 @@ func TestValidateTemplateCompliance(t *testing.T) {
 				t.Errorf("validateTemplateCompliance() error = %v, should contain %q", err, tt.errContains)
 			}
 		})
+	}
+}
+
+func TestLoadShowCandidateFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	bioPath := filepath.Join(tmpDir, "candidate-testuser.md")
+	if err := os.WriteFile(bioPath, []byte("candidate"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(tmpDir, "election.yaml"),
+		[]byte("show_candidate_fields:\n  - organization\n  - matrix\n"),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	fields, err := loadShowCandidateFields(bioPath)
+	if err != nil {
+		t.Fatalf("loadShowCandidateFields() error = %v", err)
+	}
+	want := []string{"organization", "matrix"}
+	if len(fields) != len(want) {
+		t.Fatalf("loadShowCandidateFields() = %v, want %v", fields, want)
+	}
+	for index := range want {
+		if fields[index] != want[index] {
+			t.Errorf("loadShowCandidateFields() = %v, want %v", fields, want)
+		}
 	}
 }
 
@@ -344,14 +439,14 @@ func TestFindBioFiles(t *testing.T) {
 	// Create test files
 	currentYear := time.Now().Year()
 	testFiles := []struct {
-		path      string
+		path       string
 		shouldFind bool
 	}{
-		{filepath.Join(steeringDir, "2025", "candidate-user1.md"), false}, // Before startYear (2026)
-		{filepath.Join(steeringDir, "2026", "candidate-user2.md"), true},  // At startYear
-		{filepath.Join(steeringDir, fmt.Sprintf("%d", currentYear+1), "candidate-user3.md"), true}, // Future year
-		{filepath.Join(steeringDir, "2026", "not-candidate.md"), false},     // Wrong filename format
-		{filepath.Join(steeringDir, "2026", "candidate-user4.txt"), false},  // Wrong extension
+		{filepath.Join(steeringDir, "2025", "candidate-user1.md"), false},                            // Before startYear (2026)
+		{filepath.Join(steeringDir, "2026", "candidate-user2.md"), true},                             // At startYear
+		{filepath.Join(steeringDir, fmt.Sprintf("%d", currentYear+1), "candidate-user3.md"), true},   // Future year
+		{filepath.Join(steeringDir, "2026", "not-candidate.md"), false},                              // Wrong filename format
+		{filepath.Join(steeringDir, "2026", "candidate-user4.txt"), false},                           // Wrong extension
 		{filepath.Join(steeringDir, fmt.Sprintf("%d", currentYear+10), "candidate-user5.md"), false}, // Too far in future
 	}
 


### PR DESCRIPTION
Updates the 2026 candidate bios to use the format expected by Elekto.

The Steering election validator runs as part of `pull-community-verify`, so this also updates the presubmit to:

- accept both mapping and sequence forms for candidate metadata
- load required fields from each election’s `show_candidate_fields`
- count biography text separately from YAML metadata
- cover configurable fields and invalid metadata in tests

TODO: Have Elekto accept both mapping and sequence forms for candidate info so compatibility is enforced at the application boundary as well as in presubmit.