### PR TITLE
Update candidate bio length

### DIFF
--- a/elections/steering/2026/candidate-priyankasaggu11929.md
+++ b/elections/steering/2026/candidate-priyankasaggu11929.md
@@ -16,7 +16,7 @@ info:
 
 ## What I have done
 
-I began my open source journey in 2018 with [DGPLUG](https://dgplug.org/) summer training, a program run over IRC, designed for people in areas with limited internet connectivity. I learnt from sessions conducted by maintainers from many important open source projects (like PSF, Debian, Fedora, Ansible, Tor Project, and others) which would have been almost impossible for us otherwise. It *is* the foundation of my open source ethos.
+I began contributing in 2018 with [DGPLUG](https://dgplug.org/) summer training, a program run over IRC, designed for people in areas with limited internet connectivity. I learnt from sessions conducted by maintainers from many important open source projects (like PSF, Debian, Fedora, Ansible, Tor Project, and others) which would have been almost impossible for us otherwise. It *is* the foundation of my open source ethos.
 
 I'm a contributor to the Kubernetes project since 2020, starting with the Python-Client.
 


### PR DESCRIPTION
Brings a 2026 candidate bio within the word limit.

Saw this issue on a previous run: https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/community/9116/pull-community-verify/2087966244337618944/build-log.txt on https://github.com/kubernetes/community/pull/9116
```
Verifying verify-steering-election.sh
elections/steering/2026/candidate-priyankasaggu11929.md: has 452 words

1 invalid Steering Committee election bio(s) detected.
Bios should be limited to around 300 words, excluding headers.
```

I think the issue is the validator’s [countWords() implementation](https://github.com/kubernetes/community/blob/383c114acd9c6474ddc02d4b88672d89c2f358b0/hack/verify-steering-election-tool.go#L191-L207) counted the entire file and that includes the new `-` metadata as words. 