### PR TITLE
[Steering Election 2026] Update 2026 steering election voter eligibility and links

### DIFF
--- a/elections/steering/2026/README.md
+++ b/elections/steering/2026/README.md
@@ -69,10 +69,11 @@ Eligibility for voting in 2026 is defined as:
 * People who had at least 50 contributions to the Kubernetes project over
   the past year, according to a snapshot taken 2026-06-14 of the data driving
   the [devstats developer activity counts dashboard][devstats-dashboard],
-  who are also [Org Members].
+  who are also [Org Members]. 
   Contributions include GitHub events like creating issues, creating PRs,
   reviewing PRs, commenting on issues, etc. For full details see
   [the SQL query used by devstats for developer activity counts][devstats-sql].
+  **Eligibility update:** GitHub contributions weren't accurately tracked for the first four months of 2026, the [Steering Committee voted](https://github.com/kubernetes/steering/issues/314) to make all [Org Members] eligible to vote for the 2026 Steering Committee election.
 
 * Full members of the Code of Conduct Committee (CoCC) and Security Response Committee
   (SRC), as listed in [SIGs.yaml], at any time between August 2024 and August 2026,

--- a/elections/steering/2026/election.yaml
+++ b/elections/steering/2026/election.yaml
@@ -14,7 +14,7 @@ election_officers:
   - npolshakova
   - reylejano
   - sreeram-venkitesh
-eligibility: Kubernetes Org members with 50 or more contributions in the last year can vote.  See [the election guide](https://github.com/kubernetes/community/tree/master/elections/steering/2026)
-exception_description: Not all contributions are measured by DevStats.  If you have contributions that are not so measured, then please request an exception to allow you to vote via the Elekto application.
+eligibility: Kubernetes Org members can vote.  See [the election guide](https://github.com/kubernetes/community/tree/main/elections/steering/2026)
+exception_description: If you should be eligible, but are not, then please request an exception to allow you to vote via the Elekto application.
 # End of day Anywhere on Earth for closing. Write 2023-09-23 as: 2023-09-24 11:59:59
 exception_due: 2026-09-30 11:59:59

--- a/elections/steering/2026/election_desc.md
+++ b/elections/steering/2026/election_desc.md
@@ -1,11 +1,11 @@
 # Vote for the 2026 Steering Committee
 
-As is now customary, the third calendar quarter is [Steering Committee](https://github.com/kubernetes/steering) election season for Kubernetes. Four (4) elected members (@katcosgrove, @pacoxu, @ritazh, @soltysh) will stay on for the remaining year of their terms, and there will be three (3) positions open for election. Every election term will be 2 years. More complete information on the election may be found [in the voter's guide](https://github.com/kubernetes/community/tree/master/elections/steering/2026).
+As is now customary, the third calendar quarter is [Steering Committee](https://github.com/kubernetes/steering) election season for Kubernetes. Four (4) elected members (@katcosgrove, @pacoxu, @ritazh, @soltysh) will stay on for the remaining year of their terms, and there will be three (3) positions open for election. Every election term will be 2 years. More complete information on the election may be found [in the voter's guide](https://github.com/kubernetes/community/tree/main/elections/steering/2026).
 
 Instructions on using Elekto can be found [in its docs site](https://elekto.dev/docs/voting/).
 
 If you’d like to vote or run for a seat, all details and next steps are outlined in the [election process doc](https://git.k8s.io/steering/elections.md) and this application. The application will be the single source of truth of information for this cycle. It will be updated live as new bios of candidates get committed.
 
-Please pay attention to the [scheduled dates](https://github.com/kubernetes/community/tree/master/elections/steering/2026#schedule).
+Please pay attention to the [scheduled dates](https://github.com/kubernetes/community/tree/main/elections/steering/2026#schedule).
 
-Eligibility for voting will be determined by 50 contributions to a Kubernetes project over the past year and [Kubernetes Org membership](https://github.com/kubernetes/community/blob/master/community-membership.md).  Eligible voters will be shown as such by this site when logged in.  If you should be eligible, but are not, you may also [file for an exception](https://elections.k8s.io/app/elections/steering---2026/exception).
+Eligibility for voting will be determined by [Kubernetes Org membership](https://github.com/kubernetes/community/blob/main/community-membership.md).  Eligible voters will be shown as such by this site when logged in.  If you should be eligible, but are not, you may also [file for an exception](https://elections.k8s.io/app/elections/steering---2026/exception).


### PR DESCRIPTION
This PR updates voter eligibility in the 2026 steering election dir and in elekto for the 2026 steering election.
GitHub contributions weren't accurately tracked for the first four months of 2026, the Steering Committee [voted](https://github.com/kubernetes/steering/issues/314) to make all Kubernetes org members eligible to vote this cycle.
This PR updates voter eligibility from at least 50 contributions + Kubernetes org membership to org membership.
This PR also updates links from the `master` branch to `main` branch in github links

/assign @npolshakova @sreeram-venkitesh 