### PR TITLE
Revert Steering Election nomination templates to use bulleted list

### DIFF
--- a/elections/steering/2026/nomination-template.md
+++ b/elections/steering/2026/nomination-template.md
@@ -2,8 +2,8 @@
 name: 
 ID: GitHubID
 info:
-  employer: Your Employer or "Independent"
-  slack: slack handle
+  - employer: Your Employer or "Independent"
+  - slack: slack handle
 -------------------------------------------------------------
 
 <!-- Please make a copy of this template as "candidate-githubid.md" and save it to

--- a/elections/steering/documentation/template/nomination-template.md
+++ b/elections/steering/documentation/template/nomination-template.md
@@ -2,8 +2,8 @@
 name: 
 ID: GitHubID
 info:
-  employer: Your Employer or "Independent"
-  slack: slack handle
+  - employer: Your Employer or "Independent"
+  - slack: slack handle
 -------------------------------------------------------------
 
 <!-- Please make a copy of this template as "candidate-githubid.md" and save it to


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/community/pull/9116, specifically https://github.com/kubernetes/community/pull/9116#discussion_r3778384548

The nomination template for 2026 was changed from (- employer: / - slack:) to ( employer: / slack:) but this broke links to candidate bio's in Elekto but passed checks while the (- employer: / - slack:) failed checks.

PR https://github.com/kubernetes/community/pull/9116 updated the nomination templates to use (- employer: / - slack:) and updated the checks so they pass

/assign @npolshakova @sreeram-venkitesh 