### PR TITLE
Add #kube-vm-operator Slack channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -287,6 +287,7 @@ channels:
   - name: kube-spawn
   - name: kube-state-metrics
   - name: kube-vip
+  - name: kube-vm-operator
   - name: kubeadm
   - name: kubeadm-cn
   - name: kubeaid


### PR DESCRIPTION
This PR requests addition of a new channel: #kube-vm-operator.

VM Operator is an open source project that allows for declarative management of virtual machines using Kubernetes APIs.

The project defines a set of APIs to manage virtual machines and surrounding infrastructures (e.g., hardware classes, images) and a set of controllers to reconcile them.

Repository: https://github.com/vmware-tanzu/vm-operator/
Website: https://vm-operator.rtfd.io/

