### PR TITLE
Update gophercloud maintainers

### DIFF
--- a/communication/slack-config/usergroups.yaml
+++ b/communication/slack-config/usergroups.yaml
@@ -342,10 +342,11 @@ usergroups:
     channels:
       - gophercloud
     members:
-      - EmilienM
       - kayrus
       - mandre
-      - pierreprinetti
+      - Sharpz7
+      - stephenfin
+      - winiciusallan
 
   - name: kubetail-maintainers
     long_name: kubetail Maintainers

--- a/communication/slack-config/users.yaml
+++ b/communication/slack-config/users.yaml
@@ -281,6 +281,7 @@ users:
   sethmccombs: U92LLUZ8A
   sgtcodfish: U01PQ8N3PM1
   shamus: US7EUUBK8
+  Sharpz7: U04LFLVUKDF
   shecodesmagic: U0592U4JQA3
   shipra101: U06MJ9TT031
   shubham-pampattiwar: U01QW84HBBN
@@ -291,6 +292,7 @@ users:
   soltysh: U0B4CS1GF
   sreeram-venkitesh: U03RJ6L977C
   ssuriyan7: U01F68C7VGD
+  stephenfin: U02CF35U0AU
   stevekuznetsov: U0DUKNE6B
   stlaz: UEP3FE65R
   sttts: U0A2VFE8J
@@ -338,6 +340,7 @@ users:
   whtssub: U01Q16YA35J
   willie-yao: U024EME7SQK
   wilsonehusin: U0100068GF2
+  winiciusallan: U082QVDPKJN
   wurbanski: URX7CMK97
   Xander: UDHV1RXB2
   xmudrii: U4Q2TNGVD


### PR DESCRIPTION
Update the gophercloud-maintainers group membership:
- stephenfin is a long time maintainer, but for some reason was never added to the group alias
- Sharpz7 and winiciusallan are new maintainers [1]

Also drop inactive maintainers EmilienM and pierreprinetti.

[1] https://kubernetes.slack.com/archives/C05G4NJ6P6X/p1786612126194249
