### PR TITLE
[Steering Election 2026] Update voters.yaml with voters canonical github logins for case sensitivity

### DIFF
--- a/elections/steering/2026/voters.yaml
+++ b/elections/steering/2026/voters.yaml
@@ -17,6 +17,7 @@
 # 2026-08-11 - Add voters from approved exception requests
 # 2026-08-12 - Add Kubernetes org members (kubernetes, kubernetes-sigs, kubernetes-client, kubernetes-csi, etcd) as eligible voters as a followup to https://github.com/kubernetes/steering/issues/314
 # 2026-08-14 - Update serenity611 to Serenity611
+# 2026-08-26 - Update anupamghosh to AnupamGhosh, jeffwan to Jeffwan, TommyStarK to TommyStar
 #
 eligible_voters:
 - 08volt
@@ -120,7 +121,7 @@ eligible_voters:
 - anson627
 - ant31
 - antoooks
-- anupamghosh
+- AnupamGhosh
 - anusha94
 - anyulled
 - aoi1
@@ -617,7 +618,7 @@ eligible_voters:
 - JeffLuoo
 - Jefftree
 - jefftrojan
-- jeffwan
+- Jeffwan
 - jenshu
 - JeremyOT
 - jeremyrickard
@@ -1354,7 +1355,7 @@ eligible_voters:
 - tomasaschan
 - tomergee
 - TomerNewman
-- TommyStarK
+- TommyStark
 - tomplus
 - tomsen02
 - Tomy2e


### PR DESCRIPTION
Update voters.yaml for the 2026 Steering election with the following:
- anupamghosh to AnupamGhosh, confirmed with https://api.github.com/users/anupamghosh
-  jeffwan to Jeffwan, confirmed with https://api.github.com/users/jeffwan
-  TommyStarK to TommyStark, confirmed with https://api.github.com/users/TommyStarK

/assign @npolshakova @sreeram-venkitesh