### PR TITLE
[Slack] Add new channel for organizing k8s presence at Kubecon

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -228,6 +228,7 @@ channels:
   - name: k8s-dual-stack
     archived: true
   - name: k8s-image-swapper
+  - name: k8s-kubecon-planning
   # k8s-infra-alerts is defined in sig-k8s-infra/
   - name: k8s-release
     archived: true


### PR DESCRIPTION
This adds a new channel, `#k8s-kubecon-planning`, for people who currently work on the Kubernetes presence at Kubecons.

In the past, we used `#summit-staff`, but that channel name is no longer apt, and has a huge legacy base of members who are no longer involved with Kubernetes' in-person activities at Kubecons.  As such, the KCNA presence organizers would like to start a new channel which can be used for coordinating staffing.

If accepted, sometime later we will archive summit-staff.

@stmcginnis @nataliesea @reylejano 
