### PR TITLE
Rename #kube-bind Slack channel to #kbind-dev

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -235,6 +235,8 @@ channels:
   - name: k8spin
   - name: kamaji
   - name: kapitan
+  - name: kbind-dev
+    id: C046PRXNJ4W
   - name: kcp-dev
   - name: kcp-users
     id: C021U8WSAFK
@@ -276,7 +278,6 @@ channels:
   - name: kuadrant
   - name: kubara
   - name: kube-aws
-  - name: kube-bind
   - name: kube-burner
   - name: kube-deploy
     archived: true


### PR DESCRIPTION
Renames the existing #kube-bind channel to #kbind-dev, matching the project's rename from kube-bind to kbind. Includes the channel's Slack ID so this updates the existing channel instead of creating a new one. 
 
Fixes #9102

/cc @jberkus @mrbobbytables 