### PR TITLE
Fix typo: fsmunzo to fsmunoz in release-comms usergroup

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -120,5 +120,5 @@ usergroups:
     members:
       - SwathiR03
       - dipesh-rawat
-      - fsmunzo
+      - fsmunoz
 


### PR DESCRIPTION
fsmunzo in the release-comms usergroup does not resolve against users.yaml, causing Tempelis postsubmit reconciliation to fail. Since Tempelis validates the entire config atomically, this blocks all pending Slack config changes.

Introduced in #9083.

/cc @jberkus 