### PR TITLE
Fix release-comms usergroup description exceeding Slack 140 char limit

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -111,9 +111,8 @@ usergroups:
   - name: release-comms
     long_name: Release Communications
     description: >-
-      Release Communications team for the current Kubernetes release cycle.
-      Members are updated each cycle by the Comms Lead.
-      Has access to the slack-post-message bot for broadcasting to SIG channels.
+      Release Communications team for the current release cycle. Members
+      updated each cycle by the Comms Lead. Has slack-post-message bot access.
     channels:
       - release-comms
       - sig-release


### PR DESCRIPTION
## Fixes

Job: `post-community-tempelis-apply` (kubernetes/test-infra:
`config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-tempelis.yaml`)

Latest run, build
[`2093207476580126720`](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-community-tempelis-apply/2093207476580126720),
base sha `b0257f2e8` (the #9133 merge), 2026-08-28 05:22:15 UTC
([raw build log](https://storage.googleapis.com/kubernetes-ci-logs/logs/post-community-tempelis-apply/2093207476580126720/build-log.txt)):

```
2026/08/28 05:22:15 Step 2: Create usergroup release-comms (): name = "Release Communications", description = "Release Communications team for the current Kubernetes release cycle. Members are updated each cycle by the Comms Lead. Has access to the slack-post-message bot for broadcasting to SIG channels.", channels = [release-comms sig-release].
2026/08/28 05:22:15 Failed: failed to update usergroup Release Communications (): slack call failed: description_too_long ([]).
2026/08/28 05:22:15 Step 3: Set members of usergroup release-comms () to [U065E2S9C6P U02GLF28LNM U03DL8UAEMQ].
2026/08/28 05:22:15 Failed: couldn't find the ID for the group "release-comms".
```

Refs #9042, #9083, #9133

/sig contributor-experience
/sig release
/area slack-management
/cc @jberkus

