### PR TITLE
Add charter and proposal for WG Workload Conformance

### DIFF
--- a/wg-workload-conformance/charter.md
+++ b/wg-workload-conformance/charter.md
@@ -1,0 +1,80 @@
+# WG Kubernetes Workload Conformance Charter
+
+This charter adheres to the conventions described in the [Kubernetes Charter README] and uses the Roles and Organization Management outlined in [wg-governance].
+
+## Summary
+
+The working group defines an open, objectively verifiable standard for how a
+workload should behave at runtime on Kubernetes, and delivers the tooling that
+verifies it. The specification covers a workload's live runtime behavior - its
+security posture, operational resilience under disruption, resource footprint,
+networking, storage, API stability (both the core Kubernetes API and
+node-local APIs such as the kubelet API), and observability - defined per
+Kubernetes minor version. It covers how a workload runs, not what it does: the
+workload's own application logic is out of scope.
+
+The specification, the verification methodology, and the conformance tooling
+live in a subproject under SIG Apps from the outset. The working group
+doesn't own any code itself; it's the cross-SIG forum that steers the
+subproject's direction while it's still being defined. Once SIG Apps is
+happy with the state of the specification and tooling, SIG Architecture
+completes a thorough review, and SIG Architecture spins up a subproject to host
+it for the long term. If SIG Architecture does not reach that approval, SIG
+Apps decides whether to mothball or archive the working group and its
+artifacts. No certification program on top of the standard gets created
+until after SIG Architecture has approved the specification and tooling and
+converted it into a subproject; running that program is out of scope for
+this working group and is CNCF's concern.
+
+### Meetings
+
+The working group will meet every two weeks to discuss the
+specifications. Ideally, it would take 2-3 Kubernetes release cycles to reach
+stability. In case stability of specifications is reached earlier than that, the
+working group might decide to wrap even before.
+
+The regular meetings will follow all the same standard practices followed in the Kubernetes project.
+
+## In Scope
+
+- Define a workload.
+- Define the generic characteristic behavior of an workload when running on Kubernetes.
+- Define the specs to be tested for each workload against each Kubernetes
+ version.
+- Define the verification methodology for each behavior in the specification.
+- Deliver a conformance image that can be maintained by a subproject similar to the Kubernetes conformance image.
+
+## Out of Scope
+
+- Run any certification program. It is in scope of CNCF instead.
+- Define/test the internal business logic of any workload.
+- Prefer or mandate any workload packaging or delivery format (Helm,
+ Operators, installers, etc.).
+
+## Responsibilities of chairs/organizers
+
+- Run the meetings and guide the direction of the group
+- Ensure healthy agenda for each meeting.
+- Report progress to the sponsoring SIG chairs.
+
+## Disband Criteria
+
+- Initial set of specs are finalized, workload tests reach a stable state of
+ operation, and tests are packaged into conformance tooling via Hydrophone.
+- SIG Apps is happy with the state of the specs and the test suite.
+- SIG Architecture completes a thorough review and gives its final approval and
+ then spins up a subproject to host the specs and tooling for the long term.
+- If SIG Architecture does not reach that approval, SIG Apps decides whether
+ to mothball or archive the working group and its artifacts instead.
+
+Disbanding the working group this way is what opens the path to starting an
+official CNCF conformance program on top of the standard; that program
+cannot start before the working group reaches this point.
+
+### Stakeholder SIGs
+
+- SIG Apps
+- SIG Architecture
+
+[wg-governance]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/wg-governance.md
+[Kubernetes Charter README]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/README.md

--- a/wg-workload-conformance/proposal.md
+++ b/wg-workload-conformance/proposal.md
@@ -1,0 +1,252 @@
+# WG Workload Conformance - Creation Proposal
+
+
+This document is the creation proposal for a new Kubernetes Working Group,
+**WG Workload Conformance**. It answers the questions required by
+[wg-governance.md] and follows the checklist in [sig-wg-lifecycle.md]. The
+formal charter lives alongside this document in [charter.md].
+
+
+## Summary
+
+
+The Certified Kubernetes Conformance program standardizes and verifies the
+cluster infrastructure layer, but there is no shared community standard that
+verifies the operational behavior of the *workloads* running on top of it.
+Workloads routinely break on cluster upgrades because they depend on deprecated
+APIs, ship over-privileged security defaults, mis-size their resource requests,
+or fail to survive routine node drains. These are not exotic failures; they
+happen by default in the absence of a shared baseline, and every operator ends
+up re-auditing every workload across every environment.
+
+
+WG Workload Conformance is a time-boxed effort to define an open, objectively
+verifiable standard for how a well-behaved workload runs on Kubernetes, to
+deliver the tooling that verifies it. The specification covers a workload's live
+runtime behavior — its security posture, operational resilience under
+disruption, accurate resource footprint, storage portability, usage of stable
+APIs (both the core Kubernetes API and node-local APIs such as the kubelet
+API), and provide metrics endpoint — while explicitly excluding the
+correctness of the workload's own application logic.
+
+
+The Working Group defines the specification and the conformance tooling. It does
+**not** run any certification program; operating a certification program on top
+of this standard is CNCF's concern, not the Working Group's. The specification
+and tooling live in a SIG Apps subproject from the outset — the
+Working Group doesn't own any code itself, it's the time-boxed, cross-SIG
+forum that shapes the spec while the subproject is still being defined. Once
+SIG Apps is happy with the state of the specification and tooling, SIG
+Architecture completes a thorough review, and SIG Architecture spins up a
+subproject to host it for the long term. If SIG Architecture does not reach
+that approval, SIG Apps decides whether to mothball or archive the working
+group and its artifacts.
+
+Detailed proposal: https://docs.google.com/document/d/1BGc4xVcrpQDEDVdGbj5DAvce_VRCSz9zRvQ-5FIdzrM/comment?tab=t.0
+
+## Answers to the Working Group formation questions
+
+These are the questions from [wg-governance.md] that a creation proposal must
+answer.
+
+### 1. What is the exact problem this group is trying to solve?
+
+There is no shared, community-owned standard for how a workload should behave at
+runtime on Kubernetes, and no common tooling to verify that behavior. As a
+result:
+
+- Workloads break during cluster upgrades because they call deprecated or
+ removed APIs — not just the Kubernetes API surface, but node-local ones too,
+ as with dockershim, the cgroup v1 removal, or the kubelet's read-only port.
+- Workloads use insecure defaults — running as root, requesting excessive RBAC,
+ requiring host namespaces — expanding the attack surface for no reason.
+- Workloads are mis-sized: bloated requests force over-provisioning, missing
+ limits cause node-level OOM cascades.
+- Maintainers repeat the same validation and debugging across a wide matrix of
+ providers and delivery formats (Helm, Operators, node agents, installers).
+- Operators repeat per-workload audits that a shared baseline would make
+ unnecessary.
+
+The group's job is to turn "run like a good Kubernetes citizen" from tribal
+knowledge into an objective, versioned, verifiable specification.
+
+
+### 2. What is the artifact that this group will deliver, and to whom?
+
+The Working Group delivers three artifacts:
+
+1. **A Workload Conformance specification** — the set of verifiable behaviors a
+  workload must exhibit, classified MUST / SHOULD, defined per Kubernetes minor
+  version.
+2. **A behavior verification methodology** — how each behavior in the
+  specification is tested against a live workload.
+3. **Conformance tooling** — a conformance test suite / image (in the spirit of
+  the existing Kubernetes conformance image, e.g. runnable via Hydrophone) that
+  executes the methodology against a running workload.
+
+These live in a **SIG Apps** subproject from the outset; the Working Group
+doesn't own any code, it's the cross-SIG forum that shapes the spec while the
+subproject is still finding its shape. Once SIG Apps is happy with the state
+of the spec and test suite, **SIG Architecture** completes a thorough review,
+and SIG Architecture spins up a subproject to host it for the long
+term — the same way SIG Architecture owns the existing Kubernetes conformance
+suite. If SIG Architecture does not reach that approval, SIG Apps decides
+whether to mothball or archive the working group and its artifacts.
+Downstream, the broader ecosystem — workload maintainers, platform
+operators, and any certification program that launches on top of the
+standard — consume it.
+
+
+If a certification program does launch on top of this standard, submission
+would be intentionally decoupled from Certified Kubernetes: the workload's
+owner or maintainer submits, not the cluster vendor or distributor, since they're the ones who
+control the manifests, RBAC, probes, and PDBs being assessed, not the cluster
+underneath them. An ISV shipping a Helm chart for a message queue or an
+Operator for a stateful database would run the suite against their own
+product in its live, deployed state and self-attest, the same way GKE, EKS,
+AKS, or OpenShift assert Certified Kubernetes for the cluster layer. These are
+two independent claims about two different layers — infrastructure and
+application — and the Working Group's specification only defines the latter.
+
+
+### 3. How does the group know when the problem-solving process is complete, and it is time to dissolve?
+
+
+The Working Group disbands once one of the following holds:
+
+
+- An initial, agreed-upon set of workload conformance specs and their
+ verification methodology are finalized within the SIG Apps subproject, the
+ conformance tooling reaches a stable, runnable state (e.g. via Hydrophone)
+ against real workloads, and SIG Apps is happy with that state. SIG
+ Architecture then completes a thorough review and gives its final approval,
+ and spins up a subproject to host the specs and tooling for the long term,
+ without the cross-SIG working group coordinating it.
+- SIG Architecture does not reach that approval, in which case SIG Apps
+ decides whether to mothball or archive the working group and its
+ artifacts instead.
+
+
+The group expects this to take roughly a few Kubernetes release cycles. If
+stability is reached earlier, it may wind down earlier.
+
+
+### 4. Who are all the stakeholder SIGs involved in this problem?
+
+
+- **SIG Apps** — hosts the subproject and owns the deliverables from the
+ outset, representing the workload/application perspective and the
+ archetypes being certified.
+- **SIG Architecture** — reviews the specs and tooling once SIG Apps is
+ satisfied with their state, and, if it approves taking on long-term
+ ownership, spins up the subproject that owns conformance definitions and
+ tooling going forward.
+
+
+Additional SIGs expected to be consulted as the spec touches their domains
+(not necessarily formal stakeholders at founding): SIG Node (node-local APIs
+and deprecations, e.g. the kubelet API, dockershim, cgroup v1), SIG Auth (RBAC, Pod
+Security, admission), SIG Network (NetworkPolicy, Ingress, Gateway), SIG
+Storage (access modes, portable volumes), SIG Instrumentation (metrics,
+structured logs), SIG Testing (conformance test infrastructure), WG Node Lifecycle (pod lifecycle changes around node lifecycle) and WG Batch (batch workloads).
+
+
+### 5. What are the meeting mechanics (frequency, duration, roles)?
+
+
+- **Frequency:** every two weeks.
+- **Duration:** 60 minutes.
+- **Roles:** WG organizers run meetings, curate the agenda, and report to
+ sponsoring SIG chairs. Meetings follow standard Kubernetes project practices
+ (public agenda doc, recorded, notes archived).
+
+
+### 6. Does the goal represent the needs of the project as a whole, or a narrow set of contributors/companies?
+
+
+The whole project. The absence of a workload behavior baseline is a horizontal
+problem that hits every operator and every maintainer regardless of vendor,
+distribution, or delivery format. The specification is defined against upstream
+Kubernetes behavior (Pod Security Standards, deprecated-API signals, standard
+API fields) rather than any single vendor's platform, and the deliverables are
+owned upstream — initially by SIG Apps, and by SIG Architecture long term if
+it approves taking that on. Participation is open, and the archetype set
+spans the ecosystem rather than any one company's portfolio.
+
+
+### 7. Who will chair the group and ensure it continues to meet these requirements?
+
+Proposed organizers:
+- Nabarun Pal
+- Maciej Szulik
+- Liz Rice
+- Ricardo Aravena
+
+### 8. Is diversity well-represented in the Working Group?
+
+Organizers span multiple companies and multiple areas, and the group
+will actively recruit participants across the stakeholder SIGs and across the
+workload archetypes to avoid a single-vendor or single-domain skew.
+
+## In Scope
+
+
+- Define what constitutes a "workload" for the purposes of conformance.
+- Define the ideal characteristic runtime behavior of a workload on Kubernetes.
+- Define the behaviors to be tested for each workload, per Kubernetes minor
+ version, covering node-local APIs (e.g. the kubelet API) alongside the core
+ Kubernetes API surface.
+- Define the verification methodology for each behavior.
+- Deliver conformance tooling / a conformance image, maintainable by a
+ subproject - initially under SIG Apps, moving to SIG Architecture if it
+ approves taking on long-term ownership — in the spirit of the Kubernetes
+ conformance image.
+
+
+## Out of Scope
+
+
+- Running the certification program itself — that is CNCF's concern.
+- Defining or validating the internal business logic of any workload.
+- Re-testing the infrastructure layer already covered by Certified Kubernetes.
+- Measuring a cluster's capability to run a class of workloads (e.g. AI/ML
+ readiness), which is handled by Kubernetes AI Conformance.
+- Preferring or mandating any workload packaging or delivery format (Helm
+ charts, Operators, installers, etc.) — the specification covers a workload's
+ runtime behavior, not how it's packaged to reach the cluster, and can't live
+ inside any single packaging project's governance.
+
+
+## Deliverables
+
+
+- Workload Conformance specification (behaviors, MUST/SHOULD, per K8s version).
+- Behavior verification methodology.
+- Conformance test suite / image handed to a SIG Apps subproject, later
+ transitioning to SIG Architecture if it approves taking that on.
+
+
+## Disband Criteria
+
+
+- Initial set of specs and methodology finalized within the SIG Apps
+ subproject, conformance tooling (via Hydrophone) reaches a stable state of
+ operation, and SIG Apps is happy with that state.
+- SIG Architecture completes a thorough review and gives its final approval,
+ and then spins up a subproject to host the specs and tooling for the long
+ term.
+- If SIG Architecture does not reach that approval, SIG Apps decides whether
+ to mothball or archive the working group and its artifacts instead.
+
+
+## Stakeholder SIGs
+
+
+- SIG Apps
+- SIG Architecture
+
+
+[wg-governance.md]: /committee-steering/governance/wg-governance.md
+[sig-wg-lifecycle.md]: /sig-wg-lifecycle.md
+[charter.md]: ./charter.md
+[community members]: /community-membership.md


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

This PR follows up on the feedback threads on sig-apps@ and sig-architecture@, proposing a new Kubernetes Working Group: WG Workload Conformance.

**What this PR does**:

Adds the creation proposal (`proposal.md`) and charter (`charter.md`) for WG Workload Conformance, co-sponsored by SIG Apps and SIG Architecture. The group defines an open, objectively verifiable standard for how a workload should behave at runtime on Kubernetes and delivers the tooling that verifies it; running a certification program on top of the standard is explicitly out of scope and left to CNCF.

The specification and tooling live in a SIG Apps subproject from the outset and transition to a SIG Architecture subproject once they reach stability - keeping code ownership with a SIG throughout, never with the WG itself.

The proposed organizers were chosen deliberately for cross-landscape collaboration: the slate includes ISV representatives alongside platform/vendor organizers, so the group is shaped by the people who will actually run the conformance suite against their own workloads, not only by platform maintainers.

Detailed proposal: https://docs.google.com/document/d/1BGc4xVcrpQDEDVdGbj5DAvce_VRCSz9zRvQ-5FIdzrM/comment?tab=t.0

**Notes for reviewer**:

- TBD: adding WG Workload Conformance to `sigs.yaml` and setting up OWNERS for the group/subproject. Deferred until this proposal and charter clear review and sponsorship is confirmed.

cc: @kubernetes/steering-committee @kubernetes/sig-apps-leads @kubernetes/sig-architecture-leads 

/label committee/steering
/sig apps
/sig architecture
/kind documentation
/priority important-soon