### PR TITLE
docs: remove deprecated kubetest instructions from conformance-tests.md

### DIFF
--- a/contributors/devel/sig-architecture/conformance-tests.md
+++ b/contributors/devel/sig-architecture/conformance-tests.md
@@ -178,8 +178,8 @@ following branches:
 ## Running Conformance Tests
 
 Conformance tests are designed to be run even when there is no cloud provider
-configured. Conformance tests must be able to be run against clusters that have
-not been created with `test-infra/kubetest`, just provide a kubeconfig with the
+configured. Conformance tests must be able to be run against any cluster,
+regardless of how it was created, just provide a kubeconfig with the
 appropriate endpoint and credentials.
 
 ### Running Conformance Tests With [KinD](https://kind.sigs.k8s.io/)
@@ -229,31 +229,6 @@ make WHAT="test/e2e/e2e.test"
 
 ```sh
 ./_output/bin/e2e.test -context kind-kind -ginkgo.focus="\[sig-network\].*Conformance" -num-nodes 2
-```
-
-### Running Conformance Tests With kubetest
-
-These commands are intended to be run within a kubernetes directory, either
-cloned from source, or extracted from release artifacts such as
-`kubernetes.tar.gz`. They assume you have a valid golang installation.
-
-```sh
-# ensure kubetest is installed
-go get -u k8s.io/test-infra/kubetest
-
-# build test binaries, ginkgo, and kubectl first:
-make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
-
-# setup for conformance tests
-export KUBECONFIG=/path/to/kubeconfig
-export KUBERNETES_CONFORMANCE_TEST=y
-
-# Option A: run all conformance tests serially
-kubetest --provider=skeleton --test --test_args="--ginkgo.focus=\[Conformance\]"
-
-# Option B: run parallel conformance tests first, then serial conformance tests serially
-kubetest --ginkgo-parallel --provider=skeleton --test --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]"
-kubetest --provider=skeleton --test --test_args="--ginkgo.focus=\[Serial\].*\[Conformance\]"
 ```
 
 ## Kubernetes Conformance Document


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
-->




This removes the "Running Conformance Tests With kubetest" section from `conformance-tests.md`. kubetest has been deprecated since July 2020 in favor of kubetest2 (see the deprecation notice at the top of `kubernetes/test-infra/kubetest/README.md`), and is in maintenance mode only, so this doc was pointing contributors at a `go get` command for a tool the project no longer wants new users adopting.

The KinD section immediately above the removed one already documents a current, working way to run conformance tests directly against `e2e.test`, so no replacement instructions were needed. Also updated one remaining prose reference to `test-infra/kubetest` in the "Running Conformance Tests" intro to be tool-agnostic instead of naming a tool that's now defunct.
