### PR TITLE
docs: fix broken charter link for sig-cloud-provider

### DIFF
--- a/sig-cloud-provider/README.md
+++ b/sig-cloud-provider/README.md
@@ -10,7 +10,7 @@ To understand how this file is generated, see https://git.k8s.io/community/gener
 
 Ensures that the Kubernetes ecosystem is evolving in a way that is neutral to all (public and private) cloud providers. It will be responsible for establishing standards and requirements that must be met by all providers to ensure optimal integration with Kubernetes.
 
-The [charter](CHARTER.md) defines the scope and governance of the Cloud Provider Special Interest Group.
+The [charter](charter.md) defines the scope and governance of the Cloud Provider Special Interest Group.
 
 ## Meetings
 *Joining the [mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cloud-provider) for the group will typically add invites for the following meetings to your calendar.*

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -909,7 +909,7 @@ sigs:
     mission_statement: >
       Ensures that the Kubernetes ecosystem is evolving in a way that is neutral to all (public and private) cloud providers. It will be responsible for establishing standards and requirements that must be met by all providers to ensure optimal integration with Kubernetes.
 
-    charter_link: CHARTER.md
+    charter_link: charter.md
     label: cloud-provider
     leadership:
       chairs:


### PR DESCRIPTION
Fixes a broken charter link on the sig-cloud-provider README caused by incorrect file casing in sigs.yaml.