### PR TITLE
docs: fix broken elections subproject link

### DIFF
--- a/elections/steering/documentation/README.md
+++ b/elections/steering/documentation/README.md
@@ -14,7 +14,7 @@ covered consult the older documents in each election folder.
 
 ### The Elections Subproject
 
-Members of the [Elections Subproject](elections/README.md) have three
+Members of the [Elections Subproject](/elections/README.md) have three
 responsibilities around steering elections:
 
 1. Recommending Election Officers to the Steering Committee


### PR DESCRIPTION
Fixes a broken link to the Elections Subproject page in the steering election HOWTO.