### PR TITLE
Fix dead weekly meetings link in first-contribution.md

### DIFF
--- a/contributors/guide/first-contribution.md
+++ b/contributors/guide/first-contribution.md
@@ -145,7 +145,7 @@ while opening an issue. Check the [issue triage guide] for more information.
 [sl]: /sig-list.md
 [video meetings]: https://kubernetes.io/community/
 [sig-contributor-experience]: /sig-contributor-experience/README.md
-[weekly meetings]: https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/edit
+[weekly meetings]: /sig-contributor-experience/README.md#meetings
 [container networking interface]: https://github.com/containernetworking/cni
 [network SIG]: https://git.k8s.io/community/sig-network
 [ask in Slack]: http://slack.k8s.io/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
-->

**Which issue(s) this PR fixes**:
Fixes #

The `[weekly meetings]` link in `contributors/guide/first-contribution.md` pointed to a Google Doc that now returns 410 Gone. Repointed it at the Contributor Experience SIG README's own Meetings section, which already lists the current schedule and notes doc, so this doesn't go stale the same way again.
