### PR TITLE
Fix two dead sig-release reference doc links

### DIFF
--- a/contributors/devel/sig-release/kubernetes-versions.md
+++ b/contributors/devel/sig-release/kubernetes-versions.md
@@ -281,7 +281,7 @@ gs://k8s-release-dev/ci/v1.22.0-beta.2.39+33aba7ee025dfd/bin/
 </details>
 
 A general, non-exhaustive list of the expected artifacts of a Kubernetes build
-can be found [here](https://git.k8s.io/sig-release/release-engineering/artifacts.md).
+can be found [here](https://git.k8s.io/sig-release/release-engineering/reference/artifacts.md).
 
 ## Marker types
 

--- a/contributors/devel/sig-release/release.md
+++ b/contributors/devel/sig-release/release.md
@@ -112,7 +112,7 @@ The general labeling process should be consistent across artifact types.
   referring to a release MAJOR.MINOR `vX.Y` version.
 
   See also
-  [release versioning](https://git.k8s.io/sig-release/release-engineering/versioning.md).
+  [release versioning](https://git.k8s.io/sig-release/release-engineering/reference/versioning.md).
 
 - *release branch*: Git branch `release-X.Y` created for the `vX.Y` milestone.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
-->

**Which issue(s) this PR fixes**:
Fixes #

`contributors/devel/sig-release/kubernetes-versions.md` linked to `release-engineering/artifacts.md` and `release.md` linked to `release-engineering/versioning.md` in kubernetes/sig-release, both now 404. sig-release moved both files into a `reference/` subdirectory. Updated both links to the new path and verified the new URLs resolve.
