### PR TITLE
Fix inverted SPDY and WebSocket client guidance

### DIFF
--- a/contributors/devel/sig-architecture/api-conventions.md
+++ b/contributors/devel/sig-architecture/api-conventions.md
@@ -2001,10 +2001,10 @@ a unidirectional channel from the server to the client and chunks data as binary
 WebSocket frames. An optional WebSocket subprotocol is exposed that base64
 encodes the stream before returning it to the client.
 
-Clients should use the SPDY protocols if their clients have native support, or
-WebSockets as a fallback. Note that WebSockets is susceptible to Head-of-Line
-blocking and so clients must read and process each message sequentially. In
-the future, an HTTP/2 implementation will be exposed that deprecates SPDY.
+Clients should use the WebSocket protocols if their clients have native
+support, or SPDY as a fallback. Note that WebSockets is susceptible to
+Head-of-Line blocking and so clients must read and process each message
+sequentially.
 
 
 ## Validation


### PR DESCRIPTION
kubectl and the API server now prefer WebSockets and fall back to SPDY, not the other way around.

Refs:
- [KEP-4006](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/4006-transition-spdy-to-websockets) — HTTP/2 is ruled out in [Alternatives](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/4006-transition-spdy-to-websockets/README.md#alternatives)
- [Kubernetes 1.31: Streaming Transitions from SPDY to WebSockets](https://kubernetes.io/blog/2024/08/20/websockets-transition/)

<!--  Thanks for sending a pull request!  Here are some tips for you:
- If this is your first contribution, read our Getting Started guide https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
- If you are editing SIG information, please follow these instructions: https://git.k8s.io/community/generator
  You will need to follow these steps:
  1. Edit sigs.yaml with your change 
  2. Generate docs with `make generate`. To build docs for one sig, run `make WHAT=sig-apps generate`
-->

<!--**Which issue(s) this PR fixes**:-->
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
<!--Fixes #-->
