### PR TITLE
Fix broken SIG Docs leadership link in annual-activities.md

### DIFF
--- a/sig-docs/annual-activities.md
+++ b/sig-docs/annual-activities.md
@@ -1,6 +1,6 @@
 # List of annual activities to be performed by SIG Docs leadership
 
-This document lists and details the activities to be performed annually by [SIG Docs leadership](./sig-docs/README.md#leadership)
+This document lists and details the activities to be performed annually by [SIG Docs leadership](./README.md#leadership)
 
 The recommended timeline for these activities is usually November - January due to lower levels of activity.
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #

The SIG Docs leadership link in `sig-docs/annual-activities.md` pointed to `./sig-docs/README.md`, duplicating the file's own directory in the relative path since the document already lives inside `sig-docs/`. Fixed the link to `./README.md` so it resolves correctly.