### PR TITLE
Fix SIG Node link in sig-instrumentation charter to use its reference definition

### DIFF
--- a/sig-instrumentation/charter.md
+++ b/sig-instrumentation/charter.md
@@ -39,7 +39,7 @@ APIs).
   - Guidance on what should be instrumented as well as dimensions of the same. (see [Instrumenting Kubernetes Guide][instrumenting-kubernetes])
   - Creating, adding and maintaining the Kubernetes instrumentation guidelines.
   - Coordinate cross SIG-Instrumentation efforts.
-  - The interface of log files and their directory structure written out by container runtimes to be processed by other systems further, is shared responsibility between [SIG Node](sig-node) and SIG Instrumentation.
+  - The interface of log files and their directory structure written out by container runtimes to be processed by other systems further, is shared responsibility between [SIG Node][sig-node] and SIG Instrumentation.
 
 ### Out of scope
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #

`sig-instrumentation/charter.md` linked to SIG Node using inline syntax `[SIG Node](sig-node)`, which resolves as a broken relative path under `sig-instrumentation/`. The file already has an unused reference-style definition for this exact link two lines from the bottom (`[sig-node]: https://github.com/kubernetes/community/tree/master/sig-node`). Switched the link to `[SIG Node][sig-node]` so it actually uses that existing definition.