### PR TITLE
Rename release-comms usergroup handle to release-comms-team

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -109,7 +109,7 @@ usergroups:
       - xmudrii # Release Manager
       - Verolop # subproject owner / Release Manager
   - name: release-comms-team
-    long_name: Release Communications
+    long_name: Release Communications Team
     description: >-
       Release Communications team for the current release cycle. Members
       updated each cycle by the Comms Lead. Has slack-post-message bot access.

--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -108,7 +108,7 @@ usergroups:
       - tabbysable # Product Security Committee
       - xmudrii # Release Manager
       - Verolop # subproject owner / Release Manager
-  - name: release-comms
+  - name: release-comms-team
     long_name: Release Communications
     description: >-
       Release Communications team for the current release cycle. Members


### PR DESCRIPTION
Renames the `release-comms` usergroup handle to `release-comms-team`. Tag becomes `@release-comms-team`.

After #9137 merged, `post-community-tempelis-apply` still fails to create the group ([run `2098455188724518912`](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-community-tempelis-apply/2098455188724518912), 2026-09-11):

```
Failed: failed to update usergroup Release Communications (): slack call failed: handle_already_exists ([]).
```

Refs #9042, #9083, #9133, #9137

### AI Disclosure

This PR has been created with the assistance of AI

/sig contributor-experience
/sig release
/area slack-management
/cc @jberkus