### PR TITLE
Removes release-comms usergroup per discussion.

### DIFF
--- a/communication/slack-config/sig-release/usergroups.yaml
+++ b/communication/slack-config/sig-release/usergroups.yaml
@@ -108,16 +108,5 @@ usergroups:
       - tabbysable # Product Security Committee
       - xmudrii # Release Manager
       - Verolop # subproject owner / Release Manager
-  - name: release-comms
-    long_name: Release Communications
-    description: >-
-      Release Communications team for the current release cycle. Members
-      updated each cycle by the Comms Lead. Has slack-post-message bot access.
-    channels:
-      - release-comms
-      - sig-release
-    members:
-      - SwathiR03
-      - dipesh-rawat
-      - fsmunoz
+
 


### PR DESCRIPTION
The original group request wasn't properly approved.

Removing the non-functional group until the 1.38 Release Team decides if they want it.

/sig release

@katcosgrove 
