### PR TITLE
Remove stale instructions for deprecated e2e testing tools

### DIFF
--- a/contributors/devel/sig-architecture/conformance-tests.md
+++ b/contributors/devel/sig-architecture/conformance-tests.md
@@ -231,31 +231,6 @@ make WHAT="test/e2e/e2e.test"
 ./_output/bin/e2e.test -context kind-kind -ginkgo.focus="\[sig-network\].*Conformance" -num-nodes 2
 ```
 
-### Running Conformance Tests With kubetest
-
-These commands are intended to be run within a kubernetes directory, either
-cloned from source, or extracted from release artifacts such as
-`kubernetes.tar.gz`. They assume you have a valid golang installation.
-
-```sh
-# ensure kubetest is installed
-go get -u k8s.io/test-infra/kubetest
-
-# build test binaries, ginkgo, and kubectl first:
-make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
-
-# setup for conformance tests
-export KUBECONFIG=/path/to/kubeconfig
-export KUBERNETES_CONFORMANCE_TEST=y
-
-# Option A: run all conformance tests serially
-kubetest --provider=skeleton --test --test_args="--ginkgo.focus=\[Conformance\]"
-
-# Option B: run parallel conformance tests first, then serial conformance tests serially
-kubetest --ginkgo-parallel --provider=skeleton --test --test_args="--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]"
-kubetest --provider=skeleton --test --test_args="--ginkgo.focus=\[Serial\].*\[Conformance\]"
-```
-
 ## Kubernetes Conformance Document
 
 For each Kubernetes release, a Conformance Document will be generated that lists

--- a/contributors/devel/sig-testing/e2e-tests-kubetest2.md
+++ b/contributors/devel/sig-testing/e2e-tests-kubetest2.md
@@ -58,20 +58,16 @@ The first step is to install the Ginkgo testing framework and
 Gomega. Run these commands:
 
 ```sh
-go get github.com/onsi/ginkgo/ginkgo
+go install github.com/onsi/ginkgo/v2/ginkgo@latest
 go get github.com/onsi/gomega/...
 ```
-
-In order to successfully build Kubernetes tests, you will need to
-install Bazel.
-[Follow the instructions for your development environment.](https://docs.bazel.build/versions/3.4.0/install.html)
 
 Next, you need to install the `kubetest2` binary and plugins. Run
 these commands to do that:
 
 ```sh
 cd
-GO111MODULE=on go get sigs.k8s.io/kubetest2/...@latest
+go install sigs.k8s.io/kubetest2/...@latest
 ```
 
 The currently available plugins for cloud providers are:


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #

Two devel guide pages still documented tooling that Kubernetes stopped using years ago.

`contributors/devel/sig-architecture/conformance-tests.md` had a whole "Running Conformance Tests With kubetest" section. The `kubetest` tool was deprecated in July 2020 in favor of `kubetest2`, as the sibling guide `sig-testing/e2e-tests-kubetest2.md` itself explains. The file already documents a complete, modern KinD-based way to run conformance tests directly above this section, so the kubetest section was dead weight, not just outdated. Removed it.

`contributors/devel/sig-testing/e2e-tests-kubetest2.md` told readers to install Bazel before building Kubernetes tests. Bazel was removed from Kubernetes per KEP-2420, which `sig-testing/verify-tests.md` corroborates with its own bazel-removal verification script. Removed that step. The same file also told readers to run `go get github.com/onsi/ginkgo/ginkgo`, which is both the wrong Ginkgo major version (the sibling `writing-good-e2e-tests.md` guide confirms the project uses `github.com/onsi/ginkgo/v2`) and a `go get` invocation that has not installed binaries since Go 1.17. Fixed it to `go install github.com/onsi/ginkgo/v2/ginkgo@latest`, and made the same `go get` to `go install` fix for the `kubetest2` install command a few lines below.